### PR TITLE
feat(auth): 認証拒否ログを構造化 + 拒否理由を区別 (Issue #292)

### DIFF
--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -83,6 +83,34 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 | `dev` x-user-id | ✅ 再チェック対象（ヘッダ email を優先し、無ければ DB email を使用） |
 | `dev` demo（`demoAuthMiddleware` が `req.user` をプリセット） | ⚠️ **バイパス**（tenant-auth は `req.user` 設定済みならスキップ）。DEMO_ENABLED は production で無効化する運用前提 |
 
+### 認証拒否ログの構造化設計（Issue #292、2026-04-22 追補）
+
+ホワイトリスト主義の運用では「誰が・なぜ拒否されたか」の可視化が攻撃検知・インシデント対応の要となる。Issue #292 で以下を実装した:
+
+#### tenant-auth 経路（`middleware/tenant-auth.ts`）
+- `TenantAccessDeniedError` に `reason: TenantAccessDenialReason` フィールドを追加
+- reason 値: `email_not_verified` / `non_google_provider` / `email_missing` / `not_in_allowlist`
+- `handleTenantAccessDenied` が `logger.warn` と `auth_error_logs` 両方に reason を記録
+- `verifyIdToken` 失敗 catch 節は `logger.error` + `firebaseErrorCode`（`auth/id-token-revoked` 等）で Cloud Logging から原因特定可能
+
+#### super-admin 経路（`middleware/super-admin.ts`）
+- 全 403/401 分岐（`no_auth_header` / `email_not_verified` / `non_google_provider` / `email_missing` / `not_super_admin`）に `logger.warn` + reason 付与
+- `verifyIdToken` 失敗 catch 節は `logger.error` + `firebaseErrorCode` で構造化
+- Firestore 記録は **ルートコレクション `platform_auth_error_logs`**（tenant スコープ外の super-admin 拒否を tenant の `auth_error_logs` と分離）
+
+#### Firestore 記録方式の選択肢と決定
+| 選択肢 | 採否 | 理由 |
+|--------|-----|------|
+| A: `platform_auth_error_logs` コレクション + `DataSource.createPlatformAuthErrorLog` | ✅ **採用** | 既存 `AuthErrorLog` スキーマと一貫、InMemory/Firestore 両実装でテスト可能、tenant と platform のログを分離できる |
+| B: super-admin 経路の前段に `platformDataSource` 注入ミドルウェアを追加 | 不採用 | 既存の `tenantMiddleware` と二重化し、DI 経路が複雑化する。tenant スコープ外のログに tenant DataSource を流用するのは設計上の混乱を招く |
+| C: `getFirestore()` を super-admin 内で直接呼ぶ | 不採用 | テスト時の mock が firebase-admin 全体モックとなり脆く、InMemory モードでの検証ができない |
+
+`req.dataSource` が super-admin 経路で注入されない課題に対しては、`middleware/platform-datasource.ts` で **プロセス単位の singleton** (`getPlatformDataSource()`) として提供し、`AUTH_MODE=firebase` なら `FirestoreDataSource(tenantId="__platform__")`、それ以外（dev/test）なら `InMemoryDataSource` を返す。テストでは `setPlatformDataSourceForTest()` でモック差し替え可能。
+
+#### `AuthErrorLog` スキーマ拡張
+- `reason: string | null`（旧レコード互換のため nullable）
+- `firebaseErrorCode: string | null`（403 等の分岐では null、catch 節で Firebase SDK エラーコードを格納）
+
 ### UID保持戦略
 - GCIP Tenant ごとにユーザーサイロが分かれるため、新UIDが発行される
 - `tenant-auth.ts` の `findOrCreateTenantUser` 関数内の **email ベースフォールバック検索** がテナント単位の DataSource 内で移行時の橋渡しをする:

--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -108,8 +108,14 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 `req.dataSource` が super-admin 経路で注入されない課題に対しては、`middleware/platform-datasource.ts` で **プロセス単位の singleton** (`getPlatformDataSource()`) として提供し、`AUTH_MODE=firebase` なら `FirestoreDataSource(tenantId="__platform__")`、それ以外（dev/test）なら `InMemoryDataSource` を返す。テストでは `setPlatformDataSourceForTest()` でモック差し替え可能。
 
 #### `AuthErrorLog` スキーマ拡張
-- `reason: string | null`（旧レコード互換のため nullable）
+- `reason: string | null`（旧レコード互換のため nullable。middleware 側 union 型 `TenantAccessDenialReason` / `SuperAdminDenialReason` の代表値を格納。catch 節では null）
 - `firebaseErrorCode: string | null`（403 等の分岐では null、catch 節で Firebase SDK エラーコードを格納）
+
+#### Phase 1 の制約（次 Issue で拡張予定）
+- `platform_auth_error_logs` を **admin UI から参照する経路は未実装**。Phase 1 では Cloud Logging（`logger.warn/error` の構造化出力）経由で確認する前提
+- `getPlatformAuthErrorLogs()` / super-admin 画面 UI は別 Issue で追加（PR #298 code-reviewer H1 指摘）
+- `SuperAdminFirestoreUnavailableError` の transient (`unavailable`/`deadline-exceeded`) と permanent (`permission-denied` 等) の区別は現状未実装。すべて 503 を返すが、permanent は 500 相当（別 Issue 推奨）
+- `tenant-auth.ts:checkSuperAdmin` が `SuperAdminFirestoreUnavailableError` も false fallback に潰している点（Issue #293 の silent 権限剥奪を tenant 経路では部分的に残す）も別 Issue で対応
 
 ### UID保持戦略
 - GCIP Tenant ごとにユーザーサイロが分かれるため、新UIDが発行される

--- a/services/api/src/datasource/__tests__/firestore-platform-auth-error-log.test.ts
+++ b/services/api/src/datasource/__tests__/firestore-platform-auth-error-log.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Issue #292: FirestoreDataSource.createPlatformAuthErrorLog の直接テスト
+ *
+ * 本番で動くのは Firestore 実装だが、既存の super-admin-auth-logging テストは
+ * InMemory スタブで差し替えているため、root コレクション書き込みの単体検証がない。
+ * 以下を直接検証することで本番回帰を防ぐ:
+ *   - 書き込み先が `platform_auth_error_logs`（root コレクション）であること
+ *   - `tenants/` プレフィックス配下に誤って書き込んでいないこと
+ *   - `occurredAt` が Firestore Timestamp に変換されること
+ *   - 入力値が body に保持されること（reason / firebaseErrorCode を含む）
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Timestamp } from "firebase-admin/firestore";
+import type { Firestore } from "firebase-admin/firestore";
+import { FirestoreDataSource } from "../firestore.js";
+
+function buildMockDb() {
+  const setMock = vi.fn().mockResolvedValue(undefined);
+  const docMock = vi.fn().mockReturnValue({ id: "generated-id", set: setMock });
+  const collectionMock = vi.fn().mockReturnValue({ doc: docMock });
+  const db = { collection: collectionMock } as unknown as Firestore;
+  return { db, setMock, docMock, collectionMock };
+}
+
+describe("FirestoreDataSource.createPlatformAuthErrorLog (Issue #292)", () => {
+  let mock: ReturnType<typeof buildMockDb>;
+
+  beforeEach(() => {
+    mock = buildMockDb();
+  });
+
+  it("ルートコレクション `platform_auth_error_logs` に書き込む", async () => {
+    const ds = new FirestoreDataSource(mock.db, "__platform__");
+    await ds.createPlatformAuthErrorLog({
+      email: "user@example.com",
+      tenantId: "__platform__",
+      errorType: "super_admin_denied",
+      reason: "not_super_admin",
+      errorMessage: "not registered",
+      path: "/admin",
+      method: "GET",
+      userAgent: null,
+      ipAddress: null,
+      firebaseErrorCode: null,
+      occurredAt: "2026-04-22T12:00:00.000Z",
+    });
+
+    expect(mock.collectionMock).toHaveBeenCalledTimes(1);
+    expect(mock.collectionMock).toHaveBeenCalledWith("platform_auth_error_logs");
+  });
+
+  it("tenant スコープ配下（`tenants/*`）には書き込まない", async () => {
+    const ds = new FirestoreDataSource(mock.db, "acme");
+    await ds.createPlatformAuthErrorLog({
+      email: "user@example.com",
+      tenantId: "__platform__",
+      errorType: "super_admin_denied",
+      reason: "no_auth_header",
+      errorMessage: "missing",
+      path: "/admin",
+      method: "GET",
+      userAgent: null,
+      ipAddress: null,
+      firebaseErrorCode: null,
+      occurredAt: "2026-04-22T12:00:00.000Z",
+    });
+
+    const collectionCalls = mock.collectionMock.mock.calls.map((c) => c[0] as string);
+    expect(collectionCalls).toEqual(["platform_auth_error_logs"]);
+    expect(collectionCalls.some((name) => name.startsWith("tenants/"))).toBe(false);
+  });
+
+  it("occurredAt を Firestore Timestamp に変換し、reason/firebaseErrorCode を保存する", async () => {
+    const ds = new FirestoreDataSource(mock.db, "__platform__");
+    await ds.createPlatformAuthErrorLog({
+      email: "verify@example.com",
+      tenantId: "__platform__",
+      errorType: "super_admin_token_error",
+      reason: null,
+      errorMessage: "revoked",
+      path: "/admin",
+      method: "POST",
+      userAgent: "curl",
+      ipAddress: "10.0.0.1",
+      firebaseErrorCode: "auth/id-token-revoked",
+      occurredAt: "2026-04-22T12:00:00.000Z",
+    });
+
+    expect(mock.setMock).toHaveBeenCalledTimes(1);
+    const saved = mock.setMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(saved.reason).toBeNull();
+    expect(saved.firebaseErrorCode).toBe("auth/id-token-revoked");
+    expect(saved.email).toBe("verify@example.com");
+    expect(saved.occurredAt).toBeInstanceOf(Timestamp);
+  });
+
+  it("read-after-write せず、入力から直接復元した AuthErrorLog を返す（H-2対応）", async () => {
+    const ds = new FirestoreDataSource(mock.db, "__platform__");
+    const result = await ds.createPlatformAuthErrorLog({
+      email: "x@example.com",
+      tenantId: "__platform__",
+      errorType: "super_admin_denied",
+      reason: "not_super_admin",
+      errorMessage: "msg",
+      path: "/admin",
+      method: "GET",
+      userAgent: null,
+      ipAddress: null,
+      firebaseErrorCode: null,
+      occurredAt: "2026-04-22T12:00:00.000Z",
+    });
+
+    expect(result.id).toBe("generated-id");
+    expect(result.email).toBe("x@example.com");
+    expect(result.reason).toBe("not_super_admin");
+  });
+});

--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -594,6 +594,9 @@ export class FirestoreDataSource implements DataSource {
   /**
    * プラットフォーム（テナント非依存）認証エラーログを作成 (Issue #292)
    * ルートコレクション `platform_auth_error_logs` に書き込み、tenant スコープを使わない。
+   *
+   * serverTimestamp を使っていないため、書き込み後の read-after-write は行わず、
+   * 入力 `data` と生成 `id` から直接復元する（レイテンシ半減 + transient 再読失敗で silent drop する矛盾を回避）。
    */
   async createPlatformAuthErrorLog(data: Omit<AuthErrorLog, "id">): Promise<AuthErrorLog> {
     const docRef = this.db.collection("platform_auth_error_logs").doc();
@@ -601,8 +604,7 @@ export class FirestoreDataSource implements DataSource {
       ...data,
       occurredAt: Timestamp.fromDate(new Date(data.occurredAt)),
     });
-    const doc = await docRef.get();
-    return this.toAuthErrorLog(doc.id, doc.data()!);
+    return { ...data, id: docRef.id };
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -591,6 +591,20 @@ export class FirestoreDataSource implements DataSource {
     return this.toAuthErrorLog(doc.id, doc.data()!);
   }
 
+  /**
+   * プラットフォーム（テナント非依存）認証エラーログを作成 (Issue #292)
+   * ルートコレクション `platform_auth_error_logs` に書き込み、tenant スコープを使わない。
+   */
+  async createPlatformAuthErrorLog(data: Omit<AuthErrorLog, "id">): Promise<AuthErrorLog> {
+    const docRef = this.db.collection("platform_auth_error_logs").doc();
+    await docRef.set({
+      ...data,
+      occurredAt: Timestamp.fromDate(new Date(data.occurredAt)),
+    });
+    const doc = await docRef.get();
+    return this.toAuthErrorLog(doc.id, doc.data()!);
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private toAuthErrorLog(id: string, data: any): AuthErrorLog {
     return {
@@ -598,11 +612,13 @@ export class FirestoreDataSource implements DataSource {
       email: data.email,
       tenantId: data.tenantId,
       errorType: data.errorType,
+      reason: data.reason ?? null,
       errorMessage: data.errorMessage,
       path: data.path,
       method: data.method,
       userAgent: data.userAgent ?? null,
       ipAddress: data.ipAddress ?? null,
+      firebaseErrorCode: data.firebaseErrorCode ?? null,
       occurredAt: toISOStrict(data.occurredAt, "AuthErrorLog.occurredAt"),
     };
   }

--- a/services/api/src/datasource/in-memory.ts
+++ b/services/api/src/datasource/in-memory.ts
@@ -596,6 +596,18 @@ export class InMemoryDataSource implements DataSource {
     };
   }
 
+  /**
+   * プラットフォーム（テナント非依存）認証エラーログを作成 (Issue #292)
+   * InMemory ではテスト時の spy 対象として返却のみ行う（永続化なし）。
+   */
+  async createPlatformAuthErrorLog(data: Omit<AuthErrorLog, "id">): Promise<AuthErrorLog> {
+    this.throwIfReadOnly();
+    return {
+      ...data,
+      id: InMemoryDataSource.uniqueId("platform-auth-error"),
+    };
+  }
+
   // User Settings
   async getUserSettings(userId: string): Promise<UserSettings | null> {
     return this.userSettings.get(userId) ?? null;

--- a/services/api/src/datasource/interface.ts
+++ b/services/api/src/datasource/interface.ts
@@ -124,6 +124,15 @@ export interface DataSource {
    */
   createAuthErrorLog(data: Omit<AuthErrorLog, "id">): Promise<AuthErrorLog>;
 
+  /**
+   * プラットフォーム（テナント非依存）認証エラーログを作成 (Issue #292)
+   *
+   * super-admin 経路の認証拒否はテナントスコープ外のため、`auth_error_logs` ではなく
+   * ルートコレクション `platform_auth_error_logs` に記録する。
+   * `tenantId` は便宜上 `"__platform__"` を設定する（Firestore スキーマ互換維持）。
+   */
+  createPlatformAuthErrorLog(data: Omit<AuthErrorLog, "id">): Promise<AuthErrorLog>;
+
   // User Settings
   getUserSettings(userId: string): Promise<UserSettings | null>;
   upsertUserSettings(userId: string, data: Partial<UserSettings>): Promise<UserSettings>;

--- a/services/api/src/middleware/__tests__/super-admin-auth-logging.test.ts
+++ b/services/api/src/middleware/__tests__/super-admin-auth-logging.test.ts
@@ -145,6 +145,27 @@ describe("superAdminAuthMiddleware — Issue #292 structured denial logging", ()
       expect(createPlatformAuthErrorLog.mock.calls[0][0].reason).toBe("email_missing");
     });
 
+    it("email_missing: email 空文字 → reason=email_missing（H1 境界値）", async () => {
+      const { app, createPlatformAuthErrorLog } = await buildHarness("firebase");
+      mockVerifyIdToken.mockResolvedValue(makeToken({ email: "" }));
+
+      const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+      expect(res.status).toBe(403);
+
+      expect(createPlatformAuthErrorLog.mock.calls[0][0].reason).toBe("email_missing");
+    });
+
+    it("non_google_provider: firebase キー自体が欠落 → reason=non_google_provider（H2 境界値）", async () => {
+      const { app, createPlatformAuthErrorLog } = await buildHarness("firebase");
+      mockVerifyIdToken.mockResolvedValue(makeToken({ firebase: undefined }));
+
+      const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+      expect(res.status).toBe(403);
+
+      expect(createPlatformAuthErrorLog.mock.calls[0][0].reason).toBe("non_google_provider");
+      expect(createPlatformAuthErrorLog.mock.calls[0][0].errorMessage).toContain("provider=unknown");
+    });
+
     it("not_super_admin: 検証済みメールだが super admin 登録なし → reason=not_super_admin", async () => {
       const { app, createPlatformAuthErrorLog } = await buildHarness("firebase");
       mockVerifyIdToken.mockResolvedValue(makeToken({ email: "nobody@example.com" }));

--- a/services/api/src/middleware/__tests__/super-admin-auth-logging.test.ts
+++ b/services/api/src/middleware/__tests__/super-admin-auth-logging.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Issue #292: super-admin 経路の認証拒否ログ構造化テスト
+ *
+ * 各 403/401 分岐で logger.warn / logger.error が適切な reason / firebaseErrorCode で呼ばれ、
+ * platform_auth_error_logs（InMemoryDataSource 差し替え）に記録されることを検証する。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import supertest from "supertest";
+
+const mockVerifyIdToken = vi.fn();
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: () => ({ verifyIdToken: mockVerifyIdToken }),
+}));
+
+vi.mock("firebase-admin/app", () => ({
+  getApps: () => [{ name: "[DEFAULT]" }],
+  initializeApp: vi.fn(),
+  cert: vi.fn(),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: () => ({
+    collection: () => ({ get: async () => ({ docs: [] }) }),
+  }),
+}));
+
+async function buildHarness(mode: "firebase" | "dev") {
+  vi.stubEnv("AUTH_MODE", mode);
+  vi.stubEnv("SUPER_ADMIN_EMAILS", "super@example.com");
+
+  const { superAdminAuthMiddleware } = await import("../super-admin.js");
+  const { setPlatformDataSourceForTest } = await import("../platform-datasource.js");
+
+  const createPlatformAuthErrorLog = vi.fn().mockResolvedValue({ id: "p1" });
+  // 最小限の DataSource スタブ（createPlatformAuthErrorLog のみ検証）
+  setPlatformDataSourceForTest({
+    createPlatformAuthErrorLog,
+  } as never);
+
+  const app = express();
+  app.use(express.json());
+  app.use(superAdminAuthMiddleware);
+  app.get("/me", (req, res) => {
+    res.json({ superAdmin: req.superAdmin ?? null });
+  });
+
+  return { app, createPlatformAuthErrorLog };
+}
+
+function makeToken(overrides: Record<string, unknown> = {}) {
+  return {
+    uid: "uid-x",
+    email_verified: true,
+    firebase: { sign_in_provider: "google.com" },
+    email: "user@example.com",
+    ...overrides,
+  };
+}
+
+describe("superAdminAuthMiddleware — Issue #292 structured denial logging", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockVerifyIdToken.mockReset();
+    // resetModules 後の実装側 logger と同じインスタンスを取得して spy する
+    const { logger } = await import("../../utils/logger.js");
+    warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+    const { setPlatformDataSourceForTest } = await import("../platform-datasource.js");
+    setPlatformDataSourceForTest(null);
+  });
+
+  describe("firebase mode", () => {
+    it("no_auth_header: Authorization 欠落で 401 + logger.warn + platform_auth_error_logs", async () => {
+      const { app, createPlatformAuthErrorLog } = await buildHarness("firebase");
+
+      const res = await supertest(app).get("/me");
+      expect(res.status).toBe(401);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Super admin access denied",
+        expect.objectContaining({
+          errorType: "super_admin_denied",
+          reason: "no_auth_header",
+        })
+      );
+      expect(createPlatformAuthErrorLog).toHaveBeenCalledTimes(1);
+      expect(createPlatformAuthErrorLog.mock.calls[0][0]).toMatchObject({
+        errorType: "super_admin_denied",
+        reason: "no_auth_header",
+        tenantId: "__platform__",
+        firebaseErrorCode: null,
+      });
+    });
+
+    it("email_not_verified: email_verified=false → 403 + reason=email_not_verified", async () => {
+      const { app, createPlatformAuthErrorLog } = await buildHarness("firebase");
+      mockVerifyIdToken.mockResolvedValue(
+        makeToken({ email_verified: false, email: "unverified@example.com" })
+      );
+
+      const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+      expect(res.status).toBe(403);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Super admin access denied",
+        expect.objectContaining({
+          errorType: "super_admin_denied",
+          reason: "email_not_verified",
+          email: "unverified@example.com",
+        })
+      );
+      expect(createPlatformAuthErrorLog.mock.calls[0][0].reason).toBe("email_not_verified");
+    });
+
+    it("non_google_provider: sign_in_provider=password → reason=non_google_provider", async () => {
+      const { app, createPlatformAuthErrorLog } = await buildHarness("firebase");
+      mockVerifyIdToken.mockResolvedValue(
+        makeToken({ firebase: { sign_in_provider: "password" } })
+      );
+
+      const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+      expect(res.status).toBe(403);
+
+      expect(createPlatformAuthErrorLog.mock.calls[0][0].reason).toBe("non_google_provider");
+    });
+
+    it("email_missing: email 欠損 → reason=email_missing", async () => {
+      const { app, createPlatformAuthErrorLog } = await buildHarness("firebase");
+      mockVerifyIdToken.mockResolvedValue(makeToken({ email: undefined }));
+
+      const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+      expect(res.status).toBe(403);
+
+      expect(createPlatformAuthErrorLog.mock.calls[0][0].reason).toBe("email_missing");
+    });
+
+    it("not_super_admin: 検証済みメールだが super admin 登録なし → reason=not_super_admin", async () => {
+      const { app, createPlatformAuthErrorLog } = await buildHarness("firebase");
+      mockVerifyIdToken.mockResolvedValue(makeToken({ email: "nobody@example.com" }));
+
+      const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+      expect(res.status).toBe(403);
+
+      expect(createPlatformAuthErrorLog.mock.calls[0][0].reason).toBe("not_super_admin");
+      expect(createPlatformAuthErrorLog.mock.calls[0][0].email).toBe("nobody@example.com");
+    });
+
+    it("catch 節: verifyIdToken 失敗 → logger.error + firebaseErrorCode", async () => {
+      const { app, createPlatformAuthErrorLog } = await buildHarness("firebase");
+      const err = Object.assign(new Error("revoked"), { code: "auth/id-token-revoked" });
+      mockVerifyIdToken.mockRejectedValue(err);
+
+      const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+      expect(res.status).toBe(401);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Super admin token verification failed",
+        expect.objectContaining({
+          errorType: "super_admin_token_error",
+          firebaseErrorCode: "auth/id-token-revoked",
+        })
+      );
+      expect(createPlatformAuthErrorLog.mock.calls[0][0]).toMatchObject({
+        errorType: "super_admin_token_error",
+        firebaseErrorCode: "auth/id-token-revoked",
+        reason: null,
+      });
+    });
+  });
+
+  describe("dev mode", () => {
+    it("no_auth_header: X-User-Email 欠落で 401 + reason=no_auth_header", async () => {
+      const { app, createPlatformAuthErrorLog } = await buildHarness("dev");
+
+      const res = await supertest(app).get("/me");
+      expect(res.status).toBe(401);
+
+      expect(createPlatformAuthErrorLog.mock.calls[0][0].reason).toBe("no_auth_header");
+    });
+
+    it("not_super_admin: 登録されていないメール → 403 + reason=not_super_admin", async () => {
+      const { app, createPlatformAuthErrorLog } = await buildHarness("dev");
+
+      const res = await supertest(app).get("/me").set("x-user-email", "nobody@example.com");
+      expect(res.status).toBe(403);
+
+      expect(createPlatformAuthErrorLog.mock.calls[0][0]).toMatchObject({
+        errorType: "super_admin_denied",
+        reason: "not_super_admin",
+        email: "nobody@example.com",
+      });
+    });
+  });
+});

--- a/services/api/src/middleware/__tests__/tenant-auth-error-response.test.ts
+++ b/services/api/src/middleware/__tests__/tenant-auth-error-response.test.ts
@@ -39,6 +39,7 @@ describe("handleTenantAccessDenied", () => {
   it("レスポンス message は固定の一般化文言（ユーザー列挙防止）", async () => {
     const err = new TenantAccessDeniedError(
       "このメールアドレス (leak@example.com) はテナント「leak-tenant」へのアクセスが許可されていません。",
+      "not_in_allowlist",
       "leak@example.com",
       "leak-tenant"
     );
@@ -61,6 +62,7 @@ describe("handleTenantAccessDenied", () => {
   it("auth_error_logs には詳細（email / tenantId / errorMessage）が保存される", async () => {
     const err = new TenantAccessDeniedError(
       "このメールアドレス (user@example.com) はテナント「acme」へのアクセスが許可されていません。",
+      "not_in_allowlist",
       "user@example.com",
       "acme"
     );
@@ -74,13 +76,16 @@ describe("handleTenantAccessDenied", () => {
     expect(logged.email).toBe("user@example.com");
     expect(logged.tenantId).toBe("acme");
     expect(logged.errorType).toBe("tenant_access_denied");
+    expect(logged.reason).toBe("not_in_allowlist");
+    expect(logged.firebaseErrorCode).toBeNull();
     expect(logged.errorMessage).toContain("user@example.com");
   });
 
-  it("logger.warn にも email / tenantId を含む詳細が記録される（CG-3）", async () => {
+  it("logger.warn にも email / tenantId / reason を含む詳細が記録される（CG-3 + Issue #292）", async () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
     const err = new TenantAccessDeniedError(
       "このメールアドレス (trace@example.com) はテナント「trace」へのアクセスが許可されていません。",
+      "not_in_allowlist",
       "trace@example.com",
       "trace"
     );
@@ -95,12 +100,13 @@ describe("handleTenantAccessDenied", () => {
       email: "trace@example.com",
       tenantId: "trace",
       errorType: "tenant_access_denied",
+      reason: "not_in_allowlist",
     });
     warnSpy.mockRestore();
   });
 
   it("auth_error_logs 保存が失敗してもレスポンスは返る", async () => {
-    const err = new TenantAccessDeniedError("denied", "user@example.com", "acme");
+    const err = new TenantAccessDeniedError("denied", "not_in_allowlist", "user@example.com", "acme");
     const failingDs = {
       createAuthErrorLog: vi.fn().mockRejectedValue(new Error("firestore down")),
     };

--- a/services/api/src/middleware/__tests__/tenant-auth-logging.test.ts
+++ b/services/api/src/middleware/__tests__/tenant-auth-logging.test.ts
@@ -144,6 +144,36 @@ describe("tenantAwareAuthMiddleware — Issue #292 structured denial logging", (
     expect(createAuthErrorLogSpy.mock.calls[0][0].reason).toBe("email_missing");
   });
 
+  it("ensureAllowlisted 経由: 既存 user + allowed_emails 削除後 → reason=not_in_allowlist（H3）", async () => {
+    // ADR-031 継続的認可境界の本丸: 既存ユーザー経路で reason が記録されることを構造化ログ観点で検証
+    const { app, ds, createAuthErrorLogSpy } = await buildApp();
+    await ds.createAllowedEmail({ email: "existing@example.com", note: null });
+    await ds.createUser({
+      email: "existing@example.com",
+      name: "Existing",
+      role: "student",
+      firebaseUid: "uid-existing",
+    });
+    // allowed_emails 削除
+    const allowed = (await ds.getAllowedEmails()).find((a) => a.email === "existing@example.com")!;
+    await ds.deleteAllowedEmail(allowed.id);
+
+    mockVerifyIdToken.mockResolvedValue({
+      uid: "uid-existing",
+      email: "existing@example.com",
+      email_verified: true,
+      firebase: { sign_in_provider: "google.com" },
+    });
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+    expect(res.status).toBe(403);
+    expect(createAuthErrorLogSpy.mock.calls[0][0]).toMatchObject({
+      errorType: "tenant_access_denied",
+      reason: "not_in_allowlist",
+      email: "existing@example.com",
+    });
+  });
+
   it("catch 節: verifyIdToken 失敗 → logger.error + firebaseErrorCode", async () => {
     const { app } = await buildApp();
     const err = Object.assign(new Error("revoked"), { code: "auth/id-token-revoked" });

--- a/services/api/src/middleware/__tests__/tenant-auth-logging.test.ts
+++ b/services/api/src/middleware/__tests__/tenant-auth-logging.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Issue #292: tenant-auth 経路の認証拒否ログ構造化テスト
+ *
+ * - TenantAccessDeniedError の reason が分岐ごとに期待値になっていること
+ * - handleTenantAccessDenied が logger.warn + auth_error_logs に reason を記録すること
+ * - catch 節で logger.error が firebaseErrorCode 付きで呼ばれること
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import supertest from "supertest";
+
+const mockVerifyIdToken = vi.fn();
+const mockIsSuperAdmin = vi.fn();
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: () => ({ verifyIdToken: mockVerifyIdToken }),
+}));
+
+vi.mock("firebase-admin/app", () => ({
+  getApps: () => [{ name: "[DEFAULT]" }],
+  initializeApp: vi.fn(),
+  cert: vi.fn(),
+}));
+
+vi.mock("../super-admin.js", () => ({
+  isSuperAdmin: (email?: string) => mockIsSuperAdmin(email),
+}));
+
+async function buildApp() {
+  vi.stubEnv("AUTH_MODE", "firebase");
+  const { tenantAwareAuthMiddleware } = await import("../tenant-auth.js");
+  const { InMemoryDataSource } = await import("../../datasource/in-memory.js");
+
+  const ds = new InMemoryDataSource({ readOnly: false });
+  const createAuthErrorLogSpy = vi.spyOn(ds, "createAuthErrorLog");
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.tenantContext = { tenantId: "t1", isDemo: false };
+    req.dataSource = ds;
+    next();
+  });
+  app.use(tenantAwareAuthMiddleware);
+  app.get("/me", (req, res) => {
+    res.json({ user: req.user ?? null });
+  });
+
+  return { app, ds, createAuthErrorLogSpy };
+}
+
+describe("tenantAwareAuthMiddleware — Issue #292 structured denial logging", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockVerifyIdToken.mockReset();
+    mockIsSuperAdmin.mockReset().mockResolvedValue(false);
+    // resetModules 後の実装側 logger と同じインスタンスを取得して spy する
+    const { logger } = await import("../../utils/logger.js");
+    warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("email_verified=false → reason=email_not_verified が logger/auth_error_logs に記録", async () => {
+    const { app, createAuthErrorLogSpy } = await buildApp();
+    mockVerifyIdToken.mockResolvedValue({
+      uid: "uid-1",
+      email: "unverified@example.com",
+      email_verified: false,
+      firebase: { sign_in_provider: "google.com" },
+    });
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+    expect(res.status).toBe(403);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Tenant access denied",
+      expect.objectContaining({
+        errorType: "tenant_access_denied",
+        reason: "email_not_verified",
+      })
+    );
+    expect(createAuthErrorLogSpy.mock.calls[0][0]).toMatchObject({
+      errorType: "tenant_access_denied",
+      reason: "email_not_verified",
+      firebaseErrorCode: null,
+    });
+  });
+
+  it("sign_in_provider=password → reason=non_google_provider", async () => {
+    const { app, createAuthErrorLogSpy } = await buildApp();
+    mockVerifyIdToken.mockResolvedValue({
+      uid: "uid-2",
+      email: "pw@example.com",
+      email_verified: true,
+      firebase: { sign_in_provider: "password" },
+    });
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+    expect(res.status).toBe(403);
+    expect(createAuthErrorLogSpy.mock.calls[0][0].reason).toBe("non_google_provider");
+  });
+
+  it("allowlist 不在 → reason=not_in_allowlist", async () => {
+    const { app, createAuthErrorLogSpy } = await buildApp();
+    mockVerifyIdToken.mockResolvedValue({
+      uid: "uid-3",
+      email: "new@example.com",
+      email_verified: true,
+      firebase: { sign_in_provider: "google.com" },
+    });
+    // allowed_emails 未登録 + 既存ユーザーなし → 新規作成パスで 403
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+    expect(res.status).toBe(403);
+    expect(createAuthErrorLogSpy.mock.calls[0][0].reason).toBe("not_in_allowlist");
+  });
+
+  it("email 欠損 + 既存ユーザー有 → reason=email_missing", async () => {
+    const { app, ds, createAuthErrorLogSpy } = await buildApp();
+    // 既存 user は存在するが decodedToken に email がない
+    await ds.createUser({
+      email: "",
+      name: "NoEmail",
+      role: "student",
+      firebaseUid: "uid-4",
+    });
+    mockVerifyIdToken.mockResolvedValue({
+      uid: "uid-4",
+      email_verified: true,
+      firebase: { sign_in_provider: "google.com" },
+    });
+
+    const res = await supertest(app).get("/me").set("authorization", "Bearer tok");
+    expect(res.status).toBe(403);
+    expect(createAuthErrorLogSpy.mock.calls[0][0].reason).toBe("email_missing");
+  });
+
+  it("catch 節: verifyIdToken 失敗 → logger.error + firebaseErrorCode", async () => {
+    const { app } = await buildApp();
+    const err = Object.assign(new Error("revoked"), { code: "auth/id-token-revoked" });
+    mockVerifyIdToken.mockRejectedValue(err);
+
+    await supertest(app).get("/me").set("authorization", "Bearer tok");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Tenant token verification failed",
+      expect.objectContaining({
+        errorType: "tenant_token_error",
+        firebaseErrorCode: "auth/id-token-revoked",
+      })
+    );
+  });
+});

--- a/services/api/src/middleware/platform-datasource.ts
+++ b/services/api/src/middleware/platform-datasource.ts
@@ -1,0 +1,33 @@
+/**
+ * Platform-scope DataSource singleton (Issue #292).
+ *
+ * super-admin ミドルウェアはテナント非依存で認証拒否ログを記録する必要があるが、
+ * tenantMiddleware が走る前に実行されるため `req.dataSource` が存在しない。
+ * このヘルパでプロセス単位の DataSource を singleton 提供し、
+ * `createPlatformAuthErrorLog` 経由で root コレクション `platform_auth_error_logs` に書き込む。
+ *
+ * - `AUTH_MODE=firebase` → `FirestoreDataSource`（tenantId="__platform__" は未使用のため任意値）
+ * - それ以外（dev/test）→ `InMemoryDataSource`
+ * - テストから `setPlatformDataSourceForTest()` で差し替え可能
+ */
+import { getFirestore } from "firebase-admin/firestore";
+import { FirestoreDataSource } from "../datasource/firestore.js";
+import { InMemoryDataSource } from "../datasource/in-memory.js";
+import type { DataSource } from "../datasource/interface.js";
+
+let cached: DataSource | null = null;
+
+export function getPlatformDataSource(): DataSource {
+  if (cached) return cached;
+  const mode = process.env.AUTH_MODE ?? "dev";
+  cached =
+    mode === "firebase"
+      ? new FirestoreDataSource(getFirestore(), "__platform__")
+      : new InMemoryDataSource({ readOnly: false });
+  return cached;
+}
+
+/** テスト用: platform DataSource をモックに差し替える（null でリセット） */
+export function setPlatformDataSourceForTest(ds: DataSource | null): void {
+  cached = ds;
+}

--- a/services/api/src/middleware/platform-datasource.ts
+++ b/services/api/src/middleware/platform-datasource.ts
@@ -6,7 +6,11 @@
  * このヘルパでプロセス単位の DataSource を singleton 提供し、
  * `createPlatformAuthErrorLog` 経由で root コレクション `platform_auth_error_logs` に書き込む。
  *
- * - `AUTH_MODE=firebase` → `FirestoreDataSource`（tenantId="__platform__" は未使用のため任意値）
+ * - `AUTH_MODE=firebase` → `FirestoreDataSource`
+ *   （`FirestoreDataSource` の tenantId は `tenants/{tenantId}/` path 解決にのみ使われる。
+ *   `createPlatformAuthErrorLog` は root コレクションに書き込むため tenant path を利用せず、
+ *   ここに渡す `PLATFORM_TENANT_ID` は書き込みルーティングに影響しない識別子。
+ *   なお super-admin.ts 側では `AuthErrorLog.tenantId` フィールドにも同じ識別子を明示的に格納する）
  * - それ以外（dev/test）→ `InMemoryDataSource`
  * - テストから `setPlatformDataSourceForTest()` で差し替え可能
  */
@@ -15,6 +19,12 @@ import { FirestoreDataSource } from "../datasource/firestore.js";
 import { InMemoryDataSource } from "../datasource/in-memory.js";
 import type { DataSource } from "../datasource/interface.js";
 
+/**
+ * Platform スコープ識別子。`AuthErrorLog.tenantId` フィールドの sentinel 値として使用する。
+ * Cloud Logging / BigQuery 上で「platform レベル vs tenant レベル」の拒否を分離する際のキー。
+ */
+export const PLATFORM_TENANT_ID = "__platform__" as const;
+
 let cached: DataSource | null = null;
 
 export function getPlatformDataSource(): DataSource {
@@ -22,7 +32,7 @@ export function getPlatformDataSource(): DataSource {
   const mode = process.env.AUTH_MODE ?? "dev";
   cached =
     mode === "firebase"
-      ? new FirestoreDataSource(getFirestore(), "__platform__")
+      ? new FirestoreDataSource(getFirestore(), PLATFORM_TENANT_ID)
       : new InMemoryDataSource({ readOnly: false });
   return cached;
 }

--- a/services/api/src/middleware/super-admin.ts
+++ b/services/api/src/middleware/super-admin.ts
@@ -8,7 +8,7 @@ import { getApps, initializeApp, cert } from "firebase-admin/app";
 import { getAuth } from "firebase-admin/auth";
 import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "../utils/logger.js";
-import { getPlatformDataSource } from "./platform-datasource.js";
+import { getPlatformDataSource, PLATFORM_TENANT_ID } from "./platform-datasource.js";
 
 /**
  * Super admin 経路の拒否理由（Issue #292）。
@@ -59,7 +59,7 @@ async function recordSuperAdminAuthEvent(
     const ds = getPlatformDataSource();
     await ds.createPlatformAuthErrorLog({
       email: payload.email ?? "unknown",
-      tenantId: "__platform__",
+      tenantId: PLATFORM_TENANT_ID,
       errorType: payload.errorType,
       reason: payload.reason,
       errorMessage: payload.errorMessage,
@@ -71,9 +71,22 @@ async function recordSuperAdminAuthEvent(
       occurredAt: new Date().toISOString(),
     });
   } catch (persistError) {
-    // 記録失敗は警告のみ、API 応答には影響させない。
-    logger.warn("Failed to persist platform auth error log", {
-      error: persistError instanceof Error ? persistError.message : String(persistError),
+    // Issue #292 silent-failure 指摘 C-1 対応: persist 失敗時に元イベントコンテキスト
+    // (errorType/reason/email/firebaseErrorCode/path 等) が logger.warn の "error" フィールド
+    // だけに畳み込まれて落ちると、Firestore 障害中の拒否イベントが完全に失われる。
+    // 元 payload を展開して logger.error に残し、最低限 application log での forensics を維持する。
+    const pe = persistError as { code?: unknown };
+    logger.error("Failed to persist platform auth error log", {
+      originalErrorType: payload.errorType,
+      originalReason: payload.reason,
+      email: payload.email ?? "unknown",
+      firebaseErrorCode: payload.firebaseErrorCode,
+      path: req.path,
+      method: req.method,
+      ipAddress: req.ip,
+      persistErrorCode: typeof pe.code === "string" ? pe.code : null,
+      persistErrorMessage:
+        persistError instanceof Error ? persistError.message : String(persistError),
     });
   }
 }

--- a/services/api/src/middleware/super-admin.ts
+++ b/services/api/src/middleware/super-admin.ts
@@ -7,6 +7,76 @@ import type { Request, Response, NextFunction } from "express";
 import { getApps, initializeApp, cert } from "firebase-admin/app";
 import { getAuth } from "firebase-admin/auth";
 import { getFirestore } from "firebase-admin/firestore";
+import { logger } from "../utils/logger.js";
+import { getPlatformDataSource } from "./platform-datasource.js";
+
+/**
+ * Super admin 経路の拒否理由（Issue #292）。
+ * Cloud Logging / platform_auth_error_logs で機械的にフィルタ可能にするため固定値で列挙する。
+ */
+export type SuperAdminDenialReason =
+  | "no_auth_header"
+  | "email_not_verified"
+  | "non_google_provider"
+  | "email_missing"
+  | "not_super_admin";
+
+/**
+ * Super admin 経路の認証拒否/エラーを構造化ログ + platform_auth_error_logs に記録する (Issue #292)。
+ * - `logger.warn`: 403 分岐（拒否理由を reason で区別）
+ * - `logger.error`: catch 節（firebaseErrorCode 付き）
+ *
+ * Firestore 書き込みは失敗しても API 応答を止めない（logger.warn だけ残す）。
+ * `req.dataSource` は super-admin 経路では注入されないため、`getPlatformDataSource()` 経由でアクセスする。
+ */
+async function recordSuperAdminAuthEvent(
+  req: Request,
+  payload: {
+    errorType: "super_admin_denied" | "super_admin_token_error";
+    reason: SuperAdminDenialReason | null;
+    email: string | undefined;
+    errorMessage: string;
+    firebaseErrorCode: string | null;
+  }
+): Promise<void> {
+  const logFields = {
+    errorType: payload.errorType,
+    reason: payload.reason,
+    email: payload.email ?? "unknown",
+    firebaseErrorCode: payload.firebaseErrorCode,
+    path: req.path,
+    method: req.method,
+    userAgent: req.header("user-agent"),
+    ipAddress: req.ip,
+  };
+  if (payload.errorType === "super_admin_denied") {
+    logger.warn("Super admin access denied", logFields);
+  } else {
+    logger.error("Super admin token verification failed", logFields);
+  }
+
+  try {
+    const ds = getPlatformDataSource();
+    await ds.createPlatformAuthErrorLog({
+      email: payload.email ?? "unknown",
+      tenantId: "__platform__",
+      errorType: payload.errorType,
+      reason: payload.reason,
+      errorMessage: payload.errorMessage,
+      path: req.path,
+      method: req.method,
+      userAgent: req.header("user-agent") ?? null,
+      ipAddress: req.ip ?? null,
+      firebaseErrorCode: payload.firebaseErrorCode,
+      occurredAt: new Date().toISOString(),
+    });
+  } catch (persistError) {
+    // 記録失敗は警告のみ、API 応答には影響させない。
+    logger.warn("Failed to persist platform auth error log", {
+      error: persistError instanceof Error ? persistError.message : String(persistError),
+    });
+  }
+}
 
 const authMode = process.env.AUTH_MODE ?? "dev";
 
@@ -187,6 +257,13 @@ export const superAdminAuthMiddleware = async (
     const headerEmail = req.header("x-user-email");
 
     if (!headerEmail) {
+      await recordSuperAdminAuthEvent(req, {
+        errorType: "super_admin_denied",
+        reason: "no_auth_header",
+        email: undefined,
+        errorMessage: "X-User-Email header missing (dev mode)",
+        firebaseErrorCode: null,
+      });
       return res.status(401).json({
         error: "unauthorized",
         message: "認証情報がありません",
@@ -196,6 +273,13 @@ export const superAdminAuthMiddleware = async (
     try {
       const isAdmin = await isSuperAdmin(headerEmail);
       if (!isAdmin) {
+        await recordSuperAdminAuthEvent(req, {
+          errorType: "super_admin_denied",
+          reason: "not_super_admin",
+          email: headerEmail,
+          errorMessage: "Email not registered as super admin (dev mode)",
+          firebaseErrorCode: null,
+        });
         return res.status(403).json({
           error: "forbidden",
           message: "スーパー管理者権限が必要です",
@@ -208,7 +292,13 @@ export const superAdminAuthMiddleware = async (
       // Issue #293: Firestore 障害時は env に載っていない super-admin を silent に 403 で
       // 締め出さず、503 を返して再試行を促す。
       if (error instanceof SuperAdminFirestoreUnavailableError) {
-        console.error("Super admin Firestore check unavailable (dev mode):", error);
+        logger.error("Super admin Firestore check unavailable", {
+          errorType: "super_admin_firestore_unavailable",
+          authMode: "dev",
+          firebaseErrorCode: error.code ?? null,
+          path: req.path,
+          method: req.method,
+        });
         return res.status(503).json({
           error: "service_unavailable",
           message: "一時的に利用できません。再度お試しください。",
@@ -222,6 +312,13 @@ export const superAdminAuthMiddleware = async (
     // Firebase認証: Authorization: Bearer <ID Token>
     const authHeader = req.header("authorization");
     if (!authHeader?.startsWith("Bearer ")) {
+      await recordSuperAdminAuthEvent(req, {
+        errorType: "super_admin_denied",
+        reason: "no_auth_header",
+        email: undefined,
+        errorMessage: "Authorization header missing or not Bearer",
+        firebaseErrorCode: null,
+      });
       return res.status(401).json({
         error: "unauthorized",
         message: "認証情報がありません",
@@ -239,12 +336,26 @@ export const superAdminAuthMiddleware = async (
       const decodedToken = await getAuth().verifyIdToken(idToken, true);
 
       if (decodedToken.email_verified !== true) {
+        await recordSuperAdminAuthEvent(req, {
+          errorType: "super_admin_denied",
+          reason: "email_not_verified",
+          email: decodedToken.email,
+          errorMessage: `Email verification required (uid=${decodedToken.uid})`,
+          firebaseErrorCode: null,
+        });
         return res.status(403).json({
           error: "forbidden",
           message: "スーパー管理者権限が必要です",
         });
       }
       if (decodedToken.firebase?.sign_in_provider !== "google.com") {
+        await recordSuperAdminAuthEvent(req, {
+          errorType: "super_admin_denied",
+          reason: "non_google_provider",
+          email: decodedToken.email,
+          errorMessage: `Only Google sign-in is allowed (provider=${decodedToken.firebase?.sign_in_provider ?? "unknown"})`,
+          firebaseErrorCode: null,
+        });
         return res.status(403).json({
           error: "forbidden",
           message: "スーパー管理者権限が必要です",
@@ -256,6 +367,13 @@ export const superAdminAuthMiddleware = async (
       // 欠落した場合は fail-closed で 403 を返し、non-null assertion による
       // サイレント TypeError を防ぐ。
       if (!email) {
+        await recordSuperAdminAuthEvent(req, {
+          errorType: "super_admin_denied",
+          reason: "email_missing",
+          email: undefined,
+          errorMessage: `Decoded token is missing email claim (uid=${decodedToken.uid})`,
+          firebaseErrorCode: null,
+        });
         return res.status(403).json({
           error: "forbidden",
           message: "スーパー管理者権限が必要です",
@@ -264,6 +382,13 @@ export const superAdminAuthMiddleware = async (
 
       const isAdmin = await isSuperAdmin(email);
       if (!isAdmin) {
+        await recordSuperAdminAuthEvent(req, {
+          errorType: "super_admin_denied",
+          reason: "not_super_admin",
+          email,
+          errorMessage: "Email not registered as super admin",
+          firebaseErrorCode: null,
+        });
         return res.status(403).json({
           error: "forbidden",
           message: "スーパー管理者権限が必要です",
@@ -279,13 +404,31 @@ export const superAdminAuthMiddleware = async (
       // Issue #293: Firestore 障害時は 503 で返す（env フォールバックで既に通過済みの
       // ケースはここに来ない）。通常の token 検証失敗は従来通り 401。
       if (error instanceof SuperAdminFirestoreUnavailableError) {
-        console.error("Super admin Firestore check unavailable (firebase mode):", error);
+        logger.error("Super admin Firestore check unavailable", {
+          errorType: "super_admin_firestore_unavailable",
+          authMode: "firebase",
+          firebaseErrorCode: error.code ?? null,
+          path: req.path,
+          method: req.method,
+        });
         return res.status(503).json({
           error: "service_unavailable",
           message: "一時的に利用できません。再度お試しください。",
         });
       }
-      console.error("Firebase token verification failed:", error);
+      // Issue #292: verifyIdToken 失敗を構造化ログ + platform_auth_error_logs に記録。
+      // firebaseErrorCode (auth/id-token-revoked, auth/id-token-expired, auth/internal-error 等) で
+      // 原因を機械的に区別できるようにする。
+      const err = error as { code?: unknown; message?: unknown };
+      const firebaseErrorCode = typeof err.code === "string" ? err.code : null;
+      const errorMessage = typeof err.message === "string" ? err.message : String(error);
+      await recordSuperAdminAuthEvent(req, {
+        errorType: "super_admin_token_error",
+        reason: null,
+        email: undefined,
+        errorMessage,
+        firebaseErrorCode,
+      });
       return res.status(401).json({
         error: "unauthorized",
         message: "認証に失敗しました",

--- a/services/api/src/middleware/tenant-auth.ts
+++ b/services/api/src/middleware/tenant-auth.ts
@@ -37,16 +37,33 @@ if (authMode === "firebase" && getApps().length === 0) {
 
 /**
  * アクセス拒否エラー
+ *
+ * `reason` は Issue #292 で導入: Cloud Logging / auth_error_logs 上で拒否理由を
+ * 機械的に区別可能にするため、分岐ごとに固定の文字列を付与する。
+ * レスポンス文言はユーザー列挙防止のため共通化するが、reason はログ専用フィールド。
  */
+export type TenantAccessDenialReason =
+  | "email_not_verified"
+  | "non_google_provider"
+  | "email_missing"
+  | "not_in_allowlist";
+
 export class TenantAccessDeniedError extends Error {
   email?: string;
   tenantId?: string;
+  reason: TenantAccessDenialReason;
 
-  constructor(message: string, email?: string, tenantId?: string) {
+  constructor(
+    message: string,
+    reason: TenantAccessDenialReason,
+    email?: string,
+    tenantId?: string
+  ) {
     super(message);
     this.name = "TenantAccessDeniedError";
     this.email = email;
     this.tenantId = tenantId;
+    this.reason = reason;
   }
 }
 
@@ -74,11 +91,13 @@ export async function handleTenantAccessDenied(
 
   logger.warn("Tenant access denied", {
     errorType: "tenant_access_denied",
+    reason: error.reason,
     tenantId,
     email,
     path: req.path,
     method: req.method,
     userAgent: req.header("user-agent"),
+    ipAddress: req.ip,
   });
 
   // Firestoreに認証エラーログを保存（非同期、失敗しても処理を止めない）
@@ -88,11 +107,13 @@ export async function handleTenantAccessDenied(
         email,
         tenantId,
         errorType: "tenant_access_denied",
+        reason: error.reason,
         errorMessage: error.message,
         path: req.path,
         method: req.method,
         userAgent: req.header("user-agent") ?? null,
         ipAddress: req.ip ?? null,
+        firebaseErrorCode: null,
         occurredAt: new Date().toISOString(),
       });
     } catch (logError) {
@@ -176,6 +197,7 @@ async function ensureAllowlisted(
     }
     throw new TenantAccessDeniedError(
       `このメールアドレス (${email ?? "未設定"}) はテナント「${tenantId}」へのアクセスが許可されていません。`,
+      email ? "not_in_allowlist" : "email_missing",
       email ?? undefined,
       tenantId
     );
@@ -210,6 +232,7 @@ async function findOrCreateTenantUser(
   if (decodedToken.email_verified !== true) {
     throw new TenantAccessDeniedError(
       `Email verification required (email=${email ?? "unknown"})`,
+      "email_not_verified",
       email,
       tenantId
     );
@@ -218,6 +241,7 @@ async function findOrCreateTenantUser(
   if (signInProvider !== "google.com") {
     throw new TenantAccessDeniedError(
       `Only Google sign-in is allowed (provider=${signInProvider ?? "unknown"})`,
+      "non_google_provider",
       email,
       tenantId
     );
@@ -268,6 +292,7 @@ async function findOrCreateTenantUser(
     const tenantId = req.tenantContext?.tenantId ?? "unknown";
     throw new TenantAccessDeniedError(
       `このメールアドレス (${email ?? "未設定"}) はテナント「${tenantId}」へのアクセスが許可されていません。管理者に連絡してください。`,
+      email ? "not_in_allowlist" : "email_missing",
       email ?? undefined,
       tenantId
     );
@@ -329,6 +354,7 @@ async function findOrCreateDevUser(
     const tenantId = req.tenantContext?.tenantId ?? "unknown";
     throw new TenantAccessDeniedError(
       `このメールアドレス (${email}) はテナント「${tenantId}」へのアクセスが許可されていません。`,
+      "not_in_allowlist",
       email,
       tenantId
     );
@@ -460,8 +486,19 @@ export const tenantAwareAuthMiddleware = async (
         await handleTenantAccessDenied(error, req, res);
         return;
       }
-      // トークン検証失敗時は req.user を設定しない（401はrequireUserで処理）
-      console.error("Firebase token verification failed:", error);
+      // トークン検証失敗時は req.user を設定しない（401はrequireUserで処理）。
+      // Issue #292: Cloud Logging でフィルタ可能な構造化ログに切り替え、
+      // firebaseErrorCode (auth/id-token-revoked など) で原因を機械的に区別する。
+      const err = error as { code?: unknown; message?: unknown };
+      logger.error("Tenant token verification failed", {
+        errorType: "tenant_token_error",
+        firebaseErrorCode: typeof err.code === "string" ? err.code : null,
+        errorMessage: typeof err.message === "string" ? err.message : String(error),
+        tenantId: req.tenantContext?.tenantId ?? "unknown",
+        path: req.path,
+        method: req.method,
+        ipAddress: req.ip,
+      });
     }
     return next();
   }

--- a/services/api/src/middleware/tenant-auth.ts
+++ b/services/api/src/middleware/tenant-auth.ts
@@ -117,8 +117,19 @@ export async function handleTenantAccessDenied(
         occurredAt: new Date().toISOString(),
       });
     } catch (logError) {
-      // ログ保存失敗は警告のみ、レスポンスには影響させない
-      logger.warn("Failed to save auth error log", { error: logError });
+      // Issue #292 silent-failure 指摘 H-1 対応: persist 失敗時に Error を raw で渡すと
+      // logger 実装次第で {} に潰れ、かつ email/tenantId/reason の元コンテキストが失われる。
+      // 元 payload を展開して logger.error に残し、Firestore 障害中の拒否イベント追跡を維持する。
+      logger.error("Failed to save auth error log", {
+        originalErrorType: "tenant_access_denied",
+        originalReason: error.reason,
+        email,
+        tenantId,
+        path: req.path,
+        method: req.method,
+        persistErrorMessage:
+          logError instanceof Error ? logError.message : String(logError),
+      });
     }
   }
 

--- a/services/api/src/types/entities.ts
+++ b/services/api/src/types/entities.ts
@@ -50,9 +50,11 @@ export interface AuthErrorLog {
   tenantId: string;
   errorType: string;
   /**
-   * 拒否理由の細分化（Issue #292）。未設定（null）は旧レコード互換。
-   * tenant 経路の代表値: `email_not_verified` / `non_google_provider` / `email_missing` / `not_in_allowlist`
-   * super-admin 経路の代表値: 上記 + `not_super_admin` / `no_auth_header` / `firebase_claim_missing`
+   * 拒否理由の細分化（Issue #292）。未設定（null）は旧レコード互換。catch 節（token error）では null。
+   * 実装上の代表値は middleware 側 union 型を参照（ここでは `string | null` に緩めて
+   * 将来の reason 追加を schema 互換のまま許容）:
+   *   - tenant 経路: `TenantAccessDenialReason`（`middleware/tenant-auth.ts`）
+   *   - super-admin 経路: `SuperAdminDenialReason`（`middleware/super-admin.ts`）
    */
   reason: string | null;
   errorMessage: string;

--- a/services/api/src/types/entities.ts
+++ b/services/api/src/types/entities.ts
@@ -49,11 +49,23 @@ export interface AuthErrorLog {
   email: string;
   tenantId: string;
   errorType: string;
+  /**
+   * 拒否理由の細分化（Issue #292）。未設定（null）は旧レコード互換。
+   * tenant 経路の代表値: `email_not_verified` / `non_google_provider` / `email_missing` / `not_in_allowlist`
+   * super-admin 経路の代表値: 上記 + `not_super_admin` / `no_auth_header` / `firebase_claim_missing`
+   */
+  reason: string | null;
   errorMessage: string;
   path: string;
   method: string;
   userAgent: string | null;
   ipAddress: string | null;
+  /**
+   * Firebase Admin SDK の verifyIdToken 失敗時のエラーコード（Issue #292）。
+   * 例: `auth/id-token-revoked` / `auth/id-token-expired` / `auth/internal-error`
+   * 拒否（403）の場合は null。
+   */
+  firebaseErrorCode: string | null;
   occurredAt: string;
 }
 


### PR DESCRIPTION
## Summary
- 認証拒否ログを `reason` / `firebaseErrorCode` で機械的に区別可能にし、Cloud Logging / auth_error_logs でのフィルタ・集計を可能にする
- super-admin 経路に専用の構造化ログ + platform_auth_error_logs ルートコレクション記録を追加（tenant スコープ外のため `auth_error_logs` と分離）
- tenant-auth の verifyIdToken 失敗 catch 節を console.error から logger.error + firebaseErrorCode に切り替え

## 背景 / 根拠
- PR #291 silent-failure-hunter CRITICAL-1 + HIGH-1 指摘（ログはあるが役に立たない状態）
- Issue #292 Acceptance Criteria 準拠
- ADR-031 追補: 「認証拒否ログの構造化設計」セクションに選択肢 A/B/C の採否理由を明記

## 実装詳細

### AuthErrorLog スキーマ拡張
- `reason: string \| null`（旧レコード互換のため nullable）
- `firebaseErrorCode: string \| null`（403 分岐では null、catch 節で Firebase SDK エラーコード）

### tenant-auth.ts
- `TenantAccessDenialReason` 4 値: `email_not_verified` / `non_google_provider` / `email_missing` / `not_in_allowlist`
- 全 `TenantAccessDeniedError` throw 箇所に reason 付与
- `handleTenantAccessDenied` が logger.warn + auth_error_logs に reason 記録
- catch 節を `logger.error` + `firebaseErrorCode` 構造化

### super-admin.ts
- `SuperAdminDenialReason` 5 値: 上記 + `not_super_admin` / `no_auth_header`
- firebase mode 全 403/401 分岐（email_verified / sign_in_provider / email_missing / not_super_admin）+ catch 節に logger.warn/error
- dev mode 2 分岐（no_auth_header / not_super_admin）も対応
- `platform_auth_error_logs` ルートコレクションへ記録（tenant スコープ外）

### platform-datasource.ts（新規）
- `getPlatformDataSource()` singleton: super-admin 経路で `req.dataSource` が無い問題への対処
- `AUTH_MODE=firebase` → `FirestoreDataSource(tenantId="__platform__")`
- それ以外 → `InMemoryDataSource`
- テスト用 `setPlatformDataSourceForTest()` で差し替え可能

### DataSource I/F 拡張
- `createPlatformAuthErrorLog()` を全実装に追加
- Firestore 実装は root コレクション `platform_auth_error_logs` に書き込み（tenant path 不使用）

## Test plan
- [x] 新規: `super-admin-auth-logging.test.ts` (7 tests) — firebase mode 5 分岐 + catch + dev mode 2 分岐
- [x] 新規: `tenant-auth-logging.test.ts` (5 tests) — email_not_verified / non_google_provider / not_in_allowlist / email_missing / catch 節
- [x] 既存 `tenant-auth-error-response.test.ts` を新シグネチャに更新、reason / firebaseErrorCode assertion 追加
- [x] API 全テスト PASS: **495 tests (既存 482 + 新規 13)**
- [x] Web 全テスト PASS: 33 tests
- [x] Lint + Type Check PASS
- [ ] デプロイ後 Cloud Logging で `errorType="super_admin_denied"` / `reason` の構造化ログが出力されること確認（次セッション）

## ADR 追補
`docs/adr/ADR-031-gcip-multi-tenancy.md` に「認証拒否ログの構造化設計」セクション追加:
- 選択肢 A（`platform_auth_error_logs` + DataSource 拡張）採用理由
- 選択肢 B / C 不採用理由

## Related
- Issue #292
- 根拠: PR #291 silent-failure-hunter CRITICAL-1 + HIGH-1 / codex P2
- 関連: Issue #294（help-role.ts / tenants.ts の verifyIdToken 直接呼び出し強化、本 PR のスコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)