### PR TITLE
fix: アクティブセッション未存在時に404ではなく200+nullを返す

### DIFF
--- a/services/api/src/routes/shared/lesson-sessions.ts
+++ b/services/api/src/routes/shared/lesson-sessions.ts
@@ -92,7 +92,7 @@ router.get("/lesson-sessions/active", requireUser, async (req: Request, res: Res
 
   const session = await ds.getActiveLessonSession(userId, lessonId);
   if (!session) {
-    res.status(404).json({ error: "no_active_session", message: "No active session found" });
+    res.json({ session: null });
     return;
   }
 


### PR DESCRIPTION
## Summary

強制退室後の再入室時に `GET /lesson-sessions/active` が404を返し、コンソールにエラーが表示されていた。セッション未存在は正常ケースなので `200 + { session: null }` に変更。

## Test Plan

- [x] npm run build / test: 全347テストPass
- [ ] デプロイ後: 再入室時に404エラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)