### PR TITLE
fix: forceExitSession自体で動画完了済みデータのリセットを防止 (P0)

### DIFF
--- a/services/api/src/services/lesson-session.ts
+++ b/services/api/src/services/lesson-session.ts
@@ -94,11 +94,13 @@ export async function forceExitSession(
     exitReason: reason,
   });
 
-  // レッスンの学習データを完全リセット
-  await ds.resetLessonDataForUser(session.userId, session.lessonId, session.courseId);
-
-  // コース進捗を再計算（通常ロジックと同一のupdateCourseProgressを使用）
-  await updateCourseProgress(ds, session.userId, session.courseId);
+  // 動画完了済みセッションでは学習データをリセットしない。
+  // HTML5 videoのendedはpause状態を伴うため、完了後のpauseタイムアウトや
+  // ページリロード等でデータが全消去されるのを防止する。
+  if (!session.sessionVideoCompleted) {
+    await ds.resetLessonDataForUser(session.userId, session.lessonId, session.courseId);
+    await updateCourseProgress(ds, session.userId, session.courseId);
+  }
 
   return updated!;
 }


### PR DESCRIPTION
## Summary
PR #187, #188 では個別の呼び出し経路にガードを入れていたが、forceExitSessionを呼ぶ経路が多数あり（POST /events, PATCH /force-exit, handleStaleSession等）モグラ叩きになっていた。

**根本修正**: `forceExitSession`関数自体で`sessionVideoCompleted=true`なら`resetLessonDataForUser`をスキップ。

## 修正（1ファイル, +7/-5）
`services/api/src/services/lesson-session.ts`

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)