### PR TITLE
fix: maxAttempts超過時のセッション残留を防止

### DIFF
--- a/services/api/src/routes/shared/quiz-attempts.ts
+++ b/services/api/src/routes/shared/quiz-attempts.ts
@@ -350,6 +350,13 @@ router.patch("/quiz-attempts/:attemptId", requireUser, async (req: Request, res:
         console.error(`Failed to complete session for attempt ${attemptId}`);
       }
     }
+  } else if (activeSession && quiz.maxAttempts > 0 && attempt.attemptNumber >= quiz.maxAttempts) {
+    // 不合格 + 受験上限到達: セッションを強制退室（残留防止）
+    try {
+      await forceExitSession(ds, activeSession.id, "max_attempts_failed");
+    } catch {
+      console.error(`Failed to force-exit session for max attempts: ${attemptId}`);
+    }
   }
 
   res.json({

--- a/services/api/src/types/entities.ts
+++ b/services/api/src/types/entities.ts
@@ -280,7 +280,7 @@ export interface CourseProgress {
 
 // TODO: "abandoned" はブラウザ終了検出（beforeunload/sendBeacon）で設定予定
 export type LessonSessionStatus = "active" | "completed" | "force_exited" | "abandoned";
-export type SessionExitReason = "quiz_submitted" | "pause_timeout" | "time_limit" | "browser_close";
+export type SessionExitReason = "quiz_submitted" | "pause_timeout" | "time_limit" | "browser_close" | "max_attempts_failed";
 
 export interface LessonSession {
   id: string;

--- a/web/app/[tenant]/admin/analytics/page.tsx
+++ b/web/app/[tenant]/admin/analytics/page.tsx
@@ -109,7 +109,7 @@ type SuspiciousViewingData = {
 };
 
 type AttendanceStatus = "completed" | "force_exited" | "active" | "abandoned";
-type ExitReason = "quiz_submitted" | "pause_timeout" | "time_limit" | "browser_close";
+type ExitReason = "quiz_submitted" | "pause_timeout" | "time_limit" | "browser_close" | "max_attempts_failed";
 
 const ATTENDANCE_STATUS_LABELS: Record<AttendanceStatus, string> = {
   completed: "完了",
@@ -130,6 +130,7 @@ const EXIT_REASON_LABELS: Record<ExitReason, string> = {
   pause_timeout: "一時停止超過",
   time_limit: "時間超過",
   browser_close: "ブラウザ終了",
+  max_attempts_failed: "受験上限(不合格)",
 };
 
 type AttendanceRecord = {

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -88,6 +88,7 @@ const EXIT_REASON_LABELS: Record<string, string> = {
   pause_timeout: "一時停止超過",
   time_limit: "時間制限",
   browser_close: "ブラウザ終了",
+  max_attempts_failed: "受験上限(不合格)",
 };
 
 export default function AttendanceReportPage() {


### PR DESCRIPTION
## Summary
- テスト不合格 + 受験上限到達時に `forceExitSession` で強制退室するよう追加
- `SessionExitReason` 型に `"max_attempts_failed"` を追加
- 出席レポート + 管理者分析画面の退室理由ラベルに「受験上限(不合格)」を追加

Closes #121

## Test plan
- [x] APIビルド成功
- [x] Web型チェック成功
- [x] lint通過
- [x] 全テスト26件PASS（unit 16 + E2E 10）
- [ ] maxAttempts=2のクイズで2回不合格→セッションがforce_exited確認（手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)