### PR TITLE
fix: PATCH /force-exitでも動画完了済みセッションのデータ消去を防止 (P0)

### DIFF
--- a/services/api/src/routes/shared/lesson-sessions.ts
+++ b/services/api/src/routes/shared/lesson-sessions.ts
@@ -137,6 +137,13 @@ router.patch("/lesson-sessions/:sessionId/force-exit", requireUser, async (req: 
     return;
   }
 
+  // 動画完了済みセッションではpauseタイムアウトによる強制退室を拒否
+  // (HTML5 videoのendedはpause状態を伴うため、完了後の自然なpauseでデータ全消去が発動するのを防止)
+  if (reason === "pause_timeout" && session.sessionVideoCompleted) {
+    res.json({ session: formatSession(session) });
+    return;
+  }
+
   try {
     const exited = await forceExitSession(ds, sessionId, reason);
     res.json({ session: formatSession(exited) });


### PR DESCRIPTION
## Summary
PR #187はPOST /events内のpauseタイムアウトチェックのみ修正したが、FE側のPauseTimeoutOverlay→PATCH /force-exitエンドポイントは無条件でforceExitSession（データ全消去）を呼んでいた。

## 根本原因
forceExitSessionを呼ぶ経路が**2つ**あった:
1. POST /events内のpauseタイムアウトチェック → **PR #187で修正済み**
2. FE PauseTimeoutOverlay → PATCH /force-exit → **未修正だった** ← 今回修正

## 修正（1ファイル, +7行）
`services/api/src/routes/shared/lesson-sessions.ts`: sessionVideoCompleted=trueかつreason=pause_timeoutの場合、force-exitを拒否

## Test plan
- [x] type-check pass
- [x] lint clean
- [ ] 本番QA: 動画を最後まで再生→テスト表示確認

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)