### PR TITLE
feat: 出席レポート編集ダイアログにテスト点数・合否を常時表示

### DIFF
--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -549,8 +549,8 @@ router.get("/tenants/:tenantId/attendance-report", async (req: Request, res: Res
       exitReason: data.exitReason ?? null,
       status: data.status,
       quizAttemptId: data.quizAttemptId ?? null,
-      quizScore: attempt?.score ?? null,
-      quizPassed: attempt?.isPassed ?? null,
+      quizScore: attempt?.score ?? data.quizScore ?? null,
+      quizPassed: attempt?.isPassed ?? data.quizPassed ?? null,
       quizSubmittedAt: attempt?.submittedAt ?? null,
     };
   });
@@ -597,7 +597,7 @@ router.patch("/tenants/:tenantId/attendance-report/:sessionId", async (req: Requ
     res.status(400).json({ error: "invalid_time_range", message: "entryAt must be before exitAt" });
     return;
   }
-  const VALID_EXIT_REASONS = ["quiz_submitted", "pause_timeout", "time_limit", "browser_close"];
+  const VALID_EXIT_REASONS = ["quiz_submitted", "pause_timeout", "time_limit", "browser_close", "max_attempts_failed"];
   if (exitReason !== undefined && (typeof exitReason !== "string" || !VALID_EXIT_REASONS.includes(exitReason))) {
     res.status(400).json({ error: "invalid_exitReason", message: `exitReason must be one of: ${VALID_EXIT_REASONS.join(", ")}` });
     return;
@@ -627,14 +627,22 @@ router.patch("/tenants/:tenantId/attendance-report/:sessionId", async (req: Requ
   if (exitReason !== undefined) sessionUpdate.exitReason = exitReason;
   await sessionRef.update(sessionUpdate);
 
-  // テスト結果更新（quizAttemptIdがある場合）
-  const quizAttemptId = sessionDoc.data()?.quizAttemptId;
-  if (quizAttemptId && (quizScore !== undefined || quizPassed !== undefined)) {
-    const attemptRef = db.collection(`${basePath}/quiz_attempts`).doc(quizAttemptId);
-    const attemptUpdate: Record<string, unknown> = {};
-    if (quizScore !== undefined) attemptUpdate.score = quizScore;
-    if (quizPassed !== undefined) attemptUpdate.isPassed = quizPassed;
-    await attemptRef.update(attemptUpdate);
+  // テスト結果更新
+  if (quizScore !== undefined || quizPassed !== undefined) {
+    const quizAttemptId = sessionDoc.data()?.quizAttemptId;
+    if (quizAttemptId) {
+      // quiz_attemptsドキュメントを更新
+      const attemptRef = db.collection(`${basePath}/quiz_attempts`).doc(quizAttemptId);
+      const attemptUpdate: Record<string, unknown> = {};
+      if (quizScore !== undefined) attemptUpdate.score = quizScore;
+      if (quizPassed !== undefined) attemptUpdate.isPassed = quizPassed;
+      await attemptRef.update(attemptUpdate);
+    }
+    // セッションにも直接保存（quizAttemptIdがない場合のフォールバック）
+    const quizUpdate: Record<string, unknown> = {};
+    if (quizScore !== undefined) quizUpdate.quizScore = quizScore;
+    if (quizPassed !== undefined) quizUpdate.quizPassed = quizPassed;
+    await sessionRef.update(quizUpdate);
   }
 
   res.json({ message: "updated" });

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -484,32 +484,28 @@ export default function AttendanceReportPage() {
                 onChange={(e) => setEditExitAt(e.target.value)}
               />
             </div>
-            {editRecord?.quizAttemptId && (
-              <>
-                <div className="space-y-1">
-                  <label className="text-sm font-medium">テスト点数</label>
-                  <Input
-                    type="number"
-                    min="0"
-                    max="100"
-                    value={editScore}
-                    onChange={(e) => setEditScore(e.target.value)}
-                  />
-                </div>
-                <div className="space-y-1">
-                  <label className="text-sm font-medium">合否</label>
-                  <Select value={editPassed} onValueChange={setEditPassed}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="選択" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="true">合格</SelectItem>
-                      <SelectItem value="false">不合格</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </>
-            )}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">テスト点数</label>
+              <Input
+                type="number"
+                min="0"
+                max="100"
+                value={editScore}
+                onChange={(e) => setEditScore(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">合否</label>
+              <Select value={editPassed} onValueChange={setEditPassed}>
+                <SelectTrigger>
+                  <SelectValue placeholder="選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="true">合格</SelectItem>
+                  <SelectItem value="false">不合格</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
             {editError && (
               <div className="text-sm text-destructive">{editError}</div>
             )}


### PR DESCRIPTION
## Summary
- 編集ダイアログのテスト点数・合否フィールドを`quizAttemptId`の有無に関わらず常時表示
- BE: quizAttemptIdなしでもセッションに直接保存、GETでフォールバック読み取り
- `max_attempts_failed`を退室理由の有効値に追加

Closes #251

## Test plan
- [x] 型チェック PASS（3ワークスペース）
- [x] lint PASS
- [x] テスト PASS（API 395件 + Web 33件）
- [ ] quizAttemptIdなしレコードで編集ダイアログにテスト点数・合否が表示されること
- [ ] テスト点数・合否を編集→保存後、テーブルに反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)