### PR TITLE
fix: 出席レポート編集後のスクロール位置復元

### DIFF
--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -320,7 +320,9 @@ export default function AttendanceReportPage() {
         }
       );
       setEditOpen(false);
-      fetchReport();
+      const scrollY = window.scrollY;
+      await fetchReport();
+      requestAnimationFrame(() => window.scrollTo(0, scrollY));
     } catch (e) {
       setEditError(e instanceof Error ? e.message : "更新に失敗しました");
     } finally {


### PR DESCRIPTION
## Summary
編集→保存後の`fetchReport()`でデータ再取得時にスクロールがトップに戻る問題を修正。
`window.scrollY`を保存し、再取得完了後に`requestAnimationFrame`で復元。

## Test plan
- [x] 型チェック・lint・テスト全PASS
- [ ] テーブル下部のレコードを編集→保存後にスクロール位置が維持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)