### PR TITLE
fix: quiz attempt作成をFirestoreトランザクションで原子化

### DIFF
--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -894,6 +894,56 @@ export class FirestoreDataSource implements DataSource {
     return this.toQuizAttempt(doc.id, doc.data()!);
   }
 
+  async createQuizAttemptAtomic(
+    quizId: string, userId: string, maxAttempts: number, timeLimitSec: number | null,
+    data: Omit<QuizAttempt, "id" | "attemptNumber">
+  ): Promise<{ attempt: QuizAttempt; existing: boolean } | null> {
+    return this.db.runTransaction(async (tx) => {
+      // センチネルドキュメントでドキュメントレベルロックを確保
+      const lockRef = this.collection("quiz_attempt_locks").doc(`${quizId}_${userId}`);
+      await tx.get(lockRef);
+
+      // 全attemptを取得してin_progressチェック + attemptNumber採番
+      const snapshot = await tx.get(
+        this.collection("quiz_attempts")
+          .where("quizId", "==", quizId)
+          .where("userId", "==", userId)
+          .orderBy("startedAt", "desc")
+      );
+      const attempts = snapshot.docs.map((doc) => this.toQuizAttempt(doc.id, doc.data()));
+
+      // in_progress チェック（タイムアウト自動クリア含む）
+      const inProgress = attempts.find((a) => a.status === "in_progress");
+      if (inProgress) {
+        const isTimedOut = timeLimitSec && inProgress.startedAt &&
+          (Date.now() - new Date(inProgress.startedAt).getTime()) > timeLimitSec * 1000;
+        if (isTimedOut) {
+          const docRef = this.collection("quiz_attempts").doc(inProgress.id);
+          tx.update(docRef, { status: "timed_out", submittedAt: new Date().toISOString() });
+        } else {
+          return { attempt: inProgress, existing: true };
+        }
+      }
+
+      // maxAttempts チェック（0は無制限）
+      const nonTimedOutCount = attempts.filter((a) => a.status !== "timed_out" || a === inProgress).length;
+      if (maxAttempts > 0 && nonTimedOutCount >= maxAttempts) {
+        return null;
+      }
+
+      const attemptNumber = attempts.length + 1;
+      const newDocRef = this.collection("quiz_attempts").doc();
+      const attemptData = { ...data, attemptNumber };
+      tx.create(newDocRef, attemptData);
+      tx.set(lockRef, { quizId, userId, updatedAt: new Date() });
+
+      return {
+        attempt: this.toQuizAttempt(newDocRef.id, attemptData),
+        existing: false,
+      };
+    });
+  }
+
   async updateQuizAttempt(
     id: string,
     data: Partial<Omit<QuizAttempt, "id">>

--- a/services/api/src/datasource/in-memory.ts
+++ b/services/api/src/datasource/in-memory.ts
@@ -820,6 +820,38 @@ export class InMemoryDataSource implements DataSource {
     return attempt;
   }
 
+  async createQuizAttemptAtomic(
+    quizId: string, userId: string, maxAttempts: number, timeLimitSec: number | null,
+    data: Omit<QuizAttempt, "id" | "attemptNumber">
+  ): Promise<{ attempt: QuizAttempt; existing: boolean } | null> {
+    this.throwIfReadOnly();
+    const existing = this.quizAttempts.filter((a) => a.quizId === quizId && a.userId === userId);
+
+    const inProgress = existing.find((a) => a.status === "in_progress");
+    if (inProgress) {
+      const isTimedOut = timeLimitSec && inProgress.startedAt &&
+        (Date.now() - new Date(inProgress.startedAt).getTime()) > timeLimitSec * 1000;
+      if (isTimedOut) {
+        inProgress.status = "timed_out";
+        inProgress.submittedAt = new Date().toISOString();
+      } else {
+        return { attempt: inProgress, existing: true };
+      }
+    }
+
+    if (maxAttempts > 0 && existing.length >= maxAttempts) {
+      return null;
+    }
+
+    const attempt: QuizAttempt = {
+      ...data,
+      attemptNumber: existing.length + 1,
+      id: InMemoryDataSource.uniqueId("quiz-attempt"),
+    };
+    this.quizAttempts.push(attempt);
+    return { attempt, existing: false };
+  }
+
   async updateQuizAttempt(
     id: string,
     data: Partial<Omit<QuizAttempt, "id">>

--- a/services/api/src/datasource/interface.ts
+++ b/services/api/src/datasource/interface.ts
@@ -166,6 +166,16 @@ export interface DataSource {
   getQuizAttempts(filter: QuizAttemptFilter): Promise<QuizAttempt[]>;
   getQuizAttemptById(id: string): Promise<QuizAttempt | null>;
   createQuizAttempt(data: Omit<QuizAttempt, "id">): Promise<QuizAttempt>;
+  /**
+   * quiz attempt作成をトランザクションで保護（原子的操作）
+   * - in_progress attemptが既に存在する場合は作成しない（既存attemptを返す）
+   * - maxAttemptsを超える場合はnullを返す
+   * - attemptNumberをトランザクション内で正確に採番
+   */
+  createQuizAttemptAtomic(
+    quizId: string, userId: string, maxAttempts: number, timeLimitSec: number | null,
+    data: Omit<QuizAttempt, "id" | "attemptNumber">
+  ): Promise<{ attempt: QuizAttempt; existing: boolean } | null>;
   updateQuizAttempt(id: string, data: Partial<Omit<QuizAttempt, "id">>): Promise<QuizAttempt | null>;
 
   // User Progress

--- a/services/api/src/routes/shared/quiz-attempts.ts
+++ b/services/api/src/routes/shared/quiz-attempts.ts
@@ -197,9 +197,22 @@ router.post("/quizzes/:quizId/attempts", requireUser, async (req: Request, res: 
     return;
   }
 
-  // 受験回数チェック（maxAttempts=0は無制限）
-  const attempts = await ds.getQuizAttempts({ quizId, userId });
-  if (quiz.maxAttempts > 0 && attempts.length >= quiz.maxAttempts) {
+  // 原子的にattempt作成（in_progress一意性 + attemptNumber採番 + maxAttemptsチェック）
+  const result = await ds.createQuizAttemptAtomic(
+    quizId, userId, quiz.maxAttempts, quiz.timeLimitSec,
+    {
+      quizId,
+      userId,
+      status: "in_progress",
+      answers: {},
+      score: null,
+      isPassed: null,
+      startedAt: new Date().toISOString(),
+      submittedAt: null,
+    }
+  );
+
+  if (result === null) {
     res.status(403).json({
       error: "max_attempts_exceeded",
       message: "受験可能な回数の上限に達しています",
@@ -207,40 +220,15 @@ router.post("/quizzes/:quizId/attempts", requireUser, async (req: Request, res: 
     return;
   }
 
-  // 進行中のattemptチェック（同時受験禁止）
-  const inProgress = attempts.find((a) => a.status === "in_progress");
-  if (inProgress) {
-    // タイムアウト済みのin_progressは自動クリア
-    const isTimedOut = quiz.timeLimitSec && inProgress.startedAt &&
-      (Date.now() - new Date(inProgress.startedAt).getTime()) > quiz.timeLimitSec * 1000;
-    if (isTimedOut) {
-      await ds.updateQuizAttempt(inProgress.id, {
-        status: "timed_out" as "in_progress" | "submitted" | "timed_out",
-        submittedAt: new Date().toISOString(),
-      });
-    } else {
-      res.status(409).json({
-        error: "attempt_in_progress",
-        message: "現在進行中のテストがあります。先に提出してください",
-      });
-      return;
-    }
+  if (result.existing) {
+    res.status(409).json({
+      error: "attempt_in_progress",
+      message: "現在進行中のテストがあります。先に提出してください",
+    });
+    return;
   }
 
-  const attemptNumber = attempts.length + 1;
-
-  const attempt = await ds.createQuizAttempt({
-    quizId,
-    userId,
-    attemptNumber,
-    status: "in_progress",
-    answers: {},
-    score: null,
-    isPassed: null,
-    startedAt: new Date().toISOString(),
-    submittedAt: null,
-  });
-
+  const attempt = result.attempt;
   res.status(201).json({
     attempt: {
       id: attempt.id,


### PR DESCRIPTION
## Summary
- quiz attempt 作成の並行リクエストによる重複 attempt 作成を防止（#207）
- `createQuizAttemptAtomic` メソッドを追加: センチネルドキュメント + Firestore トランザクションで in_progress 一意性・maxAttempts チェック・attemptNumber 採番を原子的に実行
- ルーター側の非原子的な read-then-write パターンを置換

## Test plan
- [x] `npm run type-check` PASS
- [x] `npm run test` 33 tests PASS
- [x] `npm run lint` PASS
- [ ] 並行リクエストで重複 attempt が作成されないこと（手動テスト）
- [ ] in_progress 既存時に 409 エラーが返ること
- [ ] maxAttempts 超過時に 403 エラーが返ること

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)