### PR TITLE
chore: 実装済みセッション関連TODOコメントを削除

### DIFF
--- a/services/api/src/types/entities.ts
+++ b/services/api/src/types/entities.ts
@@ -293,9 +293,9 @@ export interface LessonSession {
   exitAt: string | null;                  // 退室打刻（テスト送信 or 強制退室時）
   exitReason: SessionExitReason | null;
   deadlineAt: string;                     // entryAt + 2時間
-  pauseStartedAt: string | null;        // TODO: video-eventsルート拡張で更新予定
-  longestPauseSec: number;              // TODO: pause検知サーバーサイドで更新予定
-  sessionVideoCompleted: boolean;       // TODO: video-eventsルートでセッション内完了判定時に更新予定
+  pauseStartedAt: string | null;
+  longestPauseSec: number;
+  sessionVideoCompleted: boolean;
   quizAttemptId: string | null;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary
- `entities.ts`のLessonSession型定義から実装済みTODOコメント3件を削除
- `pauseStartedAt`, `longestPauseSec`, `sessionVideoCompleted`は#147-#149で実装完了済み

## Test plan
- [x] コメント削除のみ、ロジック変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)