### PR TITLE
fix: SelectItem空文字valueによるクライアントエラーを修正

### DIFF
--- a/web/app/super/progress/page.tsx
+++ b/web/app/super/progress/page.tsx
@@ -117,7 +117,8 @@ export default function StudentProgressPage() {
     setError(null);
     setExpanded({});
     try {
-      const qs = selectedCourse ? `?courseId=${selectedCourse}` : "";
+      const courseId = selectedCourse && selectedCourse !== "__all__" ? selectedCourse : "";
+      const qs = courseId ? `?courseId=${courseId}` : "";
       const data = await superFetch<SuperStudentProgressResponse>(
         `/api/v2/super/tenants/${selectedTenant}/student-progress${qs}`
       );
@@ -236,7 +237,7 @@ export default function StudentProgressPage() {
               <SelectValue placeholder="全コース" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">全コース</SelectItem>
+              <SelectItem value="__all__">全コース</SelectItem>
               {courses.map((c) => (
                 <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
               ))}


### PR DESCRIPTION
## Summary
- `/super/progress` ページで `Application error: a client-side exception has occurred` が発生していた
- 原因: `<SelectItem value="">` がRadix UI Selectで禁止されている（空文字はplaceholder表示用に予約）
- 修正: 「全コース」のvalueを `"__all__"` に変更し、API呼び出し時にフィルタ対象外として処理

## Test plan
- [ ] `/super/progress` ページが正常に表示される
- [ ] テナント選択後、「全コース」フィルタで全コースのデータが表示される
- [ ] 特定コース選択時に正しくフィルタされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)