### PR TITLE
docs(adr): 認証アーキテクチャADR-030/031とGCIP移行準備

### DIFF
--- a/docs/adr/ADR-030-auth-authz-tenant-resolution-separation.md
+++ b/docs/adr/ADR-030-auth-authz-tenant-resolution-separation.md
@@ -26,7 +26,8 @@
 **責務**: 何ができるかの判定
 - テナント内のロール（admin / teacher / student）
 - 実装: `tenants/{tenantId}/users` の `role` フィールド
-- ミドルウェア: `services/api/src/middleware/auth.ts` の `requireAdmin` 等
+- ミドルウェア: `services/api/src/middleware/auth.ts` の `requireUser` / `requireAdmin`
+- teacher/student のロール別判定はルートハンドラ内で `req.user.role` を直接参照する設計（専用ミドルウェアは未提供）
 
 ### レイヤー3: テナント解決（Tenant Resolution）
 **責務**: どのテナントに属するユーザーかの判定
@@ -37,10 +38,13 @@
 
 ### レイヤー4: Workspace連携（API代行）
 **責務**: サーバーサイドでのGoogle Drive/Docs APIアクセス
-- 認証方式: サービスアカウント Domain-Wide Delegation
+- 認証方式: サービスアカウント Domain-Wide Delegation（DWD）
 - 対象ドメイン: 279279.net限定
-- サービスアカウント: `dwd-workspace@lms-279.iam.gserviceaccount.com`
-- 実装: `services/api/src/services/google-drive.ts`、`google-docs.ts`
+- サービスアカウント鍵: Secret Manager シークレット `dwd-workspace-key` から実行時取得（`google-auth.ts` 参照）
+- 実装:
+  - `services/api/src/services/google-auth.ts`: DWD JWT認証の実体（`getDriveClient()` / `getDocsClient()`）
+  - `services/api/src/services/google-drive.ts`: Drive API呼び出し（認証経路は google-auth.ts に委譲）
+  - `services/api/src/services/google-docs.ts`: Docs API呼び出し（同上）
 - **エンドユーザー認証経路とは完全に独立**
 
 ## 根拠
@@ -52,8 +56,9 @@
 ## 影響
 - ドキュメント `docs/architecture.md` に4レイヤー図を追加
 - 新規エンジニアオンボーディング時に本ADRを必読資料として提示
-- OAuthクライアントIDの命名規則: `lms-279-auth-*`（認証用）、`lms-279-dwd-*`（DWD用）とプレフィックスで区別
-- 監査ログ: レイヤーごとに別ログストリーム（Cloud Logging の label で識別）
+- OAuthクライアントIDの命名規則（**新規作成時のみ適用**）: `lms-279-auth-*`（認証用）、`lms-279-dwd-*`（DWD用）とプレフィックスで区別
+  - 既存クライアントの改名は不要（ラベルで識別を補完する運用）
+- 監査ログ: 現状の Cloud Logging ログに `layer` ラベル（`auth` / `authz` / `tenant` / `workspace`）を追加する方針。新規ログバケット作成は不要
 
 ## 参考
 - インシデント契機: 2026-04-21 外部ドメインユーザーのログイン不可（403 org_internal）

--- a/docs/adr/ADR-030-auth-authz-tenant-resolution-separation.md
+++ b/docs/adr/ADR-030-auth-authz-tenant-resolution-separation.md
@@ -1,0 +1,61 @@
+# ADR-030: 認証・認可・テナント解決・Workspace連携の責務分離
+
+## ステータス
+ドラフト（2026-04-21起票、未承認）
+
+## コンテキスト
+現状、Firebase Authenticationを「認証」として利用し、Firestoreの `allowed_emails` を「認可」として利用している。また、Google Workspace DWD（Drive/Docs連携、ADR-026）も同じGCPプロジェクト内で稼働しており、責務の境界が暗黙的になっている。
+
+2026-04-21のインシデント（外部ドメインユーザーのログイン不可、エラー403 org_internal）を契機に、以下の課題が顕在化した:
+- OAuth同意画面（Internal設定）が「認証以前」の前段にあることの認識が薄かった
+- `allowed_emails` が「認可」と「テナント所属判定」を兼ねている
+- DWD用OAuthクライアントと Firebase Auth 用 OAuth クライアントの混在リスク
+
+本ADRはGCIPマルチテナント移行（ADR-031）の前提として、4つの責務を明文化する。
+
+## 決定
+以下の4レイヤーに責務を分離し、各レイヤーの変更が他レイヤーに波及しない設計を維持する。
+
+### レイヤー1: 認証（Authentication）
+**責務**: 誰であるかの証明
+- 現在: Firebase Authentication + Google OAuth
+- 移行後: Google Cloud Identity Platform（GCIP）マルチテナント（ADR-031）
+- 扱うデータ: Firebase UID、email、displayName
+
+### レイヤー2: 認可（Authorization）
+**責務**: 何ができるかの判定
+- テナント内のロール（admin / teacher / student）
+- 実装: `tenants/{tenantId}/users` の `role` フィールド
+- ミドルウェア: `services/api/src/middleware/auth.ts` の `requireAdmin` 等
+
+### レイヤー3: テナント解決（Tenant Resolution）
+**責務**: どのテナントに属するユーザーかの判定
+- URLパス: `/[tenant]/...`
+- Firestoreパス: `tenants/{tenantId}/...`
+- アクセス許可: `tenants/{tenantId}/allowed_emails`
+- ミドルウェア: `services/api/src/middleware/tenant.ts`
+
+### レイヤー4: Workspace連携（API代行）
+**責務**: サーバーサイドでのGoogle Drive/Docs APIアクセス
+- 認証方式: サービスアカウント Domain-Wide Delegation
+- 対象ドメイン: 279279.net限定
+- サービスアカウント: `dwd-workspace@lms-279.iam.gserviceaccount.com`
+- 実装: `services/api/src/services/google-drive.ts`、`google-docs.ts`
+- **エンドユーザー認証経路とは完全に独立**
+
+## 根拠
+- **OAuth同意画面はレイヤー1の前段に位置する**: この認識がなかったため、インシデント時に「allowed_emailsに追加すれば解決」と誤判断するリスクがあった
+- **レイヤー3は認可ではない**: `allowed_emails` は「このテナントに所属を許可されたメール」であり、ロール（レイヤー2）とは別概念
+- **DWDとエンドユーザー認証の混同防止**: OAuthクライアントID、スコープ、サービスアカウント、監査ログは別個に管理する
+- **GCIP移行の土台**: ADR-031でテナント単位の認証経路を導入する際、本ADRの責務分離が前提となる
+
+## 影響
+- ドキュメント `docs/architecture.md` に4レイヤー図を追加
+- 新規エンジニアオンボーディング時に本ADRを必読資料として提示
+- OAuthクライアントIDの命名規則: `lms-279-auth-*`（認証用）、`lms-279-dwd-*`（DWD用）とプレフィックスで区別
+- 監査ログ: レイヤーごとに別ログストリーム（Cloud Logging の label で識別）
+
+## 参考
+- インシデント契機: 2026-04-21 外部ドメインユーザーのログイン不可（403 org_internal）
+- Codex セカンドオピニオン（2026-04-21）: 「認証/認可/テナント解決/Workspace連携の責務分離を明文化すべき」
+- 関連ADR: ADR-005（Firebase Auth）、ADR-006（allowed_emails）、ADR-007（マルチテナント分離）、ADR-026（DWD）

--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -8,13 +8,20 @@
 
 暫定対応として OAuth 同意画面を External 化した（ADR-030 レイヤー1の変更）が、以下の課題が残る:
 - 全世界のGoogleアカウントがFirebase Authにユーザー作成可能となり、「所属テナントなし」の孤児ユーザーが蓄積する
-- テナントごとに「許可ドメイン」「IdP」「サインイン方法」を差別化できない
-- Firebase Auth（非マルチテナント版）はテナント単位の認証サイロを持たない
+- Firebase Auth（非マルチテナント版）はテナント単位の認証サイロを持たない（UID空間・セッション・監査ログが全テナント共通）
 
-マルチテナントLMSとして、**テナントごとに独立した認証設定**を持つ設計が本筋である。
+マルチテナントLMSとして、**テナントごとに独立した認証サイロ**を持つ設計が本筋である。
+
+なお、本システムのアクセス制御は ADR-006 で定義された **allowed_emails ホワイトリストを唯一の認可境界** とする方針を継続する。Codex セカンドオピニオン（2026-04-21）の検証により、ドメイン単位の絞り込みは本システムの設計思想と整合しない（ホワイトリストが既にゼロトラスト境界として機能しており、ドメイン縛りの多重化はむしろ運用ミスの温床）と判断し、**ドメイン縛りは採用しない** ことを本ADRで確定する。
 
 ## 決定
 Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチテナントにアップグレードし、各テナントに GCIP Tenant を対応させる。
+
+### 採用方針（本LMSの認証・認可の基本原則）
+1. **allowed_emails（メール単位ホワイトリスト）を唯一の認可境界** とする（ADR-006 を継続・強化）
+2. ドメイン単位の絞り込み（Google `hd` パラメータ / GCIP Allowed Domains / Firebase メールドメイン制御）は **採用しない**
+3. GCIP 採用の主目的は **テナント単位の認証サイロ分離**（UID空間 / セッション / 監査ログ の完全分離）
+4. 副次効果として将来の SAML/OIDC 対応の下地は得られるが、本ADRのスコープではない
 
 ### フェーズ定義
 本ADRで言及する Phase 番号は以下に対応する（インシデント対応 Issue #272 の WBS と同期）:
@@ -38,15 +45,40 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 7. **カナリア展開**: 1テナントで動作確認 → テナント単位で段階展開 → 全テナント移行
 8. **Feature flag 削除と旧経路除去**: 全テナント移行後
 
+### allowed_emails 境界の必須条件
+ホワイトリスト主義を徹底するため、以下を実装レベルの必須条件とする（Phase 3 までに全項目実装）:
+
+1. **`decodedToken.email_verified === true` を必須化**（未検証メールでのログインを拒否）
+2. **`decodedToken.firebase.sign_in_provider === "google.com"` のみ許可**（他 provider からのログインを拒否、将来拡張時は別ADRで明示的に許可）
+3. **メール正規化は `.trim().toLowerCase()` のみ**（Gmail ドット無視・plus addressing は **適用禁止**。Google Workspace 独自ドメインで事故るため）
+4. **認可単位は `(tenantId, email)` の組**（email 単独での認可判定は禁止）
+5. **認可チェックは毎リクエスト実施**（キャッシュ依存禁止、削除後の既存セッションでアクセスが残るのを防ぐ）
+6. **クライアントから Firestore 直接アクセスは引き続き禁止**（全アクセスは API 経由の Admin SDK のみ。Firestore Security Rules 不要）
+
+### As-Is 実装状況（2026-04-21時点、Phase 3 補強対象の明示）
+| 項目 | 現状 | Phase 3 必須対応 |
+|------|------|-----------------|
+| email_verified チェック | ❌ 未実装 | `middleware/tenant-auth.ts` に追加 |
+| sign_in_provider 制限 | ❌ 未実装（Firebase Console側でGoogleのみ有効化に依存） | 同上 |
+| メール正規化 | 🟡 `toLowerCase()` のみ（trim未実装） | `.trim().toLowerCase()` に統一 |
+| (tenantId, email) 認可単位 | ✅ 実装済み（テナントスコープの allowed_emails） | 維持 |
+| クライアント Firestore 直接アクセス禁止 | ✅ 実装済み（`web/` 配下で `firebase/firestore` import ゼロ） | 維持 |
+| Custom Claims 利用 | ✅ 未使用（Claims 再発行問題なし） | 維持 |
+
 ### UID保持戦略
 - GCIP Tenant ごとにユーザーサイロが分かれるため、新UIDが発行される
 - `tenant-auth.ts` の `findOrCreateTenantUser` 関数内の **email ベースフォールバック検索** がテナント単位の DataSource 内で移行時の橋渡しをする:
   - GCIP経由のログインで新UID取得 → テナント内 `users` コレクションを email で検索 → `firebaseUid` フィールドを新UIDに上書き
-- 同一メール=同一人物の前提は **Google Workspace の再割当リスク** を考慮し、移行時に以下の追加条件を満たすことを要件化する:
-  - `decodedToken.email_verified === true`（検証済みメールのみ）
-  - `providerData[].providerId === "google.com"`（Google プロバイダ限定。SAML/OIDC導入時は拡張）
-  - 既存ユーザーが suspended 状態でないこと
-- **Custom Claims 未使用**のためClaims 再発行問題なし
+- ただし、この処理は上記「必須条件 1, 2, 3」を満たしたトークンに対してのみ実施する
+- 既存ユーザーが suspended 状態でないこと
+
+### UID・メンバー識別戦略の補強
+GCIP テナント単位で UID 空間が分離するため、以下を原則とする:
+
+- 外部キーは **`(tenantId, firebaseUid)` または `(tenantId, memberId)` の組** で扱う（`firebaseUid` 単独でのグローバル参照は禁止）
+- **email は「ログイン識別子」であり「人物識別子」ではない**（emailでJOINして同一人物と扱う設計は禁止）
+- As-Is 調査: `firebaseUid` 参照は8ファイル（`tenant-auth.ts` / `super-admin.ts` / `tenants.ts` / `auth.ts` / `entities.ts` / `in-memory.ts` / `firestore.ts` / `super-admin.ts`）
+- Phase 3 実装時に上記8ファイルの各参照箇所が `(tenantId, firebaseUid)` の組で扱われているかを評価し、グローバル参照している箇所を修正
 
 ### ロールバック戦略
 - `useGcip: false` にすれば旧経路に戻る（feature flag）、`gcipTenantId` は nullable で残す
@@ -61,8 +93,8 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 - **責務分離（ADR-030）**: テナント=認証サイロの1:1対応により、認証レイヤーもマルチテナント化
 - **UID保持リスクの低さ**: 影響範囲は `firebaseUid` フィールド1箇所のみ。Custom Claims未使用
 - **拡張性**: 将来的にテナントごとのSAML/OIDC連携（大手顧客SSO要件）に対応可能
-- **セキュリティ**: テナント単位で Allowed Domains、Sign-in providers、MFA方針を独立設定
-- **Codexセカンドオピニオン（2026-04-21）**: 段階移行、feature flag、カナリア展開を推奨
+- **セキュリティ**: テナント単位で Sign-in providers、MFA方針を独立設定（Allowed Domains によるドメイン絞り込みは採用方針により不採用）
+- **Codexセカンドオピニオン（2026-04-21、2回実施）**: 段階移行、feature flag、カナリア展開を推奨。さらにホワイトリスト主義採用時の必須条件（email_verified・provider制限・メール正規化・(tenantId,email)認可単位・キャッシュ依存禁止）を指摘、本ADRに反映済
 
 ## 影響
 ### コード変更
@@ -78,15 +110,38 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
   - **既知の制約**: 現状の掃除スクリプトは `getAuth()` のデフォルトインスタンスのみを対象とし、GCIP Tenant 配下のユーザーは対象外。Phase 3 実装時に `tenantManager().authForTenant(gcipTenantId)` 対応を追加する（Phase 5 までの暫定制約）
 - 監視: GCIP ログイン成功率・エラー率を Cloud Logging で計測
 
+### 運用必須施策（Phase 5 までに整備、Issue 単位で分解）
+ドメイン縛りを採用しない代償として、allowed_emails 運用の堅牢化が必須となる（Codex セカンドオピニオン 2026-04-21 の指摘に基づく）:
+
+- **変更監査ログ**: allowed_emails の追加・削除ごとに「誰が・いつ・理由・対象テナント」を記録
+- **登録時プレビュー**: 管理画面で対象の表示名・Google account email・テナント・ロールを視覚的に確認してから確定
+- **重要テナントの二者承認**: admin が複数いるテナントでは、1人の admin 追加時にもう1人の承認を要求
+- **削除時の即時セッション失効**: allowed_emails 削除時に該当ユーザーのアクティブセッションを無効化（Firebase Auth の `revokeRefreshTokens` 利用）
+- **定期棚卸し**: 四半期ごとに全テナントの allowed_emails を棚卸しし、退職者・離任者の削除漏れを検出
+- **エラーメッセージ設計**: 「所属するテナントがありません」で統一し、メール存在確認に使えない設計を維持（ユーザー列挙防止）
+- **break-glass 管理者の別管理**: 緊急アクセス用の管理者アカウントは通常の allowed_emails とは別に管理し、使用時に強制的に監査ログとアラートを発生させる
+
+### External 化の副作用と緩和策
+OAuth 同意画面 External 化（Phase 1）により、全世界の Google アカウントが認証試行可能になる:
+
+| 副作用 | 緩和策 |
+|--------|--------|
+| 未許可ログイン試行の増加 | Phase 1.7 孤児 Auth 週次掃除 + Cloud Logging での試行監視 |
+| ユーザー列挙リスク | エラーメッセージを「所属するテナントがありません」で統一 |
+| ログノイズ増加 | Cloud Logging フィルタで「所属テナントなし」の頻度を週次集計 |
+| サポート問い合わせ増加 | ランディング画面に「アクセスには管理者の登録が必要」の案内を明示 |
+| 削除後の既存セッション継続 | 削除時の `revokeRefreshTokens` 即時実行（運用必須施策参照） |
+
 ### 費用影響
 - GCIP のマルチテナント機能（Identity Platform Tenants）は **Identity Platform の特定 Tier（Essentials 以上）** で提供される
 - 料金体系は公式ドキュメントで常に変動し得るため、**Phase 3 実装着手前に GCP コンソールで現行プランを再確認**すること
 - 現状 Firebase Auth は無料枠で運用中。GCIP移行後の費用は Tier とMAU次第で数千円〜数万円/月 の増加が見込まれる可能性があるため、Phase 3 着手前に費用試算を再実施する
 
-### 非対応事項（スコープ外）
-- SAML/OIDC連携は将来対応（現状は Google プロバイダのみ）
-- パスワード認証は現状どおり非対応
-- 匿名認証は非対応
+### 非採用事項（明示的にスコープ外、採用方針により除外）
+- **メールドメインによるログイン可否制御**（Google OAuth `hd` パラメータ / GCIP Allowed Domains 機能 / Firebase メールドメインホワイトリスト）
+- **Gmail のドット無視・plus addressing の自動同一視**（メール正規化は `.trim().toLowerCase()` のみ適用）
+- **SAML/OIDC 連携**（将来対応、本ADRのスコープ外）
+- **パスワード認証・匿名認証**（本システムは Google プロバイダのみを許可）
 
 ## 参考
 - インシデント契機: 2026-04-21 403 org_internal

--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -1,0 +1,74 @@
+# ADR-031: Google Cloud Identity Platform マルチテナント採用
+
+## ステータス
+ドラフト（2026-04-21起票、未承認）
+
+## コンテキスト
+2026-04-21、外部ドメインユーザー（kanjikai.or.jp）がログインできないインシデントが発生。根本原因はGCP OAuth同意画面の `orgInternalOnly: true` 設定で、279279.net以外のユーザーが認証経路に入れない状態だった。
+
+暫定対応として OAuth 同意画面を External 化した（ADR-030 レイヤー1の変更）が、以下の課題が残る:
+- 全世界のGoogleアカウントがFirebase Authにユーザー作成可能となり、「所属テナントなし」の孤児ユーザーが蓄積する
+- テナントごとに「許可ドメイン」「IdP」「サインイン方法」を差別化できない
+- Firebase Auth（非マルチテナント版）はテナント単位の認証サイロを持たない
+
+マルチテナントLMSとして、**テナントごとに独立した認証設定**を持つ設計が本筋である。
+
+## 決定
+Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチテナントにアップグレードし、各テナントに GCIP Tenant を対応させる。
+
+### 移行戦略
+1. **Identity Platform アップグレード**: Firebase プロジェクトで Identity Platform を有効化（SDK互換、既存UIDは保持される）
+2. **GCIP Tenant の段階的作成**: 既存 Firestore `tenants/{tenantId}` に対応する GCIP Tenant を作成
+3. **`tenants` スキーマ拡張**: `gcipTenantId: string | null` フィールド追加（nullableで後方互換）
+4. **Feature flag `useGcip: boolean`**: テナント単位で GCIP 経路 / 旧 Firebase Auth 経路を切り替え
+5. **FE ログインフロー変更**: `/[tenant]/` ルートでテナント情報を取得 → `auth.tenantId = gcipTenantId` をセット → `signInWithPopup`
+6. **BE 検証強化**: `verifyIdToken` で `decodedToken.firebase.tenant` と URL パスの一致を確認
+7. **カナリア展開**: 1テナントで動作確認 → テナント単位で段階展開 → 全テナント移行
+8. **Feature flag 削除と旧経路除去**: 全テナント移行後
+
+### UID保持戦略
+- GCIP Tenant ごとにユーザーサイロが分かれるため、新UIDが発行される
+- 既存の `email` ベースフォールバック検索（`tenant-auth.ts:158-167`）が移行時の橋渡しをする:
+  - GCIP経由のログインで新UID取得 → email でFirestore検索 → firebaseUid フィールドを新UIDに更新
+- 既存の `firebaseUid` は更新される（同一メール=同一人物の前提）
+- **Custom Claims 未使用**のためClaims 再発行問題なし
+
+### ロールバック戦略
+- `useGcip: false` にすれば即座に旧経路に戻る（feature flag）
+- `gcipTenantId` は nullable で残す
+- 移行期間中、両経路が同時稼働可能
+
+## 根拠
+- **責務分離（ADR-030）**: テナント=認証サイロの1:1対応により、認証レイヤーもマルチテナント化
+- **UID保持リスクの低さ**: 影響範囲は `firebaseUid` フィールド1箇所のみ。Custom Claims未使用
+- **拡張性**: 将来的にテナントごとのSAML/OIDC連携（大手顧客SSO要件）に対応可能
+- **セキュリティ**: テナント単位で Allowed Domains、Sign-in providers、MFA方針を独立設定
+- **Codexセカンドオピニオン（2026-04-21）**: 段階移行、feature flag、カナリア展開を推奨
+
+## 影響
+### コード変更
+- `services/api/src/middleware/tenant-auth.ts`: テナント整合性チェック追加
+- `services/api/src/routes/tenants.ts`: 新規テナント作成時に GCIP Tenant 自動作成
+- `web/lib/auth-context.tsx`: `auth.tenantId` 設定ロジック追加
+- `web/app/[tenant]/page.tsx`: ログイン前のテナント解決
+- Firestore `tenants` スキーマ: `gcipTenantId`, `useGcip` フィールド追加
+
+### 運用変更
+- GCP コンソールで GCIP Tenant 管理（新規テナント作成・削除手順の更新）
+- 週次チェック: 孤児Authユーザー → Phase 1.7 のクリーンアップスクリプトを Phase 5 で正式化
+- 監視: GCIP ログイン成功率・エラー率を Cloud Logging で計測
+
+### 費用影響
+- GCIP の月額 MAU 課金（50,000 MAU まで無料、それ以上 $0.01/MAU 程度）
+- 現状 Firebase Auth は無料枠で運用中。GCIP移行後も当面は無料枠内と想定
+
+### 非対応事項（スコープ外）
+- SAML/OIDC連携は将来対応（現状は Google プロバイダのみ）
+- パスワード認証は現状どおり非対応
+- 匿名認証は非対応
+
+## 参考
+- インシデント契機: 2026-04-21 403 org_internal
+- Codex セカンドオピニオン（2026-04-21）
+- 関連ADR: ADR-005（Firebase Auth）、ADR-006（allowed_emails）、ADR-007（マルチテナント分離）、ADR-030（責務分離）
+- Google 公式: [GCIP multi-tenancy](https://cloud.google.com/identity-platform/docs/multi-tenancy)

--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -16,27 +16,46 @@
 ## 決定
 Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチテナントにアップグレードし、各テナントに GCIP Tenant を対応させる。
 
+### フェーズ定義
+本ADRで言及する Phase 番号は以下に対応する（インシデント対応 Issue #272 の WBS と同期）:
+
+| Phase | 内容 |
+|-------|------|
+| 1 | OAuth同意画面 External 化（暫定復旧） |
+| 1.7 | 孤児Authユーザー掃除スクリプト雛形（`scripts/cleanup-orphan-auth-users.ts`） |
+| 2 | 本ADR + ADR-030 起票（ドラフト） |
+| 3 | GCIP移行実装（feature flag + カナリア） |
+| 4 | Staging検証・本番ロールアウト |
+| 5 | クリーンアップ・運用手順書整備（Cloud Scheduler正式化含む） |
+
 ### 移行戦略
 1. **Identity Platform アップグレード**: Firebase プロジェクトで Identity Platform を有効化（SDK互換、既存UIDは保持される）
 2. **GCIP Tenant の段階的作成**: 既存 Firestore `tenants/{tenantId}` に対応する GCIP Tenant を作成
 3. **`tenants` スキーマ拡張**: `gcipTenantId: string | null` フィールド追加（nullableで後方互換）
 4. **Feature flag `useGcip: boolean`**: テナント単位で GCIP 経路 / 旧 Firebase Auth 経路を切り替え
-5. **FE ログインフロー変更**: `/[tenant]/` ルートでテナント情報を取得 → `auth.tenantId = gcipTenantId` をセット → `signInWithPopup`
-6. **BE 検証強化**: `verifyIdToken` で `decodedToken.firebase.tenant` と URL パスの一致を確認
+5. **FE ログインフロー変更**: `/[tenant]/` ルートでテナント情報を取得 → GCIP Tenant ID (`gcipTenantId`) を `auth.tenantId` にセット → `signInWithPopup`
+6. **BE 検証強化**: `verifyIdToken` の戻り値 `decodedToken.firebase.tenant` は **GCIP Tenant ID**（URLパスの `tenantId` ではない）であり、これを Firestore `tenants/{tenantId}.gcipTenantId` と照合してテナント整合性を確認する
 7. **カナリア展開**: 1テナントで動作確認 → テナント単位で段階展開 → 全テナント移行
 8. **Feature flag 削除と旧経路除去**: 全テナント移行後
 
 ### UID保持戦略
 - GCIP Tenant ごとにユーザーサイロが分かれるため、新UIDが発行される
-- 既存の `email` ベースフォールバック検索（`tenant-auth.ts:158-167`）が移行時の橋渡しをする:
-  - GCIP経由のログインで新UID取得 → email でFirestore検索 → firebaseUid フィールドを新UIDに更新
-- 既存の `firebaseUid` は更新される（同一メール=同一人物の前提）
+- `tenant-auth.ts` の `findOrCreateTenantUser` 関数内の **email ベースフォールバック検索** がテナント単位の DataSource 内で移行時の橋渡しをする:
+  - GCIP経由のログインで新UID取得 → テナント内 `users` コレクションを email で検索 → `firebaseUid` フィールドを新UIDに上書き
+- 同一メール=同一人物の前提は **Google Workspace の再割当リスク** を考慮し、移行時に以下の追加条件を満たすことを要件化する:
+  - `decodedToken.email_verified === true`（検証済みメールのみ）
+  - `providerData[].providerId === "google.com"`（Google プロバイダ限定。SAML/OIDC導入時は拡張）
+  - 既存ユーザーが suspended 状態でないこと
 - **Custom Claims 未使用**のためClaims 再発行問題なし
 
 ### ロールバック戦略
-- `useGcip: false` にすれば即座に旧経路に戻る（feature flag）
-- `gcipTenantId` は nullable で残す
+- `useGcip: false` にすれば旧経路に戻る（feature flag）、`gcipTenantId` は nullable で残す
 - 移行期間中、両経路が同時稼働可能
+- **UID 揺り戻しリスク**: GCIP ログイン時に `firebaseUid` を新UIDへ上書きするため、ロールバック後は旧 Firebase Auth UID で再度上書きされる（email fallback で復旧可能だが UID 参照の揺れが発生）
+  - 監査ログ上の UID 参照
+  - 外部連携（Cloud Logging、BigQuery export、分析ダッシュボード）の UID 参照
+  - アクティブセッション（ロールバック時はユーザーに再ログイン要求）
+- 上記の影響を許容できるテナント単位でのみ段階的にロールバックを実施する
 
 ## 根拠
 - **責務分離（ADR-030）**: テナント=認証サイロの1:1対応により、認証レイヤーもマルチテナント化
@@ -55,12 +74,14 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 
 ### 運用変更
 - GCP コンソールで GCIP Tenant 管理（新規テナント作成・削除手順の更新）
-- 週次チェック: 孤児Authユーザー → Phase 1.7 のクリーンアップスクリプトを Phase 5 で正式化
+- 週次チェック: 孤児Authユーザー → 本ADRリリースと同時に追加された `scripts/cleanup-orphan-auth-users.ts` を Phase 5 で Cloud Scheduler 経由の定期実行に正式化
+  - **既知の制約**: 現状の掃除スクリプトは `getAuth()` のデフォルトインスタンスのみを対象とし、GCIP Tenant 配下のユーザーは対象外。Phase 3 実装時に `tenantManager().authForTenant(gcipTenantId)` 対応を追加する（Phase 5 までの暫定制約）
 - 監視: GCIP ログイン成功率・エラー率を Cloud Logging で計測
 
 ### 費用影響
-- GCIP の月額 MAU 課金（50,000 MAU まで無料、それ以上 $0.01/MAU 程度）
-- 現状 Firebase Auth は無料枠で運用中。GCIP移行後も当面は無料枠内と想定
+- GCIP のマルチテナント機能（Identity Platform Tenants）は **Identity Platform の特定 Tier（Essentials 以上）** で提供される
+- 料金体系は公式ドキュメントで常に変動し得るため、**Phase 3 実装着手前に GCP コンソールで現行プランを再確認**すること
+- 現状 Firebase Auth は無料枠で運用中。GCIP移行後の費用は Tier とMAU次第で数千円〜数万円/月 の増加が見込まれる可能性があるため、Phase 3 着手前に費用試算を再実施する
 
 ### 非対応事項（スコープ外）
 - SAML/OIDC連携は将来対応（現状は Google プロバイダのみ）

--- a/scripts/cleanup-orphan-auth-users.ts
+++ b/scripts/cleanup-orphan-auth-users.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env npx tsx
+/**
+ * 孤児Firebase Authユーザー掃除スクリプト（Phase 1.7 / ADR-031）
+ *
+ * OAuth同意画面のExternal化（ADR-031のPhase 1）により、全世界のGoogleユーザーが
+ * Firebase Authにユーザーレコードを作成できる状態となる。アプリ側ではallowed_emailsで
+ * 認可制御しているため実害はないが、長期的にはFirebase Authに未所属ユーザーが蓄積する。
+ *
+ * 本スクリプトは以下を実行する:
+ * 1. Firebase Authの全ユーザーを取得
+ * 2. 全テナントのusers + allowed_emails を集約
+ * 3. どのテナントにも所属していない（email非一致）ユーザーを孤児と判定
+ * 4. デフォルトはdry-run（レポート出力のみ）、--execute で実際に削除
+ *
+ * 運用: 週次 or 月次でCloud Schedulerから実行想定（Phase 5で正式化）
+ *
+ * 使用方法:
+ *   # dry-run (デフォルト)
+ *   GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json npx tsx scripts/cleanup-orphan-auth-users.ts
+ *
+ *   # 実削除
+ *   GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json npx tsx scripts/cleanup-orphan-auth-users.ts --execute
+ *
+ *   # 作成から一定時間経過したユーザーのみ対象（秒単位、デフォルト3600=1時間）
+ *   npx tsx scripts/cleanup-orphan-auth-users.ts --min-age-seconds=86400
+ */
+
+import { initializeApp, cert, type ServiceAccount } from "firebase-admin/app";
+import { getAuth } from "firebase-admin/auth";
+import { getFirestore } from "firebase-admin/firestore";
+
+// ---------- 引数パース ----------
+const args = process.argv.slice(2);
+const EXECUTE = args.includes("--execute");
+const MIN_AGE_SEC = Number(
+  args.find((a) => a.startsWith("--min-age-seconds="))?.split("=")[1] ?? "3600"
+);
+
+// ---------- Firebase初期化 ----------
+const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+if (credPath) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const serviceAccount = require(credPath) as ServiceAccount;
+  initializeApp({ credential: cert(serviceAccount) });
+} else {
+  initializeApp();
+}
+
+const db = getFirestore();
+const auth = getAuth();
+
+// ---------- 正規化 ----------
+const normalizeEmail = (email: string | undefined): string =>
+  (email ?? "").trim().toLowerCase();
+
+// ---------- 集約 ----------
+async function collectAllowedAndRegisteredEmails(): Promise<Set<string>> {
+  const emails = new Set<string>();
+  const tenantsSnap = await db.collection("tenants").get();
+  for (const tenantDoc of tenantsSnap.docs) {
+    const tenantId = tenantDoc.id;
+
+    const allowedSnap = await db
+      .collection(`tenants/${tenantId}/allowed_emails`)
+      .get();
+    for (const doc of allowedSnap.docs) {
+      const email = normalizeEmail(doc.data().email);
+      if (email) emails.add(email);
+    }
+
+    const usersSnap = await db.collection(`tenants/${tenantId}/users`).get();
+    for (const doc of usersSnap.docs) {
+      const email = normalizeEmail(doc.data().email);
+      if (email) emails.add(email);
+    }
+  }
+  return emails;
+}
+
+// ---------- 走査 ----------
+async function main() {
+  console.log("=== 孤児Firebase Authユーザー掃除 ===");
+  console.log(`モード: ${EXECUTE ? "EXECUTE（実削除）" : "DRY-RUN（レポートのみ）"}`);
+  console.log(`最小経過時間: ${MIN_AGE_SEC}秒\n`);
+
+  console.log("テナント内 allowed_emails + users を集約中...");
+  const registeredEmails = await collectAllowedAndRegisteredEmails();
+  console.log(`登録済みメール数: ${registeredEmails.size}\n`);
+
+  console.log("Firebase Auth ユーザー一覧を走査中...");
+  const orphans: Array<{ uid: string; email: string; createdMs: number }> = [];
+  let totalUsers = 0;
+  let nextPageToken: string | undefined;
+
+  do {
+    const listResult = await auth.listUsers(1000, nextPageToken);
+    nextPageToken = listResult.pageToken;
+    for (const user of listResult.users) {
+      totalUsers++;
+      const email = normalizeEmail(user.email);
+      if (!email) continue;
+      const createdMs = new Date(user.metadata.creationTime).getTime();
+      const ageSec = (Date.now() - createdMs) / 1000;
+      if (ageSec < MIN_AGE_SEC) continue;
+      if (!registeredEmails.has(email)) {
+        orphans.push({ uid: user.uid, email, createdMs });
+      }
+    }
+  } while (nextPageToken);
+
+  console.log(`Firebase Auth ユーザー総数: ${totalUsers}`);
+  console.log(`孤児候補: ${orphans.length}\n`);
+
+  if (orphans.length === 0) {
+    console.log("掃除対象なし。終了。");
+    return;
+  }
+
+  console.log("=== 孤児ユーザー一覧 ===");
+  for (const o of orphans) {
+    const created = new Date(o.createdMs).toISOString();
+    console.log(`  ${o.uid} | ${o.email} | 作成: ${created}`);
+  }
+
+  if (!EXECUTE) {
+    console.log("\n※ dry-run モードのため削除は実行しません。--execute で実削除します。");
+    return;
+  }
+
+  console.log("\n削除を実行します...");
+  let deleted = 0;
+  let failed = 0;
+  for (const o of orphans) {
+    try {
+      await auth.deleteUser(o.uid);
+      console.log(`  削除成功: ${o.uid} (${o.email})`);
+      deleted++;
+    } catch (err) {
+      console.error(`  削除失敗: ${o.uid} (${o.email})`, err);
+      failed++;
+    }
+  }
+  console.log(`\n完了: 成功=${deleted}, 失敗=${failed}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-orphan-auth-users.ts
+++ b/scripts/cleanup-orphan-auth-users.ts
@@ -6,50 +6,129 @@
  * Firebase Authにユーザーレコードを作成できる状態となる。アプリ側ではallowed_emailsで
  * 認可制御しているため実害はないが、長期的にはFirebase Authに未所属ユーザーが蓄積する。
  *
- * 本スクリプトは以下を実行する:
- * 1. Firebase Authの全ユーザーを取得
- * 2. 全テナントのusers + allowed_emails を集約
- * 3. どのテナントにも所属していない（email非一致）ユーザーを孤児と判定
- * 4. デフォルトはdry-run（レポート出力のみ）、--execute で実際に削除
+ * 本スクリプトは allowed_emails + users コレクションに登録されていない Firebase Auth
+ * ユーザー（孤児）を安全に削除する。
  *
- * 運用: 週次 or 月次でCloud Schedulerから実行想定（Phase 5で正式化）
+ * 安全機構（PR #273 レビュー結果反映）:
+ * 1. dry-run既定（--execute で実行）
+ * 2. tenants空 / 取得メール0件を異常事態として中断（全ユーザー削除誤動作防止）
+ * 3. --min-age-seconds（既定3600=1時間）未満のユーザーは対象外（ログイン直後の誤削除防止）
+ * 4. disabledユーザーはデフォルトスキップ（調査中・懲罰中等の中間状態を保護）
+ * 5. 連続失敗閾値（--fail-streak、既定3）で即座に中断
+ * 6. 削除前のバックアップJSON出力
+ * 7. エラーコード別分岐（auth/insufficient-permission → 致命、auth/user-not-found → スキップ）
+ * 8. creationTime の NaN チェック（min-age バイパス防止）
+ *
+ * ⚠️ GCIP移行期間中の注意（ADR-031 Phase 3 段階展開中）:
+ *   本スクリプトは `getAuth()` のデフォルトインスタンスのみを対象とし、
+ *   GCIP Tenant 配下のユーザーは対象外。feature flag `useGcip: true` のテナントに
+ *   所属するユーザーは GCIP tenant auth に移動しているため、本スクリプトで孤児判定
+ *   されない。Phase 3 完了時に `tenantManager().authForTenant(gcipTenantId)` 対応を
+ *   追加する（Phase 5 で正式化）。
+ *
+ * 運用: 週次 or 月次で実行想定（Phase 5で Cloud Scheduler に正式化）
  *
  * 使用方法:
- *   # dry-run (デフォルト)
+ *   # dry-run (既定)
  *   GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json npx tsx scripts/cleanup-orphan-auth-users.ts
  *
  *   # 実削除
- *   GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json npx tsx scripts/cleanup-orphan-auth-users.ts --execute
+ *   npx tsx scripts/cleanup-orphan-auth-users.ts --execute
  *
- *   # 作成から一定時間経過したユーザーのみ対象（秒単位、デフォルト3600=1時間）
- *   npx tsx scripts/cleanup-orphan-auth-users.ts --min-age-seconds=86400
+ *   # オプション
+ *   --min-age-seconds=86400   削除対象の最小経過時間（既定3600、最小60）
+ *   --include-disabled        disabledユーザーも対象に含める（既定スキップ）
+ *   --fail-streak=5           連続失敗中断閾値（既定3、最小1）
  */
 
-import { initializeApp, cert, type ServiceAccount } from "firebase-admin/app";
+import {
+  initializeApp,
+  cert,
+  applicationDefault,
+  type ServiceAccount,
+} from "firebase-admin/app";
 import { getAuth } from "firebase-admin/auth";
 import { getFirestore } from "firebase-admin/firestore";
+import { readFileSync, writeFileSync } from "fs";
+import { resolve } from "path";
+
+// ---------- 定数 ----------
+const KNOWN_FLAGS = [
+  "--execute",
+  "--include-disabled",
+  "--min-age-seconds=",
+  "--fail-streak=",
+];
+const MIN_ALLOWED_MIN_AGE_SEC = 60;
 
 // ---------- 引数パース ----------
 const args = process.argv.slice(2);
-const EXECUTE = args.includes("--execute");
-const MIN_AGE_SEC = Number(
-  args.find((a) => a.startsWith("--min-age-seconds="))?.split("=")[1] ?? "3600"
+
+// 未知フラグ検知（typo による silent failure 防止）
+const unknownArgs = args.filter(
+  (a) => !KNOWN_FLAGS.some((k) => a === k || a.startsWith(k))
 );
+if (unknownArgs.length > 0) {
+  console.error(`[FATAL] 未知のフラグ: ${unknownArgs.join(", ")}`);
+  console.error(`  既知のフラグ: ${KNOWN_FLAGS.join(" / ")}`);
+  process.exit(1);
+}
+
+const EXECUTE = args.includes("--execute");
+const INCLUDE_DISABLED = args.includes("--include-disabled");
+
+const rawMinAge = args
+  .find((a) => a.startsWith("--min-age-seconds="))
+  ?.split("=")[1];
+const MIN_AGE_SEC = rawMinAge !== undefined ? Number(rawMinAge) : 3600;
+if (!Number.isFinite(MIN_AGE_SEC) || MIN_AGE_SEC < MIN_ALLOWED_MIN_AGE_SEC) {
+  console.error(
+    `[FATAL] --min-age-seconds は${MIN_ALLOWED_MIN_AGE_SEC}以上の数値が必要です: 受け取った値="${rawMinAge}"`
+  );
+  process.exit(1);
+}
+
+const rawFailStreak = args
+  .find((a) => a.startsWith("--fail-streak="))
+  ?.split("=")[1];
+const FAIL_ABORT_STREAK =
+  rawFailStreak !== undefined ? Number(rawFailStreak) : 3;
+if (!Number.isFinite(FAIL_ABORT_STREAK) || FAIL_ABORT_STREAK < 1) {
+  console.error(
+    `[FATAL] --fail-streak は1以上の数値が必要です: 受け取った値="${rawFailStreak}"`
+  );
+  process.exit(1);
+}
 
 // ---------- Firebase初期化 ----------
 const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-if (credPath) {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const serviceAccount = require(credPath) as ServiceAccount;
-  initializeApp({ credential: cert(serviceAccount) });
-} else {
-  initializeApp();
+try {
+  if (credPath) {
+    // ServiceAccount JSON は絶対パスまたは CWD 基準で解決
+    const jsonPath = resolve(process.cwd(), credPath);
+    const serviceAccount = JSON.parse(
+      readFileSync(jsonPath, "utf8")
+    ) as ServiceAccount;
+    initializeApp({ credential: cert(serviceAccount) });
+    console.log(`認証: サービスアカウントJSON (${jsonPath})`);
+  } else {
+    initializeApp({ credential: applicationDefault() });
+    console.log("認証: Application Default Credentials");
+  }
+} catch (err) {
+  console.error(
+    `[FATAL] Firebase初期化失敗 (credPath=${credPath ?? "ADC"}): ${
+      err instanceof Error ? err.message : err
+    }`
+  );
+  process.exit(1);
 }
 
 const db = getFirestore();
 const auth = getAuth();
 
-// ---------- 正規化 ----------
+// ---------- ユーティリティ ----------
+// アプリ側（tenant-auth.ts）は toLowerCase のみだが、掃除時は誤判定防止のため trim も実施
 const normalizeEmail = (email: string | undefined): string =>
   (email ?? "").trim().toLowerCase();
 
@@ -57,23 +136,51 @@ const normalizeEmail = (email: string | undefined): string =>
 async function collectAllowedAndRegisteredEmails(): Promise<Set<string>> {
   const emails = new Set<string>();
   const tenantsSnap = await db.collection("tenants").get();
+
+  // SAFEGUARD 1: tenants が空 → 異常事態として中断
+  if (tenantsSnap.empty) {
+    throw new Error(
+      "ABORT: tenants コレクションが空です。プロジェクトID/権限設定を確認してください。" +
+        "この状態で削除を継続すると全Authユーザーを誤削除します。"
+    );
+  }
+
+  let tenantsProcessed = 0;
   for (const tenantDoc of tenantsSnap.docs) {
     const tenantId = tenantDoc.id;
-
-    const allowedSnap = await db
-      .collection(`tenants/${tenantId}/allowed_emails`)
-      .get();
-    for (const doc of allowedSnap.docs) {
-      const email = normalizeEmail(doc.data().email);
-      if (email) emails.add(email);
-    }
-
-    const usersSnap = await db.collection(`tenants/${tenantId}/users`).get();
-    for (const doc of usersSnap.docs) {
-      const email = normalizeEmail(doc.data().email);
-      if (email) emails.add(email);
+    try {
+      const allowedSnap = await db
+        .collection(`tenants/${tenantId}/allowed_emails`)
+        .get();
+      for (const doc of allowedSnap.docs) {
+        const email = normalizeEmail(doc.data().email);
+        if (email) emails.add(email);
+      }
+      const usersSnap = await db
+        .collection(`tenants/${tenantId}/users`)
+        .get();
+      for (const doc of usersSnap.docs) {
+        const email = normalizeEmail(doc.data().email);
+        if (email) emails.add(email);
+      }
+      tenantsProcessed++;
+    } catch (err) {
+      throw new Error(
+        `テナント ${tenantId} の読み取り失敗: ${
+          err instanceof Error ? err.message : err
+        }`
+      );
     }
   }
+
+  // SAFEGUARD 2: 取得メール0件 → 異常事態として中断
+  if (emails.size === 0) {
+    throw new Error(
+      `ABORT: ${tenantsProcessed}テナントから登録メールが0件取得されました。` +
+        `読み取り権限またはデータ構造を確認してください。`
+    );
+  }
+
   return emails;
 }
 
@@ -81,15 +188,27 @@ async function collectAllowedAndRegisteredEmails(): Promise<Set<string>> {
 async function main() {
   console.log("=== 孤児Firebase Authユーザー掃除 ===");
   console.log(`モード: ${EXECUTE ? "EXECUTE（実削除）" : "DRY-RUN（レポートのみ）"}`);
-  console.log(`最小経過時間: ${MIN_AGE_SEC}秒\n`);
+  console.log(`最小経過時間: ${MIN_AGE_SEC}秒`);
+  console.log(`disabled扱い: ${INCLUDE_DISABLED ? "含める" : "スキップ"}`);
+  console.log(`連続失敗中断閾値: ${FAIL_ABORT_STREAK}件\n`);
 
   console.log("テナント内 allowed_emails + users を集約中...");
   const registeredEmails = await collectAllowedAndRegisteredEmails();
   console.log(`登録済みメール数: ${registeredEmails.size}\n`);
 
   console.log("Firebase Auth ユーザー一覧を走査中...");
-  const orphans: Array<{ uid: string; email: string; createdMs: number }> = [];
+  const orphans: Array<{
+    uid: string;
+    email: string;
+    createdMs: number;
+    providers: string[];
+    disabled: boolean;
+  }> = [];
   let totalUsers = 0;
+  let skippedNoEmail = 0;
+  let skippedDisabled = 0;
+  let skippedTooYoung = 0;
+  let skippedInvalidCreationTime = 0;
   let nextPageToken: string | undefined;
 
   do {
@@ -97,19 +216,52 @@ async function main() {
     nextPageToken = listResult.pageToken;
     for (const user of listResult.users) {
       totalUsers++;
+
       const email = normalizeEmail(user.email);
-      if (!email) continue;
+      if (!email) {
+        skippedNoEmail++;
+        continue;
+      }
+
+      if (user.disabled && !INCLUDE_DISABLED) {
+        skippedDisabled++;
+        continue;
+      }
+
+      // SAFEGUARD 3: creationTime の NaN チェック（min-age バイパス防止）
       const createdMs = new Date(user.metadata.creationTime).getTime();
+      if (!Number.isFinite(createdMs)) {
+        console.warn(
+          `  警告: ${user.uid} の creationTime が不正: ${user.metadata.creationTime}`
+        );
+        skippedInvalidCreationTime++;
+        continue;
+      }
+
       const ageSec = (Date.now() - createdMs) / 1000;
-      if (ageSec < MIN_AGE_SEC) continue;
+      if (ageSec < MIN_AGE_SEC) {
+        skippedTooYoung++;
+        continue;
+      }
+
       if (!registeredEmails.has(email)) {
-        orphans.push({ uid: user.uid, email, createdMs });
+        orphans.push({
+          uid: user.uid,
+          email,
+          createdMs,
+          providers: user.providerData.map((p) => p.providerId),
+          disabled: user.disabled,
+        });
       }
     }
   } while (nextPageToken);
 
   console.log(`Firebase Auth ユーザー総数: ${totalUsers}`);
-  console.log(`孤児候補: ${orphans.length}\n`);
+  console.log(`  スキップ(emailなし): ${skippedNoEmail}`);
+  console.log(`  スキップ(disabled): ${skippedDisabled}`);
+  console.log(`  スキップ(経過時間不足): ${skippedTooYoung}`);
+  console.log(`  スキップ(creationTime不正): ${skippedInvalidCreationTime}`);
+  console.log(`  孤児候補: ${orphans.length}\n`);
 
   if (orphans.length === 0) {
     console.log("掃除対象なし。終了。");
@@ -119,31 +271,78 @@ async function main() {
   console.log("=== 孤児ユーザー一覧 ===");
   for (const o of orphans) {
     const created = new Date(o.createdMs).toISOString();
-    console.log(`  ${o.uid} | ${o.email} | 作成: ${created}`);
+    console.log(
+      `  ${o.uid} | ${o.email} | providers=${o.providers.join(",")} | 作成: ${created}`
+    );
   }
 
   if (!EXECUTE) {
-    console.log("\n※ dry-run モードのため削除は実行しません。--execute で実削除します。");
+    console.log(
+      "\n※ dry-run モードのため削除は実行しません。--execute で実削除します。"
+    );
     return;
   }
 
-  console.log("\n削除を実行します...");
+  // バックアップJSON出力（復旧用）
+  const backupPath = `orphan-cleanup-backup-${Date.now()}.json`;
+  writeFileSync(backupPath, JSON.stringify(orphans, null, 2));
+  console.log(`\nバックアップ保存: ${backupPath}`);
+
+  console.log("削除を実行します...");
   let deleted = 0;
   let failed = 0;
+  let consecutiveFailures = 0;
+  const failedUids: string[] = [];
+
   for (const o of orphans) {
     try {
       await auth.deleteUser(o.uid);
       console.log(`  削除成功: ${o.uid} (${o.email})`);
       deleted++;
+      consecutiveFailures = 0;
     } catch (err) {
-      console.error(`  削除失敗: ${o.uid} (${o.email})`, err);
+      const code = (err as { code?: string }).code;
+      // エラー種別分岐
+      if (code === "auth/user-not-found") {
+        console.log(`  スキップ（既削除）: ${o.uid}`);
+        continue;
+      }
+      if (
+        code === "auth/insufficient-permission" ||
+        code === "auth/quota-exceeded"
+      ) {
+        console.error(`  致命的エラー、中断: ${code}`, err);
+        throw err;
+      }
+      consecutiveFailures++;
       failed++;
+      failedUids.push(o.uid);
+      console.error(
+        `  削除失敗[${code ?? "unknown"}]: ${o.uid} (${o.email})`,
+        err
+      );
+      if (consecutiveFailures >= FAIL_ABORT_STREAK) {
+        throw new Error(
+          `${FAIL_ABORT_STREAK}件連続失敗のため中断（バックアップ: ${backupPath}）`
+        );
+      }
     }
   }
+
   console.log(`\n完了: 成功=${deleted}, 失敗=${failed}`);
+  if (failedUids.length > 0) {
+    console.log(`\n=== 削除失敗UID一覧（再試行用）===`);
+    failedUids.forEach((uid) => console.log(`  ${uid}`));
+  }
 }
 
 main().catch((err) => {
-  console.error(err);
+  console.error("[FATAL] 孤児Authユーザー掃除が失敗しました");
+  console.error(
+    `  message: ${err instanceof Error ? err.message : String(err)}`
+  );
+  if (err instanceof Error && err.stack) {
+    console.error(`  stack: ${err.stack}`);
+  }
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- 2026-04-21のインシデント（外部ドメインユーザーログイン不可、403 org_internal）を契機に認証アーキテクチャを整理
- ADR-030: 認証/認可/テナント解決/Workspace連携の4レイヤー責務分離を明文化
- ADR-031: GCIPマルチテナント採用と段階移行戦略（feature flag + カナリア展開）
- `scripts/cleanup-orphan-auth-users.ts`: 孤児Authユーザー掃除スクリプト雛形（dry-run既定）

## Context
緊急対応（Phase 1: OAuth同意画面External化）は別途GCP Consoleで実施中。本PRは**ドラフトとしてのADR追加**で、実装コード変更は含まない。Phase 3以降の実装は別セッションで /impl-plan 実行後に別PRで起票予定。

## Codex セカンドオピニオン要点（2026-04-21）
- A（External化）→ C（GCIP移行）段階移行は妥当、B（Authorized Domains）はスキップ
- UID保持リスク → 影響範囲は `firebaseUid` 1フィールドのみ、Custom Claims 未使用 → リスク小
- `auth.tenantId` はリロード非永続 → ログイン前テナント解決設計をADR-031に明記
- ロールバック容易性 → feature flag `useGcip` + `gcipTenantId` nullable で後方互換

## このPRでやらないこと
- Phase 1のGCP Console操作（別途ユーザー側で実施）
- Phase 3のGCIP移行実装コード（別Issueで分解、別PRで段階投入）
- ADRの確定（本PRではドラフト扱い、Phase 1結果を踏まえて微調整の可能性あり）

## Test plan
- [ ] ADR-030/031 のレビュー（別のエンジニアまたは次セッション）
- [ ] `scripts/cleanup-orphan-auth-users.ts` のdry-run実行（Firebase Admin SDK 認証情報あり環境で）
- [ ] `npm run lint` / `npm run type-check` に影響がないことを確認（ドキュメントとscripts/配下のため原則影響なし）

## Related
- Closes: なし（ADRドラフトのためPhase 3実装完了まで保留）
- Related: #272（親Issue、全WBSトラッキング）

🤖 Generated with [Claude Code](https://claude.com/claude-code)