### PR TITLE
fix: マスターコース管理・配信の3件のバグ修正

### DIFF
--- a/services/api/src/__tests__/integration/master-distribute.test.ts
+++ b/services/api/src/__tests__/integration/master-distribute.test.ts
@@ -65,6 +65,7 @@ describe("Master Distribute API", () => {
         "course-1",
         "tenant-1",
         "super@test.com", // distributedBy = req.superAdmin.email
+        { force: false },
       );
     });
 

--- a/services/api/src/routes/super-admin-master.ts
+++ b/services/api/src/routes/super-admin-master.ts
@@ -115,11 +115,29 @@ router.get("/master/courses/:id", async (req: Request, res: Response) => {
     return;
   }
 
-  const lessons = await ds.getLessons({ courseId: id });
+  const [lessons, videos, quizzes] = await Promise.all([
+    ds.getLessons({ courseId: id }),
+    ds.getVideos({ courseId: id }),
+    ds.getQuizzes({ courseId: id }),
+  ]);
 
   res.json({
     course: serializeCourse(course),
     lessons: lessons.map(serializeLesson),
+    videos: videos.map((v) => ({
+      id: v.id,
+      lessonId: v.lessonId,
+      sourceType: v.sourceType,
+      durationSec: v.durationSec,
+      gcsPath: v.gcsPath ?? null,
+    })),
+    quizzes: quizzes.map((q) => ({
+      id: q.id,
+      lessonId: q.lessonId,
+      title: q.title,
+      questionCount: q.questions.length,
+      passThreshold: q.passThreshold,
+    })),
   });
 });
 
@@ -824,7 +842,7 @@ router.delete("/master/lessons/:lessonId/quiz", async (req: Request, res: Respon
  * POST /master/distribute
  */
 router.post("/master/distribute", async (req: Request, res: Response) => {
-  const { courseIds, tenantIds } = req.body;
+  const { courseIds, tenantIds, force } = req.body;
 
   if (!Array.isArray(courseIds) || courseIds.length === 0 || !courseIds.every((id: unknown) => typeof id === "string")) {
     res.status(400).json({
@@ -851,7 +869,7 @@ router.post("/master/distribute", async (req: Request, res: Response) => {
 
   const results = await Promise.all(
     pairs.map(({ courseId, tenantId }) =>
-      distributeCourseToTenant(db, courseId, tenantId, distributedBy),
+      distributeCourseToTenant(db, courseId, tenantId, distributedBy, { force: !!force }),
     ),
   );
 

--- a/services/api/src/services/course-distributor.ts
+++ b/services/api/src/services/course-distributor.ts
@@ -61,6 +61,7 @@ export async function distributeCourseToTenant(
   masterCourseId: string,
   targetTenantId: string,
   distributedBy: string,
+  options: { force?: boolean } = {},
 ): Promise<DistributionResult> {
   const errorResult = (reason: string): DistributionResult => ({
     tenantId: targetTenantId,
@@ -105,16 +106,33 @@ export async function distributeCourseToTenant(
   }
 
   if (!existingSnap.empty) {
-    return {
-      tenantId: targetTenantId,
-      courseId: existingSnap.docs[0].id,
-      masterCourseId,
-      status: "skipped",
-      reason: "already distributed",
-      lessonsCount: 0,
-      videosCount: 0,
-      quizzesCount: 0,
-    };
+    if (!options.force) {
+      return {
+        tenantId: targetTenantId,
+        courseId: existingSnap.docs[0].id,
+        masterCourseId,
+        status: "skipped",
+        reason: "already distributed",
+        lessonsCount: 0,
+        videosCount: 0,
+        quizzesCount: 0,
+      };
+    }
+
+    // force=true: 既存の配信済みデータを削除して再配信
+    const existingCourseId = existingSnap.docs[0].id;
+    const targetDs = new FirestoreDataSource(db, targetTenantId);
+    const [existingLessons, existingVideos, existingQuizzes] = await Promise.all([
+      targetDs.getLessons({ courseId: existingCourseId }),
+      targetDs.getVideos({ courseId: existingCourseId }),
+      targetDs.getQuizzes({ courseId: existingCourseId }),
+    ]);
+    await Promise.all([
+      ...existingVideos.map((v) => targetDs.deleteVideo(v.id)),
+      ...existingQuizzes.map((q) => targetDs.deleteQuiz(q.id)),
+      ...existingLessons.map((l) => targetDs.deleteLesson(l.id)),
+    ]);
+    await targetDs.deleteCourse(existingCourseId);
   }
 
   // 3. マスターテナントから関連データを取得

--- a/web/app/[tenant]/admin/courses/page.tsx
+++ b/web/app/[tenant]/admin/courses/page.tsx
@@ -292,6 +292,8 @@ export default function CoursesPage() {
                       variant="destructive"
                       size="sm"
                       onClick={() => openDelete(course)}
+                      disabled={course.status === "published"}
+                      title={course.status === "published" ? "公開中のコースは先にアーカイブしてから削除してください" : undefined}
                     >
                       削除
                     </Button>

--- a/web/app/super/distribute/page.tsx
+++ b/web/app/super/distribute/page.tsx
@@ -55,6 +55,7 @@ export default function DistributePage() {
 
   const [distributing, setDistributing] = useState(false);
   const [results, setResults] = useState<DistributionResult[] | null>(null);
+  const [forceRedistribute, setForceRedistribute] = useState(false);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -132,6 +133,7 @@ export default function DistributePage() {
           body: JSON.stringify({
             courseIds: Array.from(selectedCourses),
             tenantIds: Array.from(selectedTenants),
+            force: forceRedistribute,
           }),
         },
       );
@@ -251,6 +253,17 @@ export default function DistributePage() {
             {selectedTenants.size} 件選択中
           </p>
         </div>
+      </div>
+
+      {/* Options */}
+      <div className="flex items-center justify-center gap-3 pt-2">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <Checkbox
+            checked={forceRedistribute}
+            onCheckedChange={(checked) => setForceRedistribute(!!checked)}
+          />
+          <span className="text-sm">再配信（配信済みコースを上書き更新）</span>
+        </label>
       </div>
 
       {/* Distribute button */}

--- a/web/app/super/master/courses/[courseId]/page.tsx
+++ b/web/app/super/master/courses/[courseId]/page.tsx
@@ -47,6 +47,21 @@ type Lesson = {
   hasQuiz: boolean;
 };
 
+type VideoSummary = {
+  id: string;
+  lessonId: string;
+  sourceType: string;
+  durationSec: number;
+};
+
+type QuizSummary = {
+  id: string;
+  lessonId: string;
+  title: string;
+  questionCount: number;
+  passThreshold: number;
+};
+
 type QuestionOption = {
   id: string;
   text: string;
@@ -95,6 +110,8 @@ export default function MasterCourseDetailPage() {
 
   const [course, setCourse] = useState<Course | null>(null);
   const [lessons, setLessons] = useState<Lesson[]>([]);
+  const [videoSummaries, setVideoSummaries] = useState<VideoSummary[]>([]);
+  const [quizSummaries, setQuizSummaries] = useState<QuizSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -173,12 +190,19 @@ export default function MasterCourseDetailPage() {
     setLoading(true);
     setError(null);
     try {
-      const data = await superFetchRef.current<{ course: Course; lessons: Lesson[] }>(
+      const data = await superFetchRef.current<{
+        course: Course;
+        lessons: Lesson[];
+        videos: VideoSummary[];
+        quizzes: QuizSummary[];
+      }>(
         `/api/v2/super/master/courses/${courseId}`,
       );
       setCourse(data.course);
       const sorted = [...data.lessons].sort((a, b) => a.order - b.order);
       setLessons(sorted);
+      setVideoSummaries(data.videos ?? []);
+      setQuizSummaries(data.quizzes ?? []);
     } catch (e) {
       setError(e instanceof Error ? e.message : "データの取得に失敗しました");
     } finally {
@@ -793,20 +817,32 @@ export default function MasterCourseDetailPage() {
                     <div className="space-y-3">
                       <h3 className="text-sm font-semibold">動画設定</h3>
                       {lesson.hasVideo ? (
-                        <div className="flex items-center gap-3">
-                          <Badge className="bg-blue-100 text-blue-800 border-blue-200">
-                            登録済み
-                          </Badge>
-                          <Button
-                            variant="destructive"
-                            size="sm"
-                            onClick={() => handleDeleteVideo(lesson.id)}
-                            disabled={videoSaving === lesson.id}
-                          >
-                            {videoSaving === lesson.id
-                              ? "削除中..."
-                              : "動画を削除"}
-                          </Button>
+                        <div className="space-y-2">
+                          <div className="flex items-center gap-3">
+                            <Badge className="bg-blue-100 text-blue-800 border-blue-200">
+                              登録済み
+                            </Badge>
+                            {(() => {
+                              const video = videoSummaries.find((v) => v.lessonId === lesson.id);
+                              if (!video) return null;
+                              return (
+                                <span className="text-sm text-muted-foreground">
+                                  {video.sourceType === "drive" ? "Drive" : "アップロード"}
+                                  {video.durationSec > 0 && ` / ${Math.floor(video.durationSec / 60)}分${video.durationSec % 60}秒`}
+                                </span>
+                              );
+                            })()}
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              onClick={() => handleDeleteVideo(lesson.id)}
+                              disabled={videoSaving === lesson.id}
+                            >
+                              {videoSaving === lesson.id
+                                ? "削除中..."
+                                : "動画を削除"}
+                            </Button>
+                          </div>
                         </div>
                       ) : (
                         <div className="space-y-3">
@@ -926,20 +962,31 @@ export default function MasterCourseDetailPage() {
                     <div className="space-y-3">
                       <h3 className="text-sm font-semibold">テスト設定</h3>
                       {lesson.hasQuiz ? (
-                        <div className="flex items-center gap-3">
-                          <Badge className="bg-purple-100 text-purple-800 border-purple-200">
-                            登録済み
-                          </Badge>
-                          <Button
-                            variant="destructive"
-                            size="sm"
-                            onClick={() => handleDeleteQuiz(lesson.id)}
-                            disabled={quizSaving === lesson.id}
-                          >
-                            {quizSaving === lesson.id
-                              ? "削除中..."
-                              : "テストを削除"}
-                          </Button>
+                        <div className="space-y-2">
+                          <div className="flex items-center gap-3">
+                            <Badge className="bg-purple-100 text-purple-800 border-purple-200">
+                              登録済み
+                            </Badge>
+                            {(() => {
+                              const quiz = quizSummaries.find((q) => q.lessonId === lesson.id);
+                              if (!quiz) return null;
+                              return (
+                                <span className="text-sm text-muted-foreground">
+                                  {quiz.title} / {quiz.questionCount}問 / 合格{quiz.passThreshold}%
+                                </span>
+                              );
+                            })()}
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              onClick={() => handleDeleteQuiz(lesson.id)}
+                              disabled={quizSaving === lesson.id}
+                            >
+                              {quizSaving === lesson.id
+                                ? "削除中..."
+                                : "テストを削除"}
+                            </Button>
+                          </div>
                         </div>
                       ) : (
                         <div className="space-y-4">


### PR DESCRIPTION
## Summary
- #64: マスター管理画面で動画・テストの内容をプレビュー表示
- #63: テナント側のpublishedコース削除ボタンを無効化+ガイダンス表示
- #65: 配信済みコースの再配信（上書き更新）機能を追加

Closes #63, Closes #64, Closes #65

## Changes
- `super-admin-master.ts`: GET /master/courses/:id に videos/quizzes 概要追加
- `courses/[courseId]/page.tsx`: 動画種別・長さ、テストタイトル・問題数をプレビュー表示
- `[tenant]/admin/courses/page.tsx`: publishedコースの削除ボタン無効化+ツールチップ
- `course-distributor.ts`: forceオプションで既存削除→再配信
- `super-admin-master.ts`: 配信エンドポイントにforce対応
- `distribute/page.tsx`: 再配信チェックボックス追加

## Test plan
- [x] ビルド: API + Web 成功
- [x] テスト: 283件全PASS
- [x] lint: エラーなし
- [ ] 手動検証: マスター画面でプレビュー確認
- [ ] 手動検証: テナント側publishedコースの削除ボタン無効化確認
- [ ] 手動検証: 再配信でコンテンツ反映確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)