### PR TITLE
fix: add supportsAllDrives to Drive API calls

### DIFF
--- a/services/api/src/services/google-drive.ts
+++ b/services/api/src/services/google-drive.ts
@@ -79,6 +79,7 @@ export async function getDriveFileMetadata(fileId: string): Promise<{
   const response = await drive.files.get({
     fileId,
     fields: "name,mimeType,size,videoMediaMetadata",
+    supportsAllDrives: true,
   });
 
   const { name, mimeType, size, videoMediaMetadata } = response.data;
@@ -115,7 +116,7 @@ export async function copyDriveFileToGCS(
 
   // Drive からストリーム取得
   const response = await drive.files.get(
-    { fileId, alt: "media" },
+    { fileId, alt: "media", supportsAllDrives: true },
     { responseType: "stream" }
   );
 


### PR DESCRIPTION
## Summary
- Drive API calls return 404 for files shared from other users' drives
- Add `supportsAllDrives: true` to both metadata fetch and stream download

## Root cause
Google Drive API requires `supportsAllDrives: true` to access files in shared drives or files shared from other users. Without it, even if the impersonated user has access, the API returns "File not found".

## Test plan
- [x] 264 API tests pass
- [x] Verified locally: Drive API returns file metadata with `supportsAllDrives: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)