### PR TITLE
fix: Critical/Highバグ6件を修正 (#85, #86, #87, #88, #89, #90)

### DIFF
--- a/services/api/src/__tests__/integration/tenant-reserved.test.ts
+++ b/services/api/src/__tests__/integration/tenant-reserved.test.ts
@@ -1,0 +1,43 @@
+/**
+ * 予約済みテナントID（_master等）へのアクセス制限テスト
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import supertest from "supertest";
+import express from "express";
+import { tenantMiddleware } from "../../middleware/tenant.js";
+
+vi.mock("../../datasource/index.js", () => ({
+  getDataSource: vi.fn(() => ({})),
+}));
+
+function createApp() {
+  const app = express();
+  // テナントパスをマウント
+  app.get("/api/v2/:tenant/test", tenantMiddleware, (_req, res) => {
+    res.json({ ok: true, tenantId: _req.tenantContext?.tenantId });
+  });
+  return app;
+}
+
+describe("予約済みテナントIDアクセス制限", () => {
+  const request = supertest(createApp());
+
+  it("_master テナントへのアクセスが403で拒否される", async () => {
+    const res = await request.get("/api/v2/_master/test");
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("reserved_tenant");
+  });
+
+  it("通常のテナントIDは正常にアクセスできる", async () => {
+    const res = await request.get("/api/v2/my-tenant/test");
+    expect(res.status).toBe(200);
+    expect(res.body.tenantId).toBe("my-tenant");
+  });
+
+  it("不正なテナントIDは400で拒否される", async () => {
+    const res = await request.get("/api/v2/invalid%20id/test");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_tenant_id");
+  });
+});

--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -853,7 +853,7 @@ export class FirestoreDataSource implements DataSource {
     const doc = await docRef.get();
     if (!doc.exists) return null;
 
-    await docRef.update({ ...data });
+    await applyUpdate(docRef, data as Record<string, unknown>);
     const updated = await docRef.get();
     return this.toQuizAttempt(updated.id, updated.data()!);
   }

--- a/services/api/src/middleware/tenant.ts
+++ b/services/api/src/middleware/tenant.ts
@@ -19,6 +19,9 @@ declare global {
 // デモテナントID
 const DEMO_TENANT_ID = "demo";
 
+// 予約済みテナントID（一般アクセス禁止）
+const RESERVED_TENANT_IDS = new Set(["_master"]);
+
 // テナントID検証用正規表現（英数字、ハイフン、アンダースコアのみ）
 const TENANT_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
 const TENANT_ID_MAX_LENGTH = 64;
@@ -59,6 +62,15 @@ export function tenantMiddleware(req: Request, res: Response, next: NextFunction
     res.status(400).json({
       error: "invalid_tenant_id",
       message: "Invalid tenant ID. Must be 1-64 alphanumeric characters, hyphens, or underscores.",
+    });
+    return;
+  }
+
+  // 予約済みテナントID（_master等）への一般アクセスを禁止
+  if (RESERVED_TENANT_IDS.has(tenantId)) {
+    res.status(403).json({
+      error: "reserved_tenant",
+      message: "This tenant ID is reserved for internal use.",
     });
     return;
   }

--- a/services/api/src/routes/shared/lessons.ts
+++ b/services/api/src/routes/shared/lessons.ts
@@ -270,6 +270,16 @@ router.delete(
       return;
     }
 
+    // 紐づく動画・テストも削除（孤立防止）
+    const [video, quiz] = await Promise.all([
+      ds.getVideoByLessonId(lessonId),
+      ds.getQuizByLessonId(lessonId),
+    ]);
+    await Promise.all([
+      video ? ds.deleteVideo(video.id) : Promise.resolve(false),
+      quiz ? ds.deleteQuiz(quiz.id) : Promise.resolve(false),
+    ]);
+
     await ds.deleteLesson(lessonId);
 
     // courseのlessonOrderからも削除

--- a/services/api/src/routes/super-admin-master.ts
+++ b/services/api/src/routes/super-admin-master.ts
@@ -760,8 +760,7 @@ router.get("/master/lessons/:lessonId", async (req: Request, res: Response) => {
   const ds = getMasterDS();
   const lessonId = req.params.lessonId as string;
 
-  const lessons = await ds.getLessons();
-  const lesson = lessons.find((l) => l.id === lessonId);
+  const lesson = await ds.getLessonById(lessonId);
   if (!lesson) {
     res.status(404).json({ error: "not_found", message: "レッスンが見つかりません。" });
     return;

--- a/services/api/src/services/course-distributor.ts
+++ b/services/api/src/services/course-distributor.ts
@@ -5,7 +5,6 @@
 
 import {
   Firestore,
-  FieldValue,
   type DocumentReference,
 } from "firebase-admin/firestore";
 import { FirestoreDataSource } from "../datasource/firestore.js";
@@ -177,8 +176,8 @@ export async function distributeCourseToTenant(
       createdBy: distributedBy,
       sourceMasterCourseId: masterCourseId,
       copiedAt: new Date(),
-      createdAt: FieldValue.serverTimestamp(),
-      updatedAt: FieldValue.serverTimestamp(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
     },
   });
 
@@ -194,8 +193,8 @@ export async function distributeCourseToTenant(
         hasVideo: lesson.hasVideo,
         hasQuiz: lesson.hasQuiz,
         videoUnlocksPrior: lesson.videoUnlocksPrior,
-        createdAt: FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
       },
     });
   }
@@ -217,8 +216,8 @@ export async function distributeCourseToTenant(
         durationSec: video.durationSec,
         requiredWatchRatio: video.requiredWatchRatio,
         speedLock: video.speedLock,
-        createdAt: FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
       },
     });
   }
@@ -242,8 +241,8 @@ export async function distributeCourseToTenant(
         randomizeAnswers: quiz.randomizeAnswers,
         requireVideoCompletion: quiz.requireVideoCompletion,
         questions: quiz.questions,
-        createdAt: FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
       },
     });
   }

--- a/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -182,6 +182,8 @@ function QuizSection({
   const [loadingSubmit, setLoadingSubmit] = useState(false);
   const [quizError, setQuizError] = useState<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const answersRef = useRef(answers);
+  answersRef.current = answers;
 
   // テスト情報取得
   const fetchQuiz = useCallback(async () => {
@@ -282,7 +284,7 @@ function QuizSection({
         {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ answers }),
+          body: JSON.stringify({ answers: answersRef.current }),
         }
       );
       // 結果取得

--- a/web/app/super/master/courses/[courseId]/preview/lessons/[lessonId]/page.tsx
+++ b/web/app/super/master/courses/[courseId]/preview/lessons/[lessonId]/page.tsx
@@ -90,6 +90,8 @@ export default function LessonPreviewPage() {
   const [gradeResult, setGradeResult] = useState<GradeResult | null>(null);
   const [remainingSec, setRemainingSec] = useState<number | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const answersRef = useRef(answers);
+  answersRef.current = answers;
 
   // Course name for breadcrumb
   const [courseName, setCourseName] = useState<string>("");
@@ -198,11 +200,12 @@ export default function LessonPreviewPage() {
     if (timerRef.current) clearInterval(timerRef.current);
     if (!quiz) return;
 
+    const currentAnswers = answersRef.current;
     let score = 0;
     let maxScore = 0;
     const details = quiz.questions.map((q) => {
       const correctIds = q.options.filter((o) => o.isCorrect).map((o) => o.id).sort();
-      const selectedIds = (answers[q.id] ?? []).sort();
+      const selectedIds = (currentAnswers[q.id] ?? []).sort();
       const isCorrect = !timedOut && correctIds.length === selectedIds.length && correctIds.every((id, i) => id === selectedIds[i]);
       maxScore += q.points;
       if (isCorrect) score += q.points;


### PR DESCRIPTION
## Summary

QA探索で発見したCritical 2件・High 4件の潜在バグを修正。

### Critical
- **#85 _masterテナントアクセス制限**: `/api/v2/_master/*` への一般ユーザーアクセスを403で拒否
- **#86 FieldValue.serverTimestamp()残留**: course-distributor.tsの8箇所を`new Date()`に置換（PR#80の修正漏れ）

### High
- **#87 stale closure修正**: タイマー自動提出時に空回答が送信される問題を`answersRef`パターンで修正
- **#88 updateQuizAttempt**: 生`update()`→`applyUpdate()`に変更（updatedAt欠落を修正）
- **#89 lessons全件取得**: `GET /master/lessons/:lessonId`を`getLessonById()`直接呼び出しに変更
- **#90 レッスン削除時の孤立データ**: テナント側レッスン削除時に紐づく動画・テストも削除

## 検証結果
- 型チェック: PASS
- lint: PASS
- APIテスト: 292件 PASS（+3件追加）
- Webテスト: 16件 PASS
- E2E: 10件 PASS

Closes #85, Closes #86, Closes #87, Closes #88, Closes #89, Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)