### PR TITLE
fix: 一時停止オーバーレイで再生ボタンが押せない問題を修正

### DIFF
--- a/web/components/session/PauseTimeoutOverlay.tsx
+++ b/web/components/session/PauseTimeoutOverlay.tsx
@@ -65,7 +65,7 @@ export function PauseTimeoutOverlay({
   const displayTime = `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
 
   return (
-    <div className="absolute inset-0 z-30 flex items-center justify-center bg-black/60">
+    <div className="absolute inset-0 z-30 flex items-center justify-center bg-black/60 pointer-events-none">
       <div className="rounded-lg bg-background/95 px-6 py-4 text-center shadow-lg">
         <p className="text-sm font-medium">
           一時停止中 — 残り {displayTime} で自動退室


### PR DESCRIPTION
## Summary

一時停止中のカウントダウンオーバーレイが動画全体を覆い、再生ボタンがクリックできなくなっていた問題を修正。

## Fix

`pointer-events-none` を追加。オーバーレイは視覚的に表示しつつ、ビデオコントロールへのクリックを通過させる。

## Test Plan

- [x] npm run build: ビルド成功
- [ ] デプロイ後: 一時停止中に再生ボタンをクリックして再開できること
- [ ] カウントダウン表示は引き続き表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)