### PR TITLE
fix: Sheets出力のDWDスコープを最小限に絞る

### DIFF
--- a/services/api/src/services/google-auth.ts
+++ b/services/api/src/services/google-auth.ts
@@ -3,7 +3,6 @@ import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
 
 const SCOPES = [
   "https://www.googleapis.com/auth/drive.readonly",
-  "https://www.googleapis.com/auth/drive.file",
   "https://www.googleapis.com/auth/documents.readonly",
   "https://www.googleapis.com/auth/spreadsheets",
 ];
@@ -105,25 +104,20 @@ export async function getSheetsClient(): Promise<sheets_v4.Sheets> {
 }
 
 /**
- * 指定ユーザーのsubjectで認証したSheets+Driveクライアントを返す
+ * 指定ユーザーのsubjectで認証したSheetsクライアントを返す
  * 操作ユーザーのマイドライブにスプレッドシートを作成するために使用
  * シングルトンキャッシュには影響しない（リクエストごとに生成）
+ * スコープはspreadsheetsのみ（DWD認可スコープを最小限にする）
  */
-export async function getClientsForUser(userEmail: string): Promise<{
-  sheets: sheets_v4.Sheets;
-  drive: drive_v3.Drive;
-}> {
+export async function getSheetsClientForUser(userEmail: string): Promise<sheets_v4.Sheets> {
   const keyData = await getDwdKeyFromSecretManager();
   const auth = new google.auth.JWT({
     email: keyData.client_email,
     key: keyData.private_key,
-    scopes: SCOPES,
+    scopes: ["https://www.googleapis.com/auth/spreadsheets"],
     subject: userEmail,
   });
-  return {
-    sheets: google.sheets({ version: "v4", auth }),
-    drive: google.drive({ version: "v3", auth }),
-  };
+  return google.sheets({ version: "v4", auth });
 }
 
 /**

--- a/services/api/src/services/google-sheets-export.ts
+++ b/services/api/src/services/google-sheets-export.ts
@@ -3,7 +3,7 @@
  * DWDを使用してスプレッドシートを作成・書き込み
  */
 
-import { getClientsForUser } from "./google-auth.js";
+import { getSheetsClientForUser } from "./google-auth.js";
 
 const HEADERS = [
   "受講者名",
@@ -32,7 +32,7 @@ export async function exportStudentProgressToSheets(
   userEmail: string
 ): Promise<{ spreadsheetUrl: string; spreadsheetId: string }> {
   // 操作ユーザーのsubjectでAPI呼び出し → ユーザーのマイドライブに作成される
-  const { sheets } = await getClientsForUser(userEmail);
+  const sheets = await getSheetsClientForUser(userEmail);
 
   const today = new Date().toISOString().split("T")[0];
   const title = `${tenantName}_受講状況_${today}`;


### PR DESCRIPTION
## Summary
- `getClientsForUser`が全4スコープをリクエストしていたため、DWD管理コンソールに未登録の`drive.file`スコープで`unauthorized_client`エラーが発生
- `getSheetsClientForUser`に改名し`spreadsheets`スコープのみリクエスト
- 不要な`drive.file`スコープと`Drive`クライアント返却を削除

## Test plan
- [x] `npm run type-check` — 通過
- [x] `npm run lint` — 通過
- [x] `npm run test` — 全395テスト通過
- [ ] デプロイ後: `/super/progress` からスプレッドシート出力が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)