### PR TITLE
fix: Docker buildでshared-typesワークスペースパッケージを解決できるよう修正

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+node_modules
+**/node_modules
+**/.next
+**/dist
+e2e
+docs
+.github
+.claude
+.vscode
+*.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,9 +72,8 @@ jobs:
         run: gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
 
       - name: Build and push API image
-        working-directory: services/api
         run: |
-          docker build -t ${{ env.ARTIFACT_REGISTRY }}/api:${{ github.sha }} -t ${{ env.ARTIFACT_REGISTRY }}/api:latest .
+          docker build -f services/api/Dockerfile -t ${{ env.ARTIFACT_REGISTRY }}/api:${{ github.sha }} -t ${{ env.ARTIFACT_REGISTRY }}/api:latest .
           docker push ${{ env.ARTIFACT_REGISTRY }}/api:${{ github.sha }}
           docker push ${{ env.ARTIFACT_REGISTRY }}/api:latest
 
@@ -118,9 +117,8 @@ jobs:
         run: gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
 
       - name: Build and push Web image
-        working-directory: web
         run: |
-          docker build \
+          docker build -f web/Dockerfile \
             --build-arg NEXT_PUBLIC_API_URL=https://api-3zcica5euq-an.a.run.app \
             --build-arg NEXT_PUBLIC_AUTH_MODE=firebase \
             --build-arg NEXT_PUBLIC_FIREBASE_API_KEY=${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }} \

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -2,27 +2,29 @@ FROM node:24-slim
 
 WORKDIR /app
 
-# package.jsonとtsconfig.jsonをコピー
-COPY package.json ./
-COPY tsconfig.json ./
+# ワークスペースルート構造をコピー（依存解決に必要）
+COPY package.json package-lock.json ./
+COPY packages/shared-types ./packages/shared-types
+COPY services/api/package.json services/api/tsconfig.json ./services/api/
 
-# 依存関係をインストール
-RUN npm install
+# ワークスペース依存関係をインストール
+RUN npm ci -w @lms-279/shared-types -w @lms-279/api
 
-# ソースコードをコピー
-COPY src ./src
+# shared-typesをビルド（型定義生成）
+RUN npm run build -w @lms-279/shared-types
 
-# TypeScriptをビルド
-RUN npm run build
+# APIソースをコピーしてビルド
+COPY services/api/src ./services/api/src
+RUN npm run build -w @lms-279/api
 
-# 不要なファイルを削除
-RUN rm -rf src node_modules/.cache
+# 不要ファイル削除
+RUN rm -rf services/api/src packages/shared-types/src node_modules/.cache
 
 # 本番用依存関係のみ再インストール
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev -w @lms-279/shared-types -w @lms-279/api
 
-# ポートを公開
+WORKDIR /app/services/api
+
 EXPOSE 8080
 
-# 起動コマンド
 CMD ["node", "dist/index.js"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,10 +2,19 @@ FROM node:24-slim AS builder
 
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install
+# ワークスペースルート構造をコピー（依存解決に必要）
+COPY package.json package-lock.json ./
+COPY packages/shared-types ./packages/shared-types
+COPY web/package.json ./web/
 
-COPY . .
+# ワークスペース依存関係をインストール
+RUN npm ci -w @lms-279/shared-types -w @lms-279/web
+
+# shared-typesをビルド（型定義生成）
+RUN npm run build -w @lms-279/shared-types
+
+# Webソースをコピー
+COPY web/ ./web/
 
 # Build-time env vars for Next.js
 ARG NEXT_PUBLIC_API_URL
@@ -23,7 +32,7 @@ ENV NEXT_PUBLIC_FIREBASE_PROJECT_ID=$NEXT_PUBLIC_FIREBASE_PROJECT_ID
 ENV NEXT_PUBLIC_USER_ID=$NEXT_PUBLIC_USER_ID
 ENV NEXT_PUBLIC_USER_ROLE=$NEXT_PUBLIC_USER_ROLE
 
-RUN npm run build
+RUN npm run build -w @lms-279/web
 
 FROM node:24-slim AS runner
 
@@ -32,7 +41,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 # Copy standalone output - handle different possible structures
-COPY --from=builder /app/.next/standalone ./standalone-temp
+COPY --from=builder /app/web/.next/standalone ./standalone-temp
 
 # Move files to correct location (including hidden dirs like .next)
 RUN if [ -d "standalone-temp/web" ]; then \
@@ -45,10 +54,10 @@ RUN if [ -d "standalone-temp/web" ]; then \
     fi
 
 # Copy static files to .next/static (required for standalone)
-COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/web/.next/static ./.next/static
 
 # Copy public directory from builder (screenshots, etc.)
-COPY --from=builder /app/public ./public
+COPY --from=builder /app/web/public ./public
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary
- `@lms-279/shared-types`導入後、Docker build時の`npm install`がnpmjsレジストリにパッケージを探しに行き404で失敗していた
- Dockerfileのbuildコンテキストをリポジトリルートに変更し、npm workspace構造を認識させた
- `.dockerignore`でビルドコンテキストの肥大化を防止

## 変更ファイル
- `services/api/Dockerfile` — workspace対応に書き換え
- `web/Dockerfile` — builder stageをworkspace対応に
- `.github/workflows/deploy.yml` — `-f Dockerfile .`パターンに変更
- `.dockerignore` — 新規作成

## Test plan
- [ ] CI（型チェック・lint・テスト）が全PASS
- [ ] Deploy to Cloud Runが成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)