### PR TITLE
fix: 分析画面・学生コース一覧のFE-BE型定義不整合を修正

### DIFF
--- a/web/app/[tenant]/admin/analytics/page.tsx
+++ b/web/app/[tenant]/admin/analytics/page.tsx
@@ -35,45 +35,44 @@ type User = {
   email: string;
 };
 
-type CourseProgressEnrollment = {
+type CourseProgressStudent = {
   userId: string;
-  name: string;
+  userName: string;
   email: string;
   completedLessons: number;
   totalLessons: number;
-  progressRate: number; // 0〜100
-  completed: boolean;
+  progressRatio: number; // 0-1
+  isCompleted: boolean;
 };
 
 type CourseProgressData = {
-  courseId: string;
-  courseTitle: string;
-  totalEnrollments: number;
-  completedCount: number;
-  averageProgressRate: number;
-  enrollments: CourseProgressEnrollment[];
+  course: { id: string; name: string };
+  totalStudents: number;
+  completedStudents: number;
+  avgProgressRatio: number;
+  students: CourseProgressStudent[];
 };
 
 type LessonProgress = {
   lessonId: string;
-  lessonTitle: string;
+  lessonTitle: string | null;
   videoCompleted: boolean;
   quizPassed: boolean;
+  lessonCompleted: boolean;
 };
 
 type UserCourseProgress = {
   courseId: string;
-  courseTitle: string;
+  courseName: string | null;
   completedLessons: number;
   totalLessons: number;
-  progressRate: number;
-  completed: boolean;
-  lessons?: LessonProgress[];
+  progressRatio: number; // 0-1
+  isCompleted: boolean;
+  lessonProgresses?: LessonProgress[];
 };
 
 type UserProgressData = {
-  userId: string;
-  userName: string;
+  user: { id: string; name: string; email: string };
   courses: UserCourseProgress[];
 };
 
@@ -327,22 +326,22 @@ function CourseProgressTab() {
           <div className="grid grid-cols-3 gap-4">
             <div className="rounded-md border p-4 space-y-1">
               <p className="text-xs text-muted-foreground">受講者数</p>
-              <p className="text-2xl font-bold">{progressData.totalEnrollments}</p>
+              <p className="text-2xl font-bold">{progressData.totalStudents}</p>
             </div>
             <div className="rounded-md border p-4 space-y-1">
               <p className="text-xs text-muted-foreground">完了者数</p>
-              <p className="text-2xl font-bold">{progressData.completedCount}</p>
+              <p className="text-2xl font-bold">{progressData.completedStudents}</p>
             </div>
             <div className="rounded-md border p-4 space-y-1">
               <p className="text-xs text-muted-foreground">平均進捗率</p>
               <p className="text-2xl font-bold">
-                {Math.round(progressData.averageProgressRate)}%
+                {Math.round(progressData.avgProgressRatio * 100)}%
               </p>
             </div>
           </div>
 
           {/* 受講者テーブル */}
-          {progressData.enrollments.length === 0 ? (
+          {progressData.students.length === 0 ? (
             <EmptyState message="受講者がいません" />
           ) : (
             <Table>
@@ -356,18 +355,18 @@ function CourseProgressTab() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {progressData.enrollments.map((e) => (
+                {progressData.students.map((e) => (
                   <TableRow key={e.userId}>
-                    <TableCell className="font-medium">{e.name}</TableCell>
+                    <TableCell className="font-medium">{e.userName}</TableCell>
                     <TableCell>{e.email}</TableCell>
                     <TableCell>
                       {e.completedLessons} / {e.totalLessons}
                     </TableCell>
                     <TableCell>
-                      <ProgressBar value={e.progressRate} />
+                      <ProgressBar value={e.progressRatio * 100} />
                     </TableCell>
                     <TableCell>
-                      {e.completed ? (
+                      {e.isCompleted ? (
                         <Badge variant="default">完了</Badge>
                       ) : (
                         <Badge variant="secondary">受講中</Badge>
@@ -506,22 +505,22 @@ function UserProgressTab() {
               {progressData.courses.map((course) => (
                 <Fragment key={course.courseId}>
                   <TableRow>
-                    <TableCell className="font-medium">{course.courseTitle}</TableCell>
+                    <TableCell className="font-medium">{course.courseName}</TableCell>
                     <TableCell>
                       {course.completedLessons} / {course.totalLessons}
                     </TableCell>
                     <TableCell>
-                      <ProgressBar value={course.progressRate} />
+                      <ProgressBar value={course.progressRatio * 100} />
                     </TableCell>
                     <TableCell>
-                      {course.completed ? (
+                      {course.isCompleted ? (
                         <Badge variant="default">完了</Badge>
                       ) : (
                         <Badge variant="secondary">受講中</Badge>
                       )}
                     </TableCell>
                     <TableCell>
-                      {course.lessons && course.lessons.length > 0 && (
+                      {course.lessonProgresses && course.lessonProgresses.length > 0 && (
                         <Button
                           variant="ghost"
                           size="sm"
@@ -535,7 +534,7 @@ function UserProgressTab() {
 
                   {/* レッスン詳細行（展開時） */}
                   {expandedCourseIds.has(course.courseId) &&
-                    course.lessons?.map((lesson) => (
+                    course.lessonProgresses?.map((lesson) => (
                       <TableRow
                         key={`${course.courseId}-${lesson.lessonId}`}
                         className="bg-muted/30"

--- a/web/app/[tenant]/student/courses/page.tsx
+++ b/web/app/[tenant]/student/courses/page.tsx
@@ -8,10 +8,10 @@ import { useAuthenticatedFetch } from "@/lib/hooks/use-authenticated-fetch";
 import { useTenant } from "@/lib/tenant-context";
 
 type CourseProgress = {
-  completedLessonCount: number;
-  totalLessonCount: number;
+  completedLessons: number;
+  totalLessons: number;
   progressRatio: number;
-  courseCompleted: boolean;
+  isCompleted: boolean;
 };
 
 type Course = {
@@ -73,14 +73,14 @@ export default function StudentCoursesPage() {
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {courses.map((course) => {
             const progress = course.progress ?? null;
-            const completedCount = progress?.completedLessonCount ?? 0;
-            const totalCount = progress?.totalLessonCount ?? course.lessonCount ?? course.lessonOrder?.length ?? 0;
+            const completedCount = progress?.completedLessons ?? 0;
+            const totalCount = progress?.totalLessons ?? course.lessonOrder?.length ?? 0;
             const progressPercent = progress
               ? Math.round(progress.progressRatio * 100)
               : totalCount > 0
               ? Math.round((completedCount / totalCount) * 100)
               : 0;
-            const isCourseCompleted = progress?.courseCompleted ?? false;
+            const isCourseCompleted = progress?.isCompleted ?? false;
 
             return (
               <Link


### PR DESCRIPTION
## Summary
FE-BE型棚卸しで発見された3箇所の型不整合を修正。不審視聴タブ(PR#122)と同パターン。

### Critical: コース進捗タブ
- `enrollments`→`students`, `totalEnrollments`→`totalStudents`, `averageProgressRate`→`avgProgressRatio`等

### Critical: ユーザー進捗タブ
- `courseTitle`→`courseName`, `progressRate`→`progressRatio`, `completed`→`isCompleted`, `lessons`→`lessonProgresses`

### High: 学生コース一覧
- `completedLessonCount`→`completedLessons`, `totalLessonCount`→`totalLessons`, `courseCompleted`→`isCompleted`

全てFE側の型定義をAPIレスポンスに合わせて修正。`progressRatio`(0-1)は表示時に`*100`でパーセント変換。

Closes #127

## Test plan
- [x] 型チェック成功
- [x] lint通過
- [x] 全テスト35件PASS（unit 25 + E2E 10）
- [ ] コース進捗タブがクラッシュせずデータ表示（手動）
- [ ] ユーザー進捗タブがクラッシュせずデータ表示（手動）
- [ ] 学生コース一覧で進捗が正しく表示（手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)