### PR TITLE
fix: シークイベントタイプ不一致によるvideo events 400エラー修正

### DIFF
--- a/services/api/src/routes/shared/video-events.ts
+++ b/services/api/src/routes/shared/video-events.ts
@@ -20,7 +20,8 @@ const router = Router();
 const VALID_EVENT_TYPES: VideoEventType[] = [
   "play",
   "pause",
-  "seek",
+  "seeking",
+  "seeked",
   "ended",
   "heartbeat",
   "ratechange",

--- a/services/api/src/services/__tests__/video-analytics.test.ts
+++ b/services/api/src/services/__tests__/video-analytics.test.ts
@@ -228,7 +228,7 @@ describe("extractWatchedRangesFromEvents", () => {
     const events = [
       makeEvent("play", 0, 0),
       makeEvent("pause", 10, 10000),
-      makeEvent("seek", 5, 5000),
+      makeEvent("seeked", 5, 5000),
       makeHeartbeat(0, 0),
       makeHeartbeat(3, 3000),
       makeHeartbeat(6, 6000),

--- a/services/api/src/services/video-analytics.ts
+++ b/services/api/src/services/video-analytics.ts
@@ -203,7 +203,7 @@ export function processVideoEvents(
   let speedViolationCountDelta = 0;
 
   for (const event of events) {
-    if (event.eventType === "seek") {
+    if (event.eventType === "seeked") {
       seekCountDelta++;
     } else if (event.eventType === "pause") {
       pauseCountDelta++;

--- a/services/api/src/types/entities.ts
+++ b/services/api/src/types/entities.ts
@@ -124,7 +124,8 @@ export interface Video {
 export type VideoEventType =
   | "play"
   | "pause"
-  | "seek"
+  | "seeking"
+  | "seeked"
   | "ended"
   | "heartbeat"
   | "ratechange"


### PR DESCRIPTION
## Summary

動画シーク操作時にvideo eventsが400 Bad Requestになるバグを修正。FE-BEのイベントタイプ名不一致（FE: `seeking`/`seeked` vs BE: `seek`）が原因。

## Test Plan

- [x] npm run build: 成功
- [x] npm test: 全347テストPass
- [x] npm run type-check: 成功
- [x] npm run lint: 成功
- [ ] デプロイ後: シーク操作で400エラーが解消されること

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)