### PR TITLE
Add master content API integration tests (34 cases)

### DIFF
--- a/services/api/src/__tests__/helpers/create-super-admin-app.ts
+++ b/services/api/src/__tests__/helpers/create-super-admin-app.ts
@@ -1,0 +1,30 @@
+/**
+ * マスターコンテンツAPI テスト用Expressアプリ作成ヘルパー
+ *
+ * 前提: 呼び出し側で vi.mock によるモックが適用済みであること
+ *   - ../../datasource/firestore.js
+ *   - firebase-admin/firestore
+ *   - ../../services/course-distributor.js
+ */
+
+import express from "express";
+import { masterRouter } from "../../routes/super-admin-master.js";
+
+/**
+ * マスターコンテンツAPI用テストアプリを作成
+ * masterRouter をマウントし、superAdmin 認証をバイパスする
+ */
+export function createSuperAdminApp() {
+  const app = express();
+  app.use(express.json());
+
+  // superAdmin を手動注入（認証バイパス）
+  app.use((req, _res, next) => {
+    req.superAdmin = { email: "super@test.com" };
+    next();
+  });
+
+  app.use(masterRouter);
+
+  return app;
+}

--- a/services/api/src/__tests__/integration/master-courses.test.ts
+++ b/services/api/src/__tests__/integration/master-courses.test.ts
@@ -4,7 +4,6 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import supertest from "supertest";
-import express from "express";
 import { InMemoryDataSource } from "../../datasource/in-memory.js";
 
 // テスト用DS（各テストでリセット）
@@ -27,35 +26,26 @@ vi.mock("../../services/course-distributor.js", () => ({
   distributeCourseToTenant: vi.fn(),
 }));
 
-// masterRouter をモック適用後にインポート
-const { masterRouter } = await import("../../routes/super-admin-master.js");
-
-function createApp() {
-  const app = express();
-  app.use(express.json());
-  app.use((req, _res, next) => {
-    req.superAdmin = { email: "super@test.com" };
-    next();
-  });
-  app.use(masterRouter);
-  return app;
-}
+// ヘルパーをモック適用後にインポート
+const { createSuperAdminApp } = await import("../helpers/create-super-admin-app.js");
 
 describe("Master Courses API", () => {
   let request: ReturnType<typeof supertest>;
 
   beforeEach(() => {
     testDS = new InMemoryDataSource({ readOnly: false });
-    request = supertest(createApp());
+    request = supertest(createSuperAdminApp());
   });
 
   describe("GET /master/courses", () => {
     it("マスターコース一覧を取得して200を返す", async () => {
+      // InMemoryDataSource の初期データ（3件）が含まれる
       const res = await request.get("/master/courses");
 
       expect(res.status).toBe(200);
       expect(res.body.courses).toBeDefined();
       expect(Array.isArray(res.body.courses)).toBe(true);
+      expect(res.body.courses.length).toBeGreaterThanOrEqual(3);
     });
 
     it("status=draftでフィルタできる", async () => {
@@ -64,6 +54,7 @@ describe("Master Courses API", () => {
       const res = await request.get("/master/courses?status=draft");
 
       expect(res.status).toBe(200);
+      expect(res.body.courses.length).toBeGreaterThanOrEqual(1);
       res.body.courses.forEach((c: { status: string }) => {
         expect(c.status).toBe("draft");
       });
@@ -151,17 +142,34 @@ describe("Master Courses API", () => {
   });
 
   describe("DELETE /master/courses/:id", () => {
-    it("マスターコースを削除してレスポンスを返す", async () => {
+    it("マスターコースと関連データを削除する", async () => {
+      // コース → レッスン → 動画・クイズを作成
       const created = await request
         .post("/master/courses")
         .send({ name: "削除テスト" });
       const courseId = created.body.course.id;
+
+      const lessonRes = await request
+        .post(`/master/courses/${courseId}/lessons`)
+        .send({ title: "削除レッスン" });
+      const lessonId = lessonRes.body.lesson.id;
+
+      await request
+        .post(`/master/lessons/${lessonId}/video`)
+        .send({ durationSec: 60 });
+      await request
+        .post(`/master/lessons/${lessonId}/quiz`)
+        .send({
+          title: "削除クイズ",
+          questions: [{ id: "q1", text: "Q", type: "single", options: [{ id: "a", text: "A", isCorrect: true }], points: 10 }],
+        });
 
       const res = await request.delete(`/master/courses/${courseId}`);
 
       expect(res.status).toBe(200);
       expect(res.body.message).toContain("削除");
 
+      // コースが削除されていること
       const getRes = await request.get(`/master/courses/${courseId}`);
       expect(getRes.status).toBe(404);
     });

--- a/services/api/src/__tests__/integration/master-distribute.test.ts
+++ b/services/api/src/__tests__/integration/master-distribute.test.ts
@@ -5,7 +5,6 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import supertest from "supertest";
-import express from "express";
 import { InMemoryDataSource } from "../../datasource/in-memory.js";
 
 let testDS: InMemoryDataSource;
@@ -22,37 +21,29 @@ vi.mock("firebase-admin/firestore", () => ({
   FieldValue: { serverTimestamp: vi.fn() },
 }));
 
+const mockDistribute = vi.fn().mockResolvedValue({
+  tenantId: "tenant-1",
+  courseId: "course-1",
+  masterCourseId: "master-1",
+  status: "success",
+  lessonsCount: 2,
+  videosCount: 1,
+  quizzesCount: 1,
+});
+
 vi.mock("../../services/course-distributor.js", () => ({
-  distributeCourseToTenant: vi.fn().mockResolvedValue({
-    tenantId: "tenant-1",
-    courseId: "course-1",
-    masterCourseId: "master-1",
-    status: "success",
-    lessonsCount: 2,
-    videosCount: 1,
-    quizzesCount: 1,
-  }),
+  distributeCourseToTenant: mockDistribute,
 }));
 
-const { masterRouter } = await import("../../routes/super-admin-master.js");
-
-function createApp() {
-  const app = express();
-  app.use(express.json());
-  app.use((req, _res, next) => {
-    req.superAdmin = { email: "super@test.com" };
-    next();
-  });
-  app.use(masterRouter);
-  return app;
-}
+const { createSuperAdminApp } = await import("../helpers/create-super-admin-app.js");
 
 describe("Master Distribute API", () => {
   let request: ReturnType<typeof supertest>;
 
   beforeEach(() => {
     testDS = new InMemoryDataSource({ readOnly: false });
-    request = supertest(createApp());
+    request = supertest(createSuperAdminApp());
+    mockDistribute.mockClear();
   });
 
   describe("POST /master/distribute", () => {
@@ -66,6 +57,34 @@ describe("Master Distribute API", () => {
       expect(Array.isArray(res.body.results)).toBe(true);
       expect(res.body.results.length).toBe(1);
       expect(res.body.results[0].status).toBe("success");
+
+      // distributeCourseToTenant が正しい引数で呼ばれること
+      expect(mockDistribute).toHaveBeenCalledTimes(1);
+      expect(mockDistribute).toHaveBeenCalledWith(
+        expect.anything(), // db (mocked getFirestore)
+        "course-1",
+        "tenant-1",
+        "super@test.com", // distributedBy = req.superAdmin.email
+      );
+    });
+
+    it("複数コース×複数テナントの直積展開で呼ばれる", async () => {
+      const res = await request
+        .post("/master/distribute")
+        .send({ courseIds: ["c1", "c2"], tenantIds: ["t1", "t2"] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.results.length).toBe(4);
+      expect(mockDistribute).toHaveBeenCalledTimes(4);
+
+      // 4つの組み合わせが全て呼ばれること
+      const calls = mockDistribute.mock.calls.map(
+        (call: unknown[]) => `${call[1]}-${call[2]}`,
+      );
+      expect(calls).toContain("c1-t1");
+      expect(calls).toContain("c1-t2");
+      expect(calls).toContain("c2-t1");
+      expect(calls).toContain("c2-t2");
     });
 
     it("courseIdsが未指定の場合400を返す", async () => {
@@ -75,6 +94,7 @@ describe("Master Distribute API", () => {
 
       expect(res.status).toBe(400);
       expect(res.body.error).toBe("invalid_course_ids");
+      expect(mockDistribute).not.toHaveBeenCalled();
     });
 
     it("tenantIdsが未指定の場合400を返す", async () => {
@@ -84,6 +104,7 @@ describe("Master Distribute API", () => {
 
       expect(res.status).toBe(400);
       expect(res.body.error).toBe("invalid_tenant_ids");
+      expect(mockDistribute).not.toHaveBeenCalled();
     });
   });
 

--- a/services/api/src/__tests__/integration/master-lessons.test.ts
+++ b/services/api/src/__tests__/integration/master-lessons.test.ts
@@ -4,7 +4,6 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import supertest from "supertest";
-import express from "express";
 import { InMemoryDataSource } from "../../datasource/in-memory.js";
 
 let testDS: InMemoryDataSource;
@@ -25,18 +24,7 @@ vi.mock("../../services/course-distributor.js", () => ({
   distributeCourseToTenant: vi.fn(),
 }));
 
-const { masterRouter } = await import("../../routes/super-admin-master.js");
-
-function createApp() {
-  const app = express();
-  app.use(express.json());
-  app.use((req, _res, next) => {
-    req.superAdmin = { email: "super@test.com" };
-    next();
-  });
-  app.use(masterRouter);
-  return app;
-}
+const { createSuperAdminApp } = await import("../helpers/create-super-admin-app.js");
 
 describe("Master Lessons API", () => {
   let request: ReturnType<typeof supertest>;
@@ -44,7 +32,7 @@ describe("Master Lessons API", () => {
 
   beforeEach(async () => {
     testDS = new InMemoryDataSource({ readOnly: false });
-    request = supertest(createApp());
+    request = supertest(createSuperAdminApp());
 
     // テスト用コースを作成
     const created = await request
@@ -79,6 +67,20 @@ describe("Master Lessons API", () => {
       expect(res.body.lesson.title).toBe("新規レッスン");
       expect(res.body.lesson.courseId).toBe(courseId);
       expect(res.body.lesson.order).toBe(0);
+    });
+
+    it("作成後にコースのlessonOrderに追加される", async () => {
+      const lesson1 = await request
+        .post(`/master/courses/${courseId}/lessons`)
+        .send({ title: "レッスン1" });
+      const lesson2 = await request
+        .post(`/master/courses/${courseId}/lessons`)
+        .send({ title: "レッスン2" });
+
+      const courseRes = await request.get(`/master/courses/${courseId}`);
+      expect(courseRes.body.course.lessonOrder).toContain(lesson1.body.lesson.id);
+      expect(courseRes.body.course.lessonOrder).toContain(lesson2.body.lesson.id);
+      expect(courseRes.body.course.lessonOrder.length).toBe(2);
     });
 
     it("titleが空の場合400を返す", async () => {
@@ -126,15 +128,18 @@ describe("Master Lessons API", () => {
   });
 
   describe("DELETE /master/lessons/:id", () => {
-    it("レッスンを削除して204を返す", async () => {
+    it("レッスンを削除して204を返し、コースのlessonOrderからも除去される", async () => {
       const created = await request
         .post(`/master/courses/${courseId}/lessons`)
         .send({ title: "削除テスト" });
       const lessonId = created.body.lesson.id;
 
       const res = await request.delete(`/master/lessons/${lessonId}`);
-
       expect(res.status).toBe(204);
+
+      // コースのlessonOrderからも除去されていること
+      const courseRes = await request.get(`/master/courses/${courseId}`);
+      expect(courseRes.body.course.lessonOrder).not.toContain(lessonId);
     });
 
     it("存在しないIDで404を返す", async () => {

--- a/services/api/src/__tests__/integration/master-media.test.ts
+++ b/services/api/src/__tests__/integration/master-media.test.ts
@@ -4,7 +4,6 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import supertest from "supertest";
-import express from "express";
 import { InMemoryDataSource } from "../../datasource/in-memory.js";
 
 let testDS: InMemoryDataSource;
@@ -25,18 +24,7 @@ vi.mock("../../services/course-distributor.js", () => ({
   distributeCourseToTenant: vi.fn(),
 }));
 
-const { masterRouter } = await import("../../routes/super-admin-master.js");
-
-function createApp() {
-  const app = express();
-  app.use(express.json());
-  app.use((req, _res, next) => {
-    req.superAdmin = { email: "super@test.com" };
-    next();
-  });
-  app.use(masterRouter);
-  return app;
-}
+const { createSuperAdminApp } = await import("../helpers/create-super-admin-app.js");
 
 describe("Master Media API", () => {
   let request: ReturnType<typeof supertest>;
@@ -45,7 +33,7 @@ describe("Master Media API", () => {
 
   beforeEach(async () => {
     testDS = new InMemoryDataSource({ readOnly: false });
-    request = supertest(createApp());
+    request = supertest(createSuperAdminApp());
 
     const course = await request
       .post("/master/courses")
@@ -73,6 +61,17 @@ describe("Master Media API", () => {
       expect(res.body.video.lessonId).toBe(lessonId);
       expect(res.body.video.courseId).toBe(courseId);
       expect(res.body.video.durationSec).toBe(120);
+    });
+
+    it("動画作成後にレッスンのhasVideoがtrueになる", async () => {
+      await request
+        .post(`/master/lessons/${lessonId}/video`)
+        .send({ durationSec: 60 });
+
+      // レッスン詳細を取得して確認
+      const courseRes = await request.get(`/master/courses/${courseId}`);
+      const lesson = courseRes.body.lessons.find((l: { id: string }) => l.id === lessonId);
+      expect(lesson.hasVideo).toBe(true);
     });
 
     it("存在しないレッスンIDで404を返す", async () => {
@@ -111,27 +110,34 @@ describe("Master Media API", () => {
   });
 
   describe("DELETE /master/videos/:id", () => {
-    it("動画を削除して204を返す", async () => {
+    it("動画を削除して204を返し、レッスンのhasVideoがfalseになる", async () => {
       const created = await request
         .post(`/master/lessons/${lessonId}/video`)
         .send({});
       const videoId = created.body.video.id;
 
       const res = await request.delete(`/master/videos/${videoId}`);
-
       expect(res.status).toBe(204);
+
+      // hasVideo が false に戻っていること
+      const courseRes = await request.get(`/master/courses/${courseId}`);
+      const lesson = courseRes.body.lessons.find((l: { id: string }) => l.id === lessonId);
+      expect(lesson.hasVideo).toBe(false);
     });
   });
 
   describe("DELETE /master/lessons/:lessonId/video", () => {
-    it("レッスンIDから動画を削除して204を返す", async () => {
+    it("レッスンIDから動画を削除して204を返し、hasVideoがfalseになる", async () => {
       await request
         .post(`/master/lessons/${lessonId}/video`)
         .send({});
 
       const res = await request.delete(`/master/lessons/${lessonId}/video`);
-
       expect(res.status).toBe(204);
+
+      const courseRes = await request.get(`/master/courses/${courseId}`);
+      const lesson = courseRes.body.lessons.find((l: { id: string }) => l.id === lessonId);
+      expect(lesson.hasVideo).toBe(false);
     });
   });
 
@@ -163,6 +169,16 @@ describe("Master Media API", () => {
       expect(res.body.quiz.title).toBe("テストクイズ");
       expect(res.body.quiz.lessonId).toBe(lessonId);
       expect(res.body.quiz.questions).toHaveLength(1);
+    });
+
+    it("クイズ作成後にレッスンのhasQuizがtrueになる", async () => {
+      await request
+        .post(`/master/lessons/${lessonId}/quiz`)
+        .send({ title: "テストクイズ", questions: sampleQuestions });
+
+      const courseRes = await request.get(`/master/courses/${courseId}`);
+      const lesson = courseRes.body.lessons.find((l: { id: string }) => l.id === lessonId);
+      expect(lesson.hasQuiz).toBe(true);
     });
 
     it("questions付きで正しく作成できる", async () => {
@@ -217,15 +233,19 @@ describe("Master Media API", () => {
   });
 
   describe("DELETE /master/quizzes/:id", () => {
-    it("クイズを削除して204を返す", async () => {
+    it("クイズを削除して204を返し、レッスンのhasQuizがfalseになる", async () => {
       const created = await request
         .post(`/master/lessons/${lessonId}/quiz`)
         .send({ title: "削除クイズ", questions: sampleQuestions });
       const quizId = created.body.quiz.id;
 
       const res = await request.delete(`/master/quizzes/${quizId}`);
-
       expect(res.status).toBe(204);
+
+      // hasQuiz が false に戻っていること
+      const courseRes = await request.get(`/master/courses/${courseId}`);
+      const lesson = courseRes.body.lessons.find((l: { id: string }) => l.id === lessonId);
+      expect(lesson.hasQuiz).toBe(false);
     });
 
     it("存在しないIDで404を返す", async () => {
@@ -237,14 +257,17 @@ describe("Master Media API", () => {
   });
 
   describe("DELETE /master/lessons/:lessonId/quiz", () => {
-    it("レッスンIDからクイズを削除して204を返す", async () => {
+    it("レッスンIDからクイズを削除して204を返し、hasQuizがfalseになる", async () => {
       await request
         .post(`/master/lessons/${lessonId}/quiz`)
         .send({ title: "削除クイズ2", questions: sampleQuestions });
 
       const res = await request.delete(`/master/lessons/${lessonId}/quiz`);
-
       expect(res.status).toBe(204);
+
+      const courseRes = await request.get(`/master/courses/${courseId}`);
+      const lesson = courseRes.body.lessons.find((l: { id: string }) => l.id === lessonId);
+      expect(lesson.hasQuiz).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- PR #10 で追加したマスターコンテンツ管理API (`/api/v2/super/master/*`) の統合テスト34ケースを追加
- `vi.mock` で `FirestoreDataSource` を `InMemoryDataSource` に差し替え、Firestore依存なしでテスト実行可能
- `distributeCourseToTenant` もモック化し、配信APIのバリデーション・正常系をテスト

## Test plan
- [x] `npm run test -w @lms-279/api` — 全348テストパス（既存314 + 新規34）
- [x] `npm run lint` — パス
- [x] `npm run type-check` — パス

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)