### PR TITLE
refactor: 受講期間管理を個人単位→テナント×コース単位に変更

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -14,7 +14,7 @@
 | `notification_policies` | 通知ポリシー |
 | `notification_logs` | 通知ログ |
 | `auth_error_logs` | 認証エラーログ |
-| `enrollments` | 受講登録 |
+| `course_enrollment_settings` | 受講期間設定（テナント×コース単位） |
 
 ### 新規コレクション
 
@@ -162,13 +162,12 @@ questions配列の各要素:
 | createdAt | Timestamp | 作成日時 |
 | updatedAt | Timestamp | 更新日時 |
 
-#### enrollments/{userId_courseId}（受講期間管理）
+#### course_enrollment_settings/{courseId}（受講期間設定 — テナント×コース単位）
 | フィールド | 型 | 説明 |
 |-----------|------|------|
-| userId | string | ユーザーID |
 | courseId | string | コースID |
 | enrolledAt | string | 受講開始日（スーパー管理者が設定） |
-| quizAccessUntil | string | テスト受験期限（デフォルト: enrolledAt + 2ヶ月） |
-| videoAccessUntil | string | 動画視聴期限（デフォルト: enrolledAt + 1年） |
+| quizAccessUntil | string | テスト受験期限（enrolledAt + 2ヶ月、自動計算） |
+| videoAccessUntil | string | 動画視聴期限（enrolledAt + 1年、自動計算） |
 | createdBy | string | 設定したスーパー管理者のメールアドレス |
 | updatedAt | string | 更新日時 |

--- a/packages/shared-types/src/enrollment.ts
+++ b/packages/shared-types/src/enrollment.ts
@@ -1,27 +1,8 @@
-export interface EnrollmentResponse {
-  id: string;
-  userId: string;
+export interface CourseEnrollmentSettingResponse {
   courseId: string;
   enrolledAt: string;
   quizAccessUntil: string;
   videoAccessUntil: string;
   createdBy: string;
   updatedAt: string;
-}
-
-export interface CreateEnrollmentRequest {
-  userId: string;
-  courseId: string;
-  enrolledAt: string;
-}
-
-export interface UpdateEnrollmentRequest {
-  quizAccessUntil?: string;
-  videoAccessUntil?: string;
-}
-
-export interface BulkCreateEnrollmentRequest {
-  userIds: string[];
-  courseId: string;
-  enrolledAt: string;
 }

--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -35,7 +35,7 @@ import type {
   UserProgress,
   CourseProgress,
   LessonSession,
-  Enrollment,
+  CourseEnrollmentSetting,
 } from "../types/entities.js";
 
 // Firestore Timestampを Date に変換
@@ -1284,58 +1284,35 @@ export class FirestoreDataSource implements DataSource {
     }
   }
 
-  // Enrollments (受講期間管理)
+  // Course Enrollment Settings (テナント単位の受講期間管理)
 
-  async getEnrollment(userId: string, courseId: string): Promise<Enrollment | null> {
-    const docId = `${userId}_${courseId}`;
-    const doc = await this.collection("enrollments").doc(docId).get();
+  async getCourseEnrollmentSetting(courseId: string): Promise<CourseEnrollmentSetting | null> {
+    const doc = await this.collection("course_enrollment_settings").doc(courseId).get();
     if (!doc.exists) return null;
-    return this.toEnrollment(docId, doc.data()!);
+    return this.toCourseEnrollmentSetting(doc.id, doc.data()!);
   }
 
-  async getEnrollmentsByCourse(courseId: string): Promise<Enrollment[]> {
-    const snapshot = await this.collection("enrollments")
-      .where("courseId", "==", courseId)
-      .get();
-    return snapshot.docs.map((doc) => this.toEnrollment(doc.id, doc.data()));
+  async getCourseEnrollmentSettings(): Promise<CourseEnrollmentSetting[]> {
+    const snapshot = await this.collection("course_enrollment_settings").get();
+    return snapshot.docs.map((doc) => this.toCourseEnrollmentSetting(doc.id, doc.data()));
   }
 
-  async getEnrollmentsByUser(userId: string): Promise<Enrollment[]> {
-    const snapshot = await this.collection("enrollments")
-      .where("userId", "==", userId)
-      .get();
-    return snapshot.docs.map((doc) => this.toEnrollment(doc.id, doc.data()));
-  }
-
-  async upsertEnrollment(data: Omit<Enrollment, "id" | "updatedAt">): Promise<Enrollment> {
-    const docId = `${data.userId}_${data.courseId}`;
-    const docRef = this.collection("enrollments").doc(docId);
-    const doc = await docRef.get();
-
-    if (doc.exists) {
-      await applyUpdate(docRef, data as unknown as Record<string, unknown>);
-    } else {
-      await docRef.set({
-        ...data,
-        updatedAt: new Date(),
-      });
-    }
-
+  async upsertCourseEnrollmentSetting(data: Omit<CourseEnrollmentSetting, "id" | "updatedAt">): Promise<CourseEnrollmentSetting> {
+    const docRef = this.collection("course_enrollment_settings").doc(data.courseId);
+    await docRef.set({ ...data, updatedAt: new Date() }, { merge: true });
     const updated = await docRef.get();
-    return this.toEnrollment(docId, updated.data()!);
+    return this.toCourseEnrollmentSetting(updated.id, updated.data()!);
   }
 
-  async deleteEnrollment(userId: string, courseId: string): Promise<void> {
-    const docId = `${userId}_${courseId}`;
-    await this.collection("enrollments").doc(docId).delete();
+  async deleteCourseEnrollmentSetting(courseId: string): Promise<void> {
+    await this.collection("course_enrollment_settings").doc(courseId).delete();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private toEnrollment(id: string, data: any): Enrollment {
+  private toCourseEnrollmentSetting(id: string, data: any): CourseEnrollmentSetting {
     return {
       id,
-      userId: data.userId,
-      courseId: data.courseId,
+      courseId: data.courseId ?? id,
       enrolledAt: toDate(data.enrolledAt).toISOString(),
       quizAccessUntil: toDate(data.quizAccessUntil).toISOString(),
       videoAccessUntil: toDate(data.videoAccessUntil).toISOString(),

--- a/services/api/src/datasource/in-memory.ts
+++ b/services/api/src/datasource/in-memory.ts
@@ -35,7 +35,7 @@ import type {
   UserProgress,
   CourseProgress,
   LessonSession,
-  Enrollment,
+  CourseEnrollmentSetting,
 } from "../types/entities.js";
 
 // デモ用初期データ
@@ -203,7 +203,7 @@ export class InMemoryDataSource implements DataSource {
   private userProgress: Map<string, UserProgress> = new Map();
   private courseProgress: Map<string, CourseProgress> = new Map();
   private lessonSessions: LessonSession[] = [];
-  private enrollments = new Map<string, Enrollment>();
+  private courseEnrollmentSettings = new Map<string, CourseEnrollmentSetting>();
 
   private readonly readOnly: boolean;
 
@@ -1033,36 +1033,29 @@ export class InMemoryDataSource implements DataSource {
     this.userProgress.delete(progressKey);
   }
 
-  // Enrollments (受講期間管理)
+  // Course Enrollment Settings (テナント単位の受講期間管理)
 
-  async getEnrollment(userId: string, courseId: string): Promise<Enrollment | null> {
-    const key = `${userId}_${courseId}`;
-    return this.enrollments.get(key) ?? null;
+  async getCourseEnrollmentSetting(courseId: string): Promise<CourseEnrollmentSetting | null> {
+    return this.courseEnrollmentSettings.get(courseId) ?? null;
   }
 
-  async getEnrollmentsByCourse(courseId: string): Promise<Enrollment[]> {
-    return Array.from(this.enrollments.values()).filter((e) => e.courseId === courseId);
+  async getCourseEnrollmentSettings(): Promise<CourseEnrollmentSetting[]> {
+    return Array.from(this.courseEnrollmentSettings.values());
   }
 
-  async getEnrollmentsByUser(userId: string): Promise<Enrollment[]> {
-    return Array.from(this.enrollments.values()).filter((e) => e.userId === userId);
-  }
-
-  async upsertEnrollment(data: Omit<Enrollment, "id" | "updatedAt">): Promise<Enrollment> {
+  async upsertCourseEnrollmentSetting(data: Omit<CourseEnrollmentSetting, "id" | "updatedAt">): Promise<CourseEnrollmentSetting> {
     this.throwIfReadOnly();
-    const key = `${data.userId}_${data.courseId}`;
-    const enrollment: Enrollment = {
+    const setting: CourseEnrollmentSetting = {
       ...data,
-      id: key,
+      id: data.courseId,
       updatedAt: new Date().toISOString(),
     };
-    this.enrollments.set(key, enrollment);
-    return enrollment;
+    this.courseEnrollmentSettings.set(data.courseId, setting);
+    return setting;
   }
 
-  async deleteEnrollment(userId: string, courseId: string): Promise<void> {
+  async deleteCourseEnrollmentSetting(courseId: string): Promise<void> {
     this.throwIfReadOnly();
-    const key = `${userId}_${courseId}`;
-    this.enrollments.delete(key);
+    this.courseEnrollmentSettings.delete(courseId);
   }
 }

--- a/services/api/src/datasource/interface.ts
+++ b/services/api/src/datasource/interface.ts
@@ -25,14 +25,14 @@ import type {
   UserProgress,
   CourseProgress,
   LessonSession,
-  Enrollment,
+  CourseEnrollmentSetting,
 } from "../types/entities.js";
 
 export type { CourseFilter, LessonFilter, Video, VideoEvent, VideoAnalytics, VideoFilter, VideoEventFilter, WatchedRange, SuspiciousFlag } from "../types/entities.js";
 export type { Quiz, QuizAttempt, QuizFilter, QuizAttemptFilter, QuizQuestion, QuizOption, QuestionType, QuizAttemptStatus } from "../types/entities.js";
 export type { UserProgress, CourseProgress } from "../types/entities.js";
 export type { LessonSession, LessonSessionFilter, LessonSessionStatus, SessionExitReason } from "../types/entities.js";
-export type { Enrollment } from "../types/entities.js";
+export type { CourseEnrollmentSetting } from "../types/entities.js";
 
 export interface NotificationPolicyFilter {
   scope?: "global" | "course" | "user";
@@ -208,12 +208,11 @@ export interface DataSource {
   // Lesson Data Reset (force exit)
   resetLessonDataForUser(userId: string, lessonId: string, courseId: string): Promise<void>;
 
-  // Enrollments (受講期間管理)
-  getEnrollment(userId: string, courseId: string): Promise<Enrollment | null>;
-  getEnrollmentsByCourse(courseId: string): Promise<Enrollment[]>;
-  getEnrollmentsByUser(userId: string): Promise<Enrollment[]>;
-  upsertEnrollment(data: Omit<Enrollment, "id" | "updatedAt">): Promise<Enrollment>;
-  deleteEnrollment(userId: string, courseId: string): Promise<void>;
+  // Course Enrollment Settings (テナント単位の受講期間管理)
+  getCourseEnrollmentSetting(courseId: string): Promise<CourseEnrollmentSetting | null>;
+  getCourseEnrollmentSettings(): Promise<CourseEnrollmentSetting[]>;
+  upsertCourseEnrollmentSetting(data: Omit<CourseEnrollmentSetting, "id" | "updatedAt">): Promise<CourseEnrollmentSetting>;
+  deleteCourseEnrollmentSetting(courseId: string): Promise<void>;
 }
 
 /**

--- a/services/api/src/routes/shared/quiz-attempts.ts
+++ b/services/api/src/routes/shared/quiz-attempts.ts
@@ -187,8 +187,8 @@ router.post("/quizzes/:quizId/attempts", requireUser, async (req: Request, res: 
   }
 
   // 受講期間チェック
-  const enrollment = await ds.getEnrollment(userId, quiz.courseId);
-  const quizAccessResult = checkQuizAccess(enrollment);
+  const enrollmentSetting = await ds.getCourseEnrollmentSetting(quiz.courseId);
+  const quizAccessResult = checkQuizAccess(enrollmentSetting);
   if (!quizAccessResult.allowed) {
     res.status(403).json({
       error: quizAccessResult.reason,

--- a/services/api/src/routes/shared/video-events.ts
+++ b/services/api/src/routes/shared/video-events.ts
@@ -146,8 +146,8 @@ router.post("/videos/:videoId/events", requireUser, async (req: Request, res: Re
   }
 
   // 2.5. 受講期間チェック
-  const enrollment = await ds.getEnrollment(userId, video.courseId);
-  const videoAccessResult = checkVideoAccess(enrollment);
+  const enrollmentSetting = await ds.getCourseEnrollmentSetting(video.courseId);
+  const videoAccessResult = checkVideoAccess(enrollmentSetting);
   if (!videoAccessResult.allowed) {
     res.status(403).json({
       error: videoAccessResult.reason,

--- a/services/api/src/routes/shared/videos.ts
+++ b/services/api/src/routes/shared/videos.ts
@@ -238,8 +238,8 @@ router.get("/videos/:videoId/playback-url", requireUser, async (req: Request, re
   }
 
   // 受講期間チェック
-  const enrollment = await ds.getEnrollment(userId, video.courseId);
-  const videoAccessResult = checkVideoAccess(enrollment);
+  const enrollmentSetting = await ds.getCourseEnrollmentSetting(video.courseId);
+  const videoAccessResult = checkVideoAccess(enrollmentSetting);
   if (!videoAccessResult.allowed) {
     res.status(403).json({
       error: videoAccessResult.reason,

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -11,7 +11,7 @@
 
 import { Router, Request, Response } from "express";
 import { getFirestore } from "firebase-admin/firestore";
-import type { SuperAttendanceResponse, SuperStudentProgressResponse, EnrollmentResponse } from "@lms-279/shared-types";
+import type { SuperAttendanceResponse, SuperStudentProgressResponse, CourseEnrollmentSettingResponse } from "@lms-279/shared-types";
 import {
   superAdminAuthMiddleware,
   getAllSuperAdmins,
@@ -964,7 +964,7 @@ router.post("/tenants/:tenantId/student-progress/export-sheets", async (req: Req
 });
 
 // ============================================================
-// 受講期間管理（Enrollments）
+// 受講期間管理（テナント×コース単位）
 // ============================================================
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z?)?$/;
@@ -974,10 +974,8 @@ function isValidISODate(value: string): boolean {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function toEnrollmentResponse(id: string, data: any): EnrollmentResponse {
+function toCourseSettingResponse(data: any): CourseEnrollmentSettingResponse {
   return {
-    id,
-    userId: data.userId ?? "",
     courseId: data.courseId ?? "",
     enrolledAt: data.enrolledAt?.toDate?.()?.toISOString?.() ?? data.enrolledAt ?? "",
     quizAccessUntil: data.quizAccessUntil?.toDate?.()?.toISOString?.() ?? data.quizAccessUntil ?? "",
@@ -987,7 +985,6 @@ function toEnrollmentResponse(id: string, data: any): EnrollmentResponse {
   };
 }
 
-const BULK_CREATE_LIMIT = 1000;
 const ENROLLEDAT_RANGE_YEARS = 5;
 
 function isEnrolledAtInRange(dateStr: string): boolean {
@@ -996,40 +993,33 @@ function isEnrolledAtInRange(dateStr: string): boolean {
 }
 
 /**
- * テナント内enrollment一覧
- * GET /super/tenants/:tenantId/enrollments?courseId=xxx
+ * テナントのコース受講期間設定一覧
+ * GET /super/tenants/:tenantId/course-settings
  */
-router.get("/tenants/:tenantId/enrollments", async (req: Request, res: Response) => {
+router.get("/tenants/:tenantId/course-settings", async (req: Request, res: Response) => {
   const db = getFirestore();
   const tenantId = req.params.tenantId as string;
-  const courseId = req.query.courseId as string | undefined;
-
   const basePath = `tenants/${tenantId}`;
-  let query: FirebaseFirestore.Query = db.collection(`${basePath}/enrollments`);
-  if (courseId) {
-    query = query.where("courseId", "==", courseId);
-  }
 
-  const snapshot = await query.get();
-  const enrollments = snapshot.docs.map((doc) =>
-    toEnrollmentResponse(doc.id, doc.data())
-  );
+  const snapshot = await db.collection(`${basePath}/course_enrollment_settings`).get();
+  const settings = snapshot.docs.map((doc) => toCourseSettingResponse(doc.data()));
 
-  res.json({ enrollments });
+  res.json({ settings });
 });
 
 /**
- * enrollment作成
- * POST /super/tenants/:tenantId/enrollments
- * body: { userId, courseId, enrolledAt }
+ * コース受講期間設定の作成/更新
+ * PUT /super/tenants/:tenantId/course-settings/:courseId
+ * body: { enrolledAt }
  */
-router.post("/tenants/:tenantId/enrollments", async (req: Request, res: Response) => {
+router.put("/tenants/:tenantId/course-settings/:courseId", async (req: Request, res: Response) => {
   const db = getFirestore();
   const tenantId = req.params.tenantId as string;
-  const { userId, courseId, enrolledAt } = req.body;
+  const courseId = req.params.courseId as string;
+  const { enrolledAt } = req.body;
 
-  if (!userId || !courseId || !enrolledAt) {
-    res.status(400).json({ error: "bad_request", message: "userId, courseId, enrolledAt are required" });
+  if (!enrolledAt) {
+    res.status(400).json({ error: "bad_request", message: "enrolledAt is required" });
     return;
   }
 
@@ -1045,177 +1035,37 @@ router.post("/tenants/:tenantId/enrollments", async (req: Request, res: Response
 
   const normalizedEnrolledAt = new Date(enrolledAt).toISOString();
   const deadlines = calculateDefaultDeadlines(normalizedEnrolledAt);
-  const docId = `${userId}_${courseId}`;
   const basePath = `tenants/${tenantId}`;
-  const docRef = db.collection(`${basePath}/enrollments`).doc(docId);
+  const docRef = db.collection(`${basePath}/course_enrollment_settings`).doc(courseId);
 
-  await docRef.set({
-    userId,
+  const settingData = {
     courseId,
     enrolledAt: normalizedEnrolledAt,
     quizAccessUntil: deadlines.quizAccessUntil,
     videoAccessUntil: deadlines.videoAccessUntil,
     createdBy: req.superAdmin!.email,
     updatedAt: new Date().toISOString(),
-  });
+  };
 
-  const created = await docRef.get();
-  res.status(201).json(toEnrollmentResponse(docId, created.data()));
+  await docRef.set(settingData, { merge: true });
+  res.json(toCourseSettingResponse(settingData));
 });
 
 /**
- * enrollment一括作成
- * POST /super/tenants/:tenantId/enrollments/bulk
- * body: { userIds: string[], courseId, enrolledAt }
+ * コース受講期間設定の削除
+ * DELETE /super/tenants/:tenantId/course-settings/:courseId
  */
-router.post("/tenants/:tenantId/enrollments/bulk", async (req: Request, res: Response) => {
+router.delete("/tenants/:tenantId/course-settings/:courseId", async (req: Request, res: Response) => {
   const db = getFirestore();
   const tenantId = req.params.tenantId as string;
-  const { userIds, courseId, enrolledAt } = req.body;
-
-  if (!Array.isArray(userIds) || userIds.length === 0 || !courseId || !enrolledAt) {
-    res.status(400).json({ error: "bad_request", message: "userIds (non-empty array), courseId, enrolledAt are required" });
-    return;
-  }
-
-  if (userIds.length > BULK_CREATE_LIMIT) {
-    res.status(400).json({ error: "too_many_users", message: `一括登録は最大${BULK_CREATE_LIMIT}件までです` });
-    return;
-  }
-
-  if (!userIds.every((id: unknown) => typeof id === "string" && (id as string).trim() !== "")) {
-    res.status(400).json({ error: "bad_request", message: "All userIds must be non-empty strings" });
-    return;
-  }
-
-  if (!isValidISODate(enrolledAt)) {
-    res.status(400).json({ error: "invalid_date", message: "enrolledAt must be a valid date string" });
-    return;
-  }
-
-  if (!isEnrolledAtInRange(enrolledAt)) {
-    res.status(400).json({ error: "date_out_of_range", message: `enrolledAt must be within ${ENROLLEDAT_RANGE_YEARS} years from now` });
-    return;
-  }
-
-  const normalizedEnrolledAt = new Date(enrolledAt).toISOString();
-  const deadlines = calculateDefaultDeadlines(normalizedEnrolledAt);
+  const courseId = req.params.courseId as string;
   const basePath = `tenants/${tenantId}`;
-  const BATCH_LIMIT = 500;
-  const results: EnrollmentResponse[] = [];
-  const errors: { chunkIndex: number; error: string }[] = [];
-  const overwritten: string[] = [];
 
-  for (let i = 0; i < userIds.length; i += BATCH_LIMIT) {
-    const batch = db.batch();
-    const chunk = userIds.slice(i, i + BATCH_LIMIT);
-    const chunkResults: EnrollmentResponse[] = [];
-
-    // 既存チェック: batch内のdocIdを一括取得
-    const docRefs = chunk.map((uid: string) =>
-      db.collection(`${basePath}/enrollments`).doc(`${uid.trim()}_${courseId}`)
-    );
-    const existingDocs = await db.getAll(...docRefs);
-    for (const doc of existingDocs) {
-      if (doc.exists) overwritten.push(doc.id);
-    }
-
-    for (const uid of chunk) {
-      const docId = `${(uid as string).trim()}_${courseId}`;
-      const docRef = db.collection(`${basePath}/enrollments`).doc(docId);
-      const enrollmentData = {
-        userId: (uid as string).trim(),
-        courseId,
-        enrolledAt: normalizedEnrolledAt,
-        quizAccessUntil: deadlines.quizAccessUntil,
-        videoAccessUntil: deadlines.videoAccessUntil,
-        createdBy: req.superAdmin!.email,
-        updatedAt: new Date().toISOString(),
-      };
-      batch.set(docRef, enrollmentData);
-      chunkResults.push(toEnrollmentResponse(docId, enrollmentData));
-    }
-
-    try {
-      await batch.commit();
-      results.push(...chunkResults);
-    } catch (err) {
-      errors.push({ chunkIndex: Math.floor(i / BATCH_LIMIT), error: String(err) });
-    }
-  }
-
-  if (errors.length > 0) {
-    res.status(207).json({
-      enrollments: results,
-      count: results.length,
-      errors,
-      ...(overwritten.length > 0 && { overwritten }),
-      message: `${results.length}件作成、${errors.length}バッチ失敗`,
-    });
-    return;
-  }
-
-  res.status(201).json({
-    enrollments: results,
-    count: results.length,
-    ...(overwritten.length > 0 && { overwritten, message: `${overwritten.length}件の既存登録を上書きしました` }),
-  });
-});
-
-/**
- * enrollment更新（期限変更）
- * PATCH /super/tenants/:tenantId/enrollments/:enrollmentId
- * body: { quizAccessUntil?, videoAccessUntil? }
- */
-router.patch("/tenants/:tenantId/enrollments/:enrollmentId", async (req: Request, res: Response) => {
-  const db = getFirestore();
-  const tenantId = req.params.tenantId as string;
-  const enrollmentId = req.params.enrollmentId as string;
-  const { quizAccessUntil, videoAccessUntil } = req.body;
-
-  if (!quizAccessUntil && !videoAccessUntil) {
-    res.status(400).json({ error: "bad_request", message: "quizAccessUntil or videoAccessUntil is required" });
-    return;
-  }
-
-  if ((quizAccessUntil && !isValidISODate(quizAccessUntil)) || (videoAccessUntil && !isValidISODate(videoAccessUntil))) {
-    res.status(400).json({ error: "invalid_date", message: "Date fields must be valid date strings" });
-    return;
-  }
-
-  const basePath = `tenants/${tenantId}`;
-  const docRef = db.collection(`${basePath}/enrollments`).doc(enrollmentId);
+  const docRef = db.collection(`${basePath}/course_enrollment_settings`).doc(courseId);
   const doc = await docRef.get();
 
   if (!doc.exists) {
-    res.status(404).json({ error: "not_found", message: "Enrollment not found" });
-    return;
-  }
-
-  const updateData: Record<string, unknown> = { updatedAt: new Date().toISOString() };
-  if (quizAccessUntil) updateData.quizAccessUntil = new Date(quizAccessUntil).toISOString();
-  if (videoAccessUntil) updateData.videoAccessUntil = new Date(videoAccessUntil).toISOString();
-  await docRef.update(updateData);
-
-  const updated = await docRef.get();
-  res.json(toEnrollmentResponse(enrollmentId, updated.data()));
-});
-
-/**
- * enrollment削除
- * DELETE /super/tenants/:tenantId/enrollments/:enrollmentId
- */
-router.delete("/tenants/:tenantId/enrollments/:enrollmentId", async (req: Request, res: Response) => {
-  const db = getFirestore();
-  const tenantId = req.params.tenantId as string;
-  const enrollmentId = req.params.enrollmentId as string;
-
-  const basePath = `tenants/${tenantId}`;
-  const docRef = db.collection(`${basePath}/enrollments`).doc(enrollmentId);
-  const doc = await docRef.get();
-
-  if (!doc.exists) {
-    res.status(404).json({ error: "not_found", message: "Enrollment not found" });
+    res.status(404).json({ error: "not_found", message: "Course setting not found" });
     return;
   }
 

--- a/services/api/src/services/__tests__/enrollment.test.ts
+++ b/services/api/src/services/__tests__/enrollment.test.ts
@@ -4,14 +4,13 @@ import {
   checkVideoAccess,
   calculateDefaultDeadlines,
 } from "../enrollment.js";
-import type { Enrollment } from "../../types/entities.js";
+import type { CourseEnrollmentSetting } from "../../types/entities.js";
 
 const NOW = new Date("2026-04-02T10:00:00Z");
 
-function makeEnrollment(overrides: Partial<Enrollment> = {}): Enrollment {
+function makeSetting(overrides: Partial<CourseEnrollmentSetting> = {}): CourseEnrollmentSetting {
   return {
-    id: "user1_course1",
-    userId: "user1",
+    id: "course1",
     courseId: "course1",
     enrolledAt: "2026-03-01T00:00:00Z",
     quizAccessUntil: "2026-05-01T00:00:00Z",
@@ -36,7 +35,7 @@ describe("checkQuizAccess", () => {
   });
 
   it("期限内はアクセス許可", () => {
-    const enrollment = makeEnrollment({
+    const enrollment = makeSetting({
       quizAccessUntil: "2026-06-01T00:00:00Z",
     });
     const result = checkQuizAccess(enrollment);
@@ -44,7 +43,7 @@ describe("checkQuizAccess", () => {
   });
 
   it("期限切れはアクセス拒否", () => {
-    const enrollment = makeEnrollment({
+    const enrollment = makeSetting({
       quizAccessUntil: "2026-03-01T00:00:00Z",
     });
     const result = checkQuizAccess(enrollment);
@@ -52,7 +51,7 @@ describe("checkQuizAccess", () => {
   });
 
   it("期限ちょうどはアクセス拒否", () => {
-    const enrollment = makeEnrollment({
+    const enrollment = makeSetting({
       quizAccessUntil: NOW.toISOString(),
     });
     const result = checkQuizAccess(enrollment);
@@ -60,7 +59,7 @@ describe("checkQuizAccess", () => {
   });
 
   it("無効な日付データはアクセス拒否（データ破損防御）", () => {
-    const enrollment = makeEnrollment({
+    const enrollment = makeSetting({
       quizAccessUntil: "invalid-date",
     });
     const result = checkQuizAccess(enrollment);
@@ -82,7 +81,7 @@ describe("checkVideoAccess", () => {
   });
 
   it("期限内はアクセス許可", () => {
-    const enrollment = makeEnrollment({
+    const enrollment = makeSetting({
       videoAccessUntil: "2027-06-01T00:00:00Z",
     });
     const result = checkVideoAccess(enrollment);
@@ -90,7 +89,7 @@ describe("checkVideoAccess", () => {
   });
 
   it("期限切れはアクセス拒否", () => {
-    const enrollment = makeEnrollment({
+    const enrollment = makeSetting({
       videoAccessUntil: "2026-01-01T00:00:00Z",
     });
     const result = checkVideoAccess(enrollment);
@@ -98,7 +97,7 @@ describe("checkVideoAccess", () => {
   });
 
   it("無効な日付データはアクセス拒否（データ破損防御）", () => {
-    const enrollment = makeEnrollment({
+    const enrollment = makeSetting({
       videoAccessUntil: "not-a-date",
     });
     const result = checkVideoAccess(enrollment);

--- a/services/api/src/services/enrollment.ts
+++ b/services/api/src/services/enrollment.ts
@@ -1,9 +1,9 @@
 /**
  * 受講期間管理サービス
- * enrollmentの期限チェックユーティリティ
+ * テナント×コース単位の期限チェックユーティリティ
  */
 
-import type { Enrollment } from "../types/entities.js";
+import type { CourseEnrollmentSetting } from "../types/entities.js";
 
 export interface AccessCheckResult {
   allowed: boolean;
@@ -12,14 +12,14 @@ export interface AccessCheckResult {
 
 /**
  * テスト受験のアクセスチェック
- * enrollment未登録(null) → アクセス許可（後方互換）
- * enrollment登録済み → quizAccessUntilで判定
+ * setting未登録(null) → アクセス許可（後方互換）
+ * setting登録済み → quizAccessUntilで判定
  */
-export function checkQuizAccess(enrollment: Enrollment | null): AccessCheckResult {
-  if (!enrollment) return { allowed: true };
+export function checkQuizAccess(setting: CourseEnrollmentSetting | null): AccessCheckResult {
+  if (!setting) return { allowed: true };
 
   const now = new Date();
-  const deadline = new Date(enrollment.quizAccessUntil);
+  const deadline = new Date(setting.quizAccessUntil);
 
   if (isNaN(deadline.getTime())) {
     return { allowed: false, reason: "invalid_deadline_data" };
@@ -34,14 +34,14 @@ export function checkQuizAccess(enrollment: Enrollment | null): AccessCheckResul
 
 /**
  * 動画視聴のアクセスチェック
- * enrollment未登録(null) → アクセス許可（後方互換）
- * enrollment登録済み → videoAccessUntilで判定
+ * setting未登録(null) → アクセス許可（後方互換）
+ * setting登録済み → videoAccessUntilで判定
  */
-export function checkVideoAccess(enrollment: Enrollment | null): AccessCheckResult {
-  if (!enrollment) return { allowed: true };
+export function checkVideoAccess(setting: CourseEnrollmentSetting | null): AccessCheckResult {
+  if (!setting) return { allowed: true };
 
   const now = new Date();
-  const deadline = new Date(enrollment.videoAccessUntil);
+  const deadline = new Date(setting.videoAccessUntil);
 
   if (isNaN(deadline.getTime())) {
     return { allowed: false, reason: "invalid_deadline_data" };

--- a/services/api/src/types/entities.ts
+++ b/services/api/src/types/entities.ts
@@ -313,13 +313,12 @@ export interface LessonSessionFilter {
 // 受講期間管理
 // ========================================
 
-export interface Enrollment {
-  id: string;              // userId_courseId
-  userId: string;
+export interface CourseEnrollmentSetting {
+  id: string;              // = courseId
   courseId: string;
   enrolledAt: string;      // ISO — スーパー管理者が設定する受講開始日
-  quizAccessUntil: string; // ISO — enrolledAt + 2ヶ月（デフォルト）
-  videoAccessUntil: string;// ISO — enrolledAt + 1年（デフォルト）
+  quizAccessUntil: string; // ISO — enrolledAt + 2ヶ月（自動計算）
+  videoAccessUntil: string;// ISO — enrolledAt + 1年（自動計算）
   createdBy: string;       // スーパー管理者email
   updatedAt: string;
 }

--- a/web/app/super/enrollments/page.tsx
+++ b/web/app/super/enrollments/page.tsx
@@ -27,7 +27,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useSuperAdminFetch } from "@/lib/super-api";
-import type { EnrollmentResponse } from "@lms-279/shared-types";
+import type { CourseEnrollmentSettingResponse } from "@lms-279/shared-types";
 
 type Tenant = { id: string; name: string };
 type Course = { id: string; name: string };
@@ -51,30 +51,16 @@ export default function EnrollmentsPage() {
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [selectedTenant, setSelectedTenant] = useState("");
   const [courses, setCourses] = useState<Course[]>([]);
-  const ALL_COURSES = "__all__";
-  const [selectedCourse, setSelectedCourse] = useState(ALL_COURSES);
-  const [enrollments, setEnrollments] = useState<EnrollmentResponse[]>([]);
+  const [settings, setSettings] = useState<CourseEnrollmentSettingResponse[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // 新規作成ダイアログ
-  const [createOpen, setCreateOpen] = useState(false);
-  const [createUserId, setCreateUserId] = useState("");
-  const [createEnrolledAt, setCreateEnrolledAt] = useState("");
-  const [createLoading, setCreateLoading] = useState(false);
-
-  // 一括作成ダイアログ
-  const [bulkOpen, setBulkOpen] = useState(false);
-  const [bulkUserIds, setBulkUserIds] = useState("");
-  const [bulkEnrolledAt, setBulkEnrolledAt] = useState("");
-  const [bulkLoading, setBulkLoading] = useState(false);
-
-  // 編集ダイアログ
-  const [editOpen, setEditOpen] = useState(false);
-  const [editTarget, setEditTarget] = useState<EnrollmentResponse | null>(null);
-  const [editQuizUntil, setEditQuizUntil] = useState("");
-  const [editVideoUntil, setEditVideoUntil] = useState("");
-  const [editLoading, setEditLoading] = useState(false);
+  // 設定ダイアログ
+  const [settingOpen, setSettingOpen] = useState(false);
+  const [settingCourseId, setSettingCourseId] = useState("");
+  const [settingCourseName, setSettingCourseName] = useState("");
+  const [settingEnrolledAt, setSettingEnrolledAt] = useState("");
+  const [settingLoading, setSettingLoading] = useState(false);
 
   // テナント一覧取得
   useEffect(() => {
@@ -91,7 +77,6 @@ export default function EnrollmentsPage() {
     }
     superFetch<{ tenants: Tenant[] }>(`/api/v2/super/tenants/${selectedTenant}`)
       .then(async () => {
-        // テナントのコース一覧は共有ルート経由で取得
         const res = await superFetch<{ courses: Course[] }>(
           `/api/v2/${selectedTenant}/courses`
         );
@@ -100,338 +85,225 @@ export default function EnrollmentsPage() {
       .catch(() => setCourses([]));
   }, [selectedTenant, superFetch]);
 
-  // enrollment一覧取得
-  const fetchEnrollments = useCallback(async () => {
+  // 設定一覧取得
+  const fetchSettings = useCallback(async () => {
     if (!selectedTenant) return;
     setLoading(true);
     setError(null);
     try {
-      const query = selectedCourse !== ALL_COURSES ? `?courseId=${selectedCourse}` : "";
-      const data = await superFetch<{ enrollments: EnrollmentResponse[] }>(
-        `/api/v2/super/tenants/${selectedTenant}/enrollments${query}`
+      const data = await superFetch<{ settings: CourseEnrollmentSettingResponse[] }>(
+        `/api/v2/super/tenants/${selectedTenant}/course-settings`
       );
-      setEnrollments(data.enrollments);
+      setSettings(data.settings);
     } catch (e) {
       setError(e instanceof Error ? e.message : "取得に失敗しました");
     } finally {
       setLoading(false);
     }
-  }, [selectedTenant, selectedCourse, superFetch]);
+  }, [selectedTenant, superFetch]);
 
   useEffect(() => {
     if (selectedTenant) {
-      fetchEnrollments();
+      fetchSettings();
     }
-  }, [selectedTenant, selectedCourse, fetchEnrollments]);
+  }, [selectedTenant, fetchSettings]);
 
-  // 新規作成
-  const handleCreate = async () => {
-    if (!selectedTenant || selectedCourse === ALL_COURSES || !createUserId || !createEnrolledAt) return;
-    setCreateLoading(true);
-    try {
-      await superFetch(`/api/v2/super/tenants/${selectedTenant}/enrollments`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          userId: createUserId,
-          courseId: selectedCourse,
-          enrolledAt: new Date(createEnrolledAt).toISOString(),
-        }),
-      });
-      setCreateOpen(false);
-      setCreateUserId("");
-      setCreateEnrolledAt("");
-      fetchEnrollments();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "作成に失敗しました");
-    } finally {
-      setCreateLoading(false);
-    }
-  };
+  // コース名マップ
+  const courseNameMap = new Map(courses.map((c) => [c.id, c.name]));
 
-  // 一括作成
-  const handleBulkCreate = async () => {
-    if (!selectedTenant || selectedCourse === ALL_COURSES || !bulkUserIds || !bulkEnrolledAt) return;
-    setBulkLoading(true);
-    try {
-      const userIds = bulkUserIds
-        .split("\n")
-        .map((id) => id.trim())
-        .filter(Boolean);
-      await superFetch(`/api/v2/super/tenants/${selectedTenant}/enrollments/bulk`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          userIds,
-          courseId: selectedCourse,
-          enrolledAt: new Date(bulkEnrolledAt).toISOString(),
-        }),
-      });
-      setBulkOpen(false);
-      setBulkUserIds("");
-      setBulkEnrolledAt("");
-      fetchEnrollments();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "一括作成に失敗しました");
-    } finally {
-      setBulkLoading(false);
-    }
-  };
-
-  // 期限更新
-  const handleEdit = async () => {
-    if (!editTarget || !selectedTenant) return;
-    setEditLoading(true);
+  // 設定保存
+  const handleSave = async () => {
+    if (!selectedTenant || !settingCourseId || !settingEnrolledAt) return;
+    setSettingLoading(true);
     try {
       await superFetch(
-        `/api/v2/super/tenants/${selectedTenant}/enrollments/${editTarget.id}`,
+        `/api/v2/super/tenants/${selectedTenant}/course-settings/${settingCourseId}`,
         {
-          method: "PATCH",
+          method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            ...(editQuizUntil && { quizAccessUntil: new Date(editQuizUntil).toISOString() }),
-            ...(editVideoUntil && { videoAccessUntil: new Date(editVideoUntil).toISOString() }),
+            enrolledAt: new Date(settingEnrolledAt).toISOString(),
           }),
         }
       );
-      setEditOpen(false);
-      setEditTarget(null);
-      fetchEnrollments();
+      setSettingOpen(false);
+      fetchSettings();
     } catch (e) {
-      setError(e instanceof Error ? e.message : "更新に失敗しました");
+      setError(e instanceof Error ? e.message : "保存に失敗しました");
     } finally {
-      setEditLoading(false);
+      setSettingLoading(false);
     }
   };
 
-  // 削除
-  const handleDelete = async (enrollment: EnrollmentResponse) => {
-    if (!confirm(`${enrollment.userId} の受講期間設定を削除しますか？`)) return;
+  // 設定削除
+  const handleDelete = async (courseId: string) => {
+    const courseName = courseNameMap.get(courseId) ?? courseId;
+    if (!confirm(`${courseName} の受講期間設定を削除しますか？\n削除するとこのコースの受講期間制限が解除されます。`)) return;
     try {
       await superFetch(
-        `/api/v2/super/tenants/${selectedTenant}/enrollments/${enrollment.id}`,
+        `/api/v2/super/tenants/${selectedTenant}/course-settings/${courseId}`,
         { method: "DELETE" }
       );
-      fetchEnrollments();
+      fetchSettings();
     } catch (e) {
       setError(e instanceof Error ? e.message : "削除に失敗しました");
     }
   };
 
+  // 設定ダイアログを開く
+  const openSettingDialog = (courseId: string, courseName: string, currentEnrolledAt?: string) => {
+    setSettingCourseId(courseId);
+    setSettingCourseName(courseName);
+    setSettingEnrolledAt(currentEnrolledAt?.split("T")[0] ?? "");
+    setSettingOpen(true);
+  };
+
+  // 未設定コース
+  const settingCourseIds = new Set(settings.map((s) => s.courseId));
+  const unconfiguredCourses = courses.filter((c) => !settingCourseIds.has(c.id));
+
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-bold">受講期間管理</h2>
+      <p className="text-sm text-muted-foreground">
+        テナント×コース単位で受講期間を設定します。テスト期限（+2ヶ月）と動画期限（+1年）は受講開始日から自動計算されます。
+      </p>
 
-      {/* フィルタ */}
-      <div className="flex gap-4 items-end flex-wrap">
-        <div className="w-64">
-          <label className="text-sm text-muted-foreground">テナント</label>
-          <Select value={selectedTenant} onValueChange={setSelectedTenant}>
-            <SelectTrigger><SelectValue placeholder="テナント選択" /></SelectTrigger>
-            <SelectContent>
-              {tenants.map((t) => (
-                <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="w-64">
-          <label className="text-sm text-muted-foreground">コース</label>
-          <Select value={selectedCourse} onValueChange={setSelectedCourse} disabled={!selectedTenant}>
-            <SelectTrigger><SelectValue placeholder="全コース" /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value={ALL_COURSES}>全コース</SelectItem>
-              {courses.map((c) => (
-                <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        {selectedTenant && selectedCourse !== ALL_COURSES && (
-          <div className="flex gap-2">
-            <Button onClick={() => setCreateOpen(true)}>新規登録</Button>
-            <Button variant="outline" onClick={() => setBulkOpen(true)}>一括登録</Button>
-          </div>
-        )}
+      {/* テナント選択 */}
+      <div className="w-64">
+        <label className="text-sm text-muted-foreground">テナント</label>
+        <Select value={selectedTenant} onValueChange={setSelectedTenant}>
+          <SelectTrigger><SelectValue placeholder="テナント選択" /></SelectTrigger>
+          <SelectContent>
+            {tenants.map((t) => (
+              <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {error && <p className="text-destructive text-sm">{error}</p>}
 
-      {/* テーブル */}
+      {/* 設定済みコース一覧 */}
       {loading ? (
         <p className="text-muted-foreground">読み込み中...</p>
-      ) : enrollments.length === 0 ? (
-        selectedTenant ? (
-          <p className="text-muted-foreground">受講期間の登録がありません</p>
-        ) : (
-          <p className="text-muted-foreground">テナントを選択してください</p>
-        )
+      ) : !selectedTenant ? (
+        <p className="text-muted-foreground">テナントを選択してください</p>
       ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>ユーザーID</TableHead>
-              <TableHead>コースID</TableHead>
-              <TableHead>受講開始日</TableHead>
-              <TableHead>テスト期限</TableHead>
-              <TableHead>動画期限</TableHead>
-              <TableHead>設定者</TableHead>
-              <TableHead>操作</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {enrollments.map((e) => (
-              <TableRow key={e.id}>
-                <TableCell className="font-mono text-xs">{e.userId}</TableCell>
-                <TableCell className="font-mono text-xs">{e.courseId}</TableCell>
-                <TableCell>{formatDate(e.enrolledAt)}</TableCell>
-                <TableCell>
-                  <span className={isExpired(e.quizAccessUntil) ? "text-destructive font-medium" : ""}>
-                    {formatDate(e.quizAccessUntil)}
-                    {isExpired(e.quizAccessUntil) && " (期限切れ)"}
-                  </span>
-                </TableCell>
-                <TableCell>
-                  <span className={isExpired(e.videoAccessUntil) ? "text-destructive font-medium" : ""}>
-                    {formatDate(e.videoAccessUntil)}
-                    {isExpired(e.videoAccessUntil) && " (期限切れ)"}
-                  </span>
-                </TableCell>
-                <TableCell className="text-xs">{e.createdBy}</TableCell>
-                <TableCell>
-                  <div className="flex gap-1">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        setEditTarget(e);
-                        setEditQuizUntil(e.quizAccessUntil?.split("T")[0] ?? "");
-                        setEditVideoUntil(e.videoAccessUntil?.split("T")[0] ?? "");
-                        setEditOpen(true);
-                      }}
-                    >
-                      延長
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="text-destructive"
-                      onClick={() => handleDelete(e)}
-                    >
-                      削除
-                    </Button>
-                  </div>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <>
+          {settings.length > 0 && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>コース</TableHead>
+                  <TableHead>受講開始日</TableHead>
+                  <TableHead>テスト期限</TableHead>
+                  <TableHead>動画期限</TableHead>
+                  <TableHead>設定者</TableHead>
+                  <TableHead>操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {settings.map((s) => (
+                  <TableRow key={s.courseId}>
+                    <TableCell>{courseNameMap.get(s.courseId) ?? s.courseId}</TableCell>
+                    <TableCell>{formatDate(s.enrolledAt)}</TableCell>
+                    <TableCell>
+                      <span className={isExpired(s.quizAccessUntil) ? "text-destructive font-medium" : ""}>
+                        {formatDate(s.quizAccessUntil)}
+                        {isExpired(s.quizAccessUntil) && " (期限切れ)"}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <span className={isExpired(s.videoAccessUntil) ? "text-destructive font-medium" : ""}>
+                        {formatDate(s.videoAccessUntil)}
+                        {isExpired(s.videoAccessUntil) && " (期限切れ)"}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-xs">{s.createdBy}</TableCell>
+                    <TableCell>
+                      <div className="flex gap-1">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => openSettingDialog(
+                            s.courseId,
+                            courseNameMap.get(s.courseId) ?? s.courseId,
+                            s.enrolledAt
+                          )}
+                        >
+                          変更
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-destructive"
+                          onClick={() => handleDelete(s.courseId)}
+                        >
+                          削除
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+
+          {settings.length === 0 && (
+            <p className="text-muted-foreground">受講期間の設定がありません</p>
+          )}
+
+          {/* 未設定コース一覧 */}
+          {unconfiguredCourses.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-muted-foreground">未設定のコース</h3>
+              <div className="flex flex-wrap gap-2">
+                {unconfiguredCourses.map((c) => (
+                  <Button
+                    key={c.id}
+                    variant="outline"
+                    size="sm"
+                    onClick={() => openSettingDialog(c.id, c.name)}
+                  >
+                    {c.name} — 期間を設定
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
       )}
 
-      {/* 新規作成ダイアログ */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+      {/* 設定ダイアログ */}
+      <Dialog open={settingOpen} onOpenChange={setSettingOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>受講期間を登録</DialogTitle>
+            <DialogTitle>受講期間を設定</DialogTitle>
             <DialogDescription>
-              受講開始日を設定するとテスト期限（+2ヶ月）と動画期限（+1年）が自動計算されます
+              {settingCourseName} の受講開始日を設定します。テスト期限（+2ヶ月）と動画期限（+1年）は自動計算されます。
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3">
-            <div>
-              <label className="text-sm">ユーザーID</label>
-              <Input
-                value={createUserId}
-                onChange={(e) => setCreateUserId(e.target.value)}
-                placeholder="ユーザーIDを入力"
-              />
-            </div>
             <div>
               <label className="text-sm">受講開始日</label>
               <Input
                 type="date"
-                value={createEnrolledAt}
-                onChange={(e) => setCreateEnrolledAt(e.target.value)}
+                value={settingEnrolledAt}
+                onChange={(e) => setSettingEnrolledAt(e.target.value)}
               />
             </div>
+            {settingEnrolledAt && (
+              <div className="text-sm text-muted-foreground space-y-1">
+                <p>テスト期限: {formatDate(new Date(new Date(settingEnrolledAt).setMonth(new Date(settingEnrolledAt).getMonth() + 2)).toISOString())}</p>
+                <p>動画期限: {formatDate(new Date(new Date(settingEnrolledAt).setFullYear(new Date(settingEnrolledAt).getFullYear() + 1)).toISOString())}</p>
+              </div>
+            )}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setCreateOpen(false)}>キャンセル</Button>
-            <Button onClick={handleCreate} disabled={createLoading || !createUserId || !createEnrolledAt}>
-              {createLoading ? "作成中..." : "登録"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* 一括作成ダイアログ */}
-      <Dialog open={bulkOpen} onOpenChange={setBulkOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>一括登録</DialogTitle>
-            <DialogDescription>
-              複数のユーザーIDを改行区切りで入力してください
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-3">
-            <div>
-              <label className="text-sm">ユーザーID（改行区切り）</label>
-              <textarea
-                className="w-full h-32 border rounded-md p-2 text-sm font-mono"
-                value={bulkUserIds}
-                onChange={(e) => setBulkUserIds(e.target.value)}
-                placeholder={"user1\nuser2\nuser3"}
-              />
-            </div>
-            <div>
-              <label className="text-sm">受講開始日</label>
-              <Input
-                type="date"
-                value={bulkEnrolledAt}
-                onChange={(e) => setBulkEnrolledAt(e.target.value)}
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setBulkOpen(false)}>キャンセル</Button>
-            <Button onClick={handleBulkCreate} disabled={bulkLoading || !bulkUserIds || !bulkEnrolledAt}>
-              {bulkLoading ? "作成中..." : "一括登録"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* 期限延長ダイアログ */}
-      <Dialog open={editOpen} onOpenChange={setEditOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>受講期限を変更</DialogTitle>
-            <DialogDescription>
-              {editTarget?.userId} の期限を変更します
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-3">
-            <div>
-              <label className="text-sm">テスト受験期限</label>
-              <Input
-                type="date"
-                value={editQuizUntil}
-                onChange={(e) => setEditQuizUntil(e.target.value)}
-              />
-            </div>
-            <div>
-              <label className="text-sm">動画視聴期限</label>
-              <Input
-                type="date"
-                value={editVideoUntil}
-                onChange={(e) => setEditVideoUntil(e.target.value)}
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setEditOpen(false)}>キャンセル</Button>
-            <Button onClick={handleEdit} disabled={editLoading}>
-              {editLoading ? "更新中..." : "更新"}
+            <Button variant="outline" onClick={() => setSettingOpen(false)}>キャンセル</Button>
+            <Button onClick={handleSave} disabled={settingLoading || !settingEnrolledAt}>
+              {settingLoading ? "保存中..." : "保存"}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary
- 受講期間設定をテナント×コース単位に変更（元の要件に合致）
- 新コレクション `course_enrollment_settings`（ドキュメントID = courseId）
- テスト期限（+2ヶ月）と動画期限（+1年）は受講開始日から自動計算
- 旧 `enrollments`（個人×コース）を完全削除（純減 331 行）
- スーパー管理画面を簡素化: テナント選択→コース一覧→受講開始日設定
- アクセスチェック参照先を3エンドポイントで変更

## Test plan
- [x] `npm run type-check` PASS
- [x] `npm run test` 33 tests PASS
- [x] `npm run lint` PASS
- [ ] テナント選択→コースに受講開始日設定→期限自動計算表示
- [ ] テスト受験: 期限内→OK、期限後→403
- [ ] 動画再生: 期限内→OK、期限後→403
- [ ] 設定削除→制限なし（setting未設定 = 無制限）

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)