### PR TITLE
refactor: improve /health/ready type safety and probe efficiency

### DIFF
--- a/services/api/src/__tests__/integration/health.test.ts
+++ b/services/api/src/__tests__/integration/health.test.ts
@@ -34,23 +34,14 @@ describe("Health endpoints", () => {
   });
 
   describe("GET /health/ready", () => {
-    it("checksオブジェクトとmemory情報を返す", async () => {
-      const res = await request.get("/health/ready");
-      // GCP認証なし環境では200（firestoreはskipped）
-      expect([200, 503]).toContain(res.status);
-      expect(res.body.checks).toBeDefined();
-      expect(res.body.checks.memory).toBeDefined();
-      expect(typeof res.body.checks.memory.heapUsedMB).toBe("number");
-      expect(typeof res.body.checks.memory.heapTotalMB).toBe("number");
-      expect(typeof res.body.checks.memory.rssMB).toBe("number");
-    });
-
-    it("GCP認証なし環境ではfirestore=skippedを返す", async () => {
-      // テスト環境ではGCP認証環境変数なし
+    it("GCP認証なし環境では200・firestore=skipped・memory情報を返す", async () => {
       const res = await request.get("/health/ready");
       expect(res.status).toBe(200);
       expect(res.body.status).toBe("ok");
       expect(res.body.checks.firestore).toBe("skipped");
+      expect(typeof res.body.checks.memory.heapUsedMB).toBe("number");
+      expect(typeof res.body.checks.memory.heapTotalMB).toBe("number");
+      expect(typeof res.body.checks.memory.rssMB).toBe("number");
     });
   });
 });

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -46,6 +46,22 @@ app.use(express.json());
 // デモモード設定
 const DEMO_ENABLED = process.env.DEMO_ENABLED === "true";
 
+// GCP認証検出（プロセス起動時に1回だけ評価）
+const HAS_GCP_CREDENTIALS = !!(
+  process.env.FIRESTORE_EMULATOR_HOST ||
+  process.env.GOOGLE_APPLICATION_CREDENTIALS ||
+  process.env.K_SERVICE // Cloud Run上で自動提供される
+);
+
+const FIRESTORE_PROBE_TIMEOUT_MS = 5_000;
+
+// Readiness チェックの型定義
+type FirestoreStatus = "ok" | "error" | "skipped";
+interface HealthChecks {
+  firestore: FirestoreStatus;
+  memory: { heapUsedMB: number; heapTotalMB: number; rssMB: number };
+}
+
 // ヘルスチェック（認証不要・レート制限対象外）
 app.get(["/health", "/healthz", "/api/health"], (_req, res) => {
   res.json({ status: "ok" });
@@ -53,39 +69,37 @@ app.get(["/health", "/healthz", "/api/health"], (_req, res) => {
 
 // Readiness チェック（Firestore接続 + メモリ使用量、レート制限対象外）
 app.get("/health/ready", async (_req, res) => {
-  const checks: Record<string, unknown> = {};
-  let healthy = true;
+  let firestoreStatus: FirestoreStatus = "skipped";
 
-  // Firestore接続確認（GCP認証がない環境ではスキップ）
-  const hasGcpCredentials = !!(
-    process.env.FIRESTORE_EMULATOR_HOST ||
-    process.env.GOOGLE_APPLICATION_CREDENTIALS ||
-    process.env.K_SERVICE // Cloud Run上で自動提供される
-  );
-  if (hasGcpCredentials) {
+  if (HAS_GCP_CREDENTIALS) {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
       const db = getFirestore();
       await Promise.race([
-        db.listCollections(),
-        new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 5000)),
+        db.doc("_health/probe").get(),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => reject(new Error("timeout")), FIRESTORE_PROBE_TIMEOUT_MS);
+        }),
       ]);
-      checks.firestore = "ok";
+      firestoreStatus = "ok";
     } catch {
-      checks.firestore = "error";
-      healthy = false;
+      firestoreStatus = "error";
+    } finally {
+      clearTimeout(timeoutId);
     }
-  } else {
-    checks.firestore = "skipped";
   }
 
-  // メモリ使用量
   const mem = process.memoryUsage();
-  checks.memory = {
-    heapUsedMB: Math.round(mem.heapUsed / 1024 / 1024),
-    heapTotalMB: Math.round(mem.heapTotal / 1024 / 1024),
-    rssMB: Math.round(mem.rss / 1024 / 1024),
+  const checks: HealthChecks = {
+    firestore: firestoreStatus,
+    memory: {
+      heapUsedMB: Math.round(mem.heapUsed / 1024 / 1024),
+      heapTotalMB: Math.round(mem.heapTotal / 1024 / 1024),
+      rssMB: Math.round(mem.rss / 1024 / 1024),
+    },
   };
 
+  const healthy = firestoreStatus !== "error";
   res.status(healthy ? 200 : 503).json({ status: healthy ? "ok" : "degraded", checks });
 });
 


### PR DESCRIPTION
## Summary
`/simplify`レビューで指摘された6件の修正。

### 修正内容
- **タイマーリーク修正**: `Promise.race`の`setTimeout`に`clearTimeout`追加（`finally`ブロック）
- **型安全性向上**: `Record<string, unknown>` → `HealthChecks`インターフェース + `FirestoreStatus`型
- **環境変数評価の最適化**: `hasGcpCredentials`をリクエスト毎→モジュールトップレベル定数に移動
- **プローブ軽量化**: `listCollections()`（全コレクション走査）→ `doc("_health/probe").get()`（単一ドキュメント読み取り）
- **マジックナンバー解消**: `5000` → `FIRESTORE_PROBE_TIMEOUT_MS`定数
- **テスト統合**: 同一前提条件の2テスト→1テストに統合

## Test plan
- [x] 216 APIテスト全パス
- [x] lint + 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)