### PR TITLE
fix: スプレッドシート出力を操作ユーザーに共有する

### DIFF
--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -1213,7 +1213,7 @@ router.post("/tenants/:tenantId/student-progress/export-sheets", async (req: Req
 
   try {
     const { exportStudentProgressToSheets } = await import("../services/google-sheets-export.js");
-    const result = await exportStudentProgressToSheets(tenantName, rows);
+    const result = await exportStudentProgressToSheets(tenantName, rows, req.superAdmin!.email);
     res.json(result);
   } catch (e) {
     console.error("[SuperAdmin] Sheets export failed:", e);

--- a/services/api/src/services/google-auth.ts
+++ b/services/api/src/services/google-auth.ts
@@ -3,6 +3,7 @@ import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
 
 const SCOPES = [
   "https://www.googleapis.com/auth/drive.readonly",
+  "https://www.googleapis.com/auth/drive.file",
   "https://www.googleapis.com/auth/documents.readonly",
   "https://www.googleapis.com/auth/spreadsheets",
 ];

--- a/services/api/src/services/google-sheets-export.ts
+++ b/services/api/src/services/google-sheets-export.ts
@@ -3,7 +3,7 @@
  * DWDを使用してスプレッドシートを作成・書き込み
  */
 
-import { getSheetsClient } from "./google-auth.js";
+import { getDriveClient, getSheetsClient } from "./google-auth.js";
 
 const HEADERS = [
   "受講者名",
@@ -28,7 +28,8 @@ const HEADERS = [
  */
 export async function exportStudentProgressToSheets(
   tenantName: string,
-  rows: string[][]
+  rows: string[][],
+  shareWithEmail?: string
 ): Promise<{ spreadsheetUrl: string; spreadsheetId: string }> {
   const sheets = await getSheetsClient();
 
@@ -122,6 +123,29 @@ export async function exportStudentProgressToSheets(
       writeError
     );
     throw writeError;
+  }
+
+  // 操作ユーザーに編集権限を付与
+  if (shareWithEmail) {
+    try {
+      const drive = await getDriveClient();
+      await drive.permissions.create({
+        fileId: spreadsheetId,
+        sendNotificationEmail: false,
+        requestBody: {
+          type: "user",
+          role: "writer",
+          emailAddress: shareWithEmail,
+        },
+      });
+    } catch (shareError) {
+      console.error(
+        "[Sheets] Failed to share spreadsheet with user:",
+        shareWithEmail,
+        shareError
+      );
+      // 共有失敗でもスプレッドシート自体は作成済みなのでエラーにしない
+    }
   }
 
   const spreadsheetUrl = `https://docs.google.com/spreadsheets/d/${spreadsheetId}`;


### PR DESCRIPTION
## Summary
- スプレッドシート出力がDWD subject（system@）のDriveに作成され、操作ユーザーがアクセスできない問題を修正
- `drive.file` スコープ追加 + Drive `permissions.create` で操作ユーザーにwriter権限を付与
- 共有失敗時はログ記録のみでスプレッドシート作成は成功扱い（非致命的エラー）

## Test plan
- [x] `npm run type-check` — 通過
- [x] `npm run lint` — 通過
- [x] `npm run test` — 全395テスト通過
- [ ] デプロイ後: DWDスコープに `drive.file` 追加（admin.google.com）
- [ ] デプロイ後: `/super/progress` からスプレッドシート出力 → 操作ユーザーでアクセス可能
- [ ] デプロイ後: Driveインポート（既存機能）が引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)