### PR TITLE
feat: テナント一覧に管理画面リンクボタンを追加

### DIFF
--- a/web/app/super/tenants/page.tsx
+++ b/web/app/super/tenants/page.tsx
@@ -287,6 +287,11 @@ export default function SuperTenantsPage() {
                 </TableCell>
                 <TableCell>
                   <div className="flex items-center gap-2 flex-wrap">
+                    <Link href={`/${tenant.id}/admin`}>
+                      <Button variant="outline" size="sm">
+                        管理画面
+                      </Button>
+                    </Link>
                     <Link href={`/super/tenants/${tenant.id}`}>
                       <Button variant="outline" size="sm">
                         詳細


### PR DESCRIPTION
## Summary
- テナント管理画面の操作列に「管理画面」ボタンを追加
- 各テナントの管理画面（`/{tenantId}/admin`）へ直接遷移可能に

## Test plan
- [ ] `/super/tenants` で「管理画面」ボタンが表示されること
- [ ] クリックで `/{tenantId}/admin` に遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)