### PR TITLE
fix: スプレッドシートを操作ユーザーのマイドライブに作成する

### DIFF
--- a/services/api/src/services/google-auth.ts
+++ b/services/api/src/services/google-auth.ts
@@ -105,6 +105,28 @@ export async function getSheetsClient(): Promise<sheets_v4.Sheets> {
 }
 
 /**
+ * 指定ユーザーのsubjectで認証したSheets+Driveクライアントを返す
+ * 操作ユーザーのマイドライブにスプレッドシートを作成するために使用
+ * シングルトンキャッシュには影響しない（リクエストごとに生成）
+ */
+export async function getClientsForUser(userEmail: string): Promise<{
+  sheets: sheets_v4.Sheets;
+  drive: drive_v3.Drive;
+}> {
+  const keyData = await getDwdKeyFromSecretManager();
+  const auth = new google.auth.JWT({
+    email: keyData.client_email,
+    key: keyData.private_key,
+    scopes: SCOPES,
+    subject: userEmail,
+  });
+  return {
+    sheets: google.sheets({ version: "v4", auth }),
+    drive: google.drive({ version: "v3", auth }),
+  };
+}
+
+/**
  * Google Workspace 連携が利用可能か確認
  * リクエスト時に環境変数を読み取る
  */

--- a/services/api/src/services/google-sheets-export.ts
+++ b/services/api/src/services/google-sheets-export.ts
@@ -3,7 +3,7 @@
  * DWDを使用してスプレッドシートを作成・書き込み
  */
 
-import { getDriveClient, getSheetsClient } from "./google-auth.js";
+import { getClientsForUser } from "./google-auth.js";
 
 const HEADERS = [
   "受講者名",
@@ -29,9 +29,10 @@ const HEADERS = [
 export async function exportStudentProgressToSheets(
   tenantName: string,
   rows: string[][],
-  shareWithEmail?: string
+  userEmail: string
 ): Promise<{ spreadsheetUrl: string; spreadsheetId: string }> {
-  const sheets = await getSheetsClient();
+  // 操作ユーザーのsubjectでAPI呼び出し → ユーザーのマイドライブに作成される
+  const { sheets } = await getClientsForUser(userEmail);
 
   const today = new Date().toISOString().split("T")[0];
   const title = `${tenantName}_受講状況_${today}`;
@@ -123,29 +124,6 @@ export async function exportStudentProgressToSheets(
       writeError
     );
     throw writeError;
-  }
-
-  // 操作ユーザーに編集権限を付与
-  if (shareWithEmail) {
-    try {
-      const drive = await getDriveClient();
-      await drive.permissions.create({
-        fileId: spreadsheetId,
-        sendNotificationEmail: false,
-        requestBody: {
-          type: "user",
-          role: "writer",
-          emailAddress: shareWithEmail,
-        },
-      });
-    } catch (shareError) {
-      console.error(
-        "[Sheets] Failed to share spreadsheet with user:",
-        shareWithEmail,
-        shareError
-      );
-      // 共有失敗でもスプレッドシート自体は作成済みなのでエラーにしない
-    }
   }
 
   const spreadsheetUrl = `https://docs.google.com/spreadsheets/d/${spreadsheetId}`;


### PR DESCRIPTION
## Summary
- DWD subjectを操作ユーザーに切り替えてSheets APIを呼び出し、ユーザー自身のマイドライブに直接作成
- `getClientsForUser()`を追加（リクエストごとにユーザーsubjectで認証クライアント生成）
- 前PR #262 の`permissions.create`による共有方式を廃止（不要になったため）

## Test plan
- [x] `npm run type-check` — 通過
- [x] `npm run lint` — 通過
- [x] `npm run test` — 全395テスト通過
- [ ] デプロイ後: `/super/progress` からスプレッドシート出力 → 操作ユーザーのマイドライブに作成されること
- [ ] デプロイ後: Driveインポート（既存機能）が引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)