### PR TITLE
fix: E2E CIにshared-types buildステップを追加

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build shared-types
+        run: npm run build -w @lms-279/shared-types
+
       - name: Build API
         run: npm run build -w @lms-279/api
 


### PR DESCRIPTION
## Summary
PR #139でci.ymlにshared-types buildステップを追加したが、e2e.ymlに漏れていた。
E2E CIが`Cannot find module '@lms-279/shared-types'`で失敗していた問題を修正。

## Test plan
- [x] CI (ci.yml): Build/Lint/Test/Type Check全PASS確認
- [ ] E2E CI (e2e.yml): mainマージ後に自動実行されPASSすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)