### PR TITLE
fix: QA指摘対応（エラーハンドリング・進捗再計算・インデックス）

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -140,6 +140,14 @@
       ]
     },
     {
+      "collectionGroup": "user_progress",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "lessonId", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "course_progress",
       "queryScope": "COLLECTION",
       "fields": [

--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -1066,7 +1066,7 @@ export class FirestoreDataSource implements DataSource {
     return snapshot.docs.map((doc) => this.toLessonSession(doc.id, doc.data()));
   }
 
-  async resetLessonDataForUser(userId: string, lessonId: string, courseId: string): Promise<void> {
+  async resetLessonDataForUser(userId: string, lessonId: string, _courseId: string): Promise<void> {
     // 削除対象ドキュメントを収集
     const docsToDelete: FirebaseFirestore.DocumentReference[] = [];
 
@@ -1121,19 +1121,6 @@ export class FirestoreDataSource implements DataSource {
       }
       await batch.commit();
     }
-
-    // 5. course_progress: 再計算（バッチ外で実行 — 読み取りが必要）
-    const allProgress = await this.getUserProgressByCourse(userId, courseId);
-    const completedCount = allProgress.filter((p) => p.quizPassed).length;
-    const courseLessons = await this.getLessons({ courseId });
-    const totalLessons = courseLessons.length;
-    const progressRatio = totalLessons > 0 ? completedCount / totalLessons : 0;
-    await this.upsertCourseProgress(userId, courseId, {
-      completedLessons: completedCount,
-      totalLessons,
-      progressRatio,
-      isCompleted: totalLessons > 0 && completedCount >= totalLessons,
-    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/services/api/src/datasource/in-memory.ts
+++ b/services/api/src/datasource/in-memory.ts
@@ -949,7 +949,7 @@ export class InMemoryDataSource implements DataSource {
     return this.lessonSessions.filter((s) => s.courseId === courseId);
   }
 
-  async resetLessonDataForUser(userId: string, lessonId: string, courseId: string): Promise<void> {
+  async resetLessonDataForUser(userId: string, lessonId: string, _courseId: string): Promise<void> {
     this.throwIfReadOnly();
 
     // 1. video_analytics: lessonId → videoId → 削除
@@ -974,18 +974,5 @@ export class InMemoryDataSource implements DataSource {
     // 4. user_progress: 削除
     const progressKey = `${userId}_${lessonId}`;
     this.userProgress.delete(progressKey);
-
-    // 5. course_progress: 再計算
-    const allLessonProgress = await this.getUserProgressByCourse(userId, courseId);
-    const completedCount = allLessonProgress.filter((p) => p.quizPassed).length;
-    const course = this.courses.find((c) => c.id === courseId);
-    const totalLessons = course?.lessonOrder?.length ?? 0;
-    const progressRatio = totalLessons > 0 ? completedCount / totalLessons : 0;
-    await this.upsertCourseProgress(userId, courseId, {
-      completedLessons: completedCount,
-      totalLessons,
-      progressRatio,
-      isCompleted: totalLessons > 0 && completedCount >= totalLessons,
-    });
   }
 }

--- a/services/api/src/routes/shared/lesson-sessions.ts
+++ b/services/api/src/routes/shared/lesson-sessions.ts
@@ -128,8 +128,13 @@ router.patch("/lesson-sessions/:sessionId/force-exit", requireUser, async (req: 
     return;
   }
 
-  const exited = await forceExitSession(ds, sessionId, reason);
-  res.json({ session: formatSession(exited) });
+  try {
+    const exited = await forceExitSession(ds, sessionId, reason);
+    res.json({ session: formatSession(exited) });
+  } catch (err) {
+    console.error(`Failed to force-exit session ${sessionId}:`, err);
+    res.status(500).json({ error: "force_exit_failed", message: "セッション終了処理に失敗しました" });
+  }
 });
 
 function formatSession(session: LessonSession) {

--- a/services/api/src/routes/shared/quiz-attempts.ts
+++ b/services/api/src/routes/shared/quiz-attempts.ts
@@ -286,7 +286,11 @@ router.patch("/quiz-attempts/:attemptId", requireUser, async (req: Request, res:
   const activeSession = await ds.getActiveLessonSession(userId, quiz.lessonId);
   if (activeSession) {
     if (!validateSessionDeadline(activeSession)) {
-      await forceExitSession(ds, activeSession.id, "time_limit");
+      try {
+        await forceExitSession(ds, activeSession.id, "time_limit");
+      } catch (err) {
+        console.error(`Failed to force-exit session (time_limit): ${activeSession.id}`, err);
+      }
       res.status(403).json({
         error: "session_time_exceeded",
         message: "入室から2時間が経過したため、セッションが終了しました",

--- a/services/api/src/services/lesson-session.ts
+++ b/services/api/src/services/lesson-session.ts
@@ -5,6 +5,7 @@
 
 import type { DataSource } from "../datasource/interface.js";
 import type { LessonSession, SessionExitReason } from "../types/entities.js";
+import { updateCourseProgress } from "./progress.js";
 
 const SESSION_DURATION_MS = 2 * 60 * 60 * 1000; // 2時間
 
@@ -82,6 +83,9 @@ export async function forceExitSession(
 
   // レッスンの学習データを完全リセット
   await ds.resetLessonDataForUser(session.userId, session.lessonId, session.courseId);
+
+  // コース進捗を再計算（通常ロジックと同一のupdateCourseProgressを使用）
+  await updateCourseProgress(ds, session.userId, session.courseId);
 
   return updated!;
 }


### PR DESCRIPTION
## Summary
PR #134のQAレビュー + Codexセカンドオピニオンで検出された4件を修正。

## QA指摘と対応

| # | 重要度 | 指摘 | 対応 |
|---|--------|------|------|
| 1 | High | quiz-attempts.ts L289 try-catchなし | **修正済み** |
| 2 | High | lesson-sessions.ts L131 try-catchなし | **修正済み** |
| 3 | High | レースコンディション | Issue #135（P2次スプリント） |
| 4 | High | 部分削除リスク | Issue #136（P2次スプリント） |
| 5 | Medium | course_progress再計算が通常ロジックと不整合 | **修正済み** |
| 6 | Medium | user_progressインデックス不足 | **修正済み** |

## Changes
- `quiz-attempts.ts` — forceExitSession(時間超過)にtry-catch追加
- `lesson-sessions.ts` — 手動force-exit APIにtry-catch+500レスポンス追加
- `lesson-session.ts` — リセット後にupdateCourseProgress()を呼び出し（通常ロジックと統一）
- `in-memory.ts` / `firestore.ts` — DataSourceからcourse_progress再計算を除去
- `firestore.indexes.json` — user_progress(userId+lessonId)インデックス追加

## Test plan
- [x] API全311テストPASS
- [x] Web全24テストPASS
- [x] lint / type-check PASS
- [ ] CI全ジョブPASS
- [ ] デプロイ後: `firebase deploy --only firestore:indexes` でインデックス反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)