### PR TITLE
fix: useVideoCompletionのラッチ削除 + E2Eテストnullガード

### DIFF
--- a/e2e/tests/attendance-api.spec.ts
+++ b/e2e/tests/attendance-api.spec.ts
@@ -89,7 +89,9 @@ test.describe.serial("出席管理 E2E テスト", () => {
     );
     if (res.status() === 200) {
       const { session } = await res.json();
-      await request.post(`${API_BASE}/lesson-sessions/${session.id}/abandon`);
+      if (session) {
+        await request.post(`${API_BASE}/lesson-sessions/${session.id}/abandon`);
+      }
     }
   });
 

--- a/web/lib/hooks/__tests__/use-video-completion.test.ts
+++ b/web/lib/hooks/__tests__/use-video-completion.test.ts
@@ -175,8 +175,8 @@ describe("useVideoCompletion", () => {
     expect(result.current.showQuizSection).toBe(false);
   });
 
-  // 8. videoCompleted=trueは一度立ったら戻らない（one-way latch）
-  it("does not revert videoCompleted once set to true", async () => {
+  // 8. fetchAnalyticsでサーバー値に追従（isComplete=false→videoCompleted=false）
+  it("reverts videoCompleted when server returns isComplete=false", async () => {
     // 初回: 完了
     mockAuthFetch.mockResolvedValueOnce(makeAnalytics({ isComplete: true }));
 
@@ -205,9 +205,9 @@ describe("useVideoCompletion", () => {
       expect(result.current.loadingAnalytics).toBe(false);
     });
 
-    // videoCompletedはtrueのまま（リバートしない）
-    expect(result.current.videoCompleted).toBe(true);
-    expect(result.current.showQuizSection).toBe(true);
+    // サーバー値に追従してvideoCompleted=falseに戻る
+    expect(result.current.videoCompleted).toBe(false);
+    expect(result.current.showQuizSection).toBe(false);
   });
 
   // 9. videoId変更時に新しいvideoIdでfetchが走る

--- a/web/lib/hooks/use-video-completion.ts
+++ b/web/lib/hooks/use-video-completion.ts
@@ -55,9 +55,8 @@ export function useVideoCompletion({
         `/api/v1/videos/${videoId}/analytics`
       );
       setAnalytics(data.analytics);
-      if (data.analytics.isComplete) {
-        setVideoCompleted(true);
-      }
+      // サーバー値を正として追従（ラッチしない）
+      setVideoCompleted(data.analytics.isComplete);
     } catch {
       // 分析取得失敗はサイレント（メイン機能ではない）
     } finally {


### PR DESCRIPTION
## Summary
- **#210**: `useVideoCompletion` の one-way latch を削除。`fetchAnalytics` でサーバー値（`isComplete`）に追従するよう変更。運用上のデータ補正後に UI が正しく反映される
- **#211**: E2E `attendance-api.spec.ts` の `beforeEach` で `session === null` のガード追加。CI の `TypeError: Cannot read properties of null` を修正

## Test plan
- [x] `npm run type-check` PASS
- [x] `npm run test` 33 tests PASS（テスト8番を更新済み）
- [ ] E2E テストが CI で全 PASS すること

Closes #210
Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)