### PR TITLE
fix: 出席レポートのTZ変換・日付境界・入力バリデーション修正

### DIFF
--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -472,13 +472,19 @@ router.get("/tenants/:tenantId/attendance-report", async (req: Request, res: Res
   let sessionsQuery = db.collection(`${basePath}/lesson_sessions`)
     .orderBy("entryAt", "desc") as FirebaseFirestore.Query;
 
+  // 日付フィルタ: JST基準（UTC+9）でUTC境界に変換
+  const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
   const fromStr = typeof from === "string" ? from : undefined;
   const toStr = typeof to === "string" ? to : undefined;
   if (fromStr) {
-    sessionsQuery = sessionsQuery.where("entryAt", ">=", fromStr);
+    // JST日付の開始 = UTC前日15:00
+    const fromUtc = new Date(new Date(`${fromStr}T00:00:00`).getTime() - JST_OFFSET_MS).toISOString();
+    sessionsQuery = sessionsQuery.where("entryAt", ">=", fromUtc);
   }
   if (toStr) {
-    sessionsQuery = sessionsQuery.where("entryAt", "<=", `${toStr}T23:59:59.999Z`);
+    // JST日付の終了 = UTC当日14:59:59.999
+    const toUtc = new Date(new Date(`${toStr}T23:59:59.999`).getTime() - JST_OFFSET_MS).toISOString();
+    sessionsQuery = sessionsQuery.where("entryAt", "<=", toUtc);
   }
 
   const sessionsSnapshot = await sessionsQuery.get();
@@ -555,6 +561,29 @@ router.patch("/tenants/:tenantId/attendance-report/:sessionId", async (req: Requ
   const tenantId = req.params.tenantId as string;
   const sessionId = req.params.sessionId as string;
   const { entryAt, exitAt, quizScore, quizPassed } = req.body;
+
+  // 入力バリデーション
+  const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+  if (entryAt !== undefined && (typeof entryAt !== "string" || !ISO_DATE_REGEX.test(entryAt) || isNaN(Date.parse(entryAt)))) {
+    res.status(400).json({ error: "invalid_entryAt", message: "entryAt must be a valid ISO 8601 UTC datetime" });
+    return;
+  }
+  if (exitAt !== undefined && (typeof exitAt !== "string" || !ISO_DATE_REGEX.test(exitAt) || isNaN(Date.parse(exitAt)))) {
+    res.status(400).json({ error: "invalid_exitAt", message: "exitAt must be a valid ISO 8601 UTC datetime" });
+    return;
+  }
+  if (entryAt !== undefined && exitAt !== undefined && new Date(entryAt) > new Date(exitAt)) {
+    res.status(400).json({ error: "invalid_time_range", message: "entryAt must be before exitAt" });
+    return;
+  }
+  if (quizScore !== undefined && (typeof quizScore !== "number" || !Number.isFinite(quizScore) || quizScore < 0 || quizScore > 100)) {
+    res.status(400).json({ error: "invalid_quizScore", message: "quizScore must be a number between 0 and 100" });
+    return;
+  }
+  if (quizPassed !== undefined && typeof quizPassed !== "boolean") {
+    res.status(400).json({ error: "invalid_quizPassed", message: "quizPassed must be a boolean" });
+    return;
+  }
 
   const basePath = `tenants/${tenantId}`;
   const sessionRef = db.collection(`${basePath}/lesson_sessions`).doc(sessionId);

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -58,14 +58,21 @@ type ReportResponse = {
   totalRecords: number;
 };
 
-function formatDateTime(iso: string | null): string {
-  if (!iso) return "—";
-  return new Date(iso).toLocaleString("ja-JP", {
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+/** ISO UTC文字列をdatetime-local用のローカル時刻文字列に変換 */
+function isoToDatetimeLocal(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const h = String(d.getHours()).padStart(2, "0");
+  const min = String(d.getMinutes()).padStart(2, "0");
+  return `${y}-${m}-${day}T${h}:${min}`;
+}
+
+/** datetime-local値をISO UTC文字列に変換 */
+function datetimeLocalToISO(local: string): string {
+  return new Date(local).toISOString();
 }
 
 function formatTime(iso: string | null): string {
@@ -102,6 +109,7 @@ export default function AttendanceReportPage() {
   const [editScore, setEditScore] = useState("");
   const [editPassed, setEditPassed] = useState("");
   const [editLoading, setEditLoading] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
 
   const tableRef = useRef<HTMLDivElement>(null);
 
@@ -134,20 +142,22 @@ export default function AttendanceReportPage() {
 
   const openEdit = (record: AttendanceRecord) => {
     setEditRecord(record);
-    setEditEntryAt(record.entryAt?.slice(0, 16) ?? "");
-    setEditExitAt(record.exitAt?.slice(0, 16) ?? "");
+    setEditEntryAt(isoToDatetimeLocal(record.entryAt));
+    setEditExitAt(isoToDatetimeLocal(record.exitAt));
     setEditScore(record.quizScore?.toString() ?? "");
     setEditPassed(record.quizPassed === null ? "" : record.quizPassed ? "true" : "false");
+    setEditError(null);
     setEditOpen(true);
   };
 
   const handleEdit = async () => {
     if (!editRecord || !selectedTenant) return;
     setEditLoading(true);
+    setEditError(null);
     try {
       const body: Record<string, unknown> = {};
-      if (editEntryAt) body.entryAt = new Date(editEntryAt).toISOString();
-      if (editExitAt) body.exitAt = new Date(editExitAt).toISOString();
+      if (editEntryAt) body.entryAt = datetimeLocalToISO(editEntryAt);
+      if (editExitAt) body.exitAt = datetimeLocalToISO(editExitAt);
       if (editScore !== "") body.quizScore = Number(editScore);
       if (editPassed !== "") body.quizPassed = editPassed === "true";
 
@@ -161,8 +171,8 @@ export default function AttendanceReportPage() {
       );
       setEditOpen(false);
       fetchReport();
-    } catch {
-      // エラーは無視しない
+    } catch (e) {
+      setEditError(e instanceof Error ? e.message : "更新に失敗しました");
     } finally {
       setEditLoading(false);
     }
@@ -353,6 +363,9 @@ export default function AttendanceReportPage() {
                   </Select>
                 </div>
               </>
+            )}
+            {editError && (
+              <div className="text-sm text-destructive">{editError}</div>
             )}
           </div>
           <DialogFooter>


### PR DESCRIPTION
## Summary
- datetime-local入力のUTC↔ローカル変換を正しく処理し、保存のたびに-9hシフトするバグを修正
- 日付フィルタをJST基準（UTC+9）でUTC境界に正規化し、JST 0:00-8:59の欠落を解消
- PATCHエンドポイントにISO日時形式・点数範囲(0-100)・前後関係の入力バリデーションを追加
- 編集ダイアログにエラーメッセージ表示を追加

Closes #117

## Test plan
- [x] APIビルド成功
- [x] Web型チェック成功
- [x] lint通過
- [x] 全テスト26件PASS（unit 16 + E2E 10）
- [ ] 編集ダイアログで未変更保存→値がずれないこと（手動確認）
- [ ] JST深夜帯のレコードが正しい日付フィルタに含まれること（手動確認）
- [ ] 不正な値（NaN, 負数, 逆転日時）でPATCH→400エラーが返ること（手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)