### PR TITLE
fix: 受講期間管理ページのコース一覧が表示されない問題を修正

### DIFF
--- a/web/app/super/enrollments/page.tsx
+++ b/web/app/super/enrollments/page.tsx
@@ -92,10 +92,10 @@ export default function EnrollmentsPage() {
     superFetch<{ tenants: Tenant[] }>(`/api/v2/super/tenants/${selectedTenant}`)
       .then(async () => {
         // テナントのコース一覧は共有ルート経由で取得
-        const res = await superFetch<Course[]>(
+        const res = await superFetch<{ courses: Course[] }>(
           `/api/v2/${selectedTenant}/courses`
         );
-        setCourses(Array.isArray(res) ? res : []);
+        setCourses(Array.isArray(res.courses) ? res.courses : []);
       })
       .catch(() => setCourses([]));
   }, [selectedTenant, superFetch]);


### PR DESCRIPTION
## Summary
- 受講期間管理ページでテナント選択後にコースプルダウンが空になる問題を修正
- 原因: コース一覧API が `{ courses: [...] }` を返すのに、FE側が配列直接（`Course[]`）を期待していた
- `superFetch<{ courses: Course[] }>` に修正し `res.courses` を参照

## Test plan
- [x] `npm run type-check` PASS
- [ ] テナント選択後にコースプルダウンにコースが表示されること
- [ ] コース選択後に「新規登録」「一括登録」ボタンが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)