### PR TITLE
fix: スーパー管理全ページの無限ループを確実に修正

### DIFF
--- a/web/app/super/distribute/page.tsx
+++ b/web/app/super/distribute/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -38,6 +38,8 @@ type DistributionResult = {
 
 export default function DistributePage() {
   const { superFetch } = useSuperAdminFetch();
+  const superFetchRef = useRef(superFetch);
+  superFetchRef.current = superFetch;
 
   const [courses, setCourses] = useState<Course[]>([]);
   const [tenants, setTenants] = useState<Tenant[]>([]);
@@ -59,8 +61,8 @@ export default function DistributePage() {
     setError(null);
     try {
       const [coursesData, tenantsData] = await Promise.all([
-        superFetch<{ courses: Course[] }>("/api/v2/super/master/courses"),
-        superFetch<{ tenants: Tenant[] }>("/api/v2/super/tenants"),
+        superFetchRef.current<{ courses: Course[] }>("/api/v2/super/master/courses"),
+        superFetchRef.current<{ tenants: Tenant[] }>("/api/v2/super/tenants"),
       ]);
       setCourses(coursesData.courses);
       setTenants(tenantsData.tenants);
@@ -69,7 +71,7 @@ export default function DistributePage() {
     } finally {
       setLoading(false);
     }
-  }, [superFetch]);
+  }, []);
 
   useEffect(() => {
     fetchData();

--- a/web/app/super/master/courses/[courseId]/page.tsx
+++ b/web/app/super/master/courses/[courseId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -90,6 +90,8 @@ export default function MasterCourseDetailPage() {
   const params = useParams();
   const courseId = params.courseId as string;
   const { superFetch } = useSuperAdminFetch();
+  const superFetchRef = useRef(superFetch);
+  superFetchRef.current = superFetch;
 
   const [course, setCourse] = useState<Course | null>(null);
   const [lessons, setLessons] = useState<Lesson[]>([]);
@@ -162,7 +164,7 @@ export default function MasterCourseDetailPage() {
     setLoading(true);
     setError(null);
     try {
-      const data = await superFetch<{ course: Course; lessons: Lesson[] }>(
+      const data = await superFetchRef.current<{ course: Course; lessons: Lesson[] }>(
         `/api/v2/super/master/courses/${courseId}`,
       );
       setCourse(data.course);
@@ -173,7 +175,7 @@ export default function MasterCourseDetailPage() {
     } finally {
       setLoading(false);
     }
-  }, [superFetch, courseId]);
+  }, [courseId]);
 
   useEffect(() => {
     fetchData();

--- a/web/app/super/master/courses/page.tsx
+++ b/web/app/super/master/courses/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -64,6 +64,8 @@ function StatusBadge({ status }: { status: CourseStatus }) {
 
 export default function MasterCoursesPage() {
   const { superFetch } = useSuperAdminFetch();
+  const superFetchRef = useRef(superFetch);
+  superFetchRef.current = superFetch;
 
   const [courses, setCourses] = useState<Course[]>([]);
   const [loading, setLoading] = useState(true);
@@ -96,7 +98,7 @@ export default function MasterCoursesPage() {
     setError(null);
     try {
       const query = statusFilter !== "all" ? `?status=${statusFilter}` : "";
-      const data = await superFetch<{ courses: Course[] }>(
+      const data = await superFetchRef.current<{ courses: Course[] }>(
         `/api/v2/super/master/courses${query}`,
       );
       setCourses(data.courses);
@@ -107,7 +109,7 @@ export default function MasterCoursesPage() {
     } finally {
       setLoading(false);
     }
-  }, [superFetch, statusFilter]);
+  }, [statusFilter]);
 
   useEffect(() => {
     fetchCourses();

--- a/web/app/super/settings/page.tsx
+++ b/web/app/super/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -15,6 +15,8 @@ type SuperAdmin = {
 
 export default function SuperAdminSettingsPage() {
   const { superFetch } = useSuperAdminFetch();
+  const superFetchRef = useRef(superFetch);
+  superFetchRef.current = superFetch;
 
   const [admins, setAdmins] = useState<SuperAdmin[]>([]);
   const [loading, setLoading] = useState(true);
@@ -30,7 +32,7 @@ export default function SuperAdminSettingsPage() {
     setLoading(true);
     setError(null);
     try {
-      const data = await superFetch<{ admins: SuperAdmin[] }>(
+      const data = await superFetchRef.current<{ admins: SuperAdmin[] }>(
         "/api/v2/super/admins"
       );
       setAdmins(data.admins);
@@ -39,7 +41,7 @@ export default function SuperAdminSettingsPage() {
     } finally {
       setLoading(false);
     }
-  }, [superFetch]);
+  }, []);
 
   useEffect(() => {
     fetchAdmins();


### PR DESCRIPTION
## Summary
superFetchの不安定な参照チェーンによる無限ループをref化で根本解決。

## Root Cause
`useSuperAdminFetch`の`superFetch`が毎レンダーで新しい参照を生成 →
useCallback依存 → useEffect再実行 → state変更 → 再レンダー → 無限ループ

## Fix
`useRef`でsuperFetchを保持し、コールバック内では`ref.current`を使用。
依存配列からsuperFetchを除去してループを断ち切り。

全4ページに適用:
- master/courses/page.tsx
- master/courses/[courseId]/page.tsx
- distribute/page.tsx
- settings/page.tsx

## Test plan
- [x] 型チェック PASS
- [x] lint PASS
- [x] テスト 264件 PASS
- [x] Webビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)