### PR TITLE
fix: skip Firestore check in /health/ready without GCP credentials

### DIFF
--- a/e2e/tests/health.spec.ts
+++ b/e2e/tests/health.spec.ts
@@ -10,10 +10,12 @@ test.describe("ヘルスチェック", () => {
 
   test("API /health/ready がchecksオブジェクトを含むレスポンスを返す", async ({ request }) => {
     const res = await request.get("http://localhost:8080/health/ready");
-    // ローカル環境ではFirestore接続状況により200 or 503
+    // GCP認証有無でステータスが変わる（200/503）
     expect([200, 503]).toContain(res.status());
     const body = await res.json();
     expect(body.checks).toBeDefined();
+    // Firestore: "ok" | "error" | "skipped"（GCP認証なし時）
+    expect(["ok", "error", "skipped"]).toContain(body.checks.firestore);
     expect(body.checks.memory).toBeDefined();
     expect(typeof body.checks.memory.heapUsedMB).toBe("number");
   });

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -56,17 +56,26 @@ app.get("/health/ready", async (_req, res) => {
   const checks: Record<string, unknown> = {};
   let healthy = true;
 
-  // Firestore接続確認（タイムアウト5秒）
-  try {
-    const db = getFirestore();
-    await Promise.race([
-      db.listCollections(),
-      new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 5000)),
-    ]);
-    checks.firestore = "ok";
-  } catch {
-    checks.firestore = "error";
-    healthy = false;
+  // Firestore接続確認（GCP認証がない環境ではスキップ）
+  const hasGcpCredentials = !!(
+    process.env.FIRESTORE_EMULATOR_HOST ||
+    process.env.GOOGLE_APPLICATION_CREDENTIALS ||
+    process.env.K_SERVICE // Cloud Run上で自動提供される
+  );
+  if (hasGcpCredentials) {
+    try {
+      const db = getFirestore();
+      await Promise.race([
+        db.listCollections(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 5000)),
+      ]);
+      checks.firestore = "ok";
+    } catch {
+      checks.firestore = "error";
+      healthy = false;
+    }
+  } else {
+    checks.firestore = "skipped";
   }
 
   // メモリ使用量


### PR DESCRIPTION
## Summary
- `/health/ready`のFirestoreチェックをGCP認証がない環境（CI等）ではスキップ
- E2Eテストのアサーションを`checks.firestore = "skipped"`に対応

## Root Cause
`getFirestore().listCollections()`はGCP認証なし環境でgRPCスタブ初期化時に`Could not load the default credentials`をthrow。これはPromise.raceのtry-catchでは捕捉できないunhandled exceptionで、APIプロセスがクラッシュ。後続の全E2Eテストが`ECONNREFUSED`で失敗。

## Fix
`FIRESTORE_EMULATOR_HOST`/`GOOGLE_APPLICATION_CREDENTIALS`/`K_SERVICE`のいずれも設定されていない場合、Firestoreチェックをスキップし`checks.firestore = "skipped"`を返す。

## Test plan
- [x] 215 APIテスト全パス
- [x] lint + 型チェック通過
- [ ] E2E CIで10/10テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)