### PR TITLE
fix: Gemini 2.5 Flash GA + Vertex AI Workload Identity設定

### DIFF
--- a/services/api/src/services/quiz-generator.ts
+++ b/services/api/src/services/quiz-generator.ts
@@ -3,7 +3,7 @@ import type { QuizQuestion, QuizOption } from "../types/entities.js";
 
 const PROJECT_ID = process.env.GCLOUD_PROJECT || process.env.FIREBASE_PROJECT_ID || "lms-279";
 const LOCATION = process.env.VERTEX_AI_LOCATION || "asia-northeast1";
-const MODEL = "gemini-2.0-flash";
+const MODEL = "gemini-2.5-flash";
 
 export interface GenerateQuizOptions {
   questionCount?: number;  // default 10, max 50


### PR DESCRIPTION
## Summary
クイズ生成のAIモデルをGemini 2.5 Flash (GA)に更新。Workload Identity経由でVertex AIにアクセス。

## Changes
- モデルID: `gemini-2.0-flash` → `gemini-2.5-flash`

## インフラ設定（実施済み）
- Vertex AI API有効化 (`aiplatform.googleapis.com`)
- Default compute SA に `roles/aiplatform.user` 付与
- Cloud Run環境変数: `GOOGLE_WORKSPACE_ADMIN_EMAIL`, `VERTEX_AI_LOCATION` 設定済み

## 残り手動設定
- Google Workspace Admin Console: DWDスコープ設定（Client ID: `113964822975918221654`）

## Test plan
- [x] 型チェック PASS
- [x] lint PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)