### PR TITLE
fix: 動画を飛ばしてendedでもテストセクションが表示される問題

### DIFF
--- a/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -906,10 +906,10 @@ export default function StudentLessonDetailPage() {
     }
   }, [videoMeta, fetchAnalytics]);
 
-  // 動画完了コールバック: analytics再取得 + テスト表示フラグを立てる
+  // 動画完了コールバック: analytics再取得し、サーバーが完了と判定した場合のみフラグを立てる
   const handleVideoComplete = useCallback(async () => {
     await fetchAnalytics();
-    setVideoCompleted(true);
+    // fetchAnalytics 内で isComplete === true の場合に setVideoCompleted(true) が呼ばれる
   }, [fetchAnalytics]);
 
   // 動画再生開始: セッション作成


### PR DESCRIPTION
## Summary

動画を飛ばして最後まで行くと `ended` イベントが発火し、`videoCompleted` が無条件で true に設定されていた。結果 QuizSection が表示されるが、サーバー側では coverageRatio 不足で 403 を返す FE-BE 不整合が発生。

## Fix

`handleVideoComplete` から `setVideoCompleted(true)` を削除。`fetchAnalytics()` 内で `isComplete === true` の場合のみ `setVideoCompleted(true)` が呼ばれる既存ロジック（L893）に委譲。

これにより、動画を飛ばした場合は `showQuizSection = false` のままとなり、PR #176 のゲートメッセージ（注意書き付き）が正しく表示される。

## Test Plan

- [x] npm run build: 成功
- [ ] デプロイ後: 動画を飛ばして終わらせた時にテストセクションではなくゲートメッセージが表示されること
- [ ] 正常視聴完了時にはテストセクションが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)