### PR TITLE
fix: heartbeat1個バッチで視聴区間が生成されない根本原因を修正 (P0)

### DIFF
--- a/services/api/src/services/__tests__/video-analytics.test.ts
+++ b/services/api/src/services/__tests__/video-analytics.test.ts
@@ -247,12 +247,12 @@ describe("extractWatchedRangesFromEvents", () => {
     expect(result).toEqual([{ start: 0, end: 10 }]);
   });
 
-  it("heartbeatが1件のみ → 区間長さ0なので新規rangesに追加されない", () => {
+  it("heartbeatが1件のみ → 直前5秒の視聴区間として生成される", () => {
     const events = [makeHeartbeat(5, 0)] as VideoEvent[];
 
     const result = extractWatchedRangesFromEvents(events, []);
-    // rangeStart=5, rangeEnd=5 → rangeEnd > rangeStart が false なので追加されない
-    expect(result).toEqual([]);
+    // heartbeat1個: position=5 → {start: 0, end: 5} として生成
+    expect(result).toEqual([{ start: 0, end: 5 }]);
   });
 
   it("clientTimestampでソートされていないheartbeatも正しく処理される", () => {

--- a/services/api/src/services/video-analytics.ts
+++ b/services/api/src/services/video-analytics.ts
@@ -66,17 +66,20 @@ export function extractWatchedRangesFromEvents(
       rangeEnd = curr.position;
     } else {
       // 不連続 → 現在の区間を確定して新しい区間を開始
-      if (rangeEnd > rangeStart) {
-        newRanges.push({ start: rangeStart, end: rangeEnd });
+      // rangeEnd === rangeStartの場合（heartbeat1個の区間）も、直前5秒の視聴としてレンジ生成
+      if (rangeEnd >= rangeStart) {
+        const start = rangeEnd === rangeStart ? Math.max(0, rangeStart - 5) : rangeStart;
+        newRanges.push({ start, end: rangeEnd });
       }
       rangeStart = curr.position;
       rangeEnd = curr.position;
     }
   }
 
-  // 最後の区間を追加
-  if (rangeEnd > rangeStart) {
-    newRanges.push({ start: rangeStart, end: rangeEnd });
+  // 最後の区間を追加（heartbeat1個の区間も含む）
+  if (rangeEnd >= rangeStart) {
+    const start = rangeEnd === rangeStart ? Math.max(0, rangeStart - 5) : rangeStart;
+    newRanges.push({ start, end: rangeEnd });
   }
 
   // endedイベントのpositionで最終レンジを拡張（末尾数秒のギャップを閉じる）


### PR DESCRIPTION
## 根本原因
5秒バッチ間隔と5秒heartbeat間隔が同期すると各バッチにheartbeat1個。
extractWatchedRangesFromEventsのrangeEnd > rangeStart条件で全て捨てられ、
coverageRatio=0のまま。これが「イベント全て200 OKなのに進捗0%」の真の原因。

## 修正
heartbeat1個の場合はposition-5〜positionの区間を生成。

Closes #185
🤖 Generated with [Claude Code](https://claude.com/claude-code)