### PR TITLE
fix: add 5s timeout to /health/ready Firestore check

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -56,10 +56,13 @@ app.get("/health/ready", async (_req, res) => {
   const checks: Record<string, unknown> = {};
   let healthy = true;
 
-  // Firestore接続確認
+  // Firestore接続確認（タイムアウト5秒）
   try {
     const db = getFirestore();
-    await db.listCollections();
+    await Promise.race([
+      db.listCollections(),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 5000)),
+    ]);
     checks.firestore = "ok";
   } catch {
     checks.firestore = "error";


### PR DESCRIPTION
## Summary
- `/health/ready`のFirestore `listCollections()`呼び出しに5秒タイムアウトを追加
- CI環境（GCP認証なし）でFirestoreチェックが無限ハングし、APIサーバーがクラッシュ→後続E2Eテストが全滅していた問題を修正

## Root Cause
`db.listCollections()`はGCP認証がない環境でリジェクトもタイムアウトもせずハングアップ。これによりAPIプロセスが応答不能になり、`ECONNREFUSED`で他のE2Eテストも巻き添え失敗。

## Fix
`Promise.race`で5秒タイムアウトを追加。タイムアウト時は`checks.firestore = "error"`として503を返す（サーバーはクラッシュしない）。

## Test plan
- [x] 215 APIテスト全パス
- [x] lint + 型チェック通過
- [ ] E2E CIで`/health/ready`テストが503で正常処理されることを確認

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)