### PR TITLE
fix: createVideoEventsのundefined値によるFirestore 500エラー修正

### DIFF
--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -614,8 +614,11 @@ export class FirestoreDataSource implements DataSource {
     const now = new Date();
 
     docRefs.forEach((docRef, index) => {
+      const event = events[index];
       batch.set(docRef, {
-        ...events[index],
+        ...event,
+        seekFrom: event.seekFrom ?? null,
+        metadata: event.metadata ?? null,
         timestamp: now,
       });
     });


### PR DESCRIPTION
## Summary

動画イベント送信時にFirestoreが500エラーを返すバグを修正。

## Root Cause

`createVideoEvents()` で `batch.set()` にイベントデータをスプレッドする際、オプショナルフィールド（`seekFrom`, `metadata`）が `undefined` のまま渡されていた。Firestoreは `undefined` を値として受け付けないため500エラーが発生。

```
Error: Cannot use "undefined" as a Firestore value (found in field "seekFrom")
```

## Fix

`?? null` でFirestore互換のnull値に変換。

## Test Plan

- [x] npm run build: ビルド成功
- [x] npm test: 全347テストPass
- [ ] デプロイ後: 動画再生→イベント送信で500エラーが解消されること

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)