### PR TITLE
fix: E2E項目7のactiveSession期待値を404→200+nullに修正

### DIFF
--- a/e2e/tests/attendance-api.spec.ts
+++ b/e2e/tests/attendance-api.spec.ts
@@ -329,12 +329,14 @@ test.describe.serial("出席管理 E2E テスト", () => {
     );
     expect(abandonRes.status()).toBe(204);
 
-    // 6. activeセッションなし
+    // 6. activeセッションなし（200 + session: null）
     activeRes = await request.get(
       `${API_BASE}/lesson-sessions/active?lessonId=${LESSON_ID}`,
       { headers: AUTH_HEADERS }
     );
-    expect(activeRes.status()).toBe(404);
+    expect(activeRes.status()).toBe(200);
+    const abandonedBody = await activeRes.json();
+    expect(abandonedBody.session).toBeNull();
 
     // 7. 新しいセッション作成可能
     const newToken = crypto.randomUUID();


### PR DESCRIPTION
## Summary
acd17bdのAPI仕様変更（activeSession未存在時に404→200+null）の残り修正。項目7（統合シナリオ）のabandon後のactiveSession確認も統一。

## Test plan
- [ ] E2E Tests CIが全テストグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)