### PR TITLE
feat: 受講状況の編集ダイアログを入退室打刻ベースに変更

### DIFF
--- a/packages/shared-types/src/student-progress.ts
+++ b/packages/shared-types/src/student-progress.ts
@@ -38,6 +38,8 @@ export interface SuperLessonRecord {
   quizPassed: boolean;
   quizBestScore: number | null;
   lessonCompleted: boolean;
+  latestSessionId: string | null;
   latestEntryAt: string | null;
   latestExitAt: string | null;
+  latestExitReason: string | null;
 }

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -563,7 +563,7 @@ router.patch("/tenants/:tenantId/attendance-report/:sessionId", async (req: Requ
   const db = getFirestore();
   const tenantId = req.params.tenantId as string;
   const sessionId = req.params.sessionId as string;
-  const { entryAt, exitAt, quizScore, quizPassed } = req.body;
+  const { entryAt, exitAt, exitReason, quizScore, quizPassed } = req.body;
 
   // 入力バリデーション
   const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
@@ -577,6 +577,11 @@ router.patch("/tenants/:tenantId/attendance-report/:sessionId", async (req: Requ
   }
   if (entryAt !== undefined && exitAt !== undefined && new Date(entryAt) > new Date(exitAt)) {
     res.status(400).json({ error: "invalid_time_range", message: "entryAt must be before exitAt" });
+    return;
+  }
+  const VALID_EXIT_REASONS = ["quiz_submitted", "pause_timeout", "time_limit", "browser_close"];
+  if (exitReason !== undefined && (typeof exitReason !== "string" || !VALID_EXIT_REASONS.includes(exitReason))) {
+    res.status(400).json({ error: "invalid_exitReason", message: `exitReason must be one of: ${VALID_EXIT_REASONS.join(", ")}` });
     return;
   }
   if (quizScore !== undefined && (typeof quizScore !== "number" || !Number.isFinite(quizScore) || quizScore < 0 || quizScore > 100)) {
@@ -601,6 +606,7 @@ router.patch("/tenants/:tenantId/attendance-report/:sessionId", async (req: Requ
   const sessionUpdate: Record<string, unknown> = { updatedAt: new Date().toISOString() };
   if (entryAt !== undefined) sessionUpdate.entryAt = entryAt;
   if (exitAt !== undefined) sessionUpdate.exitAt = exitAt;
+  if (exitReason !== undefined) sessionUpdate.exitReason = exitReason;
   await sessionRef.update(sessionUpdate);
 
   // テスト結果更新（quizAttemptIdがある場合）
@@ -627,7 +633,7 @@ type ProgressData = {
   lessonsMap: Map<string, { title: string; hasVideo: boolean; hasQuiz: boolean }>;
   progressMap: Map<string, { videoCompleted: boolean; quizPassed: boolean; quizBestScore: number | null; lessonCompleted: boolean }>;
   courseProgressMap: Map<string, { completedLessons: number; totalLessons: number; progressRatio: number; isCompleted: boolean }>;
-  sessionsMap: Map<string, { entryAt: string | null; exitAt: string | null }>;
+  sessionsMap: Map<string, { sessionId: string; entryAt: string | null; exitAt: string | null; exitReason: string | null }>;
 };
 
 async function fetchStudentProgressData(
@@ -673,14 +679,16 @@ async function fetchStudentProgressData(
   }
 
   // 最新セッションのみ保持（entryAt descでソート済みなので最初に見つかったものが最新）
-  const sessionsMap = new Map<string, { entryAt: string | null; exitAt: string | null }>();
+  const sessionsMap = new Map<string, { sessionId: string; entryAt: string | null; exitAt: string | null; exitReason: string | null }>();
   for (const doc of sessionsSnap.docs) {
     const d = doc.data();
     const key = `${d.userId}_${d.lessonId}`;
     if (!sessionsMap.has(key)) {
       sessionsMap.set(key, {
+        sessionId: doc.id,
         entryAt: d.entryAt?.toDate?.().toISOString?.() ?? d.entryAt ?? null,
         exitAt: d.exitAt?.toDate?.().toISOString?.() ?? d.exitAt ?? null,
+        exitReason: d.exitReason ?? null,
       });
     }
   }
@@ -731,8 +739,10 @@ router.get("/tenants/:tenantId/student-progress", async (req: Request, res: Resp
           quizPassed: up?.quizPassed ?? false,
           quizBestScore: up?.quizBestScore ?? null,
           lessonCompleted: up?.lessonCompleted ?? false,
+          latestSessionId: session?.sessionId ?? null,
           latestEntryAt: session?.entryAt ?? null,
           latestExitAt: session?.exitAt ?? null,
+          latestExitReason: session?.exitReason ?? null,
         };
       });
 

--- a/web/app/super/progress/page.tsx
+++ b/web/app/super/progress/page.tsx
@@ -59,10 +59,12 @@ export default function StudentProgressPage() {
     lessonTitle: string;
     lesson: SuperLessonRecord;
   } | null>(null);
-  const [editVideoCompleted, setEditVideoCompleted] = useState(false);
+  const [editDate, setEditDate] = useState("");
+  const [editEntryTime, setEditEntryTime] = useState("");
+  const [editExitTime, setEditExitTime] = useState("");
+  const [editExitReason, setEditExitReason] = useState("");
+  const [editQuizScore, setEditQuizScore] = useState("");
   const [editQuizPassed, setEditQuizPassed] = useState(false);
-  const [editQuizBestScore, setEditQuizBestScore] = useState("");
-  const [editLessonCompleted, setEditLessonCompleted] = useState(false);
   const [editLoading, setEditLoading] = useState(false);
   const [editError, setEditError] = useState<string | null>(null);
 
@@ -135,6 +137,16 @@ export default function StudentProgressPage() {
     setExpanded((prev) => ({ ...prev, [key]: !prev[key] }));
   };
 
+  const toJstDateAndTime = (iso: string | null): { date: string; time: string } => {
+    if (!iso) return { date: "", time: "" };
+    const d = new Date(iso);
+    const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000);
+    return {
+      date: jst.toISOString().slice(0, 10),
+      time: jst.toISOString().slice(11, 16),
+    };
+  };
+
   const openEdit = (userId: string, userName: string | null, lesson: SuperLessonRecord) => {
     setEditContext({
       userId,
@@ -143,36 +155,57 @@ export default function StudentProgressPage() {
       lessonTitle: lesson.lessonTitle,
       lesson,
     });
-    setEditVideoCompleted(lesson.videoCompleted);
+    const entry = toJstDateAndTime(lesson.latestEntryAt);
+    const exit = toJstDateAndTime(lesson.latestExitAt);
+    setEditDate(entry.date);
+    setEditEntryTime(entry.time);
+    setEditExitTime(exit.time);
+    setEditExitReason(lesson.latestExitReason ?? "");
+    setEditQuizScore(lesson.quizBestScore?.toString() ?? "");
     setEditQuizPassed(lesson.quizPassed);
-    setEditQuizBestScore(lesson.quizBestScore?.toString() ?? "");
-    setEditLessonCompleted(lesson.lessonCompleted);
     setEditError(null);
     setEditOpen(true);
   };
 
+  const jstToUtcIso = (date: string, time: string): string => {
+    const jstDate = new Date(`${date}T${time}:00+09:00`);
+    return jstDate.toISOString();
+  };
+
   const handleEdit = async () => {
     if (!editContext || !selectedTenant) return;
+    const sessionId = editContext.lesson.latestSessionId;
+    if (!sessionId) {
+      setEditError("このレッスンにはセッション記録がありません");
+      return;
+    }
     setEditLoading(true);
     setEditError(null);
     try {
-      const body: Record<string, unknown> = {
-        videoCompleted: editVideoCompleted,
-        quizPassed: editQuizPassed,
-        lessonCompleted: editLessonCompleted,
-      };
-      if (editQuizBestScore !== "") {
-        const score = Number(editQuizBestScore);
+      const body: Record<string, unknown> = {};
+
+      if (editDate && editEntryTime) {
+        body.entryAt = jstToUtcIso(editDate, editEntryTime);
+      }
+      if (editDate && editExitTime) {
+        body.exitAt = jstToUtcIso(editDate, editExitTime);
+      }
+      if (editExitReason) {
+        body.exitReason = editExitReason;
+      }
+      if (editQuizScore !== "") {
+        const score = Number(editQuizScore);
         if (isNaN(score) || score < 0 || score > 100) {
-          setEditError("テスト最高点は0〜100の数値を入力してください");
+          setEditError("テスト点数は0〜100の数値を入力してください");
           setEditLoading(false);
           return;
         }
-        body.quizBestScore = score;
+        body.quizScore = score;
       }
+      body.quizPassed = editQuizPassed;
 
       await superFetch(
-        `/api/v2/super/tenants/${selectedTenant}/student-progress/${editContext.lessonId}/${editContext.userId}`,
+        `/api/v2/super/tenants/${selectedTenant}/attendance-report/${sessionId}`,
         {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
@@ -406,44 +439,74 @@ export default function StudentProgressPage() {
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={editVideoCompleted}
-                onChange={(e) => setEditVideoCompleted(e.target.checked)}
-                className="h-4 w-4"
-              />
-              <span className="text-sm font-medium">動画完了</span>
-            </label>
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={editQuizPassed}
-                onChange={(e) => setEditQuizPassed(e.target.checked)}
-                className="h-4 w-4"
-              />
-              <span className="text-sm font-medium">テスト合格</span>
-            </label>
             <div className="space-y-1">
-              <label className="text-sm font-medium">テスト最高点</label>
+              <label className="text-sm font-medium">日付</label>
               <Input
-                type="number"
-                min="0"
-                max="100"
-                value={editQuizBestScore}
-                onChange={(e) => setEditQuizBestScore(e.target.value)}
-                placeholder="未受験の場合は空"
+                type="date"
+                value={editDate}
+                onChange={(e) => setEditDate(e.target.value)}
               />
             </div>
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={editLessonCompleted}
-                onChange={(e) => setEditLessonCompleted(e.target.checked)}
-                className="h-4 w-4"
-              />
-              <span className="text-sm font-medium">レッスン完了</span>
-            </label>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <label className="text-sm font-medium">入室</label>
+                <Input
+                  type="time"
+                  value={editEntryTime}
+                  onChange={(e) => setEditEntryTime(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium">退室</label>
+                <Input
+                  type="time"
+                  value={editExitTime}
+                  onChange={(e) => setEditExitTime(e.target.value)}
+                />
+              </div>
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">退室理由</label>
+              <Select value={editExitReason} onValueChange={setEditExitReason}>
+                <SelectTrigger>
+                  <SelectValue placeholder="未設定" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="quiz_submitted">テスト送信</SelectItem>
+                  <SelectItem value="pause_timeout">一時停止タイムアウト</SelectItem>
+                  <SelectItem value="time_limit">時間制限</SelectItem>
+                  <SelectItem value="browser_close">ブラウザ終了</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <label className="text-sm font-medium">テスト点数</label>
+                <Input
+                  type="number"
+                  min="0"
+                  max="100"
+                  value={editQuizScore}
+                  onChange={(e) => setEditQuizScore(e.target.value)}
+                  placeholder="未受験の場合は空"
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium">合否</label>
+                <Select
+                  value={editQuizPassed ? "passed" : "failed"}
+                  onValueChange={(v) => setEditQuizPassed(v === "passed")}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="passed">合格</SelectItem>
+                    <SelectItem value="failed">不合格</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
             {editError && (
               <div className="text-sm text-destructive">{editError}</div>
             )}


### PR DESCRIPTION
## Summary
- 受講状況ページの編集ダイアログを入退室打刻ベースに全面変更
- 編集可能フィールド: 日付、入室、退室、退室理由、テスト点数、合否
- `attendance-report/:sessionId` PATCHエンドポイントを利用（`exitReason`対応追加）
- `SuperLessonRecord`に`latestSessionId`/`latestExitReason`を追加

## Test plan
- [ ] レッスン展開→編集ボタンで新しいダイアログが表示される
- [ ] 日付・入室・退室・退室理由・テスト点数・合否が編集可能
- [ ] セッション記録がないレッスンの編集でエラーメッセージが表示される
- [ ] 更新後にデータがリフレッシュされる
- [ ] lint/type-check/build/test 全PASS確認済み（33テスト合格）

🤖 Generated with [Claude Code](https://claude.com/claude-code)