### PR TITLE
fix: マスターコースの公開・アーカイブが機能しない問題を修正

### DIFF
--- a/services/api/src/routes/super-admin-master.ts
+++ b/services/api/src/routes/super-admin-master.ts
@@ -148,6 +148,57 @@ router.patch("/master/courses/:id", async (req: Request, res: Response) => {
 });
 
 /**
+ * マスターコース公開
+ * PATCH /master/courses/:id/publish
+ */
+router.patch("/master/courses/:id/publish", async (req: Request, res: Response) => {
+  const ds = getMasterDS();
+  const id = req.params.id as string;
+
+  const existing = await ds.getCourseById(id);
+  if (!existing) {
+    res.status(404).json({ error: "not_found", message: "マスターコースが見つかりません。" });
+    return;
+  }
+
+  if (existing.status === "published") {
+    res.status(409).json({ error: "already_published", message: "このコースは既に公開されています。" });
+    return;
+  }
+
+  if (existing.status === "archived") {
+    res.status(409).json({ error: "cannot_publish_archived", message: "アーカイブ済みのコースは公開できません。" });
+    return;
+  }
+
+  const course = await ds.updateCourse(id, { status: "published" });
+  res.json({ course: serializeCourse(course!) });
+});
+
+/**
+ * マスターコースアーカイブ
+ * PATCH /master/courses/:id/archive
+ */
+router.patch("/master/courses/:id/archive", async (req: Request, res: Response) => {
+  const ds = getMasterDS();
+  const id = req.params.id as string;
+
+  const existing = await ds.getCourseById(id);
+  if (!existing) {
+    res.status(404).json({ error: "not_found", message: "マスターコースが見つかりません。" });
+    return;
+  }
+
+  if (existing.status === "archived") {
+    res.status(409).json({ error: "already_archived", message: "このコースは既にアーカイブされています。" });
+    return;
+  }
+
+  const course = await ds.updateCourse(id, { status: "archived" });
+  res.json({ course: serializeCourse(course!) });
+});
+
+/**
  * マスターコース削除（関連レッスン・動画・クイズも削除）
  * DELETE /master/courses/:id
  */

--- a/web/app/super/master/courses/page.tsx
+++ b/web/app/super/master/courses/page.tsx
@@ -199,11 +199,8 @@ export default function MasterCoursesPage() {
   const handlePublish = async (course: Course) => {
     try {
       await superFetch(
-        `/api/v2/super/master/courses/${course.id}`,
-        {
-          method: "PATCH",
-          body: JSON.stringify({ status: "published" }),
-        },
+        `/api/v2/super/master/courses/${course.id}/publish`,
+        { method: "PATCH" },
       );
       fetchCourses();
     } catch (e) {
@@ -214,11 +211,8 @@ export default function MasterCoursesPage() {
   const handleArchive = async (course: Course) => {
     try {
       await superFetch(
-        `/api/v2/super/master/courses/${course.id}`,
-        {
-          method: "PATCH",
-          body: JSON.stringify({ status: "archived" }),
-        },
+        `/api/v2/super/master/courses/${course.id}/archive`,
+        { method: "PATCH" },
       );
       fetchCourses();
     } catch (e) {


### PR DESCRIPTION
## Summary
- マスターコースの「公開」「アーカイブ」ボタンが機能しない問題を修正
- PATCH /master/courses/:id が status フィールドを無視していたことが原因
- テナント側と同じ専用エンドポイント設計に統一

## Changes
- `super-admin-master.ts`: `/master/courses/:id/publish` + `/archive` エンドポイント追加（状態遷移バリデーション付き）
- `web/super/master/courses/page.tsx`: 専用エンドポイントを呼ぶように修正

## Test plan
- [x] ビルド: API + Web 成功
- [x] テスト: 283件全PASS
- [ ] 手動検証: マスターコースの公開・アーカイブ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)