### PR TITLE
fix: exclude dist/ from vitest to fix flaky tests, add /health/ready E2E

### DIFF
--- a/e2e/tests/health.spec.ts
+++ b/e2e/tests/health.spec.ts
@@ -8,6 +8,16 @@ test.describe("ヘルスチェック", () => {
     expect(body.status).toBe("ok");
   });
 
+  test("API /health/ready がchecksオブジェクトを含むレスポンスを返す", async ({ request }) => {
+    const res = await request.get("http://localhost:8080/health/ready");
+    // ローカル環境ではFirestore接続状況により200 or 503
+    expect([200, 503]).toContain(res.status());
+    const body = await res.json();
+    expect(body.checks).toBeDefined();
+    expect(body.checks.memory).toBeDefined();
+    expect(typeof body.checks.memory.heapUsedMB).toBe("number");
+  });
+
   test("Web トップページが200を返す", async ({ page }) => {
     const res = await page.goto("/");
     expect(res?.status()).toBe(200);

--- a/services/api/vitest.config.ts
+++ b/services/api/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     passWithNoTests: true,
+    exclude: ["**/node_modules/**", "**/dist/**"],
   },
 });


### PR DESCRIPTION
## Summary
- **vitest dist/除外**: vitestがdist/のビルド済みjsテストも実行していた（25ファイル371テスト中、8ファイル156テストが重複）。src/とdist/の同一テストがInMemoryDataSourceのステートを共有しrace conditionが発生→間欠的失敗の根本原因。`exclude: ['**/dist/**']` で修正
- **/health/ready E2Eテスト追加**: ユニットテストから除外した/health/readyのE2Eカバレッジ

## Test plan
- [x] 17ファイル 215 APIテスト全パス（重複除去後の正しい数）
- [x] 10 E2Eテスト全パス
- [x] TypeScript型チェック通過
- [x] ESLint通過

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)