### PR TITLE
fix: lesson_sessions Firestoreインデックス追加 + 品質補完 (#43)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -162,6 +162,23 @@
         { "fieldPath": "email", "order": "ASCENDING" },
         { "fieldPath": "occurredAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "lesson_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "lessonId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "lesson_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "courseId", "order": "ASCENDING" },
+        { "fieldPath": "entryAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/services/api/src/routes/shared/analytics.ts
+++ b/services/api/src/routes/shared/analytics.ts
@@ -377,6 +377,58 @@ router.get(
 );
 
 // ============================================================
+// 出席管理ヘルパー
+// ============================================================
+
+interface AttendanceRecord {
+  sessionId: string;
+  userId: string;
+  userName: string;
+  userEmail: string;
+  lessonId: string;
+  lessonTitle: string;
+  status: string;
+  entryAt: string;
+  exitAt: string | null;
+  exitReason: string | null;
+  durationMin: number;
+}
+
+async function buildAttendanceRecords(
+  ds: import("../../datasource/interface.js").DataSource,
+  courseId: string
+): Promise<AttendanceRecord[]> {
+  const sessions = await ds.getLessonSessionsByCourse(courseId);
+  const users = await ds.getUsers();
+  const lessons = await ds.getLessons({ courseId });
+
+  const userMap = new Map(users.map((u) => [u.id, u]));
+  const lessonMap = new Map(lessons.map((l) => [l.id, l]));
+
+  return sessions.map((s) => {
+    const user = userMap.get(s.userId);
+    const lesson = lessonMap.get(s.lessonId);
+    const durationMs = s.exitAt
+      ? new Date(s.exitAt).getTime() - new Date(s.entryAt).getTime()
+      : Date.now() - new Date(s.entryAt).getTime();
+
+    return {
+      sessionId: s.id,
+      userId: s.userId,
+      userName: user?.name ?? user?.email ?? s.userId,
+      userEmail: user?.email ?? "",
+      lessonId: s.lessonId,
+      lessonTitle: lesson?.title ?? s.lessonId,
+      status: s.status,
+      entryAt: s.entryAt,
+      exitAt: s.exitAt,
+      exitReason: s.exitReason,
+      durationMin: Math.round(durationMs / 60000),
+    };
+  });
+}
+
+// ============================================================
 // 7. 出席管理
 // GET /admin/analytics/attendance/courses/:courseId
 // ============================================================
@@ -394,34 +446,7 @@ router.get(
       return;
     }
 
-    const sessions = await ds.getLessonSessionsByCourse(courseId);
-    const users = await ds.getUsers();
-    const lessons = await ds.getLessons({ courseId });
-
-    const userMap = new Map(users.map((u) => [u.id, u]));
-    const lessonMap = new Map(lessons.map((l) => [l.id, l]));
-
-    const records = sessions.map((s) => {
-      const user = userMap.get(s.userId);
-      const lesson = lessonMap.get(s.lessonId);
-      const durationMs = s.exitAt
-        ? new Date(s.exitAt).getTime() - new Date(s.entryAt).getTime()
-        : Date.now() - new Date(s.entryAt).getTime();
-
-      return {
-        sessionId: s.id,
-        userId: s.userId,
-        userName: user?.name ?? user?.email ?? s.userId,
-        userEmail: user?.email ?? "",
-        lessonId: s.lessonId,
-        lessonTitle: lesson?.title ?? s.lessonId,
-        status: s.status,
-        entryAt: s.entryAt,
-        exitAt: s.exitAt,
-        exitReason: s.exitReason,
-        durationMin: Math.round(durationMs / 60000),
-      };
-    });
+    const records = await buildAttendanceRecords(ds, courseId);
 
     res.json({
       courseId,
@@ -452,36 +477,24 @@ router.get(
       return;
     }
 
-    const sessions = await ds.getLessonSessionsByCourse(courseId);
-    const users = await ds.getUsers();
-    const lessons = await ds.getLessons({ courseId });
-
-    const userMap = new Map(users.map((u) => [u.id, u]));
-    const lessonMap = new Map(lessons.map((l) => [l.id, l]));
+    const records = await buildAttendanceRecords(ds, courseId);
 
     const header = "ユーザー名,メール,レッスン,入室時刻,退室時刻,ステータス,退室理由,所要時間（分）\n";
-    const rows = sessions
-      .map((s) => {
-        const user = userMap.get(s.userId);
-        const lesson = lessonMap.get(s.lessonId);
-        const durationMs = s.exitAt
-          ? new Date(s.exitAt).getTime() - new Date(s.entryAt).getTime()
-          : 0;
-        const durationMin = Math.round(durationMs / 60000);
-
-        return [
-          user?.name ?? "",
-          user?.email ?? "",
-          lesson?.title ?? "",
-          s.entryAt,
-          s.exitAt ?? "",
-          s.status,
-          s.exitReason ?? "",
-          String(durationMin),
+    const rows = records
+      .map((r) =>
+        [
+          r.userName,
+          r.userEmail,
+          r.lessonTitle,
+          r.entryAt,
+          r.exitAt ?? "",
+          r.status,
+          r.exitReason ?? "",
+          String(r.durationMin),
         ]
           .map((v) => `"${v.replace(/"/g, '""')}"`)
-          .join(",");
-      })
+          .join(",")
+      )
       .join("\n");
 
     const bom = "\uFEFF";

--- a/services/api/src/routes/shared/lesson-sessions.ts
+++ b/services/api/src/routes/shared/lesson-sessions.ts
@@ -5,6 +5,7 @@
 
 import { Router, Request, Response } from "express";
 import { requireUser } from "../../middleware/auth.js";
+import type { LessonSession } from "../../types/entities.js";
 import {
   createSession,
   getOrCreateSession,
@@ -131,7 +132,7 @@ router.patch("/lesson-sessions/:sessionId/force-exit", requireUser, async (req: 
   res.json({ session: formatSession(exited) });
 });
 
-function formatSession(session: import("../../types/entities.js").LessonSession) {
+function formatSession(session: LessonSession) {
   const remainingMs = Math.max(0, new Date(session.deadlineAt).getTime() - Date.now());
   return {
     id: session.id,

--- a/services/api/src/routes/shared/quiz-attempts.ts
+++ b/services/api/src/routes/shared/quiz-attempts.ts
@@ -271,6 +271,8 @@ router.patch("/quiz-attempts/:attemptId", requireUser, async (req: Request, res:
   const answers: Record<string, string[]> = req.body.answers ?? {};
 
   // セッション制限チェック（出席管理）
+  // 設計上、セッション未作成（activeSession=null）の場合はクイズ提出を許可する。
+  // これにより出席管理導入前の受講者や、セッション機能未使用時の後方互換性を維持する。
   const activeSession = await ds.getActiveLessonSession(userId, quiz.lessonId);
   if (activeSession) {
     if (!validateSessionDeadline(activeSession)) {

--- a/services/api/src/types/entities.ts
+++ b/services/api/src/types/entities.ts
@@ -278,6 +278,7 @@ export interface CourseProgress {
 // 出席管理（レッスンセッション）
 // ========================================
 
+// TODO: "abandoned" はブラウザ終了検出（beforeunload/sendBeacon）で設定予定
 export type LessonSessionStatus = "active" | "completed" | "force_exited" | "abandoned";
 export type SessionExitReason = "quiz_submitted" | "pause_timeout" | "time_limit" | "browser_close";
 
@@ -293,9 +294,9 @@ export interface LessonSession {
   exitAt: string | null;                  // 退室打刻（テスト送信 or 強制退室時）
   exitReason: SessionExitReason | null;
   deadlineAt: string;                     // entryAt + 2時間
-  pauseStartedAt: string | null;
-  longestPauseSec: number;
-  sessionVideoCompleted: boolean;
+  pauseStartedAt: string | null;        // TODO: video-eventsルート拡張で更新予定
+  longestPauseSec: number;              // TODO: pause検知サーバーサイドで更新予定
+  sessionVideoCompleted: boolean;       // TODO: video-eventsルートでセッション内完了判定時に更新予定
   quizAttemptId: string | null;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary
PR #41の品質スキル事後実行で発見されたHIGH 3件 + MEDIUM 5件を修正。(Closes #43, Closes #46)

## Critical Fix
- **Firestoreインデックス欠落**: `lesson_sessions`の複合クエリ用インデックス2件を追加。未追加のまま本番で実行すると`FAILED_PRECONDITION`エラーでクエリが全失敗する。
- デプロイ後に `firebase deploy --only firestore:indexes` の手動実行が必要

## Other Fixes
- セッションなし時のクイズ提出許可を設計意図としてコメント明示
- 出席API/CSV重複ロジックを`buildAttendanceRecords`に抽出 + duration計算差異修正
- 未実装フィールド（abandoned, pauseStartedAt等）にTODOコメント追加

## Test plan
- [x] 型チェック PASS
- [x] lint PASS
- [x] テスト 264件 PASS (22ファイル)

🤖 Generated with [Claude Code](https://claude.com/claude-code)