### PR TITLE
feat: テナント管理画面への直リンク追加

### DIFF
--- a/web/app/super/distribute/page.tsx
+++ b/web/app/super/distribute/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -242,6 +243,13 @@ export default function DistributePage() {
                     onCheckedChange={() => toggleTenant(tenant.id)}
                   />
                   <span className="flex-1 text-sm">{tenant.name}</span>
+                  <Link
+                    href={`/${tenant.id}/admin/courses`}
+                    className="text-xs text-blue-600 hover:underline"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    管理画面
+                  </Link>
                   <span className="text-xs text-muted-foreground">
                     {tenant.id}
                   </span>


### PR DESCRIPTION
## Summary
- スーパー管理画面のテナント配信ページで、各テナント名の横に「管理画面」リンクを追加
- クリックで `/{tenantId}/admin/courses` に遷移
- チェックボックス操作と干渉しないよう `stopPropagation` 済み

## Test plan
- [x] 型チェック PASS
- [x] lint PASS
- [ ] ブラウザで動作確認

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)