### PR TITLE
fix: 削除済みコース・レッスンのID表示をラベルに変更

### DIFF
--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -539,9 +539,9 @@ router.get("/tenants/:tenantId/attendance-report", async (req: Request, res: Res
       userName: user?.name ?? null,
       userEmail: user?.email ?? null,
       courseId: data.courseId ?? "",
-      courseName: coursesMap.get(data.courseId) ?? data.courseId ?? "",
+      courseName: coursesMap.get(data.courseId) ?? (data.courseId ? `(削除済みコース: ${data.courseId.slice(0, 8)}…)` : ""),
       lessonId: data.lessonId,
-      lessonTitle: lessonsMap.get(data.lessonId) ?? data.lessonId,
+      lessonTitle: lessonsMap.get(data.lessonId) ?? (data.lessonId ? `(削除済みレッスン: ${data.lessonId.slice(0, 8)}…)` : data.lessonId),
       date: data.entryAt?.toDate?.().toISOString?.()?.split("T")[0]
         ?? (typeof data.entryAt === "string" ? data.entryAt.split("T")[0] : null),
       entryAt: data.entryAt?.toDate?.().toISOString?.() ?? data.entryAt ?? null,


### PR DESCRIPTION
## Summary
- 出席レポートで、削除済みコース/レッスンのFirestoreドキュメントIDがそのまま表示されていた問題を修正
- `(削除済みコース: XXXX…)` / `(削除済みレッスン: XXXX…)` 形式のラベルを返すように変更

## Test plan
- [x] API ビルド成功
- [x] 全395テスト合格
- [ ] デプロイ後、TESTテナントの出席レポートでIDがラベル表示に変わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)