### PR TITLE
improve: テストゲートに視聴進捗と説明を追加

### DIFF
--- a/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -1105,10 +1105,13 @@ export default function StudentLessonDetailPage() {
           <QuizSection lessonId={lessonId} authFetch={authFetch} />
         ) : (
           /* 動画未完了ゲートメッセージ */
-          <div className="rounded-md border p-6 text-center space-y-2">
-            <p className="text-sm font-medium">テストに挑戦する</p>
-            <p className="text-sm text-muted-foreground">
-              動画を最後まで視聴するとテストに挑戦できます
+          <div className="rounded-md border p-6 space-y-3">
+            <p className="text-sm font-medium text-center">テストに挑戦する</p>
+            <p className="text-sm text-muted-foreground text-center">
+              動画の視聴進捗が95%に達するとテストを受けられます（現在: {coveragePercent}%）
+            </p>
+            <p className="text-xs text-muted-foreground/70 text-center">
+              ※ 飛ばした部分は視聴としてカウントされません。最初から通して視聴してください。
             </p>
           </div>
         )


### PR DESCRIPTION
## Summary

動画を飛ばしてテストにアクセスできない場合、ユーザーが混乱しないように説明を追加。

**Before:** 「動画を最後まで視聴するとテストに挑戦できます」のみ

**After:**
- 「視聴進捗が95%に達するとテストを受けられます（現在: X%）」
- 「※ 飛ばした部分は視聴としてカウントされません。最初から通して視聴してください。」

## Test Plan

- [x] npm run build: 成功
- [ ] デプロイ後: 視聴未完了時にゲートメッセージが正しく表示されること

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)