### PR TITLE
feat(auth): getSuperAdminsFromFirestore を fail-closed 化 (Issue #293)

### DIFF
--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -65,8 +65,8 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 > **適用スコープ注記**: 上記 ✅ は `tenantAwareAuthMiddleware` (`middleware/tenant-auth.ts`) と `superAdminAuthMiddleware` (`middleware/super-admin.ts`) の 2 経路に限定。`routes/help-role.ts` および `routes/tenants.ts` 冒頭には `verifyIdToken(idToken)` の直接呼び出しが残っており、同等ガードは未適用（後続 Issue で対応）。
 
 > **Firestore 障害時の挙動 (Issue #293 / PR)**: `getSuperAdminsFromFirestore` は Firestore アクセス失敗時に空配列を silent に返していたため、env に未登録の super-admin が silent に 403 で締め出される「部分 fail-open + ユーザー欺瞞」状態だった。
-> - 修正後: `SuperAdminFirestoreUnavailableError` を throw し、`superAdminAuthMiddleware` は 503 Service Unavailable で返却（env 高速パスで通過済みのケースはここに到達しない）
-> - `tenantAwareAuthMiddleware#checkSuperAdmin` / `routes/help-role.ts` は既存の try/catch で障害を吸収し、従来どおり権限縮小して継続する（ユーザー影響なしを維持）
+> - 修正後: `SuperAdminFirestoreUnavailableError` を throw し、`superAdminAuthMiddleware`（super-admin 専用 endpoint）は 503 Service Unavailable で返却（env 高速パスで通過済みのケースはここに到達しない）
+> - `tenantAwareAuthMiddleware#checkSuperAdmin` / `routes/help-role.ts` は既存の try/catch で障害を吸収し、従来どおり権限縮小して継続する（**セキュリティ境界として fail-open には戻らないが**、Firestore 登録 super-admin がテナント API / help 画面で一時的に通常ロール扱いになる silent UX degradation は残る。#292 等の後続 Issue で UX 改善検討）
 | メール正規化 | 🟡 `toLowerCase()` のみ（trim未実装） | `.trim().toLowerCase()` に統一 |
 | (tenantId, email) 認可単位 | ✅ 実装済み（テナントスコープの allowed_emails） | 維持 |
 | クライアント Firestore 直接アクセス禁止 | ✅ 実装済み（`web/` 配下で `firebase/firestore` import ゼロ） | 維持 |

--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -63,6 +63,10 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 | checkRevoked=true（即時失効） | ✅ 実装済み（B-1: `tenantAwareAuthMiddleware` + Issue #289: `superAdminAuthMiddleware` の 2 経路で `verifyIdToken(..., true)`） | 同上 |
 
 > **適用スコープ注記**: 上記 ✅ は `tenantAwareAuthMiddleware` (`middleware/tenant-auth.ts`) と `superAdminAuthMiddleware` (`middleware/super-admin.ts`) の 2 経路に限定。`routes/help-role.ts` および `routes/tenants.ts` 冒頭には `verifyIdToken(idToken)` の直接呼び出しが残っており、同等ガードは未適用（後続 Issue で対応）。
+
+> **Firestore 障害時の挙動 (Issue #293 / PR)**: `getSuperAdminsFromFirestore` は Firestore アクセス失敗時に空配列を silent に返していたため、env に未登録の super-admin が silent に 403 で締め出される「部分 fail-open + ユーザー欺瞞」状態だった。
+> - 修正後: `SuperAdminFirestoreUnavailableError` を throw し、`superAdminAuthMiddleware` は 503 Service Unavailable で返却（env 高速パスで通過済みのケースはここに到達しない）
+> - `tenantAwareAuthMiddleware#checkSuperAdmin` / `routes/help-role.ts` は既存の try/catch で障害を吸収し、従来どおり権限縮小して継続する（ユーザー影響なしを維持）
 | メール正規化 | 🟡 `toLowerCase()` のみ（trim未実装） | `.trim().toLowerCase()` に統一 |
 | (tenantId, email) 認可単位 | ✅ 実装済み（テナントスコープの allowed_emails） | 維持 |
 | クライアント Firestore 直接アクセス禁止 | ✅ 実装済み（`web/` 配下で `firebase/firestore` import ゼロ） | 維持 |

--- a/services/api/src/middleware/__tests__/super-admin-firestore-failure.test.ts
+++ b/services/api/src/middleware/__tests__/super-admin-firestore-failure.test.ts
@@ -147,3 +147,107 @@ describe("superAdminAuthMiddleware (firebase mode) — Issue #293: Firestore fai
     expect(res.body.superAdmin.email).toBe("firestore-admin@example.com");
   });
 });
+
+describe("superAdminAuthMiddleware (dev mode) — Issue #293: Firestore fail-closed", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("AUTH_MODE", "dev");
+    vi.stubEnv("SUPER_ADMIN_EMAILS", "env-admin@example.com");
+    mockVerifyIdToken.mockReset();
+    mockFirestoreGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("env フォールバック super-admin は Firestore 障害でも 200（dev mode 高速パス）", async () => {
+    const { app } = await buildApp();
+    // Firestore は障害を throw するが、env 高速パスで通過する設計
+    mockFirestoreGet.mockRejectedValue(new Error("UNAVAILABLE: Firestore down"));
+
+    const res = await supertest(app).get("/me").set("x-user-email", "env-admin@example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body.superAdmin.email).toBe("env-admin@example.com");
+  });
+
+  it("env 未登録 + Firestore 障害は 503 (dev mode でも silent 403 を防ぐ)", async () => {
+    const { app } = await buildApp();
+    mockFirestoreGet.mockRejectedValue(new Error("UNAVAILABLE: Firestore down"));
+
+    const res = await supertest(app)
+      .get("/me")
+      .set("x-user-email", "firestore-admin@example.com");
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("service_unavailable");
+    expect(res.body.message).toContain("一時的に利用できません");
+  });
+
+  it("Firestore 正常 + 非 super-admin は 403（既存挙動の回帰防止）", async () => {
+    const { app } = await buildApp();
+    mockFirestoreGet.mockResolvedValue({ docs: [] });
+
+    const res = await supertest(app).get("/me").set("x-user-email", "regular@example.com");
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain("スーパー管理者権限が必要です");
+  });
+});
+
+describe("isSuperAdmin (unit) — Issue #293: Firestore throw contract", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("SUPER_ADMIN_EMAILS", "env-admin@example.com");
+    mockFirestoreGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("env に登録済みなら Firestore 障害でも true を返す（高速パス契約）", async () => {
+    const { isSuperAdmin } = await import("../super-admin.js");
+    mockFirestoreGet.mockRejectedValue(new Error("UNAVAILABLE: Firestore down"));
+
+    await expect(isSuperAdmin("env-admin@example.com")).resolves.toBe(true);
+    // Firestore には到達しないはず
+    expect(mockFirestoreGet).not.toHaveBeenCalled();
+  });
+
+  it("env 未登録かつ Firestore 障害なら SuperAdminFirestoreUnavailableError を throw", async () => {
+    const { isSuperAdmin, SuperAdminFirestoreUnavailableError } = await import(
+      "../super-admin.js"
+    );
+    const firestoreErr = Object.assign(new Error("Firestore down"), {
+      code: "unavailable",
+    });
+    mockFirestoreGet.mockRejectedValue(firestoreErr);
+
+    await expect(isSuperAdmin("unknown@example.com")).rejects.toBeInstanceOf(
+      SuperAdminFirestoreUnavailableError
+    );
+  });
+
+  it("SuperAdminFirestoreUnavailableError は code と cause を保持する（#292 での分類用）", async () => {
+    const { isSuperAdmin, SuperAdminFirestoreUnavailableError } = await import(
+      "../super-admin.js"
+    );
+    const firestoreErr = Object.assign(new Error("Firestore down"), {
+      code: "unavailable",
+    });
+    mockFirestoreGet.mockRejectedValue(firestoreErr);
+
+    try {
+      await isSuperAdmin("unknown@example.com");
+      expect.fail("Expected throw but got fulfilled promise");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SuperAdminFirestoreUnavailableError);
+      const e = err as InstanceType<typeof SuperAdminFirestoreUnavailableError>;
+      expect(e.code).toBe("unavailable");
+      expect(e.cause).toBe(firestoreErr);
+      expect(e.message).toContain("SUPER_ADMIN_FIRESTORE_UNAVAILABLE");
+    }
+  });
+});

--- a/services/api/src/middleware/__tests__/super-admin-firestore-failure.test.ts
+++ b/services/api/src/middleware/__tests__/super-admin-firestore-failure.test.ts
@@ -1,0 +1,149 @@
+/**
+ * superAdminAuthMiddleware (AUTH_MODE=firebase) Firestore 障害時の fail-closed 挙動 (Issue #293)
+ *
+ * 背景:
+ *   PR #291 silent-failure-hunter CRITICAL-2 指摘。
+ *   `getSuperAdminsFromFirestore` は Firestore 障害時に空配列を silent に返していたため、
+ *   Firestore 登録された super-admin が 403 で締め出される一方で env フォールバックは
+ *   通過する「部分 fail-open + ユーザー欺瞞」状態だった。
+ *
+ * 本テストは以下を検証:
+ *   - Firestore 障害時は 503 Service Unavailable で返却（env フォールバックが効くケースを除く）
+ *   - env 経由 super-admin は Firestore 障害でも通過する（高速パス）
+ *   - 通常の Firestore 障害なし + 非 super-admin は引き続き 403（既存挙動の回帰防止）
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import supertest from "supertest";
+
+const mockVerifyIdToken = vi.fn();
+const mockFirestoreGet = vi.fn();
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: () => ({
+    verifyIdToken: mockVerifyIdToken,
+  }),
+}));
+
+vi.mock("firebase-admin/app", () => ({
+  getApps: () => [{ name: "[DEFAULT]" }],
+  initializeApp: vi.fn(),
+  cert: vi.fn(),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: () => ({
+    collection: () => ({
+      get: mockFirestoreGet,
+    }),
+  }),
+}));
+
+function makeDecodedToken(overrides: Record<string, unknown> = {}) {
+  return {
+    email_verified: true,
+    firebase: { sign_in_provider: "google.com", identities: {} },
+    ...overrides,
+  };
+}
+
+async function buildApp() {
+  const { superAdminAuthMiddleware } = await import("../super-admin.js");
+
+  const app = express();
+  app.use(express.json());
+  app.use(superAdminAuthMiddleware);
+  app.get("/me", (req, res) => {
+    res.json({ superAdmin: req.superAdmin ?? null });
+  });
+
+  return { app };
+}
+
+describe("superAdminAuthMiddleware (firebase mode) — Issue #293: Firestore fail-closed", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("AUTH_MODE", "firebase");
+    vi.stubEnv("SUPER_ADMIN_EMAILS", "env-admin@example.com");
+    mockVerifyIdToken.mockReset();
+    mockFirestoreGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("env フォールバックに載っている super-admin は Firestore 障害でも 200（高速パス）", async () => {
+    const { app } = await buildApp();
+
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        uid: "uid-env-admin",
+        email: "env-admin@example.com",
+      })
+    );
+    // Firestore は障害を throw するが、env 高速パスで通過する設計
+    mockFirestoreGet.mockRejectedValue(new Error("UNAVAILABLE: Firestore down"));
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.superAdmin.email).toBe("env-admin@example.com");
+  });
+
+  it("Firestore 障害 + env に載っていない super-admin は 503（silent 403 ではない）", async () => {
+    const { app } = await buildApp();
+
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        uid: "uid-firestore-admin",
+        email: "firestore-admin@example.com",
+      })
+    );
+    mockFirestoreGet.mockRejectedValue(new Error("UNAVAILABLE: Firestore down"));
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("service_unavailable");
+    expect(res.body.message).toContain("一時的に利用できません");
+  });
+
+  it("Firestore 正常 + 非 super-admin email は引き続き 403（既存挙動の回帰防止）", async () => {
+    const { app } = await buildApp();
+
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        uid: "uid-regular",
+        email: "regular@example.com",
+      })
+    );
+    // Firestore は docs 空で成功
+    mockFirestoreGet.mockResolvedValue({ docs: [] });
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain("スーパー管理者権限が必要です");
+  });
+
+  it("Firestore 正常 + Firestore 登録 super-admin は 200（既存挙動の回帰防止）", async () => {
+    const { app } = await buildApp();
+
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        uid: "uid-firestore-admin",
+        email: "firestore-admin@example.com",
+      })
+    );
+    // Firestore に docs が存在
+    mockFirestoreGet.mockResolvedValue({
+      docs: [{ id: "firestore-admin@example.com" }],
+    });
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.superAdmin.email).toBe("firestore-admin@example.com");
+  });
+});

--- a/services/api/src/middleware/super-admin.ts
+++ b/services/api/src/middleware/super-admin.ts
@@ -47,7 +47,26 @@ declare global {
 }
 
 /**
+ * Firestore アクセスが一時的に失敗した場合に throw される識別可能エラー (Issue #293)。
+ * 呼び出し側（super-admin middleware）で catch し 503 として返すためのマーカー。
+ */
+export class SuperAdminFirestoreUnavailableError extends Error {
+  readonly code: string | number | undefined;
+  constructor(cause: unknown) {
+    const c = cause as { code?: string | number; message?: string };
+    super(`SUPER_ADMIN_FIRESTORE_UNAVAILABLE: ${c?.code ?? "unknown"}`);
+    this.name = "SuperAdminFirestoreUnavailableError";
+    this.code = c?.code;
+  }
+}
+
+/**
  * Firestoreからスーパー管理者一覧を取得
+ *
+ * Issue #293: Firestore 障害時に空配列を返すと、登録 super-admin が silent に
+ * 403 で締め出されて「権限剥奪？」と誤認される事故につながる。
+ * エラーを SuperAdminFirestoreUnavailableError として上位に伝播させ、
+ * 呼び出し側で 503 Service Unavailable を返す設計に変更する。
  */
 export async function getSuperAdminsFromFirestore(): Promise<string[]> {
   try {
@@ -56,23 +75,27 @@ export async function getSuperAdminsFromFirestore(): Promise<string[]> {
     return snapshot.docs.map((doc) => doc.id.toLowerCase());
   } catch (error) {
     console.error("Failed to fetch super admins from Firestore:", error);
-    return [];
+    throw new SuperAdminFirestoreUnavailableError(error);
   }
 }
 
 /**
  * メールアドレスがスーパー管理者か判定（環境変数 + Firestore両方チェック）
+ *
+ * env フォールバックに載っている場合は Firestore アクセスなしで true を返す（高速パス）。
+ * Firestore 障害時は SuperAdminFirestoreUnavailableError を throw するため、
+ * 呼び出し側で catch して 503 として返却する必要がある。
  */
 export async function isSuperAdmin(email: string | undefined): Promise<boolean> {
   if (!email) return false;
   const normalizedEmail = email.toLowerCase();
 
-  // 環境変数でチェック（高速パス）
+  // 環境変数でチェック（高速パス。Firestore 障害でも通過する）
   if (envSuperAdminEmails.includes(normalizedEmail)) {
     return true;
   }
 
-  // Firestoreでチェック
+  // Firestore でチェック（障害時は throw → 呼び出し側で 503）
   const firestoreAdmins = await getSuperAdminsFromFirestore();
   return firestoreAdmins.includes(normalizedEmail);
 }
@@ -165,16 +188,29 @@ export const superAdminAuthMiddleware = async (
       });
     }
 
-    const isAdmin = await isSuperAdmin(headerEmail);
-    if (!isAdmin) {
-      return res.status(403).json({
-        error: "forbidden",
-        message: "スーパー管理者権限が必要です",
-      });
-    }
+    try {
+      const isAdmin = await isSuperAdmin(headerEmail);
+      if (!isAdmin) {
+        return res.status(403).json({
+          error: "forbidden",
+          message: "スーパー管理者権限が必要です",
+        });
+      }
 
-    req.superAdmin = { email: headerEmail.toLowerCase() };
-    return next();
+      req.superAdmin = { email: headerEmail.toLowerCase() };
+      return next();
+    } catch (error) {
+      // Issue #293: Firestore 障害時は env に載っていない super-admin を silent に 403 で
+      // 締め出さず、503 を返して再試行を促す。
+      if (error instanceof SuperAdminFirestoreUnavailableError) {
+        console.error("Super admin Firestore check unavailable (dev mode):", error);
+        return res.status(503).json({
+          error: "service_unavailable",
+          message: "一時的に利用できません。再度お試しください。",
+        });
+      }
+      throw error;
+    }
   }
 
   if (authMode === "firebase") {
@@ -235,6 +271,15 @@ export const superAdminAuthMiddleware = async (
       };
       return next();
     } catch (error) {
+      // Issue #293: Firestore 障害時は 503 で返す（env フォールバックで既に通過済みの
+      // ケースはここに来ない）。通常の token 検証失敗は従来通り 401。
+      if (error instanceof SuperAdminFirestoreUnavailableError) {
+        console.error("Super admin Firestore check unavailable (firebase mode):", error);
+        return res.status(503).json({
+          error: "service_unavailable",
+          message: "一時的に利用できません。再度お試しください。",
+        });
+      }
       console.error("Firebase token verification failed:", error);
       return res.status(401).json({
         error: "unauthorized",

--- a/services/api/src/middleware/super-admin.ts
+++ b/services/api/src/middleware/super-admin.ts
@@ -49,14 +49,18 @@ declare global {
 /**
  * Firestore アクセスが一時的に失敗した場合に throw される識別可能エラー (Issue #293)。
  * 呼び出し側（super-admin middleware）で catch し 503 として返すためのマーカー。
+ *
+ * `Error.cause` (ES2022) に原因例外を保持しており、Sentry などで stack chain を
+ * 追跡可能。`code` は Firebase Admin SDK の Firestore エラーコード文字列
+ * （"unavailable", "deadline-exceeded", "permission-denied", etc.）が入る。
  */
 export class SuperAdminFirestoreUnavailableError extends Error {
-  readonly code: string | number | undefined;
+  readonly code: string | undefined;
   constructor(cause: unknown) {
-    const c = cause as { code?: string | number; message?: string };
-    super(`SUPER_ADMIN_FIRESTORE_UNAVAILABLE: ${c?.code ?? "unknown"}`);
+    const c = cause as { code?: string } | undefined;
+    super(`SUPER_ADMIN_FIRESTORE_UNAVAILABLE: ${c?.code ?? "unknown"}`, { cause });
     this.name = "SuperAdminFirestoreUnavailableError";
-    this.code = c?.code;
+    this.code = typeof c?.code === "string" ? c.code : undefined;
   }
 }
 
@@ -67,6 +71,8 @@ export class SuperAdminFirestoreUnavailableError extends Error {
  * 403 で締め出されて「権限剥奪？」と誤認される事故につながる。
  * エラーを SuperAdminFirestoreUnavailableError として上位に伝播させ、
  * 呼び出し側で 503 Service Unavailable を返す設計に変更する。
+ *
+ * ログは呼び出し側（superAdminAuthMiddleware）で一本化するため、ここでは出力しない。
  */
 export async function getSuperAdminsFromFirestore(): Promise<string[]> {
   try {
@@ -74,7 +80,6 @@ export async function getSuperAdminsFromFirestore(): Promise<string[]> {
     const snapshot = await db.collection("superAdmins").get();
     return snapshot.docs.map((doc) => doc.id.toLowerCase());
   } catch (error) {
-    console.error("Failed to fetch super admins from Firestore:", error);
     throw new SuperAdminFirestoreUnavailableError(error);
   }
 }


### PR DESCRIPTION
## Summary

PR #291 silent-failure-hunter CRITICAL-2 指摘への対応（既存コードの負債）。

`getSuperAdminsFromFirestore` の Firestore 障害時の silent な空配列 fallback を fail-closed に変更し、登録 super-admin が silent に 403 で締め出される事故を防ぐ。

- `SuperAdminFirestoreUnavailableError` 識別可能エラークラス追加
- `getSuperAdminsFromFirestore`: 空配列 return → 上記エラー throw
- `superAdminAuthMiddleware` (dev / firebase 両モード): catch して 503 Service Unavailable 返却
- 既存の try/catch 済み呼び出し元（`tenantAwareAuthMiddleware#checkSuperAdmin` / `routes/help-role.ts`）は後方互換で権限縮小 fallback を維持
- ADR-031 に Firestore 障害時の挙動を明記

## 背景 / 問題

```typescript
// As-Was
export async function getSuperAdminsFromFirestore(): Promise<string[]> {
  try { ... } catch (error) {
    console.error("Failed to fetch super admins from Firestore:", error);
    return [];  // ← Firestore 障害 = 「super-admin は誰もいない」扱い
  }
}
```

Firestore 障害時（503 / timeout / PERMISSION_DENIED / IAM ドリフト等）に:
- SUPER_ADMIN_EMAILS env 経由の super-admin は通過（高速パス）
- Firestore 登録 super-admin は silent に 403（「権限剥奪？」と誤認）
- レスポンス文言は他拒否理由と区別不能

これは **fail-open ではなく "部分 fail-open + ユーザー欺瞞"**。権限境界として最悪のパターンで、インシデント対応者の誤認で作業が止まる。env フォールバック管理者は動作するため「部分稼働」に見え、全面障害より検知が遅れる。

## Acceptance Criteria

- [x] `getSuperAdminsFromFirestore` がエラーを throw
- [x] `superAdminAuthMiddleware` で 503 で返却
- [x] 既存 try/catch 済み呼び出し元（tenant-auth / help-role）の後方互換維持
- [x] テスト追加（4 ケース）
- [x] ADR-031 に「Firestore 障害時の挙動」を明記

## 設計判断

- **logger.error による構造化**: Issue #292 (P1 observability) のスコープに含まれるため、本 PR では `console.error` 維持。#292 で一括対応。
- **`getAllSuperAdmins`** (admin UI 一覧): 既存の silent try/catch で env 分のみ返す挙動を維持。UI 表示用で権限判定ではないため影響なし。
- **呼び出し元の挙動**:
  - `superAdminAuthMiddleware`: 503 を返す（本 PR で修正）
  - `tenantAwareAuthMiddleware#checkSuperAdmin`: 既存 try/catch で false fallback（「Firestore 障害時は tenant role で続行」を維持）
  - `routes/help-role.ts`: 既存 try/catch で student fallback を維持

## Test plan

- [x] `npm run lint` PASS
- [x] `npm run type-check` PASS
- [x] `npm test` PASS（API 464 + Web 33、既存テスト regression なし）
- [x] TDD RED→GREEN 確認（実装前 RED 1 fail → 実装後 GREEN 4/4 PASS）
- [x] 関連テスト（super-admin-firebase.test.ts 9 PASS）の回帰なし
- [ ] ステージングで Firestore 障害を疑似注入し 503 が返ることを確認（必要に応じて）

## Related

- Closes #293
- Related: PR #291（Issue #289 で本問題が CRITICAL として指摘された）
- Related: #292（本 PR で見送った構造化ログ強化）
- Related: #272 (ADR-031 Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)