### PR TITLE
feat: 受講状況ページに入退室打刻を表示

### DIFF
--- a/packages/shared-types/src/student-progress.ts
+++ b/packages/shared-types/src/student-progress.ts
@@ -38,4 +38,6 @@ export interface SuperLessonRecord {
   quizPassed: boolean;
   quizBestScore: number | null;
   lessonCompleted: boolean;
+  latestEntryAt: string | null;
+  latestExitAt: string | null;
 }

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -627,6 +627,7 @@ type ProgressData = {
   lessonsMap: Map<string, { title: string; hasVideo: boolean; hasQuiz: boolean }>;
   progressMap: Map<string, { videoCompleted: boolean; quizPassed: boolean; quizBestScore: number | null; lessonCompleted: boolean }>;
   courseProgressMap: Map<string, { completedLessons: number; totalLessons: number; progressRatio: number; isCompleted: boolean }>;
+  sessionsMap: Map<string, { entryAt: string | null; exitAt: string | null }>;
 };
 
 async function fetchStudentProgressData(
@@ -636,11 +637,12 @@ async function fetchStudentProgressData(
 ): Promise<ProgressData> {
   const basePath = `tenants/${tenantId}`;
 
-  const [usersSnapshot, lessonsSnap, progressSnap, courseProgressSnap] = await Promise.all([
+  const [usersSnapshot, lessonsSnap, progressSnap, courseProgressSnap, sessionsSnap] = await Promise.all([
     db.collection(`${basePath}/users`).where("role", "==", "student").get(),
     db.collection(`${basePath}/lessons`).get(),
     db.collection(`${basePath}/user_progress`).get(),
     db.collection(`${basePath}/course_progress`).get(),
+    db.collection(`${basePath}/lesson_sessions`).orderBy("entryAt", "desc").get(),
   ]);
 
   let coursesSnapshot: FirebaseFirestore.DocumentSnapshot[];
@@ -670,7 +672,20 @@ async function fetchStudentProgressData(
     courseProgressMap.set(doc.id, { completedLessons: d.completedLessons ?? 0, totalLessons: d.totalLessons ?? 0, progressRatio: d.progressRatio ?? 0, isCompleted: d.isCompleted ?? false });
   }
 
-  return { usersSnapshot, coursesSnapshot, lessonsMap, progressMap, courseProgressMap };
+  // 最新セッションのみ保持（entryAt descでソート済みなので最初に見つかったものが最新）
+  const sessionsMap = new Map<string, { entryAt: string | null; exitAt: string | null }>();
+  for (const doc of sessionsSnap.docs) {
+    const d = doc.data();
+    const key = `${d.userId}_${d.lessonId}`;
+    if (!sessionsMap.has(key)) {
+      sessionsMap.set(key, {
+        entryAt: d.entryAt?.toDate?.().toISOString?.() ?? d.entryAt ?? null,
+        exitAt: d.exitAt?.toDate?.().toISOString?.() ?? d.exitAt ?? null,
+      });
+    }
+  }
+
+  return { usersSnapshot, coursesSnapshot, lessonsMap, progressMap, courseProgressMap, sessionsMap };
 }
 
 /**
@@ -689,7 +704,7 @@ router.get("/tenants/:tenantId/student-progress", async (req: Request, res: Resp
     return;
   }
 
-  const { usersSnapshot, coursesSnapshot, lessonsMap, progressMap, courseProgressMap } =
+  const { usersSnapshot, coursesSnapshot, lessonsMap, progressMap, courseProgressMap, sessionsMap } =
     await fetchStudentProgressData(db, tenantId, courseIdFilter);
 
   const students = usersSnapshot.docs.map((userDoc) => {
@@ -708,6 +723,7 @@ router.get("/tenants/:tenantId/student-progress", async (req: Request, res: Resp
         const lessonInfo = lessonsMap.get(lessonId);
         const upKey = `${userId}_${lessonId}`;
         const up = progressMap.get(upKey);
+        const session = sessionsMap.get(upKey);
         return {
           lessonId,
           lessonTitle: lessonInfo?.title ?? lessonId,
@@ -715,6 +731,8 @@ router.get("/tenants/:tenantId/student-progress", async (req: Request, res: Resp
           quizPassed: up?.quizPassed ?? false,
           quizBestScore: up?.quizBestScore ?? null,
           lessonCompleted: up?.lessonCompleted ?? false,
+          latestEntryAt: session?.entryAt ?? null,
+          latestExitAt: session?.exitAt ?? null,
         };
       });
 

--- a/web/app/super/progress/page.tsx
+++ b/web/app/super/progress/page.tsx
@@ -285,6 +285,7 @@ export default function StudentProgressPage() {
                     <TableHead>コース</TableHead>
                     <TableHead>進捗</TableHead>
                     <TableHead>進捗率</TableHead>
+                    <TableHead>入退室</TableHead>
                     <TableHead>完了</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -315,6 +316,7 @@ export default function StudentProgressPage() {
                           <TableCell>
                             {(course.progressRatio * 100).toFixed(0)}%
                           </TableCell>
+                          <TableCell></TableCell>
                           <TableCell>
                             {course.isCompleted ? (
                               <span className="text-green-600 font-medium">完了</span>
@@ -347,6 +349,20 @@ export default function StudentProgressPage() {
                                   {lesson.quizBestScore !== null && (
                                     <span className="text-xs ml-1">({lesson.quizBestScore}点)</span>
                                   )}
+                                </TableCell>
+                                <TableCell>
+                                  <div className="text-xs space-y-0.5">
+                                    <div>
+                                      入室: {lesson.latestEntryAt
+                                        ? new Date(lesson.latestEntryAt).toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })
+                                        : "—"}
+                                    </div>
+                                    <div>
+                                      退室: {lesson.latestExitAt
+                                        ? new Date(lesson.latestExitAt).toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })
+                                        : "—"}
+                                    </div>
+                                  </div>
                                 </TableCell>
                                 <TableCell>
                                   {lesson.lessonCompleted ? (


### PR DESCRIPTION
## Summary
- `/super/progress` のレッスン展開行に入退室打刻（入室/退室時刻）を表示
- `lesson_sessions`コレクションからユーザー×レッスンごとの最新セッションを取得
- `SuperLessonRecord`に`latestEntryAt`/`latestExitAt`フィールドを追加

## 変更ファイル
- `packages/shared-types/src/student-progress.ts` — 型定義追加
- `services/api/src/routes/super-admin.ts` — lesson_sessions取得・マッピング
- `web/app/super/progress/page.tsx` — 入退室列の表示

## Test plan
- [ ] `/super/progress` でテナント選択→レッスン展開時に入室/退室時刻が表示される
- [ ] lesson_sessionsがないレッスンは「—」が表示される
- [ ] 日時がJST（Asia/Tokyo）で表示される
- [ ] lint/type-check/build 全PASS確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)