### PR TITLE
fix: E2Eテスト期待値修正 + quiz-importタイムアウト拡大

### DIFF
--- a/e2e/tests/attendance-api.spec.ts
+++ b/e2e/tests/attendance-api.spec.ts
@@ -235,12 +235,14 @@ test.describe.serial("出席管理 E2E テスト", () => {
     );
     expect(abandonRes.status()).toBe(204);
 
-    // activeセッションがなくなる
+    // activeセッションがなくなる（200 + session: null）
     const activeRes = await request.get(
       `${API_BASE}/lesson-sessions/active?lessonId=${LESSON_ID}`,
       { headers: AUTH_HEADERS }
     );
-    expect(activeRes.status()).toBe(404);
+    expect(activeRes.status()).toBe(200);
+    const activeBody = await activeRes.json();
+    expect(activeBody.session).toBeNull();
   });
 
   test("項目4: pause timeout後のイベント送信で強制退室される", async ({ request }) => {

--- a/services/api/src/__tests__/integration/quiz-import.test.ts
+++ b/services/api/src/__tests__/integration/quiz-import.test.ts
@@ -9,7 +9,7 @@ describe("quiz-import service", () => {
     beforeEach(async () => {
       const mod = await import("../../services/quiz-import.js");
       validateImportedQuestions = mod.validateImportedQuestions;
-    });
+    }, 30_000);
 
     it("validates well-formed questions with isCorrect set", () => {
       const input = [


### PR DESCRIPTION
## Summary
- `attendance-api.spec.ts`: アクティブセッション未存在時の期待値を404→200+`session: null`に修正
- `quiz-import.test.ts`: `beforeEach`のdynamic importタイムアウトを10秒→30秒に拡大

## Test plan
- [ ] E2E Tests CIワークフローが成功する
- [ ] API: 395テスト全PASS

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)