### PR TITLE
fix: use Secret Manager for DWD auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Deploy API to Cloud Run
         run: |
           # Build env vars string
-          ENV_VARS="DEMO_ENABLED=true,AUTH_MODE=firebase,CORS_ORIGIN=https://web-3zcica5euq-an.a.run.app"
+          ENV_VARS="DEMO_ENABLED=true,AUTH_MODE=firebase,CORS_ORIGIN=https://web-3zcica5euq-an.a.run.app,GOOGLE_WORKSPACE_ADMIN_EMAIL=system@279279.net"
           if [ -n "${{ secrets.SUPER_ADMIN_EMAILS }}" ]; then
             ENV_VARS="${ENV_VARS},SUPER_ADMIN_EMAILS=${{ secrets.SUPER_ADMIN_EMAILS }}"
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1315,6 +1315,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/@google-cloud/secret-manager": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-6.1.1.tgz",
+      "integrity": "sha512-dwSuxJ9RNmAW46FjK1StiNIeOiSHHQs/XIy4VArJ6bBMR+WsIvR+zhPh2pa40aFa9uTty67j38Rl268TVV62EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google-cloud/storage": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
@@ -13619,6 +13631,7 @@
       "name": "@lms-279/api",
       "dependencies": {
         "@google-cloud/firestore": "8.1.0",
+        "@google-cloud/secret-manager": "^6.1.1",
         "@google-cloud/storage": "^7.16.0",
         "@google-cloud/vertexai": "^1.10.2",
         "cors": "^2.8.5",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@google-cloud/firestore": "8.1.0",
+    "@google-cloud/secret-manager": "^6.1.1",
     "@google-cloud/storage": "^7.16.0",
     "@google-cloud/vertexai": "^1.10.2",
     "cors": "^2.8.5",

--- a/services/api/src/__tests__/integration/google-auth.test.ts
+++ b/services/api/src/__tests__/integration/google-auth.test.ts
@@ -5,7 +5,7 @@ vi.mock("googleapis", () => {
   const mockDrive = { files: { get: vi.fn(), list: vi.fn() } };
   const mockDocs = { documents: { get: vi.fn() } };
 
-  class MockGoogleAuth {
+  class MockJWT {
     constructor(_opts: unknown) {
       // no-op
     }
@@ -14,11 +14,27 @@ vi.mock("googleapis", () => {
   return {
     google: {
       auth: {
-        GoogleAuth: MockGoogleAuth,
+        JWT: MockJWT,
       },
       drive: vi.fn().mockReturnValue(mockDrive),
       docs: vi.fn().mockReturnValue(mockDocs),
     },
+  };
+});
+
+// Secret Managerをモック
+vi.mock("@google-cloud/secret-manager", () => {
+  const mockKeyData = JSON.stringify({
+    client_email: "dwd@test.iam.gserviceaccount.com",
+    private_key: "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n",
+  });
+  class MockSecretManagerServiceClient {
+    async accessSecretVersion() {
+      return [{ payload: { data: Buffer.from(mockKeyData) } }];
+    }
+  }
+  return {
+    SecretManagerServiceClient: MockSecretManagerServiceClient,
   };
 });
 
@@ -45,14 +61,14 @@ describe("google-auth service", () => {
 
   it("getDriveClient returns a Drive client", async () => {
     const { getDriveClient } = await import("../../services/google-auth.js");
-    const client = getDriveClient();
+    const client = await getDriveClient();
     expect(client).toBeDefined();
     expect(client.files).toBeDefined();
   });
 
   it("getDocsClient returns a Docs client", async () => {
     const { getDocsClient } = await import("../../services/google-auth.js");
-    const client = getDocsClient();
+    const client = await getDocsClient();
     expect(client).toBeDefined();
     expect(client.documents).toBeDefined();
   });
@@ -60,7 +76,7 @@ describe("google-auth service", () => {
   it("getDriveClient throws when GOOGLE_WORKSPACE_ADMIN_EMAIL is unset", async () => {
     delete process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL;
     const { getDriveClient } = await import("../../services/google-auth.js");
-    expect(() => getDriveClient()).toThrow(
+    await expect(getDriveClient()).rejects.toThrow(
       "GOOGLE_WORKSPACE_ADMIN_EMAIL is required"
     );
   });

--- a/services/api/src/services/google-auth.ts
+++ b/services/api/src/services/google-auth.ts
@@ -1,21 +1,47 @@
 import { google, type drive_v3, type docs_v1 } from "googleapis";
+import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
 
 const SCOPES = [
   "https://www.googleapis.com/auth/drive.readonly",
   "https://www.googleapis.com/auth/documents.readonly",
 ];
 
+const GCP_PROJECT_ID = "lms-279";
+const DWD_SECRET_NAME = `projects/${GCP_PROJECT_ID}/secrets/dwd-workspace-key/versions/latest`;
+
 // シングルトンインスタンス
-let authClient: InstanceType<typeof google.auth.GoogleAuth> | null = null;
+let authClient: InstanceType<typeof google.auth.JWT> | null = null;
 let driveClient: drive_v3.Drive | null = null;
 let docsClient: docs_v1.Docs | null = null;
 let cachedAdminEmail: string | null = null;
+let secretManagerClient: SecretManagerServiceClient | null = null;
+
+/**
+ * Secret Managerからサービスアカウントキーを取得
+ */
+async function getDwdKeyFromSecretManager(): Promise<{
+  client_email: string;
+  private_key: string;
+}> {
+  if (!secretManagerClient) {
+    secretManagerClient = new SecretManagerServiceClient();
+  }
+  const [version] = await secretManagerClient.accessSecretVersion({
+    name: DWD_SECRET_NAME,
+  });
+  const payload = version.payload?.data;
+  if (!payload) {
+    throw new Error("DWD service account key not found in Secret Manager");
+  }
+  const keyData = typeof payload === "string" ? payload : payload.toString();
+  return JSON.parse(keyData);
+}
 
 /**
  * Domain-Wide Delegation 用の認証クライアント（シングルトン）
- * 環境変数はリクエスト時に読み取る（Cloud Runのコンテナ再利用に対応）
+ * Secret ManagerからDWD専用SAキーを取得し、subject指定でJWT認証
  */
-function getAuthClient() {
+async function getAuthClient(): Promise<InstanceType<typeof google.auth.JWT>> {
   const email = process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL;
 
   if (!email) {
@@ -26,12 +52,13 @@ function getAuthClient() {
 
   // メールが変わった場合はクライアントを再作成
   if (!authClient || cachedAdminEmail !== email) {
+    const keyData = await getDwdKeyFromSecretManager();
     cachedAdminEmail = email;
-    authClient = new google.auth.GoogleAuth({
+    authClient = new google.auth.JWT({
+      email: keyData.client_email,
+      key: keyData.private_key,
       scopes: SCOPES,
-      clientOptions: {
-        subject: email,
-      },
+      subject: email,
     });
     // 認証が変わったのでAPIクライアントもリセット
     driveClient = null;
@@ -43,9 +70,10 @@ function getAuthClient() {
 /**
  * Google Drive API クライアント（シングルトン）
  */
-export function getDriveClient(): drive_v3.Drive {
+export async function getDriveClient(): Promise<drive_v3.Drive> {
   if (!driveClient) {
-    driveClient = google.drive({ version: "v3", auth: getAuthClient() });
+    const auth = await getAuthClient();
+    driveClient = google.drive({ version: "v3", auth });
   }
   return driveClient;
 }
@@ -53,9 +81,10 @@ export function getDriveClient(): drive_v3.Drive {
 /**
  * Google Docs API クライアント（シングルトン）
  */
-export function getDocsClient(): docs_v1.Docs {
+export async function getDocsClient(): Promise<docs_v1.Docs> {
   if (!docsClient) {
-    docsClient = google.docs({ version: "v1", auth: getAuthClient() });
+    const auth = await getAuthClient();
+    docsClient = google.docs({ version: "v1", auth });
   }
   return docsClient;
 }

--- a/services/api/src/services/google-docs.ts
+++ b/services/api/src/services/google-docs.ts
@@ -36,7 +36,7 @@ export function parseDocsUrl(url: string): string {
 export async function getDocumentContent(
   documentId: string
 ): Promise<{ title: string; content: string }> {
-  const docs = getDocsClient();
+  const docs = await getDocsClient();
   const response = await docs.documents.get({ documentId });
 
   const doc = response.data;

--- a/services/api/src/services/google-drive.ts
+++ b/services/api/src/services/google-drive.ts
@@ -75,7 +75,7 @@ export async function getDriveFileMetadata(fileId: string): Promise<{
   size: string;
   durationSec: number | null;
 }> {
-  const drive = getDriveClient();
+  const drive = await getDriveClient();
   const response = await drive.files.get({
     fileId,
     fields: "name,mimeType,size,videoMediaMetadata",
@@ -105,7 +105,7 @@ export async function copyDriveFileToGCS(
   tenantId: string,
   preloadedMetadata?: { name: string; mimeType: string; size: string; durationSec: number | null }
 ): Promise<{ gcsPath: string; fileName: string }> {
-  const drive = getDriveClient();
+  const drive = await getDriveClient();
 
   // メタデータ取得 & 検証（事前取得済みの場合はスキップ）
   const metadata = preloadedMetadata ?? await getDriveFileMetadata(fileId);


### PR DESCRIPTION
## Summary
- DWD (Domain-Wide Delegation) doesn't work with Workload Identity in Node.js googleapis library
- Switch to JWT auth using dedicated DWD service account key stored in Secret Manager
- Add `GOOGLE_WORKSPACE_ADMIN_EMAIL` to deploy.yml for persistence

## Changes
- `google-auth.ts`: Use `google.auth.JWT` with key from Secret Manager instead of `GoogleAuth` with `clientOptions.subject`
- `google-drive.ts` / `google-docs.ts`: `await` async `getDriveClient()` / `getDocsClient()`
- `deploy.yml`: Add `GOOGLE_WORKSPACE_ADMIN_EMAIL` env var
- Tests updated for async client methods and Secret Manager mock

## Infrastructure setup (already done)
- Created `dwd-workspace@lms-279.iam.gserviceaccount.com` SA
- Stored key in Secret Manager (`dwd-workspace-key`)
- Granted Cloud Run SA access to the secret
- Enabled Drive API and Docs API

## Manual step required
Admin Console DWD registration needs to be updated to new SA client ID: `118098709021350891398`

## Test plan
- [x] All 264 API tests pass
- [x] Build succeeds
- [ ] Verify Drive import works after Admin Console DWD update

🤖 Generated with [Claude Code](https://claude.com/claude-code)