### PR TITLE
fix: Auth初期化完了前のセッション取得レースコンディション修正

### DIFF
--- a/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -683,7 +683,7 @@ export default function StudentLessonDetailPage() {
   const courseId = params.courseId as string;
   const lessonId = params.lessonId as string;
   const { tenantId } = useTenant();
-  const { authFetch } = useAuthenticatedFetch();
+  const { authFetch, authLoading } = useAuthenticatedFetch();
 
   /**
    * VideoEventTracker の fetchFn シグネチャ (url, options?) => Promise<Response> に合わせるラッパー。
@@ -768,8 +768,9 @@ export default function StudentLessonDetailPage() {
   }, [authFetch, lessonId]);
 
   useEffect(() => {
+    if (authLoading) return;
     fetchActiveSession();
-  }, [fetchActiveSession]);
+  }, [fetchActiveSession, authLoading]);
 
   // 動画初回再生時: セッション作成
   // pendingTokenRefと同じtokenをBEに送信し、VideoPlayerが送るイベントと一致させる


### PR DESCRIPTION
## Summary

受講生画面でページ読み込み時に「認証トークンを取得できませんでした」エラーが発生するレースコンディションを修正。

## Root Cause

`useEffect(() => { fetchActiveSession() }, [])` が Firebase Auth の `onAuthStateChanged` コールバック完了前に実行され、`getIdToken()` が null を返していた。

## Fix

`authLoading` フラグを監視し、Auth 初期化完了後にセッション取得を開始するように変更。

```diff
- useEffect(() => {
-   fetchActiveSession();
- }, [fetchActiveSession]);
+ useEffect(() => {
+   if (authLoading) return;
+   fetchActiveSession();
+ }, [fetchActiveSession, authLoading]);
```

## Test Plan

- [x] npm run build: ビルド成功
- [ ] デプロイ後: ページ読み込み時に「認証トークンを取得できませんでした」エラーが解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)