### PR TITLE
fix: テストインポートに確定的パーサー追加（Gemini依存脱却）

### DIFF
--- a/services/api/src/__tests__/integration/quiz-parse-deterministic.test.ts
+++ b/services/api/src/__tests__/integration/quiz-parse-deterministic.test.ts
@@ -1,0 +1,116 @@
+/**
+ * 確定的テストパーサー ユニットテスト
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseQuizDeterministic } from "../../services/quiz-import.js";
+
+describe("parseQuizDeterministic", () => {
+  it("a)/b)/c) 形式の3択問題を正しくパースする", () => {
+    const content = `1. Googleドライブの無料容量について
+Googleドライブでは、Googleアカウントを持っているだけで無料でどれくらいの容量を利用できますか？
+a) 5GB
+b) 15GB
+c) 100GB
+
+2. クラウドストレージの概念について
+Googleドライブで利用される「クラウドストレージ」とは、簡単に言うとどのようなものですか？
+a) パソコン内部の補助記憶装置
+b) USBメモリーのような外部記録媒体
+c) インターネット上にある倉庫のようなもの
+
+3. Googleドライブへのアクセス方法について
+Googleドライブへアクセスする方法として正しいものはどれですか？
+a) Googleアカウントにログイン後、Googleアプリランチャーから開く
+b) GoogleドライブのURLを直接入力する
+c) 特殊な専用ソフトをインストールして開く`;
+
+    const result = parseQuizDeterministic(content);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(3);
+
+    // 問題1
+    expect(result![0].text).toContain("Googleドライブの無料容量について");
+    expect(result![0].options).toHaveLength(3);
+    expect(result![0].options[0].text).toBe("5GB");
+    expect(result![0].options[1].text).toBe("15GB");
+    expect(result![0].options[2].text).toBe("100GB");
+
+    // 問題2
+    expect(result![1].text).toContain("クラウドストレージ");
+    expect(result![1].options).toHaveLength(3);
+
+    // 全て正解不明（書式なし）
+    for (const q of result!) {
+      for (const opt of q.options) {
+        expect(opt.isCorrect).toBeNull();
+      }
+    }
+  });
+
+  it("太字マーク付き選択肢の正解を検出する", () => {
+    const content = `1. テスト問題
+a) 不正解の選択肢
+[BOLD]b) 正解の選択肢[/BOLD]
+c) 不正解の選択肢
+
+2. もう一問
+a) 選択肢A
+b) 選択肢B`;
+
+    const result = parseQuizDeterministic(content);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    // 問題1: b)が太字で正解
+    expect(result![0].options[0].isCorrect).toBeNull();
+    expect(result![0].options[1].isCorrect).toBe(true);
+    expect(result![0].options[2].isCorrect).toBeNull();
+  });
+
+  it("10問の問題を全て抽出する", () => {
+    const lines = [];
+    for (let i = 1; i <= 10; i++) {
+      lines.push(`${i}. テスト問題${i}`);
+      lines.push(`問題${i}の説明文です。`);
+      lines.push(`a) 選択肢A`);
+      lines.push(`b) 選択肢B`);
+      lines.push(`c) 選択肢C`);
+      lines.push("");
+    }
+    const content = lines.join("\n");
+
+    const result = parseQuizDeterministic(content);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(10);
+  });
+
+  it("問題文が複数行にまたがる場合を処理する", () => {
+    const content = `1. ファイルのアップロード方法について
+Googleドライブにファイルをアップロードする簡単な方法として、この講座で紹介されたものは何ですか？
+a) メールに添付して送信する
+b) ドラッグ＆ドロップまたは「＋新規」ボタンを使用する
+c) 専用のアップロードケーブルで接続する
+
+2. 次の問題
+a) 選択肢1
+b) 選択肢2`;
+
+    const result = parseQuizDeterministic(content);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![0].text).toContain("ファイルのアップロード方法について");
+    expect(result![0].text).toContain("紹介されたものは何ですか？");
+  });
+
+  it("パースできない形式の場合はnullを返す", () => {
+    const content = `これはテスト形式ではない普通の文章です。
+問題のような構造がないためパースできません。`;
+
+    const result = parseQuizDeterministic(content);
+    expect(result).toBeNull();
+  });
+});

--- a/services/api/src/services/quiz-import.ts
+++ b/services/api/src/services/quiz-import.ts
@@ -118,6 +118,99 @@ export function validateImportedQuestions(
 }
 
 /**
+ * 書式タグを除去してプレーンテキストにする
+ */
+function stripTags(text: string): string {
+  return text
+    .replace(/\[(BOLD|UNDERLINE|\/BOLD|\/UNDERLINE)\]/g, "")
+    .replace(/\[COLOR:#[0-9A-Fa-f]+\]/g, "")
+    .replace(/\[\/COLOR\]/g, "")
+    .trim();
+}
+
+/**
+ * 選択肢行に書式タグがあるかチェックしてisCorrectを判定
+ */
+function detectCorrect(rawLine: string): boolean | null {
+  if (/\[BOLD\]/.test(rawLine)) return true;
+  if (/\[UNDERLINE\]/.test(rawLine) || /\[COLOR:#/.test(rawLine)) return true;
+  return null; // 書式なし → 正解不明
+}
+
+/**
+ * 正規表現ベースの確定的パーサー
+ * 番号付き問題 + a)/b)/c) 形式の選択肢を認識する
+ * パース不能な場合はnullを返す（Geminiフォールバック用）
+ */
+export function parseQuizDeterministic(
+  formattedContent: string
+): ImportedQuizQuestion[] | null {
+  const genId = () => crypto.randomUUID();
+
+  // 行に分割（空行も保持）
+  const lines = formattedContent.split("\n");
+
+  // 問題ブロックを抽出: "数字." または "数字)" で始まる行を問題開始とする
+  // 選択肢: "a)" "b)" "A)" "B)" "ア)" "①" 等で始まる行
+  const questionPattern = /^\s*(\d+)\s*[.)．]\s*(.+)/;
+  const optionPattern = /^\s*([a-zA-Zアイウエオカキクケコ①②③④⑤⑥⑦⑧⑨⑩])\s*[)）]\s*(.+)/;
+
+  interface RawQuestion {
+    textLines: string[]; // 問題文（複数行の可能性）
+    options: { rawLine: string; text: string }[];
+  }
+
+  const questions: RawQuestion[] = [];
+  let current: RawQuestion | null = null;
+  let collectingQuestionText = false;
+
+  for (const line of lines) {
+    // 書式タグを除去してからパターンマッチ（[BOLD]a) テキスト[/BOLD] 対応）
+    const strippedLine = stripTags(line);
+    const qMatch = strippedLine.match(questionPattern);
+    const oMatch = strippedLine.match(optionPattern);
+
+    if (qMatch && !oMatch) {
+      // 新しい問題開始
+      if (current) questions.push(current);
+      current = { textLines: [qMatch[2].trim()], options: [] };
+      collectingQuestionText = true;
+    } else if (oMatch && current) {
+      // 選択肢
+      collectingQuestionText = false;
+      current.options.push({ rawLine: line, text: oMatch[2].trim() }); // rawLineは書式タグ付き原文、textはタグ除去済み
+    } else if (current && collectingQuestionText && line.trim()) {
+      // 問題文の続き（選択肢が始まるまでの非空行）
+      current.textLines.push(line.trim());
+    }
+  }
+  if (current) questions.push(current);
+
+  // パース結果の検証: 問題が3問以上あり、各問題に選択肢が2つ以上あること
+  if (questions.length < 2) return null;
+  const validQuestions = questions.filter((q) => q.options.length >= 2);
+  if (validQuestions.length < questions.length * 0.5) return null; // 半数以上がパース失敗ならGeminiに委譲
+
+  return validQuestions.map((q) => {
+    const questionText = stripTags(q.textLines.join(" "));
+    const options: ImportedQuizOption[] = q.options.map((opt) => ({
+      id: genId(),
+      text: stripTags(opt.text),
+      isCorrect: detectCorrect(opt.rawLine),
+    }));
+
+    return {
+      id: genId(),
+      text: questionText,
+      type: "single" as const,
+      options,
+      points: 1,
+      explanation: "",
+    };
+  });
+}
+
+/**
  * ドキュメントの書式付きコンテンツからテスト問題を抽出（生成ではなくパース）
  */
 export async function importQuizFromDocument(
@@ -127,6 +220,22 @@ export async function importQuizFromDocument(
   questions: ImportedQuizQuestion[];
   warnings: string[];
 }> {
+  // まず確定的パーサーを試行（Geminiの不安定さを回避）
+  const deterministicResult = parseQuizDeterministic(formattedContent);
+  if (deterministicResult && deterministicResult.length > 0) {
+    const warnings: string[] = [];
+    const unknownCorrectCount = deterministicResult.filter((q) =>
+      q.options.every((o) => o.isCorrect === null)
+    ).length;
+    if (unknownCorrectCount > 0) {
+      warnings.push(
+        `${deterministicResult.length}問中${unknownCorrectCount}問で正解が検出できませんでした。手動で正解を設定してください。`
+      );
+    }
+    return { questions: deterministicResult, warnings };
+  }
+
+  // 確定的パーサーで認識できない場合はGeminiフォールバック
   const { language = "ja" } = options;
   const langLabel = language === "ja" ? "日本語" : "English";
 


### PR DESCRIPTION
## Summary
Googleドキュメントからのテストインポートで問題欠落・選択肢創作が発生する問題を根本修正。

## 原因
Gemini(LLM)によるパースが不安定で、問題数の欠落・選択肢の創作・原文の改変が発生。

## 修正内容
- **正規表現ベースの確定的パーサー**を新規追加（`parseQuizDeterministic`）
- `a)` `b)` `c)` / `A)` `B)` / `ア)` `イ)` / `①` `②` 形式を正規表現で確実にパース
- 書式タグ（[BOLD]等）の正解検出にも対応
- Geminiは確定的パーサーで認識できない形式の場合のみフォールバック使用
- テスト5件追加（3択、太字正解、10問、複数行問題文、非テスト形式）

## 検証結果
- 型チェック: PASS / lint: PASS / テスト299件: 全PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)