### PR TITLE
fix: 退室打刻をテスト合格時のみ実行

### DIFF
--- a/services/api/src/routes/shared/quiz-attempts.ts
+++ b/services/api/src/routes/shared/quiz-attempts.ts
@@ -332,7 +332,7 @@ router.patch("/quiz-attempts/:attemptId", requireUser, async (req: Request, res:
     submittedAt: now.toISOString(),
   });
 
-  // 進捗更新: 合格した場合
+  // 合格した場合: 進捗更新 + 退室打刻
   if (gradingResult.isPassed) {
     if (quiz) {
       await updateLessonProgress(ds, userId, quiz.lessonId, quiz.courseId, {
@@ -340,15 +340,15 @@ router.patch("/quiz-attempts/:attemptId", requireUser, async (req: Request, res:
         quizBestScore: gradingResult.score,
       });
     }
-  }
 
-  // セッション完了（退室打刻）
-  if (activeSession) {
-    try {
-      await completeSession(ds, activeSession.id, updated!.id);
-    } catch {
-      // セッション完了失敗はテスト提出自体をブロックしない
-      console.error(`Failed to complete session for attempt ${attemptId}`);
+    // セッション完了（退室打刻）— 合格時のみ実行、不合格時は再挑戦可能
+    if (activeSession) {
+      try {
+        await completeSession(ds, activeSession.id, updated!.id);
+      } catch {
+        // セッション完了失敗はテスト提出自体をブロックしない
+        console.error(`Failed to complete session for attempt ${attemptId}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

テスト提出時の退室打刻を合格時のみに限定。不合格時はセッションをactiveのまま維持し再挑戦可能にする。

## 変更内容

`quiz-attempts.ts`のセッション完了処理を`isPassed`の条件ブロック内に移動（9行の移動のみ）。

## Before/After

| テスト結果 | Before | After |
|-----------|--------|-------|
| 合格 | 退室打刻 | 退室打刻（変更なし） |
| 不合格 | 退室打刻 | **セッション維持（再挑戦可能）** |

## Test plan

- [ ] テスト合格 → セッションが`completed`になり退室打刻される
- [ ] テスト不合格 → セッションが`active`のまま再挑戦可能
- [ ] 不合格後に2時間制限 → 通常の強制退室フロー動作
- [ ] APIビルド成功、テスト300/300 PASS

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)