### PR TITLE
fix: E2E pause timeoutテストのCI安定化（待機8秒に拡大）

### DIFF
--- a/e2e/tests/attendance-api.spec.ts
+++ b/e2e/tests/attendance-api.spec.ts
@@ -260,8 +260,8 @@ test.describe.serial("出席管理 E2E テスト", () => {
       { eventType: "pause", position: 30, clientTimestamp: pauseTime },
     ]);
 
-    // 6秒待機（PAUSE_TIMEOUT_MS=5000を超過）
-    await new Promise((resolve) => setTimeout(resolve, 6000));
+    // 8秒待機（PAUSE_TIMEOUT_MS=5000を十分超過。CI環境のタイミングずれを考慮）
+    await new Promise((resolve) => setTimeout(resolve, 8000));
 
     // heartbeat送信 → 409
     const res = await sendEvents(request, token, [


### PR DESCRIPTION
## Summary
`PAUSE_TIMEOUT_MS=5000`に対し6秒待機ではCI環境でflakyなため、8秒に拡大。

## Test plan
- [ ] E2E Tests CIワークフローが成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)