### PR TITLE
fix: テストパーサーが第N問+A.形式を認識するよう拡張

### DIFF
--- a/services/api/src/__tests__/integration/quiz-parse-deterministic.test.ts
+++ b/services/api/src/__tests__/integration/quiz-parse-deterministic.test.ts
@@ -106,6 +106,40 @@ b) 選択肢2`;
     expect(result![0].text).toContain("紹介されたものは何ですか？");
   });
 
+  it("第N問 + A./B./C. 形式をパースし太字正解を検出する", () => {
+    const content = `第1問 Googleワークスペースはどのように説明されていますか？
+A. 写真や動画編集に特化したプロフェッショナル向けソフトウェア。
+B. Googleが開発した単一のウェブブラウザ。
+[BOLD]C. Microsoft Officeのような、様々なツールが1つのセットになったサービス。[/BOLD]
+
+第2問 Google ChromeとGoogleワークスペースの最も適切な関係性は何ですか？
+A. Microsoft Edgeブラウザと機能的に同じであり、どちらを使っても違いはない。
+[BOLD]B. Googleワークスペースの性能を最大限に引き出す、推奨される「相棒」である。[/BOLD]
+C. 全く関係なく、独立して使用される。
+
+第3問 Googleワークスペースを活用する主なメリットとして何が挙げられていますか？
+A. 文書の編集は一度に一人しか行えず、共同作業には不向きである。
+[BOLD]B. データがオンライン上のクラウドに保存され、ペーパーレス化やBCP対策に有効である。[/BOLD]
+C. 全てのデータを物理的な書類として保管する。`;
+
+    const result = parseQuizDeterministic(content);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(3);
+
+    // 問題1: C.が太字（正解）
+    expect(result![0].text).toContain("Googleワークスペースはどのように説明されていますか");
+    expect(result![0].options).toHaveLength(3);
+    expect(result![0].options[0].isCorrect).toBeNull(); // A
+    expect(result![0].options[1].isCorrect).toBeNull(); // B
+    expect(result![0].options[2].isCorrect).toBe(true);  // C (太字)
+
+    // 問題2: B.が太字（正解）
+    expect(result![1].options[0].isCorrect).toBeNull(); // A
+    expect(result![1].options[1].isCorrect).toBe(true);  // B (太字)
+    expect(result![1].options[2].isCorrect).toBeNull(); // C
+  });
+
   it("パースできない形式の場合はnullを返す", () => {
     const content = `これはテスト形式ではない普通の文章です。
 問題のような構造がないためパースできません。`;

--- a/services/api/src/services/quiz-import.ts
+++ b/services/api/src/services/quiz-import.ts
@@ -150,10 +150,18 @@ export function parseQuizDeterministic(
   // 行に分割（空行も保持）
   const lines = formattedContent.split("\n");
 
-  // 問題ブロックを抽出: "数字." または "数字)" で始まる行を問題開始とする
-  // 選択肢: "a)" "b)" "A)" "B)" "ア)" "①" 等で始まる行
-  const questionPattern = /^\s*(\d+)\s*[.)．]\s*(.+)/;
-  const optionPattern = /^\s*([a-zA-Zアイウエオカキクケコ①②③④⑤⑥⑦⑧⑨⑩])\s*[)）]\s*(.+)/;
+  // 問題ブロックを抽出:
+  //   "1." "2)" "第1問" "問1" "問題1" "Q1" 等で始まる行を問題開始とする
+  // 選択肢:
+  //   "a)" "A." "A:" "A）" "ア)" "①" 等で始まる行
+  const questionPatterns = [
+    /^\s*(\d+)\s*[.)．）]\s*(.+)/,                  // 1. / 1) / 1．
+    /^\s*第\s*(\d+)\s*問\s*(.+)/,                   // 第1問
+    /^\s*問\s*(\d+)\s*[.)．:：]?\s*(.+)/,           // 問1 / 問1.
+    /^\s*問題\s*(\d+)\s*[.)．:：]?\s*(.+)/,         // 問題1
+    /^\s*Q\s*(\d+)\s*[.)．:：]?\s*/i,               // Q1 / q1
+  ];
+  const optionPattern = /^\s*([a-zA-Zアイウエオカキクケコ①②③④⑤⑥⑦⑧⑨⑩])\s*[.)）．:：]\s*(.+)/;
 
   interface RawQuestion {
     textLines: string[]; // 問題文（複数行の可能性）
@@ -167,13 +175,21 @@ export function parseQuizDeterministic(
   for (const line of lines) {
     // 書式タグを除去してからパターンマッチ（[BOLD]a) テキスト[/BOLD] 対応）
     const strippedLine = stripTags(line);
-    const qMatch = strippedLine.match(questionPattern);
     const oMatch = strippedLine.match(optionPattern);
+    // 複数の問題パターンを順に試行
+    let qMatch: RegExpMatchArray | null = null;
+    if (!oMatch) {
+      for (const qp of questionPatterns) {
+        qMatch = strippedLine.match(qp);
+        if (qMatch) break;
+      }
+    }
 
     if (qMatch && !oMatch) {
       // 新しい問題開始
       if (current) questions.push(current);
-      current = { textLines: [qMatch[2].trim()], options: [] };
+      const questionText = (qMatch[2] ?? "").trim();
+      current = { textLines: questionText ? [questionText] : [], options: [] };
       collectingQuestionText = true;
     } else if (oMatch && current) {
       // 選択肢


### PR DESCRIPTION
## Summary
「第1問」「A. B. C.」形式のGoogleドキュメントがパースできなかった問題を修正。

## 修正内容
- 問題パターン追加: `第N問` / `問N` / `問題N` / `QN`
- 選択肢パターン拡張: `A.` / `B:` / `A）` 形式（ピリオド・コロン・全角括弧）
- 太字の正解検出テスト追加

## 検証結果
- テスト300件: 全PASS（+1件追加）/ 型チェック・lint: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)