### PR TITLE
fix: Google Drive動画の再生時間を自動取得

### DIFF
--- a/services/api/src/services/drive-import.ts
+++ b/services/api/src/services/drive-import.ts
@@ -28,7 +28,7 @@ export interface DriveImportValidationError {
 
 export interface DriveImportResult {
   video: Video;
-  metadata: { name: string; mimeType: string; size: string };
+  metadata: { name: string; mimeType: string; size: string; durationSec: number | null };
   fileId: string;
 }
 
@@ -79,7 +79,7 @@ export async function prepareDriveImport(
   }
 
   // Driveファイルメタデータ検証
-  let metadata: { name: string; mimeType: string; size: string };
+  let metadata: { name: string; mimeType: string; size: string; durationSec: number | null };
   try {
     metadata = await getDriveFileMetadata(fileId);
     validateDriveFileMetadata(metadata);
@@ -95,7 +95,7 @@ export async function prepareDriveImport(
     sourceType: "google_drive",
     driveFileId: fileId,
     importStatus: "pending",
-    durationSec: durationSec ?? 0,
+    durationSec: durationSec ?? metadata.durationSec ?? 0,
     requiredWatchRatio: requiredWatchRatio ?? 0.95,
     speedLock: speedLock ?? true,
   });
@@ -122,7 +122,7 @@ export function startAsyncDriveCopy(
   lessonId: string,
   fileId: string,
   tenantId: string,
-  metadata: { name: string; mimeType: string; size: string }
+  metadata: { name: string; mimeType: string; size: string; durationSec: number | null }
 ): void {
   (async () => {
     try {

--- a/services/api/src/services/google-drive.ts
+++ b/services/api/src/services/google-drive.ts
@@ -73,19 +73,23 @@ export async function getDriveFileMetadata(fileId: string): Promise<{
   name: string;
   mimeType: string;
   size: string;
+  durationSec: number | null;
 }> {
   const drive = getDriveClient();
   const response = await drive.files.get({
     fileId,
-    fields: "name,mimeType,size",
+    fields: "name,mimeType,size,videoMediaMetadata",
   });
 
-  const { name, mimeType, size } = response.data;
+  const { name, mimeType, size, videoMediaMetadata } = response.data;
   if (!name || !mimeType || !size) {
     throw new Error("Failed to retrieve file metadata from Google Drive");
   }
 
-  return { name, mimeType, size };
+  const durationMs = videoMediaMetadata?.durationMillis;
+  const durationSec = durationMs ? Math.round(Number(durationMs) / 1000) : null;
+
+  return { name, mimeType, size, durationSec };
 }
 
 /**
@@ -99,7 +103,7 @@ export async function getDriveFileMetadata(fileId: string): Promise<{
 export async function copyDriveFileToGCS(
   fileId: string,
   tenantId: string,
-  preloadedMetadata?: { name: string; mimeType: string; size: string }
+  preloadedMetadata?: { name: string; mimeType: string; size: string; durationSec: number | null }
 ): Promise<{ gcsPath: string; fileName: string }> {
   const drive = getDriveClient();
 

--- a/web/app/[tenant]/admin/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/admin/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -989,7 +989,6 @@ export default function LessonDetailPage() {
   // Google Drive import state
   const [videoSourceMode, setVideoSourceMode] = useState<"upload" | "google_drive">("upload");
   const [driveUrl, setDriveUrl] = useState("");
-  const [driveDurationSec, setDriveDurationSec] = useState("");
   const [driveImporting, setDriveImporting] = useState(false);
   const [driveImportStatus, setDriveImportStatus] = useState<string | null>(null);
 
@@ -1145,7 +1144,6 @@ export default function LessonDetailPage() {
           body: JSON.stringify({
             driveUrl,
             lessonId,
-            durationSec: driveDurationSec ? Number(driveDurationSec) : 0,
           }),
         },
       );
@@ -1166,7 +1164,6 @@ export default function LessonDetailPage() {
 
           if (status.importStatus === "completed") {
             setDriveUrl("");
-            setDriveDurationSec("");
             fetchData();
             return;
           }
@@ -1361,16 +1358,9 @@ export default function LessonDetailPage() {
                       />
                     </div>
 
-                    <div className="space-y-2">
-                      <label className="text-sm font-medium">再生時間（秒）</label>
-                      <Input
-                        type="number"
-                        value={driveDurationSec}
-                        onChange={(e) => setDriveDurationSec(e.target.value)}
-                        placeholder="例: 300"
-                        disabled={driveImporting}
-                      />
-                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      再生時間は動画ファイルから自動取得されます
+                    </p>
 
                     {driveImportStatus && (
                       <div className="text-sm text-muted-foreground">

--- a/web/app/super/master/courses/[courseId]/page.tsx
+++ b/web/app/super/master/courses/[courseId]/page.tsx
@@ -402,7 +402,6 @@ export default function MasterCourseDetailPage() {
       const body = {
         driveUrl: form.driveUrl,
         lessonId,
-        durationSec: form.durationSec ? Number(form.durationSec) : 0,
       };
       const data = await superFetch<{ video: { id: string } }>(
         `/api/v2/super/master/videos/import-from-drive`,
@@ -820,17 +819,9 @@ export default function MasterCourseDetailPage() {
                                   placeholder="https://drive.google.com/file/d/.../view"
                                 />
                               </div>
-                              <div className="space-y-1">
-                                <label className="text-sm font-medium">再生時間（秒）</label>
-                                <Input
-                                  type="number"
-                                  value={vForm.durationSec}
-                                  onChange={(e) =>
-                                    updateVideoForm(lesson.id, { durationSec: e.target.value })
-                                  }
-                                  placeholder="例: 300"
-                                />
-                              </div>
+                              <p className="text-xs text-muted-foreground">
+                                再生時間は動画ファイルから自動取得されます
+                              </p>
                               {importStatus[lesson.id] && (
                                 <div className={`text-sm ${
                                   importStatus[lesson.id].status === "error"


### PR DESCRIPTION
## Summary
Google Drive APIの`videoMediaMetadata.durationMillis`から再生時間を自動取得。手動入力を不要に。

## Changes
- `getDriveFileMetadata`: `videoMediaMetadata`フィールドを取得し`durationSec`を返す
- `prepareDriveImport`: Driveメタデータからdurationを自動設定
- 両管理画面のGoogle Driveタブから再生時間入力を削除→「自動取得されます」表示

## Test plan
- [x] 型チェック PASS
- [x] lint PASS
- [x] Webビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)