### PR TITLE
improve: テストゲートの注意書きを赤背景で目立たせる

### DIFF
--- a/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -1110,9 +1110,11 @@ export default function StudentLessonDetailPage() {
             <p className="text-sm text-muted-foreground text-center">
               動画を最後まで視聴するとテストに挑戦できます
             </p>
-            <p className="text-xs text-muted-foreground/70 text-center">
-              ※ 飛ばした部分は視聴としてカウントされません。最初から通して視聴してください。
-            </p>
+            <div className="rounded bg-destructive/10 px-3 py-2">
+              <p className="text-xs font-medium text-destructive text-center">
+                飛ばした部分は視聴としてカウントされません。最初から通して視聴してください。
+              </p>
+            </div>
           </div>
         )
       )}


### PR DESCRIPTION
## Summary

飛ばし無効の注意書きが薄いグレーで目立たなかった。赤背景+赤文字で視認性を向上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)