### PR TITLE
Rename UI label クイズ → テスト

### DIFF
--- a/web/app/[tenant]/admin/analytics/page.tsx
+++ b/web/app/[tenant]/admin/analytics/page.tsx
@@ -508,7 +508,7 @@ function UserProgressTab() {
                               variant={lesson.quizPassed ? "default" : "outline"}
                               className="text-xs"
                             >
-                              クイズ{lesson.quizPassed ? "合格" : "未合格"}
+                              テスト{lesson.quizPassed ? "合格" : "未合格"}
                             </Badge>
                           </div>
                         </TableCell>

--- a/web/app/[tenant]/admin/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/admin/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -145,7 +145,7 @@ function QuizSection({ lessonId }: { lessonId: string }) {
       if (e instanceof Error && e.message.includes("404")) {
         setQuiz(null);
       } else {
-        setQuizError(e instanceof Error ? e.message : "クイズの取得に失敗しました");
+        setQuizError(e instanceof Error ? e.message : "テストの取得に失敗しました");
       }
     } finally {
       setQuizLoading(false);
@@ -228,7 +228,7 @@ function QuizSection({ lessonId }: { lessonId: string }) {
   // ── Delete quiz ───────────────────────────────────────────────────────────
 
   const handleDeleteQuiz = async () => {
-    if (!confirm("クイズを削除しますか？この操作は取り消せません。")) return;
+    if (!confirm("テストを削除しますか？この操作は取り消せません。")) return;
     setDeleteQuizLoading(true);
     setDeleteQuizError(null);
     try {
@@ -379,7 +379,7 @@ function QuizSection({ lessonId }: { lessonId: string }) {
   if (quizLoading) {
     return (
       <section className="rounded-md border p-6 space-y-2">
-        <h2 className="text-lg font-semibold">クイズ</h2>
+        <h2 className="text-lg font-semibold">テスト</h2>
         <p className="text-sm text-muted-foreground">読み込み中...</p>
       </section>
     );
@@ -387,7 +387,7 @@ function QuizSection({ lessonId }: { lessonId: string }) {
 
   return (
     <section className="rounded-md border p-6 space-y-4">
-      <h2 className="text-lg font-semibold">クイズ</h2>
+      <h2 className="text-lg font-semibold">テスト</h2>
 
       {quizError && (
         <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
@@ -399,9 +399,9 @@ function QuizSection({ lessonId }: { lessonId: string }) {
         /* ── No quiz yet ── */
         <div className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            このレッスンにはまだクイズが作成されていません。
+            このレッスンにはまだテストが作成されていません。
           </p>
-          <Button onClick={openCreateQuizDialog}>クイズを作成</Button>
+          <Button onClick={openCreateQuizDialog}>テストを作成</Button>
         </div>
       ) : (
         /* ── Quiz exists ── */
@@ -546,7 +546,7 @@ function QuizSection({ lessonId }: { lessonId: string }) {
         <DialogContent className="max-w-lg">
           <DialogHeader>
             <DialogTitle>
-              {isEditingQuiz ? "クイズ設定を編集" : "クイズを作成"}
+              {isEditingQuiz ? "テスト設定を編集" : "テストを作成"}
             </DialogTitle>
           </DialogHeader>
 
@@ -559,7 +559,7 @@ function QuizSection({ lessonId }: { lessonId: string }) {
                 onChange={(e) =>
                   setQuizForm((p) => ({ ...p, title: e.target.value }))
                 }
-                placeholder="クイズのタイトル"
+                placeholder="テストのタイトル"
               />
             </div>
 

--- a/web/app/[tenant]/admin/courses/[courseId]/lessons/page.tsx
+++ b/web/app/[tenant]/admin/courses/[courseId]/lessons/page.tsx
@@ -227,7 +227,7 @@ export default function LessonsPage() {
               <TableHead>順序</TableHead>
               <TableHead>タイトル</TableHead>
               <TableHead>動画</TableHead>
-              <TableHead>クイズ</TableHead>
+              <TableHead>テスト</TableHead>
               <TableHead>操作</TableHead>
             </TableRow>
           </TableHeader>

--- a/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -64,7 +64,7 @@ type Analytics = {
 };
 
 // ============================================================
-// クイズ関連の型定義
+// テスト関連の型定義
 // ============================================================
 
 type QuizOption = {
@@ -144,7 +144,7 @@ type AttemptResult = {
 type QuizUIState = "idle" | "taking" | "result";
 
 // ============================================================
-// クイズセクションコンポーネント
+// テストセクションコンポーネント
 // ============================================================
 
 function QuizSection({
@@ -169,7 +169,7 @@ function QuizSection({
   const [quizError, setQuizError] = useState<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // クイズ情報取得
+  // テスト情報取得
   const fetchQuiz = useCallback(async () => {
     setLoadingQuiz(true);
     setQuizError(null);
@@ -181,7 +181,7 @@ function QuizSection({
       setUserAttemptCount(data.userAttemptCount);
       setAttemptSummaries(data.attemptSummaries);
     } catch (e) {
-      setQuizError(e instanceof Error ? e.message : "クイズ情報の取得に失敗しました");
+      setQuizError(e instanceof Error ? e.message : "テスト情報の取得に失敗しました");
     } finally {
       setLoadingQuiz(false);
     }
@@ -217,7 +217,7 @@ function QuizSection({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [quizState, activeAttempt]);
 
-  // クイズ開始
+  // テスト開始
   const handleStart = async () => {
     if (!quiz) return;
     setLoadingStart(true);
@@ -232,7 +232,7 @@ function QuizSection({
       setResult(null);
       setQuizState("taking");
     } catch (e) {
-      setQuizError(e instanceof Error ? e.message : "クイズの開始に失敗しました");
+      setQuizError(e instanceof Error ? e.message : "テストの開始に失敗しました");
     } finally {
       setLoadingStart(false);
     }
@@ -280,7 +280,7 @@ function QuizSection({
       // 受験回数などを更新
       await fetchQuiz();
     } catch (e) {
-      setQuizError(e instanceof Error ? e.message : "クイズの提出に失敗しました");
+      setQuizError(e instanceof Error ? e.message : "テストの提出に失敗しました");
     } finally {
       setLoadingSubmit(false);
     }
@@ -305,7 +305,7 @@ function QuizSection({
   if (loadingQuiz) {
     return (
       <div className="rounded-md border p-6">
-        <p className="text-sm text-muted-foreground">クイズを読み込み中...</p>
+        <p className="text-sm text-muted-foreground">テストを読み込み中...</p>
       </div>
     );
   }
@@ -323,7 +323,7 @@ function QuizSection({
   const remainingAttempts = quiz.maxAttempts - userAttemptCount;
 
   // ============================================================
-  // 状態1: クイズ未開始
+  // 状態1: テスト未開始
   // ============================================================
   if (quizState === "idle") {
     return (
@@ -349,7 +349,7 @@ function QuizSection({
             disabled={loadingStart}
             className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {loadingStart ? "開始中..." : "クイズを開始"}
+            {loadingStart ? "開始中..." : "テストを開始"}
           </button>
         ) : (
           <p className="text-sm text-muted-foreground">
@@ -390,7 +390,7 @@ function QuizSection({
   }
 
   // ============================================================
-  // 状態2: クイズ受験中
+  // 状態2: テスト受験中
   // ============================================================
   if (quizState === "taking") {
     const totalQuestions = quiz.questions.length;
@@ -489,7 +489,7 @@ function QuizSection({
         {showSubmitDialog && (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
             <div className="bg-background rounded-lg border shadow-lg p-6 w-full max-w-sm space-y-4 mx-4">
-              <h3 className="text-base font-semibold">クイズを提出しますか？</h3>
+              <h3 className="text-base font-semibold">テストを提出しますか？</h3>
               {answeredCount < totalQuestions && (
                 <p className="text-sm text-orange-600">
                   {totalQuestions - answeredCount} 問が未回答です。このまま提出しますか？
@@ -688,7 +688,7 @@ export default function StudentLessonDetailPage() {
   const [videoMeta, setVideoMeta] = useState<VideoMeta | null>(null);
   const [playbackUrl, setPlaybackUrl] = useState<string | null>(null);
   const [analytics, setAnalytics] = useState<Analytics | null>(null);
-  // 動画完了ゲート: 動画完了時にクイズセクションを表示するためのフラグ
+  // 動画完了ゲート: 動画完了時にテストセクションを表示するためのフラグ
   const [videoCompleted, setVideoCompleted] = useState(false);
 
   const [loadingCourse, setLoadingCourse] = useState(true);
@@ -786,7 +786,7 @@ export default function StudentLessonDetailPage() {
     }
   }, [videoMeta, fetchAnalytics]);
 
-  // 動画完了コールバック: analytics再取得 + クイズ表示フラグを立てる
+  // 動画完了コールバック: analytics再取得 + テスト表示フラグを立てる
   const handleVideoComplete = useCallback(async () => {
     await fetchAnalytics();
     setVideoCompleted(true);
@@ -810,7 +810,7 @@ export default function StudentLessonDetailPage() {
     ? Math.round(analytics.coverageRatio * 100)
     : 0;
 
-  // クイズセクションを表示すべきか:
+  // テストセクションを表示すべきか:
   // - 動画なしレッスン: 常に表示
   // - 動画ありレッスン: analytics.isComplete === true または videoCompleted フラグ
   const showQuizSection =
@@ -946,16 +946,16 @@ export default function StudentLessonDetailPage() {
         )}
       </div>
 
-      {/* クイズセクション */}
+      {/* テストセクション */}
       {currentLesson.hasQuiz && (
         showQuizSection ? (
           <QuizSection lessonId={lessonId} authFetch={authFetch} />
         ) : (
           /* 動画未完了ゲートメッセージ */
           <div className="rounded-md border p-6 text-center space-y-2">
-            <p className="text-sm font-medium">クイズに挑戦する</p>
+            <p className="text-sm font-medium">テストに挑戦する</p>
             <p className="text-sm text-muted-foreground">
-              動画を最後まで視聴するとクイズに挑戦できます
+              動画を最後まで視聴するとテストに挑戦できます
             </p>
           </div>
         )

--- a/web/app/[tenant]/student/courses/[courseId]/page.tsx
+++ b/web/app/[tenant]/student/courses/[courseId]/page.tsx
@@ -202,7 +202,7 @@ export default function StudentCourseDetailPage() {
                     <TableHead className="w-12">#</TableHead>
                     <TableHead>タイトル</TableHead>
                     <TableHead>動画</TableHead>
-                    <TableHead>クイズ</TableHead>
+                    <TableHead>テスト</TableHead>
                     <TableHead>進捗</TableHead>
                   </TableRow>
                 </TableHeader>


### PR DESCRIPTION
## Summary
- UI上の「クイズ」表記を「テスト」に統一（LMSとして適切な用語に変更）
- 5ファイル、29箇所を置換
- API/DB内部名称（quizzes, quiz_attempts等）は変更なし

## Test plan
- [x] 型チェック PASS
- [x] lint 0 errors
- [x] テスト 300件 全PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)