### PR TITLE
feat(auth): help-role.ts / tenants.ts に verifyIdToken 境界ガード拡張 (Issue #294)

### DIFF
--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -58,9 +58,9 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 ### As-Is 実装状況（2026-04-22更新、Phase 3 補強対象の明示）
 | 項目 | 現状 | Phase 3 必須対応 |
 |------|------|-----------------|
-| email_verified チェック | ✅ 実装済み（Issue #286 / PR #288: `findOrCreateTenantUser` + Issue #289: `superAdminAuthMiddleware` の 2 経路で必須化） | `help-role.ts` / `tenants.ts` 等の `verifyIdToken` 直接呼び出し箇所にも適用（後続 Issue） |
-| sign_in_provider 制限 | ✅ 実装済み（Issue #286 / PR #288 + Issue #289: 上記 2 経路で `firebase.sign_in_provider === "google.com"` のみ許可） | 同上 |
-| checkRevoked=true（即時失効） | ✅ 実装済み（B-1: `tenantAwareAuthMiddleware` + Issue #289: `superAdminAuthMiddleware` の 2 経路で `verifyIdToken(..., true)`） | 同上 |
+| email_verified チェック | ✅ 実装済み（Issue #286 / PR #288: `findOrCreateTenantUser` + Issue #289 / PR #291: `superAdminAuthMiddleware` + **Issue #294: `routes/help-role.ts` / `routes/tenants.ts` の直接 `verifyIdToken` 経路にも拡張**） | 維持 |
+| sign_in_provider 制限 | ✅ 実装済み（Issue #286 / PR #288 + Issue #289 / PR #291 + **Issue #294: `help-role.ts` / `tenants.ts` にも `firebase.sign_in_provider === "google.com"` ガード拡張**） | 維持 |
+| checkRevoked=true（即時失効） | ✅ 実装済み（B-1: `tenantAwareAuthMiddleware` + Issue #289 / PR #291: `superAdminAuthMiddleware` + **Issue #294: `help-role.ts` / `tenants.ts` も `verifyIdToken(..., true)` に統一**） | 維持 |
 | メール正規化（allowed_emails） | ✅ `.trim().toLowerCase()` で統一（PR #277 で route/middleware 層、Issue #278 / PR #284 で DataSource 層に拡張） | 維持 |
 | メール正規化（users） | ✅ マイグレーションスクリプト実装済み（Issue #285 / PR #287: `scripts/normalize-users-email.ts`） | 本番 dry-run → 補正実施（Phase 3 着手前の前提作業） |
 | (tenantId, email) 認可単位 | ✅ 実装済み（テナントスコープの allowed_emails） | 維持 |
@@ -69,7 +69,13 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 | クライアント Firestore 直接アクセス禁止 | ✅ 実装済み（`web/` 配下で `firebase/firestore` import ゼロ） | 維持 |
 | Custom Claims 利用 | ✅ 未使用（Claims 再発行問題なし） | 維持 |
 
-> **適用スコープ注記**: 上記 ✅ は `tenantAwareAuthMiddleware` (`middleware/tenant-auth.ts`) と `superAdminAuthMiddleware` (`middleware/super-admin.ts`) の 2 経路に限定。`routes/help-role.ts` および `routes/tenants.ts` 冒頭には `verifyIdToken(idToken)` の直接呼び出しが残っており、同等ガードは未適用（後続 Issue で対応）。
+> **適用スコープ (2026-04-22 Issue #294 で拡張)**: `email_verified` / `sign_in_provider` / `checkRevoked=true` の 3 ガードは以下 4 経路すべてに適用済み:
+> - `middleware/tenant-auth.ts` (`tenantAwareAuthMiddleware`) — Issue #286 / PR #288
+> - `middleware/super-admin.ts` (`superAdminAuthMiddleware`) — Issue #289 / PR #291
+> - `routes/help-role.ts` (`GET /api/v2/help/role`) — Issue #294（不適合時は super/admin 昇格させず "student" フォールバック）
+> - `routes/tenants.ts` (`verifyAuthToken`) — Issue #294（不適合時は 403 でテナント作成/一覧取得を拒否）
+>
+> 4 経路で同じパターンが重複しているため、将来の共通ヘルパー化は別 Issue で検討予定。
 
 > **Firestore 障害時の挙動 (Issue #293 / PR)**: `getSuperAdminsFromFirestore` は Firestore アクセス失敗時に空配列を silent に返していたため、env に未登録の super-admin が silent に 403 で締め出される「部分 fail-open + ユーザー欺瞞」状態だった。
 > - 修正後: `SuperAdminFirestoreUnavailableError` を throw し、`superAdminAuthMiddleware`（super-admin 専用 endpoint）は 503 Service Unavailable で返却（env 高速パスで通過済みのケースはここに到達しない）

--- a/services/api/src/routes/__tests__/help-role.test.ts
+++ b/services/api/src/routes/__tests__/help-role.test.ts
@@ -1,0 +1,181 @@
+/**
+ * GET /api/v2/help/role (routes/help-role.ts) 統合テスト
+ *
+ * 確認対象:
+ *   - Issue #294 / ADR-031: `verifyIdToken` 直接呼び出し経路への境界統一
+ *     - checkRevoked=true で revoke 後のトークンを拒否（student フォールバック）
+ *     - email_verified=true 必須
+ *     - sign_in_provider=google.com 必須
+ *     - 不適合時は super/admin 昇格させず "student" レベルを返す
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import supertest from "supertest";
+
+const mockVerifyIdToken = vi.fn();
+const mockIsSuperAdmin = vi.fn();
+const mockGetFirestore = vi.fn();
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: () => ({
+    verifyIdToken: mockVerifyIdToken,
+  }),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: () => mockGetFirestore(),
+}));
+
+vi.mock("../../middleware/super-admin.js", () => ({
+  isSuperAdmin: mockIsSuperAdmin,
+}));
+
+function makeDecodedToken(overrides: Record<string, unknown> = {}) {
+  return {
+    uid: "uid-default",
+    email: "user@example.com",
+    email_verified: true,
+    firebase: { sign_in_provider: "google.com", identities: {} },
+    ...overrides,
+  };
+}
+
+/** Firestore `tenants` 走査を空コレクションでモック（student フォールバック経路を確実化）。 */
+function mockEmptyTenants() {
+  mockGetFirestore.mockReturnValue({
+    collection: () => ({
+      get: vi.fn().mockResolvedValue({ docs: [] }),
+    }),
+  });
+}
+
+async function buildApp() {
+  const { helpRoleRouter } = await import("../help-role.js");
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v2/help", helpRoleRouter);
+  return app;
+}
+
+describe("GET /api/v2/help/role — firebase mode (Issue #294)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("AUTH_MODE", "firebase");
+    mockVerifyIdToken.mockReset();
+    mockIsSuperAdmin.mockReset();
+    mockGetFirestore.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("Bearer トークン欠落時は student を返す（既存挙動）", async () => {
+    const app = await buildApp();
+    const res = await supertest(app).get("/api/v2/help/role");
+    expect(res.status).toBe(200);
+    expect(res.body.helpLevel).toBe("student");
+    expect(mockVerifyIdToken).not.toHaveBeenCalled();
+  });
+
+  it("verifyIdToken は checkRevoked=true で呼ばれる", async () => {
+    mockVerifyIdToken.mockResolvedValue(makeDecodedToken());
+    mockIsSuperAdmin.mockResolvedValue(false);
+    mockEmptyTenants();
+    const app = await buildApp();
+
+    await supertest(app)
+      .get("/api/v2/help/role")
+      .set("authorization", "Bearer id-token-xyz");
+
+    expect(mockVerifyIdToken).toHaveBeenCalledWith("id-token-xyz", true);
+  });
+
+  it("email_verified=false なら student にフォールバック（super/admin 昇格を拒否）", async () => {
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({ email_verified: false })
+    );
+    // 万が一呼ばれても super を返さないように明示しておく
+    mockIsSuperAdmin.mockResolvedValue(true);
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/help/role")
+      .set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.helpLevel).toBe("student");
+    expect(mockIsSuperAdmin).not.toHaveBeenCalled();
+  });
+
+  it("email_verified が undefined（欠落）なら student にフォールバック", async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: "uid-missing-verified",
+      email: "user@example.com",
+      firebase: { sign_in_provider: "google.com", identities: {} },
+      // email_verified フィールドなし
+    });
+    mockIsSuperAdmin.mockResolvedValue(true);
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/help/role")
+      .set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.helpLevel).toBe("student");
+    expect(mockIsSuperAdmin).not.toHaveBeenCalled();
+  });
+
+  it("sign_in_provider=password なら student にフォールバック", async () => {
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        firebase: { sign_in_provider: "password", identities: {} },
+      })
+    );
+    mockIsSuperAdmin.mockResolvedValue(true);
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/help/role")
+      .set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.helpLevel).toBe("student");
+    expect(mockIsSuperAdmin).not.toHaveBeenCalled();
+  });
+
+  it("decodedToken.firebase が undefined でも student にフォールバック（fail-closed）", async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: "uid-no-firebase",
+      email: "user@example.com",
+      email_verified: true,
+      // firebase フィールドなし（SDK 形状差対策）
+    });
+    mockIsSuperAdmin.mockResolvedValue(true);
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/help/role")
+      .set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.helpLevel).toBe("student");
+    expect(mockIsSuperAdmin).not.toHaveBeenCalled();
+  });
+
+  it("email_verified=true + sign_in_provider=google.com + スーパー管理者 → super", async () => {
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({ email: "super@example.com" })
+    );
+    mockIsSuperAdmin.mockResolvedValue(true);
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/help/role")
+      .set("authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.helpLevel).toBe("super");
+  });
+});

--- a/services/api/src/routes/__tests__/tenants.test.ts
+++ b/services/api/src/routes/__tests__/tenants.test.ts
@@ -1,0 +1,177 @@
+/**
+ * POST /api/v2/tenants (routes/tenants.ts) の認証ガード統合テスト
+ *
+ * 確認対象:
+ *   - Issue #294 / ADR-031: `verifyIdToken` 直接呼び出し経路への境界統一
+ *     - checkRevoked=true で revoke 後のトークンを拒否
+ *     - email_verified=true 必須（未検証メールでのテナント作成禁止）
+ *     - sign_in_provider=google.com 必須（IdP 追加時のバイパス防止）
+ *     - 不適合時は 403 を返し、成功経路（Firestore アクセス）に進まない
+ *
+ * スコープ外: テナント作成の正常系（Firestore トランザクション成功経路）は
+ *             Firestore モックが広範になるため本テストでは扱わず、別 Issue で担保する。
+ *
+ * 補足: `verifyAuthToken` は POST `/` と GET `/mine` の両方で共通使用される。
+ *       本テストは POST 経路で代表して検証し、GET `/mine` は同じ関数を通るため
+ *       ガード効果は自動的に波及する。`verifyAuthToken` の分岐を変更する場合は
+ *       `mine` 経路のテストを追加すること。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import supertest from "supertest";
+
+const mockVerifyIdToken = vi.fn();
+const mockGetFirestore = vi.fn(() => {
+  throw new Error(
+    "getFirestore should not be called in guard-rejection tests (reached Firestore after guard was supposed to 403)"
+  );
+});
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: () => ({
+    verifyIdToken: mockVerifyIdToken,
+  }),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: () => mockGetFirestore(),
+}));
+
+function makeDecodedToken(overrides: Record<string, unknown> = {}) {
+  return {
+    uid: "uid-default",
+    email: "owner@example.com",
+    name: "Owner User",
+    email_verified: true,
+    firebase: { sign_in_provider: "google.com", identities: {} },
+    ...overrides,
+  };
+}
+
+async function buildApp() {
+  const { tenantsRouter } = await import("../tenants.js");
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v2/tenants", tenantsRouter);
+  return app;
+}
+
+describe("POST /api/v2/tenants — auth guards (Issue #294)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockVerifyIdToken.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("Authorization ヘッダ欠落時は 401", async () => {
+    const app = await buildApp();
+    const res = await supertest(app)
+      .post("/api/v2/tenants")
+      .send({ name: "Test Org" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("unauthorized");
+    expect(mockVerifyIdToken).not.toHaveBeenCalled();
+  });
+
+  it("verifyIdToken は checkRevoked=true で呼ばれる", async () => {
+    // 正常系に進めないように email_verified=false で 403 に落とす。
+    // 目的は "checkRevoked=true" で呼ばれたかだけを検証すること。
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({ email_verified: false })
+    );
+    const app = await buildApp();
+
+    await supertest(app)
+      .post("/api/v2/tenants")
+      .set("authorization", "Bearer id-token-xyz")
+      .send({ name: "Test Org" });
+
+    expect(mockVerifyIdToken).toHaveBeenCalledWith("id-token-xyz", true);
+  });
+
+  it("email_verified=false なら 403 でテナント作成を拒否", async () => {
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({ email_verified: false })
+    );
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .post("/api/v2/tenants")
+      .set("authorization", "Bearer dummy")
+      .send({ name: "Test Org" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("unauthorized");
+  });
+
+  it("email_verified が undefined（欠落）なら 403", async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: "uid-missing",
+      email: "owner@example.com",
+      firebase: { sign_in_provider: "google.com", identities: {} },
+      // email_verified フィールドなし
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .post("/api/v2/tenants")
+      .set("authorization", "Bearer dummy")
+      .send({ name: "Test Org" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("sign_in_provider=password なら 403（Google 以外の provider を拒否）", async () => {
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({
+        firebase: { sign_in_provider: "password", identities: {} },
+      })
+    );
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .post("/api/v2/tenants")
+      .set("authorization", "Bearer dummy")
+      .send({ name: "Test Org" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("decodedToken.firebase が undefined でも 403（fail-closed, SDK 形状変化対策）", async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: "uid-no-firebase",
+      email: "owner@example.com",
+      email_verified: true,
+      // firebase フィールドなし
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .post("/api/v2/tenants")
+      .set("authorization", "Bearer dummy")
+      .send({ name: "Test Org" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("verifyIdToken が throw（トークン検証失敗）なら従来通り 401", async () => {
+    mockVerifyIdToken.mockRejectedValue(
+      Object.assign(new Error("token expired"), {
+        code: "auth/id-token-expired",
+      })
+    );
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .post("/api/v2/tenants")
+      .set("authorization", "Bearer expired-token")
+      .send({ name: "Test Org" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("unauthorized");
+  });
+});

--- a/services/api/src/routes/help-role.ts
+++ b/services/api/src/routes/help-role.ts
@@ -30,7 +30,24 @@ router.get("/role", async (req: Request, res: Response) => {
         return;
       }
       const idToken = authHeader.slice(7);
-      const decoded = await getAuth().verifyIdToken(idToken);
+      // Issue #294 / ADR-031 境界統一:
+      //   - checkRevoked=true で revoke 後の既発行トークンも拒否
+      //   - email_verified=true と sign_in_provider=google.com を必須化し、
+      //     不適合なら super/admin 昇格を許さず "student" フォールバックする
+      //     （ヘルプ画面自体は閲覧可能にして UX 劣化を避ける）
+      const decoded = await getAuth().verifyIdToken(idToken, true);
+      if (
+        decoded.email_verified !== true ||
+        decoded.firebase?.sign_in_provider !== "google.com"
+      ) {
+        logger.warn("Help role check falling back to student (guard failed)", {
+          uid: decoded.uid,
+          emailVerified: decoded.email_verified === true,
+          signInProvider: decoded.firebase?.sign_in_provider ?? null,
+        });
+        res.json({ helpLevel: "student" as HelpLevel });
+        return;
+      }
       email = decoded.email;
     } else {
       // 開発モード: X-User-Emailヘッダを使用

--- a/services/api/src/routes/help-role.ts
+++ b/services/api/src/routes/help-role.ts
@@ -35,14 +35,24 @@ router.get("/role", async (req: Request, res: Response) => {
       //   - email_verified=true と sign_in_provider=google.com を必須化し、
       //     不適合なら super/admin 昇格を許さず "student" フォールバックする
       //     （ヘルプ画面自体は閲覧可能にして UX 劣化を避ける）
+      //   - reason は email_not_verified / non_google_provider で区別し、
+      //     外側 catch の "help_role_fallback_error"（Firestore 例外等）と
+      //     errorType で切り分け可能にする（Cloud Logging 検索・集計用）。
       const decoded = await getAuth().verifyIdToken(idToken, true);
-      if (
-        decoded.email_verified !== true ||
-        decoded.firebase?.sign_in_provider !== "google.com"
-      ) {
-        logger.warn("Help role check falling back to student (guard failed)", {
+      if (decoded.email_verified !== true) {
+        logger.warn("Help role guard failed", {
+          errorType: "help_role_guard_failed",
+          reason: "email_not_verified",
           uid: decoded.uid,
-          emailVerified: decoded.email_verified === true,
+        });
+        res.json({ helpLevel: "student" as HelpLevel });
+        return;
+      }
+      if (decoded.firebase?.sign_in_provider !== "google.com") {
+        logger.warn("Help role guard failed", {
+          errorType: "help_role_guard_failed",
+          reason: "non_google_provider",
+          uid: decoded.uid,
           signInProvider: decoded.firebase?.sign_in_provider ?? null,
         });
         res.json({ helpLevel: "student" as HelpLevel });
@@ -73,10 +83,16 @@ router.get("/role", async (req: Request, res: Response) => {
 
     res.json({ helpLevel });
   } catch (error) {
-    logger.error("Help role check failed", {
+    // Issue #294: 意図的な guard フォールバック (errorType=help_role_guard_failed) と
+    // 区別するため、想定外の例外（Firestore 障害 / verifyIdToken の auth/internal-error 等）
+    // は errorType=help_role_fallback_error で構造化ログに残す。
+    // レスポンス形状は UX 維持のため student で揃えるが、Cloud Logging 上では分離できる。
+    const err = error as { code?: unknown };
+    logger.error("Help role fallback due to unexpected error", {
+      errorType: "help_role_fallback_error",
+      firebaseErrorCode: typeof err.code === "string" ? err.code : null,
       error: error instanceof Error ? error.message : String(error),
     });
-    // エラー時はstudentレベルにフォールバック
     res.json({ helpLevel: "student" as HelpLevel });
   }
 });

--- a/services/api/src/routes/tenants.ts
+++ b/services/api/src/routes/tenants.ts
@@ -9,6 +9,7 @@ import { getFirestore } from "firebase-admin/firestore";
 import { getAuth, type DecodedIdToken } from "firebase-admin/auth";
 import type { TenantMetadata, CreateTenantRequest } from "../types/tenant.js";
 import { RESERVED_TENANT_IDS, generateTenantId, validateOrganizationName, normalizeEmail } from "../utils/tenant-id.js";
+import { logger } from "../utils/logger.js";
 
 const router = Router();
 
@@ -70,10 +71,55 @@ async function verifyAuthToken(
 
   const idToken = authHeader.slice(7);
   try {
-    const decodedToken = await getAuth().verifyIdToken(idToken);
+    // Issue #294 / ADR-031 境界統一:
+    //   - checkRevoked=true で revoke 後の既発行トークンを拒否
+    //   - email_verified=true と sign_in_provider=google.com を必須化し、
+    //     非 Google / 未検証メールでのテナント作成経路をブロックする。
+    //   - レスポンスはユーザー列挙防止のため既存の 401 文言「認証トークンが無効です」で統一し、
+    //     詳細は console.warn に残す。
+    const decodedToken = await getAuth().verifyIdToken(idToken, true);
+    if (decodedToken.email_verified !== true) {
+      logger.warn("Tenant auth denied: email_not_verified", {
+        errorType: "tenant_creation_denied",
+        reason: "email_not_verified",
+        uid: decodedToken.uid,
+        path: req.path,
+        method: req.method,
+      });
+      return {
+        success: false,
+        error: "認証トークンが無効です。再ログインしてください。",
+        status: 403,
+      };
+    }
+    if (decodedToken.firebase?.sign_in_provider !== "google.com") {
+      logger.warn("Tenant auth denied: non_google_provider", {
+        errorType: "tenant_creation_denied",
+        reason: "non_google_provider",
+        uid: decodedToken.uid,
+        provider: decodedToken.firebase?.sign_in_provider ?? null,
+        path: req.path,
+        method: req.method,
+      });
+      return {
+        success: false,
+        error: "認証トークンが無効です。再ログインしてください。",
+        status: 403,
+      };
+    }
     return { success: true, token: decodedToken };
   } catch (error) {
-    console.error("Token verification failed:", error);
+    // 分類: トークン署名不正/期限切れ/revoke 済み → 401。
+    // `email_verified` / `sign_in_provider` ガード拒否（上の 2 分岐）→ 403。
+    // `middleware/tenant-auth.ts` の分類（検証失敗 401 / ガード拒否 403）と揃えている。
+    const err = error as { code?: unknown; message?: unknown };
+    logger.error("Tenant token verification failed", {
+      errorType: "tenant_token_error",
+      firebaseErrorCode: typeof err.code === "string" ? err.code : null,
+      errorMessage: typeof err.message === "string" ? err.message : String(error),
+      path: req.path,
+      method: req.method,
+    });
     return {
       success: false,
       error: "認証トークンが無効です。再ログインしてください。",

--- a/services/api/src/routes/tenants.ts
+++ b/services/api/src/routes/tenants.ts
@@ -75,8 +75,9 @@ async function verifyAuthToken(
     //   - checkRevoked=true で revoke 後の既発行トークンを拒否
     //   - email_verified=true と sign_in_provider=google.com を必須化し、
     //     非 Google / 未検証メールでのテナント作成経路をブロックする。
-    //   - レスポンスはユーザー列挙防止のため既存の 401 文言「認証トークンが無効です」で統一し、
-    //     詳細は console.warn に残す。
+    //   - レスポンスはユーザー列挙防止のため既存の文言「認証トークンが無効です」で統一
+    //     （status は tenant-auth.ts と同じ分類で 401: トークン検証失敗 / 403: guard 拒否）、
+    //     詳細は構造化 logger.warn に errorType / reason で残す (Issue #292 と同形式)。
     const decodedToken = await getAuth().verifyIdToken(idToken, true);
     if (decodedToken.email_verified !== true) {
       logger.warn("Tenant auth denied: email_not_verified", {


### PR DESCRIPTION
## Summary
- ADR-031「allowed_emails 境界」の 4 経路統一。`routes/help-role.ts` と `routes/tenants.ts` の `verifyIdToken` 直接呼び出し経路にも、既存の `middleware/tenant-auth.ts` / `middleware/super-admin.ts` と同等の `email_verified` / `sign_in_provider="google.com"` / `checkRevoked=true` ガードを追加。
- `tenants.ts#verifyAuthToken` の `console` を `logger` に統一し、Issue #292 の構造化ログ資産を活かす。
- `routes/__tests__/` を新設して help-role (7) + tenants (7) の新規統合テスト 14 ケースを追加。ADR-031 As-Is 表とスコープ注記も 4 経路適用済みに更新。

## Acceptance Criteria
- [x] help-role.ts / tenants.ts に email_verified / sign_in_provider / checkRevoked ガード追加
- [x] 統合テスト追加（各経路で新ガードの効果を検証、14 ケース）
- [x] ADR-031 As-Is 表とスコープ注記を更新
- [ ] （任意）共通ヘルパー化 → **ADR-031 L78 に「将来の共通ヘルパー化は別 Issue で検討予定」と明記。スコープ外。**

## 挙動の差分
- **help-role.ts** 不適合時: super/admin 昇格を拒否し `helpLevel: "student"` フォールバック（ヘルプ画面自体は閲覧可能で UX 維持）
- **tenants.ts** 不適合時: 403 でテナント作成 / 一覧取得を拒否。レスポンス文言はユーザー列挙防止のため既存の「認証トークンが無効です」で統一、詳細は `logger.warn` に `reason: email_not_verified` / `non_google_provider` で記録。
- 既存の `middleware/tenant-auth.ts` / `middleware/super-admin.ts` は**無変更**（回帰リスクなし）。

## Test plan
- [x] `npm test --workspace=@lms-279/api` → 516/516 PASS (48 files)
- [x] 新規テスト `routes/__tests__/help-role.test.ts` + `routes/__tests__/tenants.test.ts` → 14/14 PASS
- [x] `npm run type-check` → 全ワークスペース PASS
- [x] `npm run lint` → PASS
- [ ] デプロイ後に help / tenants 経路のログに `errorType: tenant_creation_denied` が入っていないことを Cloud Logging で確認

## Quality Gate
- [x] `evaluator` エージェント評価: AC すべて PASS、HIGH 問題なし（MEDIUM 2 件は本 PR で修正済み）
- [x] `code-reviewer` エージェント評価: ブロッカーなし、MEDIUM 2 件反映済み（`logger` 統一 / ADR 日付修正）
- [x] LOW 指摘のうち低コスト項目（catch 節のコメント、テストファイル冒頭補足）も反映

## 関連 Issue / ADR
- Closes #294
- Parent: #272 (ADR-031 Phase 3 前提条件)
- ADR: `docs/adr/ADR-031-gcip-multi-tenancy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)