### PR TITLE
fix: コース詳細ページの進捗表示がAPI型不一致で未反映

### DIFF
--- a/services/api/src/routes/shared/progress.ts
+++ b/services/api/src/routes/shared/progress.ts
@@ -20,39 +20,39 @@ router.get("/courses/:courseId/progress", requireUser, async (req: Request, res:
   const userId = req.user!.id;
   const courseId = req.params.courseId as string;
 
-  const progress = await ds.getCourseProgress(userId, courseId);
-
-  if (!progress) {
-    // 進捗未開始の場合はデフォルト値を返す
-    const course = await ds.getCourseById(courseId);
-    if (!course) {
-      res.status(404).json({ error: "not_found", message: "Course not found" });
-      return;
-    }
-    res.json({
-      progress: {
-        userId,
-        courseId,
-        completedLessons: 0,
-        totalLessons: course.lessonOrder.length,
-        progressRatio: 0,
-        isCompleted: false,
-        updatedAt: null,
-      },
-    });
+  const course = await ds.getCourseById(courseId);
+  if (!course) {
+    res.status(404).json({ error: "not_found", message: "Course not found" });
     return;
   }
 
+  const [courseProgress, userProgresses] = await Promise.all([
+    ds.getCourseProgress(userId, courseId),
+    ds.getUserProgressByCourse(userId, courseId),
+  ]);
+
+  const lessonProgresses = userProgresses.map((p) => ({
+    lessonId: p.lessonId,
+    videoCompleted: p.videoCompleted,
+    quizPassed: p.quizPassed,
+    lessonCompleted: p.lessonCompleted,
+  }));
+
   res.json({
-    progress: {
-      userId: progress.userId,
-      courseId: progress.courseId,
-      completedLessons: progress.completedLessons,
-      totalLessons: progress.totalLessons,
-      progressRatio: progress.progressRatio,
-      isCompleted: progress.isCompleted,
-      updatedAt: progress.updatedAt,
-    },
+    courseProgress: courseProgress
+      ? {
+          completedLessonCount: courseProgress.completedLessons,
+          totalLessonCount: courseProgress.totalLessons,
+          progressRatio: courseProgress.progressRatio,
+          courseCompleted: courseProgress.isCompleted,
+        }
+      : {
+          completedLessonCount: 0,
+          totalLessonCount: course.lessonOrder.length,
+          progressRatio: 0,
+          courseCompleted: false,
+        },
+    lessonProgresses,
   });
 });
 


### PR DESCRIPTION
## Summary
GET /courses/:courseId/progress のレスポンスがFE側の型（CourseProgressData）と不一致で、レッスン進捗が全て「未開始」と表示されていた。

### 原因
- APIは `progress` キーでコース進捗のみ返していた
- FEは `courseProgress` キー + `lessonProgresses[]` を期待していた
- フィールド名も不一致（`completedLessons` vs `completedLessonCount` 等）

### 修正
- APIレスポンスを `courseProgress` + `lessonProgresses[]` 形式に変更
- `getUserProgressByCourse()` でレッスン進捗を一括取得して返却

Closes #203

## Test plan
- [ ] コース詳細ページで動画視聴完了済みレッスンが「進行中」or「完了」と表示される
- [ ] 未開始レッスンが「未開始」と表示される
- [ ] コース全体の進捗バーが正しいパーセンテージで表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)