### PR TITLE
fix: 動画視聴パイプラインにビジネスロジックログを追加

### DIFF
--- a/services/api/src/routes/shared/video-events.ts
+++ b/services/api/src/routes/shared/video-events.ts
@@ -131,6 +131,13 @@ router.post("/videos/:videoId/events", requireUser, async (req: Request, res: Re
     }
   }
 
+  // イベント受信ログ
+  const eventTypes = events.reduce((acc: Record<string, number>, e: { eventType: string }) => {
+    acc[e.eventType] = (acc[e.eventType] || 0) + 1;
+    return acc;
+  }, {});
+  logger.info("Video events received", { userId, videoId, eventCount: events.length, eventTypes });
+
   // 2. 動画取得（durationSec, requiredWatchRatio取得）
   const video = await ds.getVideoById(videoId);
   if (!video) {
@@ -244,6 +251,14 @@ router.post("/videos/:videoId/events", requireUser, async (req: Request, res: Re
       const isComplete = coverageRatio >= video.requiredWatchRatio;
       return { ...analyticsUpdate, isComplete };
     });
+    logger.info("Video analytics updated", {
+      userId, videoId,
+      coverageRatio: updatedAnalytics.coverageRatio,
+      isComplete: updatedAnalytics.isComplete,
+      watchedRangesCount: updatedAnalytics.watchedRanges?.length ?? 0,
+      totalWatchTimeSec: updatedAnalytics.totalWatchTimeSec,
+      requiredWatchRatio: video.requiredWatchRatio,
+    });
   } catch (err) {
     logger.error("Failed to update video analytics", {
       error: err instanceof Error ? err : String(err),
@@ -260,6 +275,12 @@ router.post("/videos/:videoId/events", requireUser, async (req: Request, res: Re
 
   // 8. 進捗更新: isComplete=true になった場合
   if (isComplete) {
+    logger.info("Video completed - updating progress", {
+      userId, videoId, lessonId: video.lessonId,
+      coverageRatio: updatedAnalytics.coverageRatio,
+      requiredWatchRatio: video.requiredWatchRatio,
+    });
+
     const lesson = await ds.getLessonById(video.lessonId);
     if (lesson) {
       // テストなしレッスンの場合、quizPassed=trueとして完了扱い
@@ -268,11 +289,16 @@ router.post("/videos/:videoId/events", requireUser, async (req: Request, res: Re
         videoCompleted: true,
         quizPassed: quizPassed ? true : undefined,
       });
+      logger.info("Lesson progress updated", {
+        userId, lessonId: lesson.id, courseId: lesson.courseId,
+        videoCompleted: true, quizPassed,
+      });
     }
 
     // セッション内動画視聴完了フラグを更新（step 3.5で取得済みのセッションを再利用）
     if (activeSession && !activeSession.sessionVideoCompleted) {
       await ds.updateLessonSession(activeSession.id, { sessionVideoCompleted: true });
+      logger.info("Session video completed", { sessionId: activeSession.id, userId, videoId });
     }
   }
 

--- a/services/api/src/routes/shared/videos.ts
+++ b/services/api/src/routes/shared/videos.ts
@@ -12,6 +12,7 @@ import {
   deleteVideoFile,
 } from "../../services/gcs.js";
 import { checkVideoAccess } from "../../services/enrollment.js";
+import { logger } from "../../utils/logger.js";
 
 const router = Router();
 
@@ -257,6 +258,10 @@ router.get("/videos/:videoId/playback-url", requireUser, async (req: Request, re
     res.status(500).json({ error: "invalid_video_source", message: "Video source is not properly configured" });
     return;
   }
+
+  logger.info("Playback URL issued", {
+    userId, videoId, sourceType: video.sourceType, lessonId: video.lessonId,
+  });
 
   res.json({
     playbackUrl,

--- a/services/api/src/services/video-analytics.ts
+++ b/services/api/src/services/video-analytics.ts
@@ -5,6 +5,7 @@
  */
 
 import type { VideoEvent, VideoAnalytics, WatchedRange, SuspiciousFlag } from "../types/entities.js";
+import { logger } from "../utils/logger.js";
 
 /**
  * 視聴区間をマージ（重複排除）
@@ -253,6 +254,16 @@ export function processVideoEvents(
   };
 
   const updatedSuspiciousFlags = detectSuspiciousFlags(analyticsForDetection, events);
+
+  if (updatedSuspiciousFlags.length > 0) {
+    logger.warn("Suspicious activity detected", {
+      userId: base.userId, videoId: base.videoId,
+      flags: updatedSuspiciousFlags,
+      seekCount: updatedSeekCount,
+      pauseCount: updatedPauseCount,
+      speedViolationCount: updatedSpeedViolationCount,
+    });
+  }
 
   // isComplete判定はcaller側で requiredWatchRatio と比較して行う
   return {


### PR DESCRIPTION
## Summary
- video-events.ts: イベント受信（件数・種別）、analytics計算結果（coverageRatio, isComplete）、videoCompleted遷移、レッスン進捗更新、セッション完了のログ追加
- video-analytics.ts: 不審行動検出時のwarnログ追加（flags, seekCount等の詳細付き）
- videos.ts: playback-url発行ログ追加

これにより本番Cloud Loggingで以下が追跡可能になる:
- 動画再生開始〜完了の全フロー
- coverageRatioの推移とvideoCompleted判定の根拠
- 不審行動の検出タイミングと詳細

Closes #199

## Test plan
- [x] type-check PASS
- [x] lint PASS
- [x] API 363テスト PASS、Web 33テスト PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)