### PR TITLE
fix: 視聴完了時のプログレスバーを100%表示に修正

### DIFF
--- a/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/web/app/[tenant]/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -924,7 +924,7 @@ export default function StudentLessonDetailPage() {
   // ============================================================
 
   const coveragePercent = analytics
-    ? Math.round(analytics.coverageRatio * 100)
+    ? (analytics.isComplete ? 100 : Math.round(analytics.coverageRatio * 100))
     : 0;
 
   // ============================================================


### PR DESCRIPTION
## Summary
視聴完了（isComplete=true）時、プログレスバーが95%のまま「視聴完了」バッジが表示されていた。
isComplete=true の場合は表示上100%にする。内部判定のrequiredWatchRatio(0.95)は技術的安全マージンとして維持。

Closes: N/A（UX改善）

## Test plan
- [ ] 動画視聴完了後、プログレスバーが100%・「視聴完了」バッジが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)