### PR TITLE
test: timed_out除外のHTTP統合テスト追加

### DIFF
--- a/services/api/src/__tests__/integration/quiz-flow.test.ts
+++ b/services/api/src/__tests__/integration/quiz-flow.test.ts
@@ -290,6 +290,30 @@ describe("Quiz Flow (complete flow)", () => {
       expect(res.status).toBe(403);
       expect(res.body.error).toBe("max_attempts_exceeded");
     });
+
+    it("timed_outはカウントから除外され、再受験できる", async () => {
+      // 1回目: 開始して timed_out にする（DataSource直接操作）
+      const start1 = await studentRequest.post(`/quizzes/${quizId}/attempts`);
+      expect(start1.status).toBe(201);
+      const attempt1Id = start1.body.attempt.id;
+      await ds.updateQuizAttempt(attempt1Id, {
+        status: "timed_out",
+        submittedAt: new Date().toISOString(),
+      });
+
+      // 2回目: 正常に提出
+      const start2 = await studentRequest.post(`/quizzes/${quizId}/attempts`);
+      expect(start2.status).toBe(201);
+      const attempt2Id = start2.body.attempt.id;
+      await studentRequest
+        .patch(`/quiz-attempts/${attempt2Id}`)
+        .send({ answers: { q1: ["q1-a"], q2: ["q2-a"] } });
+
+      // 3回目: timed_outは除外されるので、有効試行は1回 → 再受験可能
+      const start3 = await studentRequest.post(`/quizzes/${quizId}/attempts`);
+      expect(start3.status).toBe(201);
+      expect(start3.body.attempt.attemptNumber).toBe(3);
+    });
   });
 
   describe("進行中attempt重複防止", () => {


### PR DESCRIPTION
## Summary

QA評価のCritical Gap（Criticality 8/10）を解消。

`countEffectiveAttempts`（PR #233で導入）のHTTPレイヤー統合テストを追加。
ユニットテストはあったが、route→DataSource→countEffectiveAttempts の接続がHTTPレベルで未検証だった。

## 追加テスト
- maxAttempts=2 で timed_out 1件 + submitted 1件 → 3回目が 201（timed_outは除外）

## Test plan
- [x] API 395テスト全パス（+1 新規）
- [x] Web 33テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)