### PR TITLE
feat: プレビュー画面に受講生側カスタムプレイヤーを適用

### DIFF
--- a/web/app/super/master/courses/[courseId]/preview/lessons/[lessonId]/page.tsx
+++ b/web/app/super/master/courses/[courseId]/preview/lessons/[lessonId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { VideoPlayer } from "@/components/video/VideoPlayer";
 import { useSuperAdminFetch } from "@/lib/super-api";
 
 // --- Types ---
@@ -81,7 +82,6 @@ export default function LessonPreviewPage() {
   const [videoMeta, setVideoMeta] = useState<VideoMeta | null>(null);
   const [playbackUrl, setPlaybackUrl] = useState<string | null>(null);
   const [videoCompleted, setVideoCompleted] = useState(false);
-  const videoRef = useRef<HTMLVideoElement>(null);
 
   // Quiz
   const [quiz, setQuiz] = useState<Quiz | null>(null);
@@ -280,15 +280,12 @@ export default function LessonPreviewPage() {
           <h2 className="text-lg font-semibold">動画</h2>
           {playbackUrl ? (
             <div className="space-y-3">
-              <div className="relative bg-black rounded-lg overflow-hidden aspect-video">
-                <video
-                  ref={videoRef}
-                  src={playbackUrl}
-                  controls
-                  className="w-full h-full"
-                  onEnded={() => setVideoCompleted(true)}
-                />
-              </div>
+              <VideoPlayer
+                src={playbackUrl}
+                preview
+                speedLock={videoMeta?.speedLock ?? true}
+                onComplete={() => setVideoCompleted(true)}
+              />
               {videoMeta && (
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-muted-foreground">

--- a/web/components/video/VideoPlayer.tsx
+++ b/web/components/video/VideoPlayer.tsx
@@ -5,7 +5,7 @@ import { VideoControls } from "./VideoControls";
 import { VideoEventTracker } from "./VideoEventTracker";
 
 interface VideoPlayerProps {
-  videoId: string;
+  videoId?: string;
   src: string;
   speedLock?: boolean;
   onComplete?: () => void;
@@ -19,6 +19,8 @@ interface VideoPlayerProps {
   fetchFn?: (url: string, options?: RequestInit) => Promise<Response>;
   /** セッショントークン。省略時は内部で生成 */
   sessionToken?: string;
+  /** プレビューモード: イベント送信・タブ離脱検知を無効化 */
+  preview?: boolean;
 }
 
 /** crypto.randomUUID が使えない環境向けフォールバック */
@@ -42,6 +44,7 @@ export function VideoPlayer({
   eventEndpoint,
   fetchFn,
   sessionToken: externalSessionToken,
+  preview = false,
 }: VideoPlayerProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
 
@@ -132,8 +135,9 @@ export function VideoPlayer({
     };
   }, [onComplete, onPlay, onPause]);
 
-  // --- タブ離脱検知 ---
+  // --- タブ離脱検知（プレビューモードでは無効） ---
   useEffect(() => {
+    if (preview) return;
     const handleVisibilityChange = () => {
       if (document.hidden) {
         videoRef.current?.pause();
@@ -143,7 +147,7 @@ export function VideoPlayer({
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, []);
+  }, [preview]);
 
   // --- コントロール自動非表示 ---
   const resetHideTimer = useCallback(() => {
@@ -246,14 +250,16 @@ export function VideoPlayer({
         />
       </div>
 
-      {/* イベントトラッカー（UIなし） */}
-      <VideoEventTracker
-        videoRef={videoRef}
-        videoId={videoId}
-        sessionToken={sessionToken}
-        apiEndpoint={eventEndpoint ?? `/api/v1/videos/${videoId}/events`}
-        fetchFn={fetchFn ?? fetch}
-      />
+      {/* イベントトラッカー（UIなし、プレビューモードでは無効） */}
+      {!preview && videoId && (
+        <VideoEventTracker
+          videoRef={videoRef}
+          videoId={videoId}
+          sessionToken={sessionToken}
+          apiEndpoint={eventEndpoint ?? `/api/v1/videos/${videoId}/events`}
+          fetchFn={fetchFn ?? fetch}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 管理者プレビューのネイティブ`<video>`を`VideoPlayer`コンポーネントに差し替え
- 受講生と同じカスタムUI（コントロールバー、シークバー、音量、フルスクリーン）を表示
- `VideoPlayer`に`preview`モードを追加し、イベント送信・タブ離脱検知を無効化

## Test plan
- [ ] プレビュー画面でカスタムコントロール（再生/一時停止、シークバー、音量、フルスクリーン）が表示される
- [ ] 倍速禁止が動画設定に応じて機能する
- [ ] 動画再生完了後にテストセクションが表示される
- [ ] 「視聴完了にする（プレビュー用）」ボタンが引き続き機能する
- [ ] 受講生側のプレイヤーが従来通り動作する（イベント送信、タブ離脱検知が有効）

🤖 Generated with [Claude Code](https://claude.com/claude-code)