### PR TITLE
fix: CSVインポートのallowed_emails追加順序を修正

### DIFF
--- a/services/api/src/routes/shared/users.ts
+++ b/services/api/src/routes/shared/users.ts
@@ -310,17 +310,17 @@ router.post("/admin/users/import", requireAdmin, async (req: Request, res: Respo
     }
 
     try {
+      // allowed_emailsを先に追加（冪等: 既存なら何もしない）
+      const isAllowed = await ds.isEmailAllowed(email);
+      if (!isAllowed) {
+        await ds.createAllowedEmail({ email, note: "CSV import" });
+      }
+
       const user = await ds.createUser({
         email,
         name,
         role: role as "admin" | "teacher" | "student",
       });
-
-      // allowed_emailsにも自動追加
-      const isAllowed = await ds.isEmailAllowed(email);
-      if (!isAllowed) {
-        await ds.createAllowedEmail({ email, note: "CSV import" });
-      }
 
       results.created.push({ email: user.email!, name: user.name, role: user.role });
     } catch {

--- a/web/app/[tenant]/admin/users/page.tsx
+++ b/web/app/[tenant]/admin/users/page.tsx
@@ -324,6 +324,8 @@ export default function UsersPage() {
           <div className="space-y-4">
             <p className="text-sm text-muted-foreground">
               CSV形式: <code>email,name,role</code>（ヘッダー行必須、name/roleは任意）
+              <br />
+              <span className="text-xs">※ 値にカンマや改行を含めないでください。上限500行。</span>
             </p>
             <input
               type="file"


### PR DESCRIPTION
## Summary
- `createAllowedEmail`を`createUser`の前に移動し、ユーザーだけ作成済みでログイン不可になる中間状態を防止
- UIにCSVフォーマット制約（カンマ・改行を含めない旨、上限500行）を追加

Closes #118

## Test plan
- [x] APIビルド成功
- [x] Web型チェック成功
- [x] lint通過
- [x] 全テスト26件PASS（unit 16 + E2E 10）
- [ ] CSVインポート→ユーザー+allowed_emails同時作成確認（手動）
- [ ] UIにフォーマット制約表示確認（手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)