### PR TITLE
docs(handoff): Session 4 (2026-04-22) ハンドオフ更新

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,12 +1,12 @@
-# Session Handoff — 2026-04-22 (Session 3)
+# Session Handoff — 2026-04-22 (Session 4)
 
 ## TL;DR
 
-**4 PR 連続マージ達成**。Issue #278 前提の周辺 security 強化を完了。ADR-031 allowed_emails 境界の必須条件 #1/#2/#3 は `tenantAwareAuthMiddleware` + `superAdminAuthMiddleware` の 2 経路で実装済み。Firestore 障害時の silent 403 も fail-closed 化。
+**2 PR マージ達成**。Session 3 の残課題 PR #284 (Issue #278) を rebase 解消して取り込み、P1 #292 の認証拒否ログ構造化を実装。これで **P1 Issue ゼロ化**、P0 は #272 (GCIP 移行 Phase 3) のみ。Session 3 以降の認証強化シリーズは ADR-031 追補で 6 + 3 項目の As-Is 表が全て ✅ / 🟡（未対応は UID 紐付けの原子性のみ）。
 
-- **マージ完了** (今セッション): PR #287 / #288 / #291 / #295
-- **要対応**: PR #284 は **CONFLICTING** (main 更新による衝突) → **次セッション冒頭で rebase 必須**
-- **残タスク**: 新規 Issue 5 件（#292 P1 / #290 P2 / #294 P2 / #296 P2 / 既存 #281 P2）+ ユーザー作業（#272 Phase 1, PR #284 棚卸し）
+- **マージ完了** (今セッション): PR #284 (Issue #278 Close), PR #298 (Issue #292 Close)
+- **新規 Issue**: #299 (P2 observability, `platform_auth_error_logs` admin UI 読み取り経路)
+- **Issue Net**: -1（Close 2件 / 起票 1件）
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -14,139 +14,128 @@
 # 1. 状況復元
 cat docs/handoff/LATEST.md
 
-# 2. 現在の OPEN PR / Issue
-gh pr list --state open           # #284 (DRAFT, CONFLICTING)
+# 2. 現在の OPEN Issue（P0: 1 / P1: 0 / P2: 8）
 gh issue list --state open --limit 15
 
-# 3. PR #284 の衝突解消（最優先）
-git checkout fix/issue-278-allowlist-recheck
-git fetch origin && git rebase origin/main
-# tenant-auth.ts は PR #288 の email_verified / sign_in_provider ガード追加済み
-# #284 側の allowlist 再チェック処理が新ガードの後に位置するよう conflict 解消
-# ADR-031 As-Is 表も #288/#291/#295 の追記と衝突するので手動 merge
-npm run lint && npm run type-check && npm test
-git push --force-with-lease
+# 3. ユーザー側作業の確認（GCP Console / 本番 Firestore dry-run など）
+# 必要なら PR/Issue コメントで進捗確認
 ```
 
 ---
 
-## セッション成果物 (2026-04-22 Session 3)
+## セッション成果物 (2026-04-22 Session 4)
 
 ### マージ完了 PR
 
 | # | Issue | Title | Merge Commit |
 |---|-------|-------|-------------|
-| #287 | #285 | feat(auth): users.email 正規化マイグレーションスクリプト | `90d35fd` |
-| #288 | #286 | feat(auth): email_verified と sign_in_provider の必須チェック追加 | `c2d3511` |
-| #291 | #289 | feat(auth): super-admin 経路に email_verified / sign_in_provider / checkRevoked 追加 | `606e96b` |
-| #295 | #293 | feat(auth): getSuperAdminsFromFirestore を fail-closed 化 | `f106d75` |
+| #284 | #278 | fix(auth): allowed_emails 継続的認可境界の実装 | `88a90cb` |
+| #298 | #292 | feat(auth): 認証拒否ログを構造化 + 拒否理由を区別 | `0731191` |
 
 ### 主要変更の要点
 
-#### PR #287 (Issue #285): users.email 正規化スクリプト
-- `scripts/normalize-users-email.ts` 新規（PR #277 `normalize-allowed-emails.ts` と同パターン）
-- 重複検出時は skip + 警告（人物同一判定はスクリプトで行わない）
-- `scripts/__tests__/normalize-users-email.smoke.ts` (9 ケース、`npm run test:scripts`)
-- `docs/runbook/normalize-users-email.md` に手動マージ手順含む運用手順
-- ADR-031 Phase 3 (GCIP 移行) 前提作業
+#### PR #284 (Issue #278): allowed_emails 継続的認可境界
+- Session 3 で conflict していた PR を rebase して取り込み
+- `tenant-auth.ts` の既存ユーザー経路 4 箇所に `ensureAllowlisted` 再チェック追加（firebaseUid / email / x-user-id / x-user-email）
+- スーパー管理者は `checkSuperAdmin` で例外
+- `firestore.ts` / `in-memory.ts` の `createAllowedEmail` に保存時正規化（`.trim().toLowerCase()`）
+- ADR-006 改訂 + ADR-031 As-Is 表を認証強化 5 PR（#287/#288/#291/#295/#284）反映版に統合
+- テスト: `tenant-auth-allowlist-recheck.test.ts` 12 ケース
 
-#### PR #288 (Issue #286): tenantAwareAuthMiddleware ガード
-- `findOrCreateTenantUser` 冒頭に 2 ガード追加（既存ユーザー検索より**前**）
-  - `decodedToken.email_verified === true` 必須
-  - `decodedToken.firebase?.sign_in_provider === "google.com"` のみ許可
-- `tenant-auth-firebase.test.ts` 12 ケース（既存ユーザー経路 / super-admin 経路 / firebase undefined も固定）
-- ADR-031 As-Is 表 ❌ → ✅
+#### PR #298 (Issue #292): 認証拒否ログ構造化
+- `AuthErrorLog` スキーマに `reason: string | null` + `firebaseErrorCode: string | null` 追加
+- `TenantAccessDenialReason` (4値) / `SuperAdminDenialReason` (5値) union 型導入
+- `tenant-auth.ts` の全 `TenantAccessDeniedError` throw 箇所に reason 付与、catch 節を `logger.error` + `firebaseErrorCode` 構造化
+- `super-admin.ts` の全 403/401 分岐（firebase 4 + dev 2 + catch）に `logger.warn/error` + reason 付与
+- 新規 `platform-datasource.ts`: `getPlatformDataSource()` singleton + `PLATFORM_TENANT_ID` 定数
+- root コレクション `platform_auth_error_logs` に super-admin 経路の拒否を記録（tenant スコープと分離）
+- ADR-031 追補「認証拒否ログの構造化設計」セクション + 選択肢 A/B/C 採否理由
+- テスト: 新規 `super-admin-auth-logging.test.ts` (9 tests), `tenant-auth-logging.test.ts` (6 tests), `firestore-platform-auth-error-log.test.ts` (4 tests)
 
-#### PR #291 (Issue #289): superAdminAuthMiddleware ガード
-- `verifyIdToken(idToken, true)` で checkRevoked=true 化（B-1 即時失効を super-admin に拡張）
-- email_verified / sign_in_provider 2 ガード追加（`isSuperAdmin` より前）
-- `email!` non-null assertion 除去 + email 欠落時の 403 明示化
-- `super-admin-firebase.test.ts` 9 ケース新規
-- ADR-031 As-Is 表に 3 行追記 + スコープ注記（help-role.ts / tenants.ts 残存）
-
-#### PR #295 (Issue #293): Firestore fail-closed
-- `SuperAdminFirestoreUnavailableError` クラス追加（Error.cause 保持 + Firebase FirestoreError code）
-- `getSuperAdminsFromFirestore`: 空配列 return → throw に変更
-- `superAdminAuthMiddleware` (dev / firebase 両モード): catch して 503 返却
-- `tenantAwareAuthMiddleware#checkSuperAdmin` / `routes/help-role.ts` は既存 try/catch で吸収 (セキュリティ境界は fail-open しないが silent UX degradation は残る → #292 で改善検討)
-- `super-admin-firestore-failure.test.ts` 10 ケース（firebase 4 + dev 3 + unit 3）
+### `/review-pr` レビュー対応（PR #298）
+- 5 エージェント並列 (silent-failure / test / type-design / code-review / comment)
+- **マージ前対応済み**: CRITICAL 2件 (C-1 silent-failure, comment `firebase_claim_missing` 誤記) + HIGH 4件
+  - `recordSuperAdminAuthEvent` / `handleTenantAccessDenied` の persist 失敗時に元 payload を展開して `logger.error` に残す
+  - `createPlatformAuthErrorLog` の read-after-write 削除
+  - Firestore 直接テスト 4 件追加
+  - 境界値テスト 3 件追加（email 空文字 / firebase 欠落 / ensureAllowlisted 経由）
+- **マージ後フォロー**: Issue #299 起票 + PR #298 コメントで MEDIUM/LOW 10+ 件記録 + Issue #290 にコメント追記
 
 ### 新規 Issue 起票 (今セッション)
 
 | # | P | カテゴリ | タイトル | 根拠 |
 |---|---|---------|---------|------|
-| #290 | P2 | security | AUTH_MODE=dev 本番誤有効化 fail-safe (起動時 assertion) | PR #288 silent-failure C-3 |
-| #292 | P1 | observability | super-admin / tenant-auth の認証拒否ログを構造化 + 拒否理由区別 | PR #291 silent-failure CRITICAL-1/HIGH-1 + codex P2 |
-| #294 | P2 | security | help-role.ts / tenants.ts の verifyIdToken に同等ガード適用 | PR #291 codex P2 |
-| #296 | P2 | ux | getAllSuperAdmins の silent fallback で管理 API 誤 404 リスク | PR #295 code-reviewer I-2 + silent-failure #7 |
+| #299 | P2 | observability | `platform_auth_error_logs` の admin UI 読み取り経路追加 | PR #298 code-reviewer H1 (rating 7, confidence 85%) |
 
 ## 品質ゲート結果
 
 | ゲート | 結果 |
 |--------|------|
-| `npm run lint` | ✅ PASS (全マージで 0 error) |
+| `npm run lint` | ✅ PASS |
 | `npm run type-check` | ✅ PASS (4 workspaces) |
-| `npm test` | ✅ API 470 PASS + Web 33 PASS (累積 +28 新規テスト: smoke 9 / tenant-auth +5 / super-admin-firebase 9 / super-admin-firestore 10) |
-| CI (PR #287/#288/#291/#295) | ✅ Lint / Type Check / Test / Build 全 PASS |
-| TDD RED→GREEN | ✅ 全 PR で実施 |
-| `/review-pr` + `/codex review` | ✅ 各 PR でマージブロッカーなし判定 |
+| `npm test` | ✅ API 502 PASS + Web 33 PASS（累積 +20 新規: allowlist-recheck 12 + auth-logging 15 + firestore-platform 4 で整理後実測 502）|
+| CI (PR #284 / #298) | ✅ Lint / Type Check / Test / Build 全 PASS |
+| `/review-pr` 5 エージェント並列 | ✅ CRITICAL/HIGH 全修正、MEDIUM/LOW は triage 後 Issue 化 or コメント |
 
 ## 次セッションの着手候補 (優先度順)
 
-### 🔴 最優先（次セッション冒頭必須）
-1. **PR #284 rebase** — main との衝突解消（tenant-auth.ts + ADR-031 As-Is 表）
+### 🔴 P0 残
+1. **Issue #272 Phase 3** (GCIP 移行本体) — `/impl-plan` で計画化が必要（Issue 内に別セッション予定と明記）
+   - 前提作業: ADR-031 As-Is 表の 🟡「UID 紐付けの原子性」のみ残存
+   - ユーザー側作業待ち: Phase 1.1 (GCP Console OAuth External 化) + 本番 `normalize-users-email.ts` dry-run
 
-### 🟠 ユーザー作業待ち（並行）
-2. **PR #284 本番棚卸し**: `scripts/normalize-allowed-emails.ts` + `scripts/audit-users-vs-allowed-emails.ts` を本番で実行 → Ready for Review 化 → マージ
-3. **Issue #272 Phase 1.1–1.3**: GCP Console 操作（OAuth External 化, Authorized Domains 確認, sayori-maeda@kanjikai.or.jp 再ログイン）
+### 🟢 P2 並行着手可能（Prerequisite なし）
+2. **Issue #294** (P2 security): `help-role.ts` / `tenants.ts` の `verifyIdToken` 直接呼び出しに email_verified / sign_in_provider / checkRevoked 適用（PR #291/#298 と同パターン、着手容易）
+3. **Issue #296** (P2 ux): `getAllSuperAdmins` の Firestore silent fallback で管理 API が誤 404 を返すリスク（PR #298 と関連）
+4. **Issue #299** (P2 observability): `platform_auth_error_logs` admin UI 読み取り経路（今回起票、#272 Phase 3 前に解消推奨）
+5. **Issue #290** (P2 security): AUTH_MODE=dev 起動時 assertion（PR #298 silent-failure H-3 と統合検討可）
+6. **Issue #281** (P2 refactor): allowed_emails 監査 CLI 純粋関数分割
 
-### 🟢 並行着手可能（Prerequisite なし）
-4. **Issue #292 (P1 observability)**: super-admin / tenant-auth 認証拒否ログを logger + reason 細分化 + auth_error_logs 設計変更
-5. **Issue #294 (P2 security)**: help-role.ts / tenants.ts に email_verified / sign_in_provider / checkRevoked 適用（#288/#291 と同パターン）
-6. **Issue #290 (P2 security)**: AUTH_MODE=dev 起動時 assertion
-7. **Issue #296 (P2 ux)**: getAllSuperAdmins fail-closed 化 (選択肢 A/B/C のどれを採用するか設計判断から)
-8. **Issue #281 (P2 refactor)**: allowed_emails 監査 CLI 純粋関数分割
+### 🟡 Phase 5
+7. Issue #276 / #275 / #274: Phase 5 運用改善
 
-### 🟡 Phase 3 / Phase 5
-9. **Issue #278 案 B 本実装** (PR #284 マージ後)
-10. **Issue #272 Phase 3**: GCIP 移行本体（#285/#286/#289 完了済みで前提揃う）
-11. Issue #276 / #275 / #274: Phase 5 各種
-
-## ブロッカー / ユーザー側タスク
+## ブロッカー / ユーザー側タスク（継続）
 
 | 項目 | 内容 | 影響 |
 |------|------|------|
-| 本番 Firestore 棚卸し 2 スクリプト | PR #284 マージ前提（`normalize-allowed-emails.ts` + `audit-users-vs-allowed-emails.ts`） | Issue #278 デプロイ時の一斉ブロック防止 |
-| GCP Console: OAuth 同意画面 External 化 | Issue #272 Phase 1.1 | sayori-maeda@kanjikai.or.jp のログイン復旧 |
-| 本番 `normalize-users-email.ts` dry-run / execute | PR #287 マージ済み、本番実行は任意（GCIP 移行前に推奨） | users.email 大文字/空白混入の正規化 |
+| GCP Console: OAuth 同意画面 External 化 | Issue #272 Phase 1.1 | sayori-maeda@kanjikai.or.jp 再ログイン復旧 + #272 Phase 3 の前提 |
+| 本番 `normalize-users-email.ts` dry-run / execute | PR #287 マージ済み、GCIP 移行前に推奨 | users.email 大文字/空白混入の正規化 |
 
 ## ADR / ドキュメント状態
 
-- **ADR-031** 更新済み (As-Is 表 ❌ → ✅ を 3 行 + Firestore 障害時の挙動補足)
-- **ドキュメント整合性**: CLAUDE.md は phase 11 完了、本セッションでの変更なし（#272 Phase 3 未着手）
-- **handoff サイズ**: 本ファイル 約 130 行（<500 行目標 OK）
+- **ADR-031** 更新済み
+  - PR #284 で As-Is 表を 6 行に拡張（認証モード関係テーブル、UID 紐付け原子性、users email 正規化等）
+  - PR #298 で「認証拒否ログの構造化設計」セクション + 選択肢 A/B/C + Phase 1 の制約（admin UI 読み取り未実装）追補
+- **ADR-006** 更新済み（PR #284: 継続的認可境界の明文化）
+- **CLAUDE.md**: Phase 11 完了、変更なし（#272 Phase 3 未着手）
+- **handoff サイズ**: 本ファイル（<500 行目標 OK）
+
+## Issue Net 変化（CLAUDE.md KPI）
+
+```
+Close 数: 2 件 (#278, #292)
+起票数: 1 件 (#299)
+Net: -1 件
+```
+
+✅ **Net ≤ 0 達成**。rating 5-6 の review agent 提案は全て PR コメント / 既存 Issue 追記で処理（PR #298 コメント参照）。起票した #299 は triage 基準 #1（実害: 記録したログが admin UI から見えない）+ #4（rating 7 confidence 85%）の両方を満たす。
 
 ## 作業ブランチ状態
 
 ```
-main: f106d75 feat(auth): getSuperAdminsFromFirestore を fail-closed 化 (Issue #293) (#295)
+main: 0731191 feat(auth): 認証拒否ログを構造化 + 拒否理由を区別 (Issue #292) (#298)
 
-fix/issue-278-allowlist-recheck (PR #284, DRAFT, CONFLICTING)
-  ├─ main 起点の古い branch
-  ├─ tenant-auth.ts で PR #288 と衝突
-  └─ ADR-031 As-Is 表で PR #288/#291/#295 と衝突
-  →  次セッション冒頭で rebase 必須
+docs/handoff-session-4-2026-04-22 (本ファイル更新用、PR 作成予定)
 ```
 
-main push なし、destructive 操作なし、残留 Node プロセスなし。
+main 直接 push なし、destructive 操作なし、残留 Node プロセスなし ✅。
 
 ## 参考: 今セッションで使った規範 / スキル
 
-- `rules/quality-gate.md` — Evaluator 分離プロトコル（5 ファイル未満でも `/review-pr` は全 PR で実行）
-- `rules/testing.md` §6 — AAA / DAMP / 1テスト1検証
-- `rules/error-handling.md` §2 — Error.cause による stack chain 保持 (PR #295)
-- `rules/production-data-safety.md` — PR #287 `normalize-users-email.ts` は新規 doc ではなく既存 user の partial update、undefined サニタイズ不要（`update({email: n})` 単一フィールドのみ）
-- `feedback_pr_merge_authorization.md` — PR 番号単位で明示認可を受けてからマージ（ユーザーから「マージ OK」指示を PR 番号ごとに取得）
-- `feedback_issue_triage.md` — review agent Rating 5-6 は Issue 化せず PR コメント / TODO 扱い
-- `/codex review` — PR #287/#288/#291/#295 でセカンドオピニオン（いずれもマージブロッカーなし）
-- `/review-pr` (pr-review-toolkit) — 3-5 エージェント並列、各 PR でレビュー
+- `/impl-plan` — Issue #292 の計画化（Phase 1-5 + Acceptance Criteria + Firestore 記録方式選択肢 A/B/C）
+- `/review-pr` (pr-review-toolkit) — 5 エージェント並列レビュー（silent-failure / test / type-design / code-review / comment）
+- `rules/quality-gate.md` — Evaluator 分離プロトコル発動条件（5 ファイル以上）→ `/review-pr` で代替実施
+- `feedback_pr_merge_authorization.md` — PR 番号単位で明示認可を受けてからマージ（#284, #298 両方ユーザー承認後にマージ）
+- `feedback_issue_triage.md` — 起票は triage 基準を満たす 1 件のみ、rating 5-6 は PR コメント / 既存 Issue 追記で対応
+- `rules/error-handling.md` §1 — エラーハンドラ自体のエラー耐性（recordSuperAdminAuthEvent の catch で元 payload 展開）
+- `rules/error-handling.md` §3 — transient/permanent 分類（Issue #290 関連コメントで記録、別 Issue 化せず統合判断）


### PR DESCRIPTION
## Summary
- Session 4 のハンドオフメモリ更新
- PR #284 (Issue #278) + PR #298 (Issue #292) のマージ結果を反映
- 新規 Issue #299 起票 / Issue Net -1 を記録
- 次セッション着手候補を優先度順に整理

## Test plan
- [x] ドキュメント単体変更のため構文確認のみ（500 行以下目標 OK、141 行）
- [x] 次セッション冒頭の `cat docs/handoff/LATEST.md` + `gh issue list --state open` で状況復元可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)