### PR TITLE
feat: 動画視聴中にプログレスバーをリアルタイム更新

### DIFF
--- a/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -1043,6 +1043,7 @@ export default function StudentLessonDetailPage() {
                     fetchFn={eventFetchFn}
                     onComplete={handleVideoComplete}
                     onEndedFlush={setAnalyticsFromFlush}
+                    onAnalyticsUpdate={setAnalyticsFromFlush}
                     onPlay={handleVideoPlay}
                     onPause={handleVideoPause}
                     sessionToken={session?.sessionToken ?? pendingTokenRef.current}

--- a/web/components/video/VideoEventTracker.tsx
+++ b/web/components/video/VideoEventTracker.tsx
@@ -29,6 +29,7 @@ interface VideoEventTrackerProps {
   apiEndpoint: string;
   fetchFn: (url: string, options?: RequestInit) => Promise<Response>;
   onEndedFlush?: (analytics: FlushAnalytics | null) => void;
+  onAnalyticsUpdate?: (analytics: FlushAnalytics) => void;
 }
 
 const BATCH_INTERVAL_MS = 5000;
@@ -42,6 +43,7 @@ export function VideoEventTracker({
   apiEndpoint,
   fetchFn,
   onEndedFlush,
+  onAnalyticsUpdate,
 }: VideoEventTrackerProps) {
   const eventQueueRef = useRef<VideoEvent[]>([]);
   const lastHeartbeatTimeRef = useRef<number>(-1);
@@ -190,8 +192,11 @@ export function VideoEventTracker({
 
   // 5秒間隔バッチ送信（ADR-021）
   useEffect(() => {
-    batchIntervalRef.current = setInterval(() => {
-      drainQueue();
+    batchIntervalRef.current = setInterval(async () => {
+      const result = await drainQueue();
+      if (result && onAnalyticsUpdate) {
+        onAnalyticsUpdate(result);
+      }
     }, BATCH_INTERVAL_MS);
 
     return () => {
@@ -200,7 +205,7 @@ export function VideoEventTracker({
         batchIntervalRef.current = null;
       }
     };
-  }, [drainQueue]);
+  }, [drainQueue, onAnalyticsUpdate]);
 
   // ページ離脱時にnavigator.sendBeaconで未送信イベントを送信
   useEffect(() => {

--- a/web/components/video/VideoPlayer.tsx
+++ b/web/components/video/VideoPlayer.tsx
@@ -23,6 +23,8 @@ interface VideoPlayerProps {
   preview?: boolean;
   /** ended時にイベントflush後のサーバー確認済みanalyticsを受け取るコールバック */
   onEndedFlush?: (analytics: FlushAnalytics | null) => void;
+  /** 5秒バッチ送信ごとのanalytics更新コールバック */
+  onAnalyticsUpdate?: (analytics: FlushAnalytics) => void;
 }
 
 /** crypto.randomUUID が使えない環境向けフォールバック */
@@ -48,6 +50,7 @@ export function VideoPlayer({
   sessionToken: externalSessionToken,
   preview = false,
   onEndedFlush,
+  onAnalyticsUpdate,
 }: VideoPlayerProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
 
@@ -266,6 +269,7 @@ export function VideoPlayer({
           apiEndpoint={eventEndpoint ?? `/api/v1/videos/${videoId}/events`}
           fetchFn={fetchFn ?? fetch}
           onEndedFlush={onEndedFlush}
+          onAnalyticsUpdate={onAnalyticsUpdate}
         />
       )}
     </div>

--- a/web/lib/hooks/use-video-completion.ts
+++ b/web/lib/hooks/use-video-completion.ts
@@ -77,13 +77,20 @@ export function useVideoCompletion({
 
   const setAnalyticsFromFlush = useCallback(
     (flush: { isComplete: boolean; coverageRatio: number } | null) => {
-      if (flush?.isComplete) {
+      if (!flush) {
+        // flush失敗時はfetchAnalyticsにフォールバック
+        fetchAnalytics();
+        return;
+      }
+      if (flush.isComplete) {
         setVideoCompleted(true);
       }
-      // flush失敗時はfetchAnalyticsにフォールバック
-      if (!flush) {
-        fetchAnalytics();
-      }
+      // coverageRatioをリアルタイム反映
+      setAnalytics((prev) =>
+        prev
+          ? { ...prev, coverageRatio: flush.coverageRatio, isComplete: flush.isComplete }
+          : prev
+      );
     },
     [fetchAnalytics]
   );


### PR DESCRIPTION
## Summary
- 5秒間隔のイベント送信レスポンスに含まれるcoverageRatioを視聴進捗プログレスバーにリアルタイム反映
- 追加のAPIコールなし（既存のバッチ送信レスポンスを活用）

## 変更内容
| ファイル | 変更 |
|---------|------|
| `VideoEventTracker.tsx` | `onAnalyticsUpdate` コールバック追加、5秒バッチレスポンスで呼び出し |
| `VideoPlayer.tsx` | `onAnalyticsUpdate` prop パススルー |
| `use-video-completion.ts` | `setAnalyticsFromFlush` で coverageRatio をstateに反映 |
| `page.tsx` (lesson) | `onAnalyticsUpdate={setAnalyticsFromFlush}` を追加 |

Closes #201

## Test plan
- [ ] 動画再生中に視聴進捗プログレスバーが5秒ごとに更新されること
- [ ] 動画完了時に100%に到達すること
- [ ] プレビューモードではイベント送信されないこと（既存動作維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)