### PR TITLE
test: PATCHバリデーション + セッション終端のテスト補完

### DIFF
--- a/services/api/src/__tests__/integration/attendance-validation.test.ts
+++ b/services/api/src/__tests__/integration/attendance-validation.test.ts
@@ -1,0 +1,105 @@
+/**
+ * 出席レコード編集（PATCH）の入力バリデーションテスト
+ *
+ * super-adminルーターのFirestoreアクセスの前に400が返ることを検証。
+ * Firestoreの初期化が不要なため、バリデーションロジックのみの高速テスト。
+ */
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import supertest from "supertest";
+import express from "express";
+
+// Firebase Admin SDKのモック（super-admin.tsがimport時にgetFirestore()を使うため）
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: vi.fn(() => ({
+    collection: vi.fn(() => ({
+      doc: vi.fn(() => ({
+        get: vi.fn(() => Promise.resolve({ exists: false })),
+      })),
+    })),
+  })),
+}));
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: vi.fn(() => ({
+    verifyIdToken: vi.fn(),
+  })),
+}));
+
+// super-admin認証をバイパス
+vi.mock("../../middleware/super-admin.js", () => ({
+  superAdminAuthMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  getAllSuperAdmins: vi.fn(() => Promise.resolve([])),
+  addSuperAdmin: vi.fn(),
+  removeSuperAdmin: vi.fn(),
+  isSuperAdmin: vi.fn(() => Promise.resolve(false)),
+}));
+
+describe("PATCH /attendance-report/:sessionId バリデーション", () => {
+  let request: ReturnType<typeof supertest>;
+
+  beforeAll(async () => {
+    const { superAdminRouter } = await import("../../routes/super-admin.js");
+    const app = express();
+    app.use(express.json());
+    app.use(superAdminRouter);
+    request = supertest(app);
+  });
+
+  const endpoint = "/tenants/test-tenant/attendance-report/test-session";
+
+  it("不正なentryAt形式で400を返す", async () => {
+    const res = await request.patch(endpoint).send({ entryAt: "not-a-date" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_entryAt");
+  });
+
+  it("不正なexitAt形式で400を返す", async () => {
+    const res = await request.patch(endpoint).send({ exitAt: "2026-03-30" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_exitAt");
+  });
+
+  it("entryAt > exitAtで400を返す", async () => {
+    const res = await request.patch(endpoint).send({
+      entryAt: "2026-03-30T10:00:00.000Z",
+      exitAt: "2026-03-30T09:00:00.000Z",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_time_range");
+  });
+
+  it("quizScoreが負数で400を返す", async () => {
+    const res = await request.patch(endpoint).send({ quizScore: -1 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_quizScore");
+  });
+
+  it("quizScoreが101で400を返す", async () => {
+    const res = await request.patch(endpoint).send({ quizScore: 101 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_quizScore");
+  });
+
+  it("quizScoreがNaNで400を返す", async () => {
+    const res = await request.patch(endpoint).send({ quizScore: "abc" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_quizScore");
+  });
+
+  it("quizPassedが文字列で400を返す", async () => {
+    const res = await request.patch(endpoint).send({ quizPassed: "yes" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_quizPassed");
+  });
+
+  it("正しいISO日時はバリデーションを通過する", async () => {
+    // Firestore側で404になるが、バリデーションは通過する
+    const res = await request.patch(endpoint).send({
+      entryAt: "2026-03-30T01:00:00.000Z",
+      exitAt: "2026-03-30T03:00:00.000Z",
+    });
+    // 404 = バリデーション通過後にFirestoreでsession not found
+    expect(res.status).toBe(404);
+  });
+});

--- a/services/api/src/__tests__/integration/session-quiz-integration.test.ts
+++ b/services/api/src/__tests__/integration/session-quiz-integration.test.ts
@@ -298,4 +298,56 @@ describe("Quiz submission × Session integration", () => {
     expect(activeRes.status).toBe(404);
     expect(activeRes.body.error).toBe("session_expired");
   });
+
+  // =========================================================
+  // 8. maxAttempts到達 + 不合格 → セッションが強制退室される
+  // =========================================================
+  it("maxAttempts到達で不合格の場合セッションがforce_exitedになる", async () => {
+    // maxAttempts=1のクイズを作成
+    const quiz1 = await ds.createQuiz({
+      lessonId,
+      courseId: (await ds.getCourses())[0].id,
+      title: "1回限りテスト",
+      passThreshold: 100, // 100点必要（不正解で必ず不合格）
+      maxAttempts: 1,
+      timeLimitSec: null,
+      randomizeQuestions: false,
+      randomizeAnswers: false,
+      requireVideoCompletion: false,
+      questions: testQuestions,
+    });
+
+    // セッション作成
+    const sessionRes = await studentRequest
+      .post("/lesson-sessions")
+      .send({
+        lessonId,
+        videoId: "dummy-video",
+        sessionToken: "test-token-max-attempts",
+      });
+    expect(sessionRes.status).toBe(201);
+    const sessionId = sessionRes.body.session.id;
+
+    // attempt作成
+    const attemptRes = await studentRequest
+      .post(`/quizzes/${quiz1.id}/attempts`)
+      .send({});
+    expect(attemptRes.status).toBe(201);
+
+    // 不正解で提出（passThreshold=100なので不合格）
+    const submitRes = await studentRequest
+      .patch(`/quiz-attempts/${attemptRes.body.attempt.id}`)
+      .send({
+        answers: { q1: ["q1-b"] }, // 不正解を選択
+      });
+
+    expect(submitRes.status).toBe(200);
+    expect(submitRes.body.attempt.isPassed).toBe(false);
+
+    // セッションがforce_exitedになっていることを確認
+    const session = await ds.getLessonSession(sessionId);
+    expect(session?.status).toBe("force_exited");
+    expect(session?.exitReason).toBe("max_attempts_failed");
+    expect(session?.exitAt).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- 出席レコード編集PATCHの入力バリデーション8テストケース追加
- maxAttempts到達+不合格時のセッションforce_exited検証テスト追加
- QA指摘のテスト債務を解消

## Test plan
- [x] 新規テスト9件PASS
- [x] 全テスト35件PASS（unit 25 + E2E 10）
- [x] lint通過
- [x] APIビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)