### PR TITLE
fix: 動画完了後のpauseタイムアウトによるデータ全消去を防止 (P0)

### DIFF
--- a/services/api/src/routes/shared/video-events.ts
+++ b/services/api/src/routes/shared/video-events.ts
@@ -160,7 +160,10 @@ router.post("/videos/:videoId/events", requireUser, async (req: Request, res: Re
     });
     return;
   }
-  if (activeSession?.pauseStartedAt) {
+  if (activeSession?.pauseStartedAt && !activeSession.sessionVideoCompleted) {
+    // 動画完了済みセッション（sessionVideoCompleted=true）ではpauseタイムアウトを適用しない。
+    // 動画のendedイベントはHTML5のpause状態を伴うため、完了後の自然なpauseで
+    // 強制退室→データ全消去が発動するのを防止する。
     const pausedMs = Date.now() - new Date(activeSession.pauseStartedAt).getTime();
     if (pausedMs > PAUSE_TIMEOUT_MS) {
       try {

--- a/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -1023,7 +1023,7 @@ export default function StudentLessonDetailPage() {
                   />
                   {session && (
                     <PauseTimeoutOverlay
-                      isPaused={videoPaused}
+                      isPaused={videoPaused && !showQuizSection}
                       onTimeout={handlePauseTimeout}
                     />
                   )}


### PR DESCRIPTION
## Summary
- **P0バグの真の根本原因を修正**: 動画を最後まで正常視聴しても進捗0%・テスト非表示になる問題
- HTML5 videoのendedイベントはpause状態を伴うため、動画完了後にpauseタイムアウト(15分)が発動→`forceExitSession`→学習データ**完全消去**(video_analytics, video_events, user_progress)が起きていた

## 修正内容（2ファイル, +5/-2）
| ファイル | 変更 |
|---------|------|
| `services/api/src/routes/shared/video-events.ts` | `sessionVideoCompleted=true`のセッションではpauseタイムアウト判定をスキップ |
| `web/app/.../page.tsx` | `showQuizSection=true`時はPauseTimeoutOverlayを無効化 |

## なぜPR #186だけでは不十分だったか
PR #186はended時のイベントflushタイミングを修正したが、flushが成功してisComplete=trueになった**後**に、HTML5のpause状態が15分続くとforceExitSessionがデータを全消去していた。

## Test plan
- [x] `npm run type-check` — 全pass
- [x] `npm run lint` — clean
- [x] FE tests — 33 pass
- [x] `npm run build -w @lms-279/web` — 成功
- [ ] **本番QA**: 動画を最初から最後まで再生 → 15分以上放置 → テストセクション表示＋進捗が消えないことを確認

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)