### PR TITLE
feat: 出席レポート リニューアル — フィルター・ソート・コース列追加

### DIFF
--- a/packages/shared-types/src/attendance.ts
+++ b/packages/shared-types/src/attendance.ts
@@ -45,6 +45,8 @@ export interface SuperAttendanceRecord {
   userId: string;
   userName: string | null;
   userEmail: string | null;
+  courseId: string;
+  courseName: string;
   lessonId: string;
   lessonTitle: string;
   date: string | null;

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -520,6 +520,13 @@ router.get("/tenants/:tenantId/attendance-report", async (req: Request, res: Res
     lessonsMap.set(doc.id, doc.data().title ?? doc.id);
   }
 
+  // コース名を取得
+  const coursesSnapshot = await db.collection(`${basePath}/courses`).get();
+  const coursesMap = new Map<string, string>();
+  for (const doc of coursesSnapshot.docs) {
+    coursesMap.set(doc.id, doc.data().name ?? doc.id);
+  }
+
   // レポート行を構築
   const records = sessionsSnapshot.docs.map((doc) => {
     const data = doc.data();
@@ -531,6 +538,8 @@ router.get("/tenants/:tenantId/attendance-report", async (req: Request, res: Res
       userId: data.userId,
       userName: user?.name ?? null,
       userEmail: user?.email ?? null,
+      courseId: data.courseId ?? "",
+      courseName: coursesMap.get(data.courseId) ?? data.courseId ?? "",
       lessonId: data.lessonId,
       lessonTitle: lessonsMap.get(data.lessonId) ?? data.lessonId,
       date: data.entryAt?.toDate?.().toISOString?.()?.split("T")[0]
@@ -544,6 +553,15 @@ router.get("/tenants/:tenantId/attendance-report", async (req: Request, res: Res
       quizPassed: attempt?.isPassed ?? null,
       quizSubmittedAt: attempt?.submittedAt ?? null,
     };
+  });
+
+  // デフォルトソート: 受講者名 → コース名 → レッスン名
+  records.sort((a, b) => {
+    const nameComp = (a.userName ?? "").localeCompare(b.userName ?? "", "ja");
+    if (nameComp !== 0) return nameComp;
+    const courseComp = a.courseName.localeCompare(b.courseName, "ja");
+    if (courseComp !== 0) return courseComp;
+    return a.lessonTitle.localeCompare(b.lessonTitle, "ja");
   });
 
   const response: SuperAttendanceResponse = {

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isoToDatetimeLocal, datetimeLocalToISO } from "@/lib/tz-helpers";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -33,17 +33,27 @@ import type {
   SuperAttendanceResponse,
 } from "@lms-279/shared-types";
 
-type Tenant = {
-  id: string;
-  name: string;
-};
+type Tenant = { id: string; name: string };
 
+type SortDir = "asc" | "desc" | null;
+type SortKey = keyof SuperAttendanceRecord;
 
 function formatTime(iso: string | null): string {
   if (!iso) return "—";
   return new Date(iso).toLocaleTimeString("ja-JP", {
     hour: "2-digit",
     minute: "2-digit",
+    timeZone: "Asia/Tokyo",
+  });
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZone: "Asia/Tokyo",
   });
 }
 
@@ -55,18 +65,33 @@ const EXIT_REASON_LABELS: Record<string, string> = {
   max_attempts_failed: "受験上限(不合格)",
 };
 
+function SortIcon({ dir }: { dir: SortDir }) {
+  if (dir === "asc") return <span className="ml-1">▲</span>;
+  if (dir === "desc") return <span className="ml-1">▼</span>;
+  return <span className="ml-1 text-muted-foreground/30">⇅</span>;
+}
+
 export default function AttendanceReportPage() {
   const { superFetch } = useSuperAdminFetch();
 
   const [tenants, setTenants] = useState<Tenant[]>([]);
-  const [selectedTenant, setSelectedTenant] = useState<string>("");
-  const [dateFrom, setDateFrom] = useState("");
-  const [dateTo, setDateTo] = useState("");
+  const [selectedTenant, setSelectedTenant] = useState("");
   const [report, setReport] = useState<SuperAttendanceResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Edit dialog
+  // フィルター
+  const [filterUser, setFilterUser] = useState("");
+  const [filterCourse, setFilterCourse] = useState("");
+  const [filterLesson, setFilterLesson] = useState("");
+  const [filterExitReason, setFilterExitReason] = useState("");
+  const [filterQuizPassed, setFilterQuizPassed] = useState("");
+
+  // ソート
+  const [sortKey, setSortKey] = useState<SortKey | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>(null);
+
+  // 編集ダイアログ
   const [editOpen, setEditOpen] = useState(false);
   const [editRecord, setEditRecord] = useState<SuperAttendanceRecord | null>(null);
   const [editEntryAt, setEditEntryAt] = useState("");
@@ -85,17 +110,14 @@ export default function AttendanceReportPage() {
       .catch(() => setTenants([]));
   }, [superFetch]);
 
+  // テナント選択時にデータ取得
   const fetchReport = useCallback(async () => {
     if (!selectedTenant) return;
     setLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams();
-      if (dateFrom) params.set("from", dateFrom);
-      if (dateTo) params.set("to", dateTo);
-      const qs = params.toString();
       const data = await superFetch<SuperAttendanceResponse>(
-        `/api/v2/super/tenants/${selectedTenant}/attendance-report${qs ? `?${qs}` : ""}`
+        `/api/v2/super/tenants/${selectedTenant}/attendance-report`
       );
       setReport(data);
     } catch (e) {
@@ -103,7 +125,95 @@ export default function AttendanceReportPage() {
     } finally {
       setLoading(false);
     }
-  }, [superFetch, selectedTenant, dateFrom, dateTo]);
+  }, [superFetch, selectedTenant]);
+
+  useEffect(() => {
+    if (selectedTenant) {
+      fetchReport();
+      // フィルター・ソートをリセット
+      setFilterUser("");
+      setFilterCourse("");
+      setFilterLesson("");
+      setFilterExitReason("");
+      setFilterQuizPassed("");
+      setSortKey(null);
+      setSortDir(null);
+    } else {
+      setReport(null);
+    }
+  }, [selectedTenant, fetchReport]);
+
+  // ソートトグル
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      if (sortDir === "asc") setSortDir("desc");
+      else if (sortDir === "desc") { setSortKey(null); setSortDir(null); }
+      else setSortDir("asc");
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  };
+
+  // コース一覧（フィルタ用）
+  const courseOptions = useMemo(() => {
+    if (!report) return [];
+    const map = new Map<string, string>();
+    for (const r of report.records) {
+      if (r.courseId) map.set(r.courseId, r.courseName);
+    }
+    return Array.from(map, ([id, name]) => ({ id, name }));
+  }, [report]);
+
+  // フィルタ＋ソート適用
+  const filteredRecords = useMemo(() => {
+    if (!report) return [];
+    let records = report.records;
+
+    // フィルタ
+    if (filterUser) {
+      const q = filterUser.toLowerCase();
+      records = records.filter(
+        (r) =>
+          (r.userName ?? "").toLowerCase().includes(q) ||
+          (r.userEmail ?? "").toLowerCase().includes(q)
+      );
+    }
+    if (filterCourse) {
+      records = records.filter((r) => r.courseId === filterCourse);
+    }
+    if (filterLesson) {
+      const q = filterLesson.toLowerCase();
+      records = records.filter((r) => r.lessonTitle.toLowerCase().includes(q));
+    }
+    if (filterExitReason) {
+      records = records.filter((r) => r.exitReason === filterExitReason);
+    }
+    if (filterQuizPassed === "passed") {
+      records = records.filter((r) => r.quizPassed === true);
+    } else if (filterQuizPassed === "failed") {
+      records = records.filter((r) => r.quizPassed === false);
+    } else if (filterQuizPassed === "none") {
+      records = records.filter((r) => r.quizPassed === null);
+    }
+
+    // ソート
+    if (sortKey && sortDir) {
+      const dir = sortDir === "asc" ? 1 : -1;
+      records = [...records].sort((a, b) => {
+        const av = a[sortKey];
+        const bv = b[sortKey];
+        if (av === null && bv === null) return 0;
+        if (av === null) return 1;
+        if (bv === null) return -1;
+        if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+        if (typeof av === "boolean" && typeof bv === "boolean") return (Number(av) - Number(bv)) * dir;
+        return String(av).localeCompare(String(bv), "ja") * dir;
+      });
+    }
+
+    return records;
+  }, [report, filterUser, filterCourse, filterLesson, filterExitReason, filterQuizPassed, sortKey, sortDir]);
 
   const openEdit = (record: SuperAttendanceRecord) => {
     setEditRecord(record);
@@ -147,11 +257,26 @@ export default function AttendanceReportPage() {
     window.print();
   };
 
+  const sortDirFor = (key: SortKey): SortDir => (sortKey === key ? sortDir : null);
+
+  type Column = { key: SortKey; label: string; className?: string };
+  const columns: Column[] = [
+    { key: "userName", label: "受講者" },
+    { key: "courseName", label: "コース" },
+    { key: "lessonTitle", label: "レッスン" },
+    { key: "date", label: "日付", className: "whitespace-nowrap" },
+    { key: "entryAt", label: "入室", className: "whitespace-nowrap" },
+    { key: "exitAt", label: "退室", className: "whitespace-nowrap" },
+    { key: "exitReason", label: "退室理由" },
+    { key: "quizScore", label: "テスト点数" },
+    { key: "quizPassed", label: "合否" },
+  ];
+
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">出席・テスト結果レポート</h1>
 
-      {/* フィルター */}
+      {/* テナント選択 */}
       <div className="flex flex-wrap items-end gap-4">
         <div className="space-y-1">
           <label className="text-sm font-medium">テナント</label>
@@ -161,69 +286,103 @@ export default function AttendanceReportPage() {
             </SelectTrigger>
             <SelectContent>
               {tenants.map((t) => (
-                <SelectItem key={t.id} value={t.id}>
-                  {t.name}
-                </SelectItem>
+                <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
               ))}
             </SelectContent>
           </Select>
         </div>
-        <div className="space-y-1">
-          <label className="text-sm font-medium">開始日</label>
-          <Input
-            type="date"
-            value={dateFrom}
-            onChange={(e) => setDateFrom(e.target.value)}
-            className="w-40"
-          />
-        </div>
-        <div className="space-y-1">
-          <label className="text-sm font-medium">終了日</label>
-          <Input
-            type="date"
-            value={dateTo}
-            onChange={(e) => setDateTo(e.target.value)}
-            className="w-40"
-          />
-        </div>
-        <Button onClick={fetchReport} disabled={!selectedTenant || loading}>
-          {loading ? "取得中..." : "表示"}
-        </Button>
         {report && (
-          <Button variant="outline" onClick={handlePrintPdf}>
-            PDF出力
-          </Button>
+          <Button variant="outline" onClick={handlePrintPdf}>PDF出力</Button>
         )}
       </div>
 
       {error && (
-        <div className="rounded-md bg-destructive/10 p-4 text-destructive text-sm">
-          {error}
-        </div>
+        <div className="rounded-md bg-destructive/10 p-4 text-destructive text-sm">{error}</div>
       )}
 
-      {/* レポートテーブル */}
-      {report && (
+      {loading && <p className="text-muted-foreground">読み込み中...</p>}
+
+      {report && !loading && (
         <div ref={tableRef}>
+          {/* 印刷用ヘッダー */}
           <div className="print:block hidden mb-4">
             <h2 className="text-xl font-bold">{report.tenantName} — 出席・テスト結果レポート</h2>
             <p className="text-sm text-muted-foreground">
-              {dateFrom && dateTo
-                ? `期間: ${dateFrom} 〜 ${dateTo}`
-                : dateFrom
-                  ? `${dateFrom} 以降`
-                  : dateTo
-                    ? `${dateTo} まで`
-                    : "全期間"}
-              {" / "}出力日: {new Date().toLocaleDateString("ja-JP")}
+              出力日: {new Date().toLocaleDateString("ja-JP")}
             </p>
           </div>
 
           <p className="text-sm text-muted-foreground mb-2">
-            {report.tenantName} — {report.totalRecords}件
+            {report.tenantName} — {filteredRecords.length}件
+            {filteredRecords.length !== report.totalRecords && ` / 全${report.totalRecords}件`}
           </p>
 
-          {report.records.length === 0 ? (
+          {/* フィルター行 */}
+          <div className="flex flex-wrap gap-2 mb-3 print:hidden">
+            <Input
+              placeholder="受講者名で絞り込み"
+              value={filterUser}
+              onChange={(e) => setFilterUser(e.target.value)}
+              className="w-44 h-8 text-xs"
+            />
+            <Select value={filterCourse || "__all__"} onValueChange={(v) => setFilterCourse(v === "__all__" ? "" : v)}>
+              <SelectTrigger className="w-44 h-8 text-xs">
+                <SelectValue placeholder="コース" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">全コース</SelectItem>
+                {courseOptions.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Input
+              placeholder="レッスン名で絞り込み"
+              value={filterLesson}
+              onChange={(e) => setFilterLesson(e.target.value)}
+              className="w-44 h-8 text-xs"
+            />
+            <Select value={filterExitReason || "__all__"} onValueChange={(v) => setFilterExitReason(v === "__all__" ? "" : v)}>
+              <SelectTrigger className="w-44 h-8 text-xs">
+                <SelectValue placeholder="退室理由" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">全退室理由</SelectItem>
+                {Object.entries(EXIT_REASON_LABELS).map(([k, v]) => (
+                  <SelectItem key={k} value={k}>{v}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={filterQuizPassed || "__all__"} onValueChange={(v) => setFilterQuizPassed(v === "__all__" ? "" : v)}>
+              <SelectTrigger className="w-32 h-8 text-xs">
+                <SelectValue placeholder="合否" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">全て</SelectItem>
+                <SelectItem value="passed">合格</SelectItem>
+                <SelectItem value="failed">不合格</SelectItem>
+                <SelectItem value="none">未受験</SelectItem>
+              </SelectContent>
+            </Select>
+            {(filterUser || filterCourse || filterLesson || filterExitReason || filterQuizPassed) && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 text-xs"
+                onClick={() => {
+                  setFilterUser("");
+                  setFilterCourse("");
+                  setFilterLesson("");
+                  setFilterExitReason("");
+                  setFilterQuizPassed("");
+                }}
+              >
+                フィルタ解除
+              </Button>
+            )}
+          </div>
+
+          {filteredRecords.length === 0 ? (
             <div className="rounded-md border p-8 text-center text-muted-foreground">
               データがありません
             </div>
@@ -232,30 +391,37 @@ export default function AttendanceReportPage() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>日付</TableHead>
-                    <TableHead>受講者</TableHead>
-                    <TableHead>レッスン</TableHead>
-                    <TableHead>入室</TableHead>
-                    <TableHead>退室</TableHead>
-                    <TableHead>退室理由</TableHead>
-                    <TableHead>テスト点数</TableHead>
-                    <TableHead>合否</TableHead>
+                    {columns.map((col) => (
+                      <TableHead
+                        key={col.key}
+                        className={`cursor-pointer select-none hover:bg-muted/50 ${col.className ?? ""}`}
+                        onClick={() => toggleSort(col.key)}
+                      >
+                        {col.label}
+                        <SortIcon dir={sortDirFor(col.key)} />
+                      </TableHead>
+                    ))}
                     <TableHead className="print:hidden">操作</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {report.records.map((r) => (
+                  {filteredRecords.map((r) => (
                     <TableRow key={r.id}>
-                      <TableCell className="whitespace-nowrap">{r.date ?? "—"}</TableCell>
                       <TableCell>
                         <div className="text-sm">{r.userName ?? "—"}</div>
                         <div className="text-xs text-muted-foreground">{r.userEmail}</div>
                       </TableCell>
-                      <TableCell className="max-w-[200px] truncate">{r.lessonTitle}</TableCell>
-                      <TableCell className="whitespace-nowrap">{formatTime(r.entryAt)}</TableCell>
-                      <TableCell className="whitespace-nowrap">{formatTime(r.exitAt)}</TableCell>
-                      <TableCell>{r.exitReason ? (EXIT_REASON_LABELS[r.exitReason] ?? r.exitReason) : "—"}</TableCell>
-                      <TableCell>{r.quizScore !== null ? `${r.quizScore}点` : "—"}</TableCell>
+                      <TableCell className="text-sm">{r.courseName}</TableCell>
+                      <TableCell className="max-w-[200px] truncate text-sm">{r.lessonTitle}</TableCell>
+                      <TableCell className="whitespace-nowrap text-sm">{formatDate(r.entryAt)}</TableCell>
+                      <TableCell className="whitespace-nowrap text-sm">{formatTime(r.entryAt)}</TableCell>
+                      <TableCell className="whitespace-nowrap text-sm">{formatTime(r.exitAt)}</TableCell>
+                      <TableCell className="text-sm">
+                        {r.exitReason ? (EXIT_REASON_LABELS[r.exitReason] ?? r.exitReason) : "—"}
+                      </TableCell>
+                      <TableCell className="text-sm">
+                        {r.quizScore !== null ? `${r.quizScore}点` : "—"}
+                      </TableCell>
                       <TableCell>
                         {r.quizPassed === null
                           ? "—"
@@ -334,9 +500,7 @@ export default function AttendanceReportPage() {
             )}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setEditOpen(false)}>
-              キャンセル
-            </Button>
+            <Button variant="outline" onClick={() => setEditOpen(false)}>キャンセル</Button>
             <Button onClick={handleEdit} disabled={editLoading}>
               {editLoading ? "更新中..." : "更新"}
             </Button>


### PR DESCRIPTION
## Summary
- 出席レポートをテーブル一覧形式にリニューアル
- `SuperAttendanceRecord`に`courseId`/`courseName`を追加
- テナント選択で全データ取得（日付範囲フィルタ廃止）
- 各カラムにフィルター（受講者テキスト、コースSelect、レッスンテキスト、退室理由Select、合否Select）
- カラムヘッダークリックで昇順/降順/解除のトグルソート
- デフォルトソート: 受講者名→コース名→レッスン名
- 編集ダイアログ・PDF出力は維持

## Test plan
- [ ] テナント選択で全出席データがテーブル一覧で表示される
- [ ] 受講者→コース→レッスン順でデフォルトソートされている
- [ ] 各フィルターで絞り込みが動作する
- [ ] カラムヘッダークリックでソートがasc→desc→解除にトグルする
- [ ] 編集ダイアログが正常動作する
- [ ] API: 395テスト / Web: 33テスト 全PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)