### PR TITLE
feat: マスター管理画面にテスト編集機能を追加

### DIFF
--- a/services/api/src/__tests__/integration/master-media.test.ts
+++ b/services/api/src/__tests__/integration/master-media.test.ts
@@ -215,6 +215,31 @@ describe("Master Media API", () => {
     });
   });
 
+  describe("GET /master/quizzes/:id", () => {
+    it("テストをquestions含めて取得して200を返す", async () => {
+      const created = await request
+        .post(`/master/lessons/${lessonId}/quiz`)
+        .send({ title: "取得テスト", questions: sampleQuestions });
+      const quizId = created.body.quiz.id;
+
+      const res = await request.get(`/master/quizzes/${quizId}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.quiz.id).toBe(quizId);
+      expect(res.body.quiz.title).toBe("取得テスト");
+      expect(res.body.quiz.questions).toHaveLength(1);
+      expect(res.body.quiz.questions[0].text).toBe("テスト問題1");
+      expect(res.body.quiz.lessonId).toBe(lessonId);
+    });
+
+    it("存在しないIDで404を返す", async () => {
+      const res = await request.get("/master/quizzes/xxx");
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("not_found");
+    });
+  });
+
   describe("PATCH /master/quizzes/:id", () => {
     it("テストを更新して200を返す", async () => {
       const created = await request

--- a/services/api/src/routes/super-admin-master.ts
+++ b/services/api/src/routes/super-admin-master.ts
@@ -753,6 +753,23 @@ router.post("/master/lessons/:lessonId/quiz", async (req: Request, res: Response
 });
 
 /**
+ * マスターテスト個別取得
+ * GET /master/quizzes/:id
+ */
+router.get("/master/quizzes/:id", async (req: Request, res: Response) => {
+  const ds = getMasterDS();
+  const id = req.params.id as string;
+
+  const quiz = await ds.getQuizById(id);
+  if (!quiz) {
+    res.status(404).json({ error: "not_found", message: "テストが見つかりません。" });
+    return;
+  }
+
+  res.json({ quiz });
+});
+
+/**
  * マスターテスト更新
  * PATCH /master/quizzes/:id
  */

--- a/web/app/super/master/courses/[courseId]/page.tsx
+++ b/web/app/super/master/courses/[courseId]/page.tsx
@@ -186,6 +186,10 @@ export default function MasterCourseDetailPage() {
   const [quizImportSelectedTab, setQuizImportSelectedTab] = useState<string | null>(null);
   const [quizImportWarnings, setQuizImportWarnings] = useState<string[]>([]);
 
+  // Quiz edit state
+  const [editingQuizLessonId, setEditingQuizLessonId] = useState<string | null>(null);
+  const [quizLoadingLessonId, setQuizLoadingLessonId] = useState<string | null>(null);
+
   const fetchData = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -564,16 +568,33 @@ export default function MasterCourseDetailPage() {
     setQuizSaving(lessonId);
     setQuizError(null);
     try {
-      await superFetch(
-        `/api/v2/super/master/lessons/${lessonId}/quiz`,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            title: form.title.trim(),
-            questions: form.questions,
-          }),
-        },
-      );
+      const existingQuiz = quizSummaries.find((q) => q.lessonId === lessonId);
+      if (existingQuiz) {
+        // 編集: PATCH
+        await superFetch(
+          `/api/v2/super/master/quizzes/${existingQuiz.id}`,
+          {
+            method: "PATCH",
+            body: JSON.stringify({
+              title: form.title.trim(),
+              questions: form.questions,
+            }),
+          },
+        );
+        setEditingQuizLessonId(null);
+      } else {
+        // 新規作成: POST
+        await superFetch(
+          `/api/v2/super/master/lessons/${lessonId}/quiz`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              title: form.title.trim(),
+              questions: form.questions,
+            }),
+          },
+        );
+      }
       fetchData();
     } catch (e) {
       setQuizError(
@@ -581,6 +602,34 @@ export default function MasterCourseDetailPage() {
       );
     } finally {
       setQuizSaving(null);
+    }
+  };
+
+  const handleEditQuiz = async (lessonId: string) => {
+    const quiz = quizSummaries.find((q) => q.lessonId === lessonId);
+    if (!quiz) return;
+    setQuizLoadingLessonId(lessonId);
+    try {
+      const data = await superFetch<{ quiz: { title: string; questions: Question[] } }>(
+        `/api/v2/super/master/quizzes/${quiz.id}`,
+      );
+      updateQuizForm(lessonId, {
+        title: data.quiz.title,
+        questions: data.quiz.questions.map((q: Question) => ({
+          ...q,
+          options: q.options.map((o: QuestionOption) => ({
+            ...o,
+            isCorrect: o.isCorrect ?? false,
+          })),
+        })),
+      });
+      setEditingQuizLessonId(lessonId);
+    } catch (e) {
+      setQuizError(
+        e instanceof Error ? e.message : "テストの取得に失敗しました",
+      );
+    } finally {
+      setQuizLoadingLessonId(null);
     }
   };
 
@@ -961,7 +1010,7 @@ export default function MasterCourseDetailPage() {
                     {/* Quiz section */}
                     <div className="space-y-3">
                       <h3 className="text-sm font-semibold">テスト設定</h3>
-                      {lesson.hasQuiz ? (
+                      {lesson.hasQuiz && editingQuizLessonId !== lesson.id ? (
                         <div className="space-y-2">
                           <div className="flex items-center gap-3">
                             <Badge className="bg-purple-100 text-purple-800 border-purple-200">
@@ -976,6 +1025,16 @@ export default function MasterCourseDetailPage() {
                                 </span>
                               );
                             })()}
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleEditQuiz(lesson.id)}
+                              disabled={quizLoadingLessonId === lesson.id}
+                            >
+                              {quizLoadingLessonId === lesson.id
+                                ? "読込中..."
+                                : "テストを編集"}
+                            </Button>
                             <Button
                               variant="destructive"
                               size="sm"
@@ -1200,18 +1259,38 @@ export default function MasterCourseDetailPage() {
                             </Button>
                           </div>
 
-                          <Button
-                            size="sm"
-                            onClick={() => handleSaveQuiz(lesson.id)}
-                            disabled={
-                              quizSaving === lesson.id ||
-                              !qForm.title.trim()
-                            }
-                          >
-                            {quizSaving === lesson.id
-                              ? "保存中..."
-                              : "テストを登録"}
-                          </Button>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              onClick={() => handleSaveQuiz(lesson.id)}
+                              disabled={
+                                quizSaving === lesson.id ||
+                                !qForm.title.trim()
+                              }
+                            >
+                              {quizSaving === lesson.id
+                                ? "保存中..."
+                                : editingQuizLessonId === lesson.id
+                                  ? "テストを更新"
+                                  : "テストを登録"}
+                            </Button>
+                            {editingQuizLessonId === lesson.id && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => {
+                                  setEditingQuizLessonId(null);
+                                  setQuizForms((prev) => {
+                                    const next = { ...prev };
+                                    delete next[lesson.id];
+                                    return next;
+                                  });
+                                }}
+                              >
+                                キャンセル
+                              </Button>
+                            )}
+                          </div>
                         </div>
                       )}
                       {quizError && quizSaving === null && (


### PR DESCRIPTION
## Summary
- マスター管理画面で登録済みテストの編集が不可能だった問題を修正
- `GET /master/quizzes/:id` エンドポイント追加（questions含む全データ取得）
- 「テストを編集」ボタン追加 → 既存テストデータをフォームにロードして編集可能に
- `handleSaveQuiz` を新規作成(POST)/更新(PATCH)の両対応に拡張
- 編集キャンセル機能付き

## Test plan
- [x] 型チェック PASS
- [x] lint PASS
- [x] テスト 311件全PASS（web 16 + E2E 10 + API 285）
- [x] GET /master/quizzes/:id の統合テスト2件追加（正常系・404）
- [ ] ブラウザで動作確認（テスト編集→保存→再表示）

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)