### PR TITLE
chore: WBS最終クリーンアップ（TZテスト+監査スクリプト）

### DIFF
--- a/scripts/audit-email-case.ts
+++ b/scripts/audit-email-case.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env npx tsx
+/**
+ * メールアドレス大文字小文字監査スクリプト
+ *
+ * 全テナントのusersコレクションとallowed_emailsコレクションをスキャンし、
+ * 大文字を含むメールアドレスを検出する。
+ *
+ * 使用方法:
+ *   GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json npx tsx scripts/audit-email-case.ts
+ *   または:
+ *   npx tsx scripts/audit-email-case.ts  (環境変数が既に設定済みの場合)
+ */
+
+import { initializeApp, cert, type ServiceAccount } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+// Firebase初期化
+const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+if (credPath) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const serviceAccount = require(credPath) as ServiceAccount;
+  initializeApp({ credential: cert(serviceAccount) });
+} else {
+  // Application Default Credentials (Cloud Run等)
+  initializeApp();
+}
+
+const db = getFirestore();
+
+interface Finding {
+  tenantId: string;
+  collection: string;
+  docId: string;
+  email: string;
+  lowered: string;
+}
+
+async function audit() {
+  console.log("=== メールアドレス大文字小文字監査 ===\n");
+
+  const tenantsSnap = await db.collection("tenants").get();
+  console.log(`テナント数: ${tenantsSnap.size}\n`);
+
+  const findings: Finding[] = [];
+
+  for (const tenantDoc of tenantsSnap.docs) {
+    const tenantId = tenantDoc.id;
+
+    // users コレクション
+    const usersSnap = await db.collection(`tenants/${tenantId}/users`).get();
+    for (const userDoc of usersSnap.docs) {
+      const email = userDoc.data().email as string | undefined;
+      if (email && email !== email.toLowerCase()) {
+        findings.push({
+          tenantId,
+          collection: "users",
+          docId: userDoc.id,
+          email,
+          lowered: email.toLowerCase(),
+        });
+      }
+    }
+
+    // allowed_emails コレクション
+    const allowedSnap = await db.collection(`tenants/${tenantId}/allowed_emails`).get();
+    for (const doc of allowedSnap.docs) {
+      const email = doc.data().email as string | undefined;
+      if (email && email !== email.toLowerCase()) {
+        findings.push({
+          tenantId,
+          collection: "allowed_emails",
+          docId: doc.id,
+          email,
+          lowered: email.toLowerCase(),
+        });
+      }
+    }
+  }
+
+  // 結果出力
+  if (findings.length === 0) {
+    console.log("✅ 大文字を含むメールアドレスは見つかりませんでした。\n");
+    console.log("マイグレーション不要です。");
+  } else {
+    console.log(`⚠️  ${findings.length}件の大文字メールを検出:\n`);
+    console.log("テナント\tコレクション\tドキュメントID\tメール\t正規化後");
+    for (const f of findings) {
+      console.log(`${f.tenantId}\t${f.collection}\t${f.docId}\t${f.email}\t${f.lowered}`);
+    }
+    console.log(`\n修正が必要です。--fix オプションで自動修正を実行できます。`);
+  }
+
+  // --fix オプション
+  if (process.argv.includes("--fix") && findings.length > 0) {
+    console.log(`\n--- 修正実行中 (${findings.length}件) ---\n`);
+    for (const f of findings) {
+      const ref = db.collection(`tenants/${f.tenantId}/${f.collection}`).doc(f.docId);
+      await ref.update({ email: f.lowered });
+      console.log(`  ✓ ${f.collection}/${f.docId}: ${f.email} → ${f.lowered}`);
+    }
+    console.log(`\n✅ ${findings.length}件を修正しました。`);
+  }
+}
+
+audit().catch((err) => {
+  console.error("監査に失敗:", err);
+  process.exit(1);
+});

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { isoToDatetimeLocal, datetimeLocalToISO } from "@/lib/tz-helpers";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -58,22 +59,6 @@ type ReportResponse = {
   totalRecords: number;
 };
 
-/** ISO UTC文字列をdatetime-local用のローカル時刻文字列に変換 */
-function isoToDatetimeLocal(iso: string | null): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  const h = String(d.getHours()).padStart(2, "0");
-  const min = String(d.getMinutes()).padStart(2, "0");
-  return `${y}-${m}-${day}T${h}:${min}`;
-}
-
-/** datetime-local値をISO UTC文字列に変換 */
-function datetimeLocalToISO(local: string): string {
-  return new Date(local).toISOString();
-}
 
 function formatTime(iso: string | null): string {
   if (!iso) return "—";

--- a/web/lib/__tests__/tz-helpers.test.ts
+++ b/web/lib/__tests__/tz-helpers.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isoToDatetimeLocal, datetimeLocalToISO } from "../tz-helpers";
+
+describe("isoToDatetimeLocal", () => {
+  it("null を空文字に変換する", () => {
+    expect(isoToDatetimeLocal(null)).toBe("");
+  });
+
+  it("空文字を空文字に変換する", () => {
+    expect(isoToDatetimeLocal("")).toBe("");
+  });
+
+  it("ISO UTC文字列をローカルdatetime-local形式に変換する", () => {
+    // TZをJSTに固定してテスト
+    vi.stubEnv("TZ", "Asia/Tokyo");
+    const result = isoToDatetimeLocal("2026-03-30T01:00:00.000Z");
+    // UTC 01:00 → JST 10:00
+    expect(result).toBe("2026-03-30T10:00");
+  });
+
+  it("日付をまたぐケース（UTC夕方→JST翌日早朝）", () => {
+    vi.stubEnv("TZ", "Asia/Tokyo");
+    const result = isoToDatetimeLocal("2026-03-29T18:00:00.000Z");
+    // UTC 18:00 → JST 翌日 03:00
+    expect(result).toBe("2026-03-30T03:00");
+  });
+});
+
+describe("datetimeLocalToISO", () => {
+  it("datetime-local値をISO UTC文字列に変換する", () => {
+    vi.stubEnv("TZ", "Asia/Tokyo");
+    const result = datetimeLocalToISO("2026-03-30T10:00");
+    // JST 10:00 → UTC 01:00
+    expect(result).toBe("2026-03-30T01:00:00.000Z");
+  });
+
+  it("空文字でRangeErrorをthrowする", () => {
+    expect(() => datetimeLocalToISO("")).toThrow(RangeError);
+  });
+});
+
+describe("ラウンドトリップ", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("ISO → datetime-local → ISO でラウンドトリップが成立する", () => {
+    vi.stubEnv("TZ", "Asia/Tokyo");
+    const original = "2026-03-30T01:00:00.000Z";
+    const local = isoToDatetimeLocal(original);
+    const roundTripped = datetimeLocalToISO(local);
+    expect(roundTripped).toBe(original);
+  });
+
+  it("異なるTZ（UTC）でもラウンドトリップが成立する", () => {
+    vi.stubEnv("TZ", "UTC");
+    const original = "2026-06-15T14:30:00.000Z";
+    const local = isoToDatetimeLocal(original);
+    expect(local).toBe("2026-06-15T14:30");
+    const roundTripped = datetimeLocalToISO(local);
+    expect(roundTripped).toBe(original);
+  });
+});

--- a/web/lib/tz-helpers.ts
+++ b/web/lib/tz-helpers.ts
@@ -1,0 +1,16 @@
+/** ISO UTC文字列をdatetime-local用のローカル時刻文字列に変換 */
+export function isoToDatetimeLocal(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const h = String(d.getHours()).padStart(2, "0");
+  const min = String(d.getMinutes()).padStart(2, "0");
+  return `${y}-${m}-${day}T${h}:${min}`;
+}
+
+/** datetime-local値をISO UTC文字列に変換 */
+export function datetimeLocalToISO(local: string): string {
+  return new Date(local).toISOString();
+}


### PR DESCRIPTION
## Summary
- TZヘルパー関数（`isoToDatetimeLocal`/`datetimeLocalToISO`）を`web/lib/tz-helpers.ts`に抽出しユニットテスト8件を追加
- メールアドレス大文字小文字監査スクリプトをリポジトリに追加
- WBS WP4-1（テスト債務返済）を完了

## Changes
- `web/lib/tz-helpers.ts` — 新規: TZ変換ユーティリティ（attendance/page.tsxから抽出）
- `web/lib/__tests__/tz-helpers.test.ts` — 新規: null/空文字、TZ境界、ラウンドトリップテスト
- `web/app/super/attendance/page.tsx` — ローカル関数をインポートに置換（動作変更なし）
- `scripts/audit-email-case.ts` — 新規: 全テナントの大文字メール検出+修正ツール

## Test plan
- [x] Web全24テストPASS（TZヘルパー8件含む）
- [x] 型チェックPASS
- [ ] CI全ジョブPASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)