### PR TITLE
fix: QA指摘対応（エラーハンドリング強化）

### DIFF
--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -1141,7 +1141,8 @@ export class FirestoreDataSource implements DataSource {
       if (lastError) {
         throw new Error(
           `resetLessonDataForUser: batch deletion failed after ${MAX_RETRIES} retries. ` +
-          `${i} of ${docsToDelete.length} docs were already deleted.`
+          `${i} of ${docsToDelete.length} docs were already deleted.`,
+          { cause: lastError }
         );
       }
     }

--- a/services/api/src/routes/shared/quiz-attempts.ts
+++ b/services/api/src/routes/shared/quiz-attempts.ts
@@ -340,20 +340,25 @@ router.patch("/quiz-attempts/:attemptId", requireUser, async (req: Request, res:
   // forceExitSessionが並行実行されていた場合、セッションはforce_exitedになり
   // レッスンデータもリセット済み。この場合、進捗書き込みをスキップする。
   if (activeSession) {
-    const currentSession = await ds.getLessonSession(activeSession.id);
-    if (!currentSession || currentSession.status === "force_exited") {
-      res.status(409).json({
-        error: "session_force_exited",
-        message: "セッションが終了したため、結果は記録されません",
-        attempt: {
-          id: updated!.id,
-          status: updated!.status,
-          score: updated!.score,
-          isPassed: updated!.isPassed,
-          submittedAt: updated!.submittedAt,
-        },
-      });
-      return;
+    try {
+      const currentSession = await ds.getLessonSession(activeSession.id);
+      if (!currentSession || currentSession.status === "force_exited") {
+        res.status(409).json({
+          error: "session_force_exited",
+          message: "セッションが強制終了されたため、進捗には反映されません。再受講が必要です。",
+          attempt: {
+            id: updated!.id,
+            status: updated!.status,
+            score: updated!.score,
+            isPassed: updated!.isPassed,
+            submittedAt: updated!.submittedAt,
+          },
+        });
+        return;
+      }
+    } catch (err) {
+      // セッション再確認失敗時は楽観的に続行（レース検出より提出成功を優先）
+      console.error(`Session re-check failed for session ${activeSession.id}, proceeding:`, err);
     }
   }
 
@@ -370,17 +375,16 @@ router.patch("/quiz-attempts/:attemptId", requireUser, async (req: Request, res:
     if (activeSession) {
       try {
         await completeSession(ds, activeSession.id, updated!.id);
-      } catch {
-        // セッション完了失敗はテスト提出自体をブロックしない
-        console.error(`Failed to complete session for attempt ${attemptId}`);
+      } catch (err) {
+        console.error(`Failed to complete session for attempt ${attemptId}:`, err);
       }
     }
   } else if (activeSession && quiz.maxAttempts > 0 && attempt.attemptNumber >= quiz.maxAttempts) {
     // 不合格 + 受験上限到達: セッションを強制退室（残留防止）
     try {
       await forceExitSession(ds, activeSession.id, "max_attempts_failed");
-    } catch {
-      console.error(`Failed to force-exit session for max attempts: ${attemptId}`);
+    } catch (err) {
+      console.error(`Failed to force-exit session for max attempts ${attemptId}:`, err);
     }
   }
 


### PR DESCRIPTION
## Summary
QAレビュー（Silent Failure Hunter + Codex）で検出された4件のエラーハンドリング問題を修正。

- **CRITICAL**: セッション再確認の`getLessonSession`にtry-catch追加。Firestoreエラー時は楽観的に続行（提出成功を優先）
- **HIGH**: 409メッセージを「進捗には反映されません。再受講が必要です。」に修正（attemptは保存済みである事実と整合）
- **HIGH**: リトライ全失敗時のErrorに`{ cause: lastError }`を追加し元エラー情報を保持
- **MEDIUM**: bare `catch {}`を`catch (err)`に修正し、全catch節でエラーオブジェクトをログ出力

## Test plan
- [x] `npm run test -w @lms-279/api` — 312 tests passed (26 files)
- [x] `npm run type-check` — 全ワークスペースPASS
- [x] `npm run lint` — 0 errors
- [x] 既存のレースコンディションテスト（test #11）が引き続きPASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)