### PR TITLE
feat: ブラウザ終了時のセッション放棄検出 (#147)

### DIFF
--- a/services/api/src/__tests__/integration/lesson-session.test.ts
+++ b/services/api/src/__tests__/integration/lesson-session.test.ts
@@ -206,6 +206,26 @@ describe("lesson-session service", () => {
       expect(newSession.id).not.toBe(session.id);
       expect(newSession.status).toBe("active");
     });
+
+    it("throws when session does not exist", async () => {
+      await expect(abandonSession(ds, "nonexistent-id")).rejects.toThrow("not found");
+    });
+
+    it("returns session as-is if already completed (TOCTOU safety)", async () => {
+      const { lesson, video } = await setupLesson();
+      const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
+
+      // テスト送信でセッション完了
+      await ds.updateLessonSession(session.id, {
+        status: "completed",
+        exitAt: new Date().toISOString(),
+        exitReason: "quiz_submitted",
+      });
+
+      // abandonは完了済みセッションを上書きしない
+      const result = await abandonSession(ds, session.id);
+      expect(result.status).toBe("completed");
+    });
   });
 
   describe("handleStaleSession", () => {

--- a/services/api/src/__tests__/integration/session-abandon-endpoint.test.ts
+++ b/services/api/src/__tests__/integration/session-abandon-endpoint.test.ts
@@ -1,0 +1,156 @@
+/**
+ * POST /lesson-sessions/:sessionId/abandon エンドポイントのHTTPレベルテスト
+ *
+ * sendBeacon互換（認証なし）エンドポイントの動作検証:
+ * - 204: activeセッションの正常放棄
+ * - 404: 存在しないセッションID
+ * - 409: 非activeセッション
+ * - 認証ヘッダーなしでもアクセス可能
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import supertest from "supertest";
+import express from "express";
+import cors from "cors";
+import { InMemoryDataSource } from "../../datasource/in-memory.js";
+import { createSharedRouter } from "../../routes/shared/index.js";
+
+describe("POST /lesson-sessions/:sessionId/abandon", () => {
+  let request: ReturnType<typeof supertest>;
+  let ds: InMemoryDataSource;
+  let lessonId: string;
+  let courseId: string;
+  let videoId: string;
+
+  beforeEach(async () => {
+    ds = new InMemoryDataSource({ readOnly: false });
+
+    const course = await ds.createCourse({
+      name: "Test Course",
+      description: null,
+      status: "published",
+      lessonOrder: [],
+      passThreshold: 80,
+      createdBy: "admin",
+    });
+    courseId = course.id;
+
+    const lesson = await ds.createLesson({
+      courseId,
+      title: "Test Lesson",
+      order: 1,
+      hasVideo: true,
+      hasQuiz: true,
+      videoUnlocksPrior: false,
+    });
+    lessonId = lesson.id;
+
+    const video = await ds.createVideo({
+      lessonId,
+      courseId,
+      sourceType: "gcs",
+      gcsPath: "test/video.mp4",
+      durationSec: 300,
+      requiredWatchRatio: 0.95,
+      speedLock: true,
+    });
+    videoId = video.id;
+
+    // 認証なしのアプリ（sendBeacon互換テスト）
+    const app = express();
+    app.use(cors());
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.tenantContext = { tenantId: "test-tenant", isDemo: false };
+      req.dataSource = ds;
+      // req.user を意図的に設定しない（sendBeaconは認証ヘッダーを送れない）
+      next();
+    });
+    app.use(createSharedRouter());
+
+    request = supertest(app);
+  });
+
+  it("returns 204 for an active session (no auth required)", async () => {
+    const session = await ds.createLessonSession({
+      userId: "user1",
+      lessonId,
+      courseId,
+      videoId,
+      sessionToken: "token-1",
+      status: "active",
+      entryAt: new Date().toISOString(),
+      exitAt: null,
+      exitReason: null,
+      deadlineAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+      pauseStartedAt: null,
+      longestPauseSec: 0,
+      sessionVideoCompleted: false,
+      quizAttemptId: null,
+    });
+
+    const res = await request.post(`/lesson-sessions/${session.id}/abandon`);
+    expect(res.status).toBe(204);
+
+    // DBで状態を確認
+    const updated = await ds.getLessonSession(session.id);
+    expect(updated!.status).toBe("abandoned");
+    expect(updated!.exitReason).toBe("browser_close");
+  });
+
+  it("returns 404 for nonexistent session ID", async () => {
+    const res = await request.post("/lesson-sessions/nonexistent-uuid/abandon");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("not_found");
+  });
+
+  it("returns 409 for already completed session", async () => {
+    const session = await ds.createLessonSession({
+      userId: "user1",
+      lessonId,
+      courseId,
+      videoId,
+      sessionToken: "token-1",
+      status: "completed",
+      entryAt: new Date().toISOString(),
+      exitAt: new Date().toISOString(),
+      exitReason: "quiz_submitted",
+      deadlineAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+      pauseStartedAt: null,
+      longestPauseSec: 0,
+      sessionVideoCompleted: true,
+      quizAttemptId: "attempt-1",
+    });
+
+    const res = await request.post(`/lesson-sessions/${session.id}/abandon`);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("session_not_active");
+  });
+
+  it("returns 409 for already abandoned session (idempotency guard)", async () => {
+    const session = await ds.createLessonSession({
+      userId: "user1",
+      lessonId,
+      courseId,
+      videoId,
+      sessionToken: "token-1",
+      status: "active",
+      entryAt: new Date().toISOString(),
+      exitAt: null,
+      exitReason: null,
+      deadlineAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+      pauseStartedAt: null,
+      longestPauseSec: 0,
+      sessionVideoCompleted: false,
+      quizAttemptId: null,
+    });
+
+    // 1回目: 成功
+    const res1 = await request.post(`/lesson-sessions/${session.id}/abandon`);
+    expect(res1.status).toBe(204);
+
+    // 2回目: 409（既にabandoned）
+    const res2 = await request.post(`/lesson-sessions/${session.id}/abandon`);
+    expect(res2.status).toBe(409);
+  });
+});

--- a/services/api/src/routes/shared/lesson-sessions.ts
+++ b/services/api/src/routes/shared/lesson-sessions.ts
@@ -1,10 +1,11 @@
 /**
  * レッスンセッション（出席管理）ルーター
- * 入室打刻・退室打刻・強制退室の管理
+ * 入室打刻・退室打刻・強制退室・放棄の管理
  */
 
 import { Router, Request, Response } from "express";
 import { requireUser } from "../../middleware/auth.js";
+import { logger } from "../../utils/logger.js";
 import type { LessonSession } from "../../types/entities.js";
 import type { LessonSessionResponse } from "@lms-279/shared-types";
 import {
@@ -134,7 +135,7 @@ router.patch("/lesson-sessions/:sessionId/force-exit", requireUser, async (req: 
     const exited = await forceExitSession(ds, sessionId, reason);
     res.json({ session: formatSession(exited) });
   } catch (err) {
-    console.error(`Failed to force-exit session ${sessionId}:`, err);
+    logger.error(`Failed to force-exit session ${sessionId}`, { error: String(err) });
     res.status(500).json({ error: "force_exit_failed", message: "セッション終了処理に失敗しました" });
   }
 });
@@ -145,29 +146,30 @@ router.patch("/lesson-sessions/:sessionId/force-exit", requireUser, async (req: 
  *
  * sendBeaconはカスタムヘッダーを送れないためrequireUserを使わず、
  * セッションID（UUID）の知識を暗黙的な認証とする。
- * セッションIDはセッション作成者のみが知る値であり、
- * abandoned操作は非破壊的（データリセットなし）なためリスクは限定的。
+ * セッションIDはURL上に露出せず推測困難なUUIDであるため、認証なしでも実用上のリスクは低い。
+ * abandoned操作は非破壊的（データリセットなし）かつ冪等性が高いため、
+ * 最悪ケースでもセッションが早期終了するだけに留まる。
  */
 router.post("/lesson-sessions/:sessionId/abandon", async (req: Request, res: Response) => {
   const ds = req.dataSource!;
   const sessionId = req.params.sessionId as string;
 
-  const session = await ds.getLessonSession(sessionId);
-  if (!session) {
-    res.status(404).json({ error: "not_found", message: "Session not found" });
-    return;
-  }
-
-  if (session.status !== "active") {
-    res.status(409).json({ error: "session_not_active", message: "Session is not active" });
-    return;
-  }
-
   try {
+    const session = await ds.getLessonSession(sessionId);
+    if (!session) {
+      res.status(404).json({ error: "not_found", message: "Session not found" });
+      return;
+    }
+
+    if (session.status !== "active") {
+      res.status(409).json({ error: "session_not_active", message: "Session is not active" });
+      return;
+    }
+
     await abandonSession(ds, sessionId);
     res.status(204).end();
   } catch (err) {
-    console.error(`Failed to abandon session ${sessionId}:`, err);
+    logger.error(`Failed to abandon session ${sessionId}`, { error: String(err) });
     res.status(500).json({ error: "abandon_failed", message: "セッション放棄処理に失敗しました" });
   }
 });

--- a/services/api/src/services/lesson-session.ts
+++ b/services/api/src/services/lesson-session.ts
@@ -93,11 +93,21 @@ export async function forceExitSession(
 /**
  * セッションを放棄状態に更新（ブラウザ終了時）
  * forceExitSessionと異なり、学習データのリセットは行わない。
+ * 放棄後、同一ユーザーは同じレッスンで新規セッションを作成可能。
  */
 export async function abandonSession(
   ds: DataSource,
   sessionId: string
 ): Promise<LessonSession> {
+  // TOCTOU対策: 更新前にstatusを再確認（テスト送信による完了との競合防止）
+  const session = await ds.getLessonSession(sessionId);
+  if (!session) {
+    throw new Error(`Session ${sessionId} not found`);
+  }
+  if (session.status !== "active") {
+    return session;
+  }
+
   const updated = await ds.updateLessonSession(sessionId, {
     status: "abandoned",
     exitAt: new Date().toISOString(),

--- a/services/api/src/types/entities.ts
+++ b/services/api/src/types/entities.ts
@@ -278,7 +278,6 @@ export interface CourseProgress {
 // 出席管理（レッスンセッション）
 // ========================================
 
-// TODO: "abandoned" はブラウザ終了検出（beforeunload/sendBeacon）で設定予定
 export type LessonSessionStatus = "active" | "completed" | "force_exited" | "abandoned";
 export type SessionExitReason = "quiz_submitted" | "pause_timeout" | "time_limit" | "browser_close" | "max_attempts_failed";
 

--- a/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -819,14 +819,25 @@ export default function StudentLessonDetailPage() {
   }, [handleForceExit]);
 
   // ブラウザ終了時: sendBeaconでセッション放棄
+  // fetch()はbeforeunloadで中断されるためsendBeaconを使用。
+  // sendBeaconはカスタムヘッダーを送れないため、authFetchを使わず/api/v2パスに直接リクエスト。
+  // モバイルではbeforeunloadが発火しないためvisibilitychangeも併用。
   useEffect(() => {
-    const handleBeforeUnload = () => {
+    const sendAbandon = () => {
       if (!session || session.status !== "active") return;
       const url = `/api/v2/${tenantId}/lesson-sessions/${session.id}/abandon`;
       navigator.sendBeacon(url);
     };
+    const handleBeforeUnload = () => sendAbandon();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") sendAbandon();
+    };
     window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
   }, [session, tenantId]);
 
   // ============================================================


### PR DESCRIPTION
## Summary
- `abandonSession()` サービス関数を追加（`force_exited`と異なり学習データのリセットなし）
- `POST /lesson-sessions/:sessionId/abandon` エンドポイントを追加（sendBeacon互換: requireUser不使用、204レスポンス）
- FEレッスンページに `beforeunload` → `sendBeacon` でセッション放棄を通知するハンドラを追加
- 統合テスト3件追加（abandoned状態遷移、データ非リセット確認、再セッション作成）

## Test plan
- [x] `npm run test -w @lms-279/api` — 316テスト全PASS
- [x] `npm run type-check` — 全ワークスペースPASS
- [x] `npm run lint` — PASS
- [ ] ブラウザでレッスンページを開き、タブを閉じた後にセッションがabandonedになることを確認

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)