### PR TITLE
fix: log Firestore health check errors instead of silently catching

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -82,8 +82,9 @@ app.get("/health/ready", async (_req, res) => {
         }),
       ]);
       firestoreStatus = "ok";
-    } catch {
+    } catch (err) {
       firestoreStatus = "error";
+      logger.warn("Firestore health check failed", { error: String(err) });
     } finally {
       clearTimeout(timeoutId);
     }


### PR DESCRIPTION
## Summary
`/safe-refactor`で検出: `/health/ready`のFirestoreチェックで空catchブロックがエラーを握りつぶしていた。`logger.warn`でエラー内容を記録。

## Test plan
- [x] 216 APIテスト全パス
- [x] lint + 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)