### PR TITLE
feat: 受講者CSV一括インポート機能

### DIFF
--- a/services/api/src/routes/shared/users.ts
+++ b/services/api/src/routes/shared/users.ts
@@ -233,4 +233,109 @@ router.patch("/admin/users/:id/settings", requireAdmin, async (req: Request, res
   res.json({ settings });
 });
 
+/**
+ * 管理者向け: CSV一括ユーザーインポート
+ * POST /admin/users/import
+ *
+ * Body: { csv: string } — CSV文字列（ヘッダー行あり、email必須、name/role任意）
+ * 上限: 500行、1MB
+ */
+router.post("/admin/users/import", requireAdmin, async (req: Request, res: Response) => {
+  const ds = req.dataSource!;
+  const { csv } = req.body;
+
+  if (!csv || typeof csv !== "string") {
+    res.status(400).json({ error: "invalid_request", message: "csv field is required" });
+    return;
+  }
+
+  if (csv.length > 1_000_000) {
+    res.status(400).json({ error: "too_large", message: "CSV must be under 1MB" });
+    return;
+  }
+
+  // BOM除去
+  const cleanCsv = csv.replace(/^\uFEFF/, "");
+  const lines = cleanCsv.split(/\r?\n/).filter((line) => line.trim());
+
+  if (lines.length < 2) {
+    res.status(400).json({ error: "invalid_csv", message: "CSV must have a header row and at least one data row" });
+    return;
+  }
+
+  if (lines.length > 501) {
+    res.status(400).json({ error: "too_many_rows", message: "CSV must have 500 rows or fewer (excluding header)" });
+    return;
+  }
+
+  // ヘッダー解析
+  const headers = lines[0].split(",").map((h) => h.trim().toLowerCase());
+  const emailIdx = headers.indexOf("email");
+  if (emailIdx === -1) {
+    res.status(400).json({ error: "missing_header", message: "CSV must have an 'email' column" });
+    return;
+  }
+  const nameIdx = headers.indexOf("name");
+  const roleIdx = headers.indexOf("role");
+
+  const results: {
+    created: { email: string; name: string | null; role: string }[];
+    skipped: { email: string; reason: string }[];
+    errors: { line: number; email?: string; reason: string }[];
+  } = { created: [], skipped: [], errors: [] };
+
+  for (let i = 1; i < lines.length; i++) {
+    const cols = lines[i].split(",").map((c) => c.trim());
+    const email = cols[emailIdx]?.toLowerCase();
+
+    if (!email || !EMAIL_REGEX.test(email)) {
+      results.errors.push({ line: i + 1, email: email || undefined, reason: "invalid_email" });
+      continue;
+    }
+
+    const name = nameIdx !== -1 ? cols[nameIdx] || null : null;
+    const role = roleIdx !== -1 ? cols[roleIdx]?.toLowerCase() || "student" : "student";
+
+    if (!(VALID_ROLES as readonly string[]).includes(role)) {
+      results.errors.push({ line: i + 1, email, reason: `invalid_role: ${role}` });
+      continue;
+    }
+
+    // 重複チェック
+    const existing = await ds.getUserByEmail(email);
+    if (existing) {
+      results.skipped.push({ email, reason: "already_exists" });
+      continue;
+    }
+
+    try {
+      const user = await ds.createUser({
+        email,
+        name,
+        role: role as "admin" | "teacher" | "student",
+      });
+
+      // allowed_emailsにも自動追加
+      const isAllowed = await ds.isEmailAllowed(email);
+      if (!isAllowed) {
+        await ds.createAllowedEmail({ email, note: "CSV import" });
+      }
+
+      results.created.push({ email: user.email!, name: user.name, role: user.role });
+    } catch {
+      results.errors.push({ line: i + 1, email, reason: "creation_failed" });
+    }
+  }
+
+  res.status(200).json({
+    summary: {
+      total: lines.length - 1,
+      created: results.created.length,
+      skipped: results.skipped.length,
+      errors: results.errors.length,
+    },
+    ...results,
+  });
+});
+
 export const usersRouter = router;

--- a/web/app/[tenant]/admin/users/page.tsx
+++ b/web/app/[tenant]/admin/users/page.tsx
@@ -63,6 +63,17 @@ export default function UsersPage() {
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
+  // CSV import dialog
+  const [importOpen, setImportOpen] = useState(false);
+  const [importLoading, setImportLoading] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importResult, setImportResult] = useState<{
+    summary: { total: number; created: number; skipped: number; errors: number };
+    created: { email: string; name: string | null; role: string }[];
+    skipped: { email: string; reason: string }[];
+    errors: { line: number; email?: string; reason: string }[];
+  } | null>(null);
+
   const fetchUsers = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -112,6 +123,28 @@ export default function UsersPage() {
     setDeleteOpen(true);
   };
 
+  const handleCsvImport = async (file: File) => {
+    setImportLoading(true);
+    setImportError(null);
+    setImportResult(null);
+    try {
+      const csv = await file.text();
+      const data = await authFetch<typeof importResult>("/api/v1/admin/users/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ csv }),
+      });
+      setImportResult(data);
+      if (data && data.summary.created > 0) {
+        fetchUsers();
+      }
+    } catch (e) {
+      setImportError(e instanceof Error ? e.message : "インポートに失敗しました");
+    } finally {
+      setImportLoading(false);
+    }
+  };
+
   const handleDelete = async () => {
     if (!deletingUser) return;
     setDeleteLoading(true);
@@ -134,17 +167,29 @@ export default function UsersPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">ユーザー管理</h1>
-        <Button
-          onClick={() => {
-            setCreateName("");
-            setCreateEmail("");
-            setCreateRole("student");
-            setCreateError(null);
-            setCreateOpen(true);
-          }}
-        >
-          新規作成
-        </Button>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => {
+              setImportError(null);
+              setImportResult(null);
+              setImportOpen(true);
+            }}
+          >
+            CSVインポート
+          </Button>
+          <Button
+            onClick={() => {
+              setCreateName("");
+              setCreateEmail("");
+              setCreateRole("student");
+              setCreateError(null);
+              setCreateOpen(true);
+            }}
+          >
+            新規作成
+          </Button>
+        </div>
       </div>
 
       {error && (
@@ -266,6 +311,70 @@ export default function UsersPage() {
             </Button>
             <Button variant="destructive" onClick={handleDelete} disabled={deleteLoading}>
               {deleteLoading ? "削除中..." : "削除"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      {/* CSVインポートダイアログ */}
+      <Dialog open={importOpen} onOpenChange={setImportOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>CSVインポート</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              CSV形式: <code>email,name,role</code>（ヘッダー行必須、name/roleは任意）
+            </p>
+            <input
+              type="file"
+              accept=".csv,text/csv"
+              className="block w-full text-sm file:mr-4 file:rounded file:border-0 file:bg-primary/10 file:px-4 file:py-2 file:text-sm file:font-medium hover:file:bg-primary/20"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) handleCsvImport(file);
+              }}
+              disabled={importLoading}
+            />
+            {importLoading && (
+              <div className="text-sm text-muted-foreground">インポート中...</div>
+            )}
+            {importError && (
+              <div className="text-sm text-destructive">{importError}</div>
+            )}
+            {importResult && (
+              <div className="space-y-2 text-sm">
+                <div className="rounded-md bg-muted p-3 space-y-1">
+                  <div>合計: {importResult.summary.total}件</div>
+                  <div className="text-green-600">作成: {importResult.summary.created}件</div>
+                  <div className="text-yellow-600">スキップ: {importResult.summary.skipped}件</div>
+                  <div className="text-destructive">エラー: {importResult.summary.errors}件</div>
+                </div>
+                {importResult.errors.length > 0 && (
+                  <details className="text-xs">
+                    <summary className="cursor-pointer text-destructive">エラー詳細</summary>
+                    <ul className="mt-1 space-y-0.5 pl-4">
+                      {importResult.errors.map((err, i) => (
+                        <li key={i}>行{err.line}: {err.email ?? "不明"} — {err.reason}</li>
+                      ))}
+                    </ul>
+                  </details>
+                )}
+                {importResult.skipped.length > 0 && (
+                  <details className="text-xs">
+                    <summary className="cursor-pointer text-yellow-600">スキップ詳細</summary>
+                    <ul className="mt-1 space-y-0.5 pl-4">
+                      {importResult.skipped.map((s, i) => (
+                        <li key={i}>{s.email} — 既存ユーザー</li>
+                      ))}
+                    </ul>
+                  </details>
+                )}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setImportOpen(false)}>
+              閉じる
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary

各テナントの管理者が受講者をCSVファイルで一括インポートできる機能を追加。

## 機能

- **API**: `POST /admin/users/import` — CSV文字列を受け取り、バリデーション+一括登録
- **フロント**: 受講者管理ページにCSVインポートボタン+結果サマリーダイアログ

## CSV形式

```csv
email,name,role
user1@example.com,山田太郎,student
user2@example.com,鈴木花子,admin
```

## バリデーション

- メール形式チェック（不正→エラー報告、スキップ）
- 既存ユーザー重複チェック（重複→スキップ）
- ロール検証（admin/teacher/student以外→エラー）
- BOM付きUTF-8対応
- 上限: 500行 / 1MB

## Test plan

- [ ] 正常なCSVで受講者が一括作成されること
- [ ] 重複メールがスキップされること
- [ ] 不正メール形式がエラー報告されること
- [ ] allowed_emailsにも自動追加されること
- [ ] APIビルド・Webビルド成功、テスト300/300 PASS

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)