### PR TITLE
feat(auth): super-admin 経路に email_verified / sign_in_provider / checkRevoked 追加 (Issue #289)

### DIFF
--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -58,8 +58,9 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 ### As-Is 実装状況（2026-04-22更新、Phase 3 補強対象の明示）
 | 項目 | 現状 | Phase 3 必須対応 |
 |------|------|-----------------|
-| email_verified チェック | ✅ 実装済み（Issue #286 / PR #288: `findOrCreateTenantUser` 冒頭で必須化） | 維持 |
-| sign_in_provider 制限 | ✅ 実装済み（Issue #286 / PR #288: `firebase.sign_in_provider === "google.com"` のみ許可） | 維持 |
+| email_verified チェック | ✅ 実装済み（Issue #286 / PR #288: `findOrCreateTenantUser` + Issue #289: `superAdminAuthMiddleware` 両経路で必須化） | 維持 |
+| sign_in_provider 制限 | ✅ 実装済み（Issue #286 / PR #288 + Issue #289: 両経路で `firebase.sign_in_provider === "google.com"` のみ許可） | 維持 |
+| checkRevoked=true（即時失効） | ✅ 実装済み（B-1: `tenantAwareAuthMiddleware` + Issue #289: `superAdminAuthMiddleware` 両経路で `verifyIdToken(..., true)`） | 維持 |
 | メール正規化 | 🟡 `toLowerCase()` のみ（trim未実装） | `.trim().toLowerCase()` に統一 |
 | (tenantId, email) 認可単位 | ✅ 実装済み（テナントスコープの allowed_emails） | 維持 |
 | クライアント Firestore 直接アクセス禁止 | ✅ 実装済み（`web/` 配下で `firebase/firestore` import ゼロ） | 維持 |

--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -58,9 +58,11 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 ### As-Is 実装状況（2026-04-22更新、Phase 3 補強対象の明示）
 | 項目 | 現状 | Phase 3 必須対応 |
 |------|------|-----------------|
-| email_verified チェック | ✅ 実装済み（Issue #286 / PR #288: `findOrCreateTenantUser` + Issue #289: `superAdminAuthMiddleware` 両経路で必須化） | 維持 |
-| sign_in_provider 制限 | ✅ 実装済み（Issue #286 / PR #288 + Issue #289: 両経路で `firebase.sign_in_provider === "google.com"` のみ許可） | 維持 |
-| checkRevoked=true（即時失効） | ✅ 実装済み（B-1: `tenantAwareAuthMiddleware` + Issue #289: `superAdminAuthMiddleware` 両経路で `verifyIdToken(..., true)`） | 維持 |
+| email_verified チェック | ✅ 実装済み（Issue #286 / PR #288: `findOrCreateTenantUser` + Issue #289: `superAdminAuthMiddleware` の 2 経路で必須化） | `help-role.ts` / `tenants.ts` 等の `verifyIdToken` 直接呼び出し箇所にも適用（後続 Issue） |
+| sign_in_provider 制限 | ✅ 実装済み（Issue #286 / PR #288 + Issue #289: 上記 2 経路で `firebase.sign_in_provider === "google.com"` のみ許可） | 同上 |
+| checkRevoked=true（即時失効） | ✅ 実装済み（B-1: `tenantAwareAuthMiddleware` + Issue #289: `superAdminAuthMiddleware` の 2 経路で `verifyIdToken(..., true)`） | 同上 |
+
+> **適用スコープ注記**: 上記 ✅ は `tenantAwareAuthMiddleware` (`middleware/tenant-auth.ts`) と `superAdminAuthMiddleware` (`middleware/super-admin.ts`) の 2 経路に限定。`routes/help-role.ts` および `routes/tenants.ts` 冒頭には `verifyIdToken(idToken)` の直接呼び出しが残っており、同等ガードは未適用（後続 Issue で対応）。
 | メール正規化 | 🟡 `toLowerCase()` のみ（trim未実装） | `.trim().toLowerCase()` に統一 |
 | (tenantId, email) 認可単位 | ✅ 実装済み（テナントスコープの allowed_emails） | 維持 |
 | クライアント Firestore 直接アクセス禁止 | ✅ 実装済み（`web/` 配下で `firebase/firestore` import ゼロ） | 維持 |

--- a/services/api/src/middleware/__tests__/super-admin-firebase.test.ts
+++ b/services/api/src/middleware/__tests__/super-admin-firebase.test.ts
@@ -195,4 +195,20 @@ describe("superAdminAuthMiddleware (firebase mode) — Issue #289: email_verifie
     expect(res.status).toBe(401);
     expect(res.body.error).toBe("unauthorized");
   });
+
+  it("decodedToken.email 不在でも 403 (非 super-admin として拒否、non-null assertion 回避)", async () => {
+    const { app } = await buildApp();
+
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        uid: "uid-no-email",
+        // email フィールドなし
+      })
+    );
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain("スーパー管理者権限が必要です");
+  });
 });

--- a/services/api/src/middleware/__tests__/super-admin-firebase.test.ts
+++ b/services/api/src/middleware/__tests__/super-admin-firebase.test.ts
@@ -1,0 +1,198 @@
+/**
+ * superAdminAuthMiddleware (AUTH_MODE=firebase) 統合テスト (Issue #289)
+ *
+ * tenantAwareAuthMiddleware の Issue #286 ガード（email_verified / sign_in_provider）と
+ * checkRevoked=true を super-admin 経路にも適用する。背景:
+ *   - Codex セカンドオピニオン (PR #288 P1) + pr-test-analyzer C2 指摘
+ *   - super-admin は全テナント横断で admin 権限を持つため、バイパスが成立した場合の影響が最大
+ *   - ADR-031「allowed_emails 境界の必須条件 #1, #2」を両経路で徹底
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import supertest from "supertest";
+
+const mockVerifyIdToken = vi.fn();
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: () => ({
+    verifyIdToken: mockVerifyIdToken,
+  }),
+}));
+
+vi.mock("firebase-admin/app", () => ({
+  getApps: () => [{ name: "[DEFAULT]" }],
+  initializeApp: vi.fn(),
+  cert: vi.fn(),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: () => ({
+    collection: () => ({
+      get: async () => ({ docs: [] }),
+    }),
+  }),
+}));
+
+/**
+ * Google プロバイダ + 検証済みメールの標準 decodedToken を生成するヘルパー。
+ * Issue #289 で新規に必須化される `email_verified` / `firebase.sign_in_provider` を
+ * デフォルト有効化し、失敗系テストは明示的に override する。
+ */
+function makeDecodedToken(overrides: Record<string, unknown> = {}) {
+  return {
+    email_verified: true,
+    firebase: { sign_in_provider: "google.com", identities: {} },
+    ...overrides,
+  };
+}
+
+async function buildApp() {
+  const { superAdminAuthMiddleware } = await import("../super-admin.js");
+
+  const app = express();
+  app.use(express.json());
+  app.use(superAdminAuthMiddleware);
+  app.get("/me", (req, res) => {
+    res.json({ superAdmin: req.superAdmin ?? null });
+  });
+
+  return { app };
+}
+
+describe("superAdminAuthMiddleware (firebase mode) — Issue #289: email_verified / sign_in_provider / checkRevoked", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("AUTH_MODE", "firebase");
+    vi.stubEnv("SUPER_ADMIN_EMAILS", "super@example.com");
+    mockVerifyIdToken.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("正常系: super-admin email + Google + email_verified=true なら 200", async () => {
+    const { app } = await buildApp();
+
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        uid: "uid-super",
+        email: "super@example.com",
+      })
+    );
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.superAdmin).toEqual({
+      email: "super@example.com",
+      firebaseUid: "uid-super",
+    });
+  });
+
+  it("super-admin email でも email_verified=false なら 403", async () => {
+    const { app } = await buildApp();
+
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        uid: "uid-super-unverified",
+        email: "super@example.com",
+        email_verified: false,
+      })
+    );
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(403);
+    // ユーザー列挙防止のため既存メッセージと同一
+    expect(res.body.message).toContain("スーパー管理者権限が必要です");
+  });
+
+  it("super-admin email でも email_verified が undefined（欠落）なら 403", async () => {
+    const { app } = await buildApp();
+
+    // email_verified を明示的に未設定
+    mockVerifyIdToken.mockResolvedValue({
+      uid: "uid-super-missing",
+      email: "super@example.com",
+      firebase: { sign_in_provider: "google.com", identities: {} },
+      // email_verified フィールドなし
+    });
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("super-admin email でも sign_in_provider=password なら 403", async () => {
+    const { app } = await buildApp();
+
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        uid: "uid-super-password",
+        email: "super@example.com",
+        firebase: { sign_in_provider: "password", identities: {} },
+      })
+    );
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain("スーパー管理者権限が必要です");
+  });
+
+  it("super-admin email でも decodedToken.firebase が undefined なら 403（SDK 形状変化対策、fail-closed）", async () => {
+    const { app } = await buildApp();
+
+    mockVerifyIdToken.mockResolvedValue({
+      uid: "uid-super-no-firebase",
+      email: "super@example.com",
+      email_verified: true,
+      // firebase フィールドなし
+    });
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("verifyIdToken は checkRevoked=true で呼ばれる（revoke後の即時失効）", async () => {
+    const { app } = await buildApp();
+
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        uid: "uid-super-check",
+        email: "super@example.com",
+      })
+    );
+
+    await supertest(app).get("/me").set("authorization", "Bearer idToken-xyz");
+
+    expect(mockVerifyIdToken).toHaveBeenCalledWith("idToken-xyz", true);
+  });
+
+  it("非 super-admin email + Google + email_verified=true は 403（既存挙動の回帰防止）", async () => {
+    const { app } = await buildApp();
+
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        uid: "uid-regular",
+        email: "regular@example.com",
+      })
+    );
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain("スーパー管理者権限が必要です");
+  });
+
+  it("Authorization ヘッダなしは 401（既存挙動の回帰防止）", async () => {
+    const { app } = await buildApp();
+
+    const res = await supertest(app).get("/me");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("unauthorized");
+  });
+});

--- a/services/api/src/middleware/super-admin.ts
+++ b/services/api/src/middleware/super-admin.ts
@@ -189,7 +189,27 @@ export const superAdminAuthMiddleware = async (
 
     const idToken = authHeader.slice(7);
     try {
-      const decodedToken = await getAuth().verifyIdToken(idToken);
+      // Issue #289 / ADR-031 allowed_emails 境界:
+      //   #1: email_verified=true 必須（未検証メール詐称の防止）
+      //   #2: sign_in_provider=google.com のみ許可（IdP 追加時の allowlist バイパス防止）
+      //   + checkRevoked=true で B-1「即時失効」を super-admin 経路にも適用
+      // いずれも super-admin 判定より前に実行してホワイトリスト主義を徹底する。
+      // レスポンス文言は既存の 403「スーパー管理者権限が必要です」で統一（ユーザー列挙防止）。
+      const decodedToken = await getAuth().verifyIdToken(idToken, true);
+
+      if (decodedToken.email_verified !== true) {
+        return res.status(403).json({
+          error: "forbidden",
+          message: "スーパー管理者権限が必要です",
+        });
+      }
+      if (decodedToken.firebase?.sign_in_provider !== "google.com") {
+        return res.status(403).json({
+          error: "forbidden",
+          message: "スーパー管理者権限が必要です",
+        });
+      }
+
       const email = decodedToken.email;
 
       const isAdmin = await isSuperAdmin(email);

--- a/services/api/src/middleware/super-admin.ts
+++ b/services/api/src/middleware/super-admin.ts
@@ -211,6 +211,15 @@ export const superAdminAuthMiddleware = async (
       }
 
       const email = decodedToken.email;
+      // Google sign-in なら email は必須だが、将来の SDK 仕様変更や特殊トークンで
+      // 欠落した場合は fail-closed で 403 を返し、non-null assertion による
+      // サイレント TypeError を防ぐ。
+      if (!email) {
+        return res.status(403).json({
+          error: "forbidden",
+          message: "スーパー管理者権限が必要です",
+        });
+      }
 
       const isAdmin = await isSuperAdmin(email);
       if (!isAdmin) {
@@ -221,7 +230,7 @@ export const superAdminAuthMiddleware = async (
       }
 
       req.superAdmin = {
-        email: email!.toLowerCase(),
+        email: email.toLowerCase(),
         firebaseUid: decodedToken.uid,
       };
       return next();


### PR DESCRIPTION
## Summary

PR #288（Issue #286）で `tenantAwareAuthMiddleware` に追加した認証ガードを、`superAdminAuthMiddleware` にも同等に適用する。

- `verifyIdToken(idToken, true)` で **checkRevoked=true 化**（B-1「即時失効」を super-admin 経路にも拡張）
- `decodedToken.email_verified === true` を必須化
- `decodedToken.firebase?.sign_in_provider === "google.com"` のみ許可
- 3 ガードは `isSuperAdmin` チェックより**前**に実行（ホワイトリスト主義の徹底）
- 403 メッセージは既存の「スーパー管理者権限が必要です」で統一（ユーザー列挙防止）
- ADR-031 As-Is 表を更新（両経路実装済み明記 + checkRevoked 行新規追加）

## 背景

PR #288 Codex セカンドオピニオン (P1) + pr-test-analyzer C2 指摘。super-admin は全テナント横断で admin 権限を持つため、**バイパスが成立した場合の影響が最大**。ADR-031「allowed_emails 境界の必須条件 #1, #2」を `tenantAwareAuthMiddleware` だけでなく `superAdminAuthMiddleware` にも徹底する必要がある。

## As-Was の問題点

```typescript
// 変更前
const decodedToken = await getAuth().verifyIdToken(idToken);  // ❌ checkRevoked 未指定
const email = decodedToken.email;
const isAdmin = await isSuperAdmin(email);
// email_verified / sign_in_provider チェックなし
```

3 点の穴:
1. `checkRevoked=true` 未指定 → `revokeRefreshTokens` 後の既発行 ID token で super-admin ログイン可能
2. `email_verified === true` 未実装 → 未検証メールで super-admin email を偽装可能
3. `sign_in_provider === "google.com"` 未実装 → Firebase Console で他 provider 有効化時に super-admin email のトークンが発行され得る

## Acceptance Criteria

- [x] super-admin.ts に 3 チェック追加（firebase モードのみ）
- [x] 統合テスト 8 項目追加（新規テストファイル作成）
  - 正常系: super-admin + Google + 検証済み → 200
  - email_verified=false / undefined → 403
  - sign_in_provider=password → 403
  - decodedToken.firebase 欠落 → 403（fail-closed）
  - checkRevoked=true で呼ばれる検証
  - 非 super-admin email → 403（既存挙動の回帰防止）
  - Authorization なし → 401（既存挙動の回帰防止）
- [x] ADR-031 As-Is 表更新（email_verified / sign_in_provider / checkRevoked の 3 行）

## Test plan

- [x] `npm run lint` PASS
- [x] `npm run type-check` PASS
- [x] `npm test` PASS（API 459 + Web 33、既存テスト regression なし）
- [x] TDD RED→GREEN 確認（実装前 RED 5 fail → 実装後 GREEN 8/8 PASS）
- [ ] ステージングで super-admin Google ログインの正常経路（200）を確認
- [ ] ステージングで revoke 後の super-admin 即時失効を確認

## Related

- Closes #289
- Related: #286 / PR #288（同等ガードの `tenantAwareAuthMiddleware` 実装）
- Related: #272 (ADR-031 Phase 3)
- 根拠: PR #288 Codex セカンドオピニオン P1 + pr-test-analyzer C2

🤖 Generated with [Claude Code](https://claude.com/claude-code)