### PR TITLE
fix: 管理画面ロールガード追加・/internalページ本番除外

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -8,6 +8,9 @@ NEXT_PUBLIC_API_URL=http://localhost:8080
 NEXT_PUBLIC_USER_ID=admin-dev
 NEXT_PUBLIC_USER_ROLE=admin
 
+# Internal portal page (dev only, do not set in production)
+# NEXT_PUBLIC_INTERNAL_PAGE_ENABLED=true
+
 # Firebase Auth (required when AUTH_MODE=firebase)
 # NEXT_PUBLIC_FIREBASE_API_KEY=
 # NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=

--- a/web/app/[tenant]/admin/layout.tsx
+++ b/web/app/[tenant]/admin/layout.tsx
@@ -1,21 +1,76 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useTenant } from "@/lib/tenant-context";
+import { useAuth } from "@/lib/auth-context";
+import { useAuthFetch } from "@/lib/auth-fetch-context";
 import { cn } from "@/lib/utils";
 
 /**
  * テナント対応管理者レイアウト
- * LMS管理メニューのサブナビゲーションを提供
+ * adminロール以外はテナントトップにリダイレクト
  */
 export default function TenantAdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const { tenantId } = useTenant();
+  const { tenantId, isDemo } = useTenant();
+  const { user, loading: authLoading } = useAuth();
+  const authFetch = useAuthFetch();
+  const router = useRouter();
   const pathname = usePathname();
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    // デモモードはガードなし
+    if (isDemo) {
+      setAuthorized(true);
+      return;
+    }
+
+    if (!user) {
+      setAuthorized(false);
+      return;
+    }
+
+    const checkAccess = async () => {
+      try {
+        const data = await authFetch<{ user?: { role?: string }; isSuperAdminAccess?: boolean }>("/auth/me");
+        const role = data.user?.role;
+        // admin のみ許可（スーパー管理者は tenant-auth で role="admin" に上書き済み）
+        setAuthorized(role === "admin");
+      } catch {
+        setAuthorized(false);
+      }
+    };
+
+    checkAccess();
+  }, [authFetch, user, authLoading, isDemo]);
+
+  useEffect(() => {
+    if (authorized === false) {
+      router.replace(`/${tenantId}`);
+    }
+  }, [authorized, router, tenantId]);
+
+  // ローディング中
+  if (authorized === null) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <div className="size-8 rounded-full border-4 border-muted border-t-primary animate-spin" />
+      </div>
+    );
+  }
+
+  // 権限なし（リダイレクト中）
+  if (!authorized) {
+    return null;
+  }
 
   const navItems = [
     { href: `/${tenantId}/admin`, label: "ダッシュボード", exact: true },

--- a/web/app/[tenant]/layout.tsx
+++ b/web/app/[tenant]/layout.tsx
@@ -55,7 +55,7 @@ function TenantNav({ isSuperAdminAccess }: { isSuperAdminAccess: boolean }) {
     fetchUserRole();
   }, [authFetch, user, authLoading, isDemo]);
 
-  const isAdmin = role === "admin" || role === "teacher" || isSuperAdminAccess;
+  const isAdmin = role === "admin" || isSuperAdminAccess;
 
   // ナビリンクを決定
   // - 管理画面にいる場合: 「受講者向け」を表示

--- a/web/app/[tenant]/page.tsx
+++ b/web/app/[tenant]/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { useTenant } from "@/lib/tenant-context";
 import { useAuth } from "@/lib/auth-context";
+import { useAuthFetch } from "@/lib/auth-fetch-context";
 
 const AUTH_MODE = process.env.NEXT_PUBLIC_AUTH_MODE ?? "dev";
 
@@ -14,6 +16,22 @@ const AUTH_MODE = process.env.NEXT_PUBLIC_AUTH_MODE ?? "dev";
 export default function TenantPage() {
   const { tenantId, isDemo } = useTenant();
   const { user, loading, error, signInWithGoogle } = useAuth();
+  const authFetch = useAuthFetch();
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    if (loading || (!user && !isDemo)) return;
+    const fetchRole = async () => {
+      try {
+        const data = await authFetch<{ user?: { role?: string }; isSuperAdminAccess?: boolean }>("/auth/me");
+        const role = data.user?.role;
+        setIsAdmin(role === "admin" || !!data.isSuperAdminAccess);
+      } catch {
+        setIsAdmin(false);
+      }
+    };
+    fetchRole();
+  }, [authFetch, user, loading, isDemo]);
 
   // Firebase認証モードで未ログインの場合はログイン画面を表示
   if (AUTH_MODE === "firebase" && !isDemo && !user && !loading) {
@@ -66,12 +84,14 @@ export default function TenantPage() {
           >
             受講者として学習を開始
           </Link>
-          <Link
-            href={`/${tenantId}/admin`}
-            className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
-          >
-            管理画面
-          </Link>
+          {isAdmin && (
+            <Link
+              href={`/${tenantId}/admin`}
+              className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+            >
+              管理画面
+            </Link>
+          )}
         </div>
 
         {isDemo && (

--- a/web/app/internal/page.tsx
+++ b/web/app/internal/page.tsx
@@ -1,3 +1,4 @@
+import { notFound } from "next/navigation";
 import Link from "next/link";
 import {
   Monitor,
@@ -283,7 +284,14 @@ const features: Feature[] = [
 
 // ─── ページ ─────────────────────────────────
 
+const INTERNAL_PAGE_ENABLED =
+  process.env.NEXT_PUBLIC_INTERNAL_PAGE_ENABLED === "true";
+
 export default function InternalPortalPage() {
+  if (!INTERNAL_PAGE_ENABLED) {
+    notFound();
+  }
+
   return (
     <>
       {/* Header */}


### PR DESCRIPTION
## Summary
- admin/layout.tsxにロールガード追加（adminロール以外はテナントトップにリダイレクト）
- TenantNav・テナントトップページからteacherのadmin扱いを除外（API側`requireAdmin`と一致）
- /internalページを`NEXT_PUBLIC_INTERNAL_PAGE_ENABLED`環境変数で本番除外（未設定時は404）

Closes #196, Closes #197

## Test plan
- [ ] adminロールで`/{tenantId}/admin`にアクセス → 管理画面が表示される
- [ ] studentロールで`/{tenantId}/admin`をURL直接入力 → テナントトップにリダイレクト
- [ ] teacherロールで`/{tenantId}/admin`をURL直接入力 → テナントトップにリダイレクト
- [ ] teacherロールでテナントトップ → 「管理画面」ボタンが非表示
- [ ] スーパー管理者で`/{tenantId}/admin`にアクセス → 管理画面が表示される
- [ ] `/internal`に`NEXT_PUBLIC_INTERNAL_PAGE_ENABLED`未設定でアクセス → 404
- [ ] `/internal`に`NEXT_PUBLIC_INTERNAL_PAGE_ENABLED=true`でアクセス → 正常表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)