### PR TITLE
fix: メールアドレス正規化の統一

### DIFF
--- a/services/api/src/middleware/tenant-auth.ts
+++ b/services/api/src/middleware/tenant-auth.ts
@@ -142,7 +142,8 @@ async function findOrCreateTenantUser(
   decodedToken: DecodedIdToken
 ): Promise<AuthUser> {
   const ds = req.dataSource!;
-  const { uid, email } = decodedToken;
+  const uid = decodedToken.uid;
+  const email = decodedToken.email?.toLowerCase();
 
   // firebaseUidでユーザーを検索（テナント内の既存ユーザーは常に許可）
   const existingByUid = await ds.getUserByFirebaseUid(uid);

--- a/services/api/src/routes/shared/users.ts
+++ b/services/api/src/routes/shared/users.ts
@@ -61,7 +61,8 @@ router.get("/admin/users", requireAdmin, async (req: Request, res: Response) => 
  */
 router.post("/admin/users", requireAdmin, async (req: Request, res: Response) => {
   const ds = req.dataSource!;
-  const { email, name, role } = req.body;
+  const { name, role } = req.body;
+  const email = typeof req.body.email === "string" ? req.body.email.toLowerCase().trim() : req.body.email;
 
   if (!email || !EMAIL_REGEX.test(email)) {
     res.status(400).json({ error: "invalid_email", message: "Valid email is required" });


### PR DESCRIPTION
## Summary
- `POST /admin/users` でemailを `toLowerCase().trim()` して保存するよう修正
- `tenant-auth.ts` でFirebase IDトークンのemailを `toLowerCase()` して検索・保存するよう修正
- 大文字混在によるFirestore検索失敗・権限判定ミスを防止

Closes #120

## Test plan
- [x] APIビルド成功
- [x] lint通過
- [x] 全テスト26件PASS
- [ ] 大文字メールでPOST /admin/users → 小文字で保存確認（手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)