### PR TITLE
Improve admin UX: tenant name, dashboard nav, fix links

### DIFF
--- a/services/api/src/routes/shared/users.ts
+++ b/services/api/src/routes/shared/users.ts
@@ -15,9 +15,23 @@ const router = Router();
  * 認証ユーザー情報取得
  * GET /auth/me
  */
-router.get("/auth/me", requireUser, (req: Request, res: Response) => {
+router.get("/auth/me", requireUser, async (req: Request, res: Response) => {
+  const tenantId = req.tenantContext?.tenantId;
+  let tenantName: string | undefined;
+
+  if (tenantId && !req.tenantContext?.isDemo) {
+    try {
+      const { getFirestore } = await import("firebase-admin/firestore");
+      const doc = await getFirestore().collection("tenants").doc(tenantId).get();
+      tenantName = doc.exists ? (doc.data()?.name as string) : undefined;
+    } catch {
+      // ignore - tenant name is optional
+    }
+  }
+
   res.json({
     user: req.user,
+    ...(tenantName && { tenantName }),
   });
 });
 

--- a/web/app/[tenant]/admin/layout.tsx
+++ b/web/app/[tenant]/admin/layout.tsx
@@ -18,6 +18,7 @@ export default function TenantAdminLayout({
   const pathname = usePathname();
 
   const navItems = [
+    { href: `/${tenantId}/admin`, label: "ダッシュボード", exact: true },
     { href: `/${tenantId}/admin/courses`, label: "講座管理" },
     { href: `/${tenantId}/admin/users`, label: "受講者管理" },
     { href: `/${tenantId}/admin/allowed-emails`, label: "許可メール管理" },
@@ -29,7 +30,9 @@ export default function TenantAdminLayout({
       {/* サブナビゲーション */}
       <nav className="flex gap-4 text-sm border-b pb-2 overflow-x-auto">
         {navItems.map((item) => {
-          const isActive = pathname?.startsWith(item.href);
+          const isActive = item.exact
+            ? pathname === item.href
+            : pathname?.startsWith(item.href);
           return (
             <Link
               key={item.href}

--- a/web/app/[tenant]/admin/page.tsx
+++ b/web/app/[tenant]/admin/page.tsx
@@ -102,12 +102,12 @@ export default function TenantAdminPage() {
           </p>
         </Link>
         <Link
-          href={`/${tenantId}/admin/lessons`}
+          href={`/${tenantId}/admin/courses`}
           className="rounded-lg border bg-card p-6 hover:bg-accent transition-colors"
         >
           <h2 className="font-semibold">レッスン管理</h2>
           <p className="mt-2 text-sm text-muted-foreground">
-            レッスンの作成・編集・並び替え
+            講座を選んでレッスンを管理
           </p>
         </Link>
         <Link

--- a/web/app/[tenant]/layout.tsx
+++ b/web/app/[tenant]/layout.tsx
@@ -12,6 +12,7 @@ type UserRole = "admin" | "teacher" | "student" | null;
 interface AuthMeResponse {
   user?: { role?: string };
   isSuperAdminAccess?: boolean;
+  tenantName?: string;
 }
 
 /**
@@ -88,6 +89,7 @@ function TenantLayoutInner({ children }: { children: React.ReactNode }) {
   const { user, loading: authLoading } = useAuth();
   const authFetch = useAuthFetch();
   const [isSuperAdminAccess, setIsSuperAdminAccess] = useState(false);
+  const [tenantName, setTenantName] = useState<string | null>(null);
 
   useEffect(() => {
     if (authLoading || !user) return;
@@ -96,6 +98,7 @@ function TenantLayoutInner({ children }: { children: React.ReactNode }) {
       try {
         const data = await authFetch<AuthMeResponse>("/auth/me");
         setIsSuperAdminAccess(data.isSuperAdminAccess ?? false);
+        if (data.tenantName) setTenantName(data.tenantName);
       } catch {
         setIsSuperAdminAccess(false);
       }
@@ -129,6 +132,11 @@ function TenantLayoutInner({ children }: { children: React.ReactNode }) {
           >
             LMS 279{isDemo ? " (DEMO)" : ""}
           </Link>
+          {tenantName && (
+            <span className="text-sm text-muted-foreground border-l pl-4">
+              {tenantName}
+            </span>
+          )}
           <TenantNav isSuperAdminAccess={isSuperAdminAccess} />
         </div>
       </header>


### PR DESCRIPTION
## Summary
- ヘッダーにテナント名を表示（`/auth/me`レスポンスにtenantName追加）(Closes #4)
- 管理画面ナビに「ダッシュボード」リンク追加 (Closes #5)
- レッスン管理のカードリンクを講座管理に修正（`/admin/lessons`は存在しない）

## Test plan
- [x] 型チェック PASS
- [x] lint 0 errors
- [x] テスト 300件 全PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)