### PR TITLE
test: add /health/ready unit tests for credential skip logic

### DIFF
--- a/services/api/src/__tests__/integration/health.test.ts
+++ b/services/api/src/__tests__/integration/health.test.ts
@@ -33,6 +33,24 @@ describe("Health endpoints", () => {
     });
   });
 
-  // /health/ready はFirestore接続を試みるためCI環境ではタイムアウトする。
-  // Firestore接続テストはE2E（ローカル環境）で検証する。
+  describe("GET /health/ready", () => {
+    it("checksオブジェクトとmemory情報を返す", async () => {
+      const res = await request.get("/health/ready");
+      // GCP認証なし環境では200（firestoreはskipped）
+      expect([200, 503]).toContain(res.status);
+      expect(res.body.checks).toBeDefined();
+      expect(res.body.checks.memory).toBeDefined();
+      expect(typeof res.body.checks.memory.heapUsedMB).toBe("number");
+      expect(typeof res.body.checks.memory.heapTotalMB).toBe("number");
+      expect(typeof res.body.checks.memory.rssMB).toBe("number");
+    });
+
+    it("GCP認証なし環境ではfirestore=skippedを返す", async () => {
+      // テスト環境ではGCP認証環境変数なし
+      const res = await request.get("/health/ready");
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("ok");
+      expect(res.body.checks.firestore).toBe("skipped");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- `/health/ready`のGCP認証スキップロジックのユニットテスト追加（2テスト）
- PR #29で追加した条件分岐（firestore: ok/error/skipped）のテストカバレッジを補完

## Context
PR #28, #29でTest Firstルールを守らずに実装・マージした。このPRはそのリカバリー。

## Test plan
- [x] 217 APIテスト全パス（+2テスト追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)