### PR TITLE
Fix lint warning, add .env.example, configure Firebase Auth

### DIFF
--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -1,0 +1,23 @@
+# Server
+PORT=8080
+
+# Auth mode: "dev" (header-based) or "firebase" (production)
+AUTH_MODE=dev
+
+# GCP/Firebase
+GCLOUD_PROJECT=lms-279
+FIREBASE_PROJECT_ID=lms-279
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
+# CORS (comma-separated origins)
+CORS_ORIGIN=http://localhost:3000,http://localhost:3003
+
+# Demo mode
+DEMO_ENABLED=true
+
+# Super admin emails (comma-separated)
+# SUPER_ADMIN_EMAILS=admin@example.com
+
+# GCS buckets
+# GCS_VIDEO_BUCKET=lms-279-videos
+# GCS_UPLOAD_BUCKET=lms-279-uploads

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,14 @@
+# Auth mode: "dev" (header-based) or "firebase" (production)
+NEXT_PUBLIC_AUTH_MODE=dev
+
+# API backend URL
+NEXT_PUBLIC_API_URL=http://localhost:8080
+
+# Dev mode only (ignored when AUTH_MODE=firebase)
+NEXT_PUBLIC_USER_ID=admin-dev
+NEXT_PUBLIC_USER_ROLE=admin
+
+# Firebase Auth (required when AUTH_MODE=firebase)
+# NEXT_PUBLIC_FIREBASE_API_KEY=
+# NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+# NEXT_PUBLIC_FIREBASE_PROJECT_ID=

--- a/web/lib/hooks/use-authenticated-fetch.ts
+++ b/web/lib/hooks/use-authenticated-fetch.ts
@@ -70,7 +70,7 @@ export function useAuthenticatedFetch() {
         idToken: idToken ?? undefined,
       });
     },
-    [user, authLoading, getIdToken, router, tenantId, isDemo]
+    [user, authLoading, getIdToken, router, tenant, tenantId, isDemo]
   );
 
   return {


### PR DESCRIPTION
## Summary
- lint warning修正（useCallback依存配列に`tenant`追加）→ lint 0 errors, 0 warnings
- API/Web用の`.env.example`テンプレート追加（設定項目のドキュメント化）
- Firebase Auth接続設定完了（`.env.local`でfirebaseモードに切替済み）

## Test plan
- [x] 型チェック PASS
- [x] lint 0 errors, 0 warnings
- [x] テスト 300件 全PASS
- [x] Firebase Authモードでログイン画面表示確認
- [ ] Googleログインフロー（手動確認待ち）

🤖 Generated with [Claude Code](https://claude.com/claude-code)