### PR TITLE
feat(auth): NODE_ENV=production で AUTH_MODE=firebase を必須化 (Issue #290)

### DIFF
--- a/docs/runbook/auth-mode-production-check.md
+++ b/docs/runbook/auth-mode-production-check.md
@@ -1,6 +1,15 @@
 # Runbook: 本番 AUTH_MODE=firebase 確認手順
 
-Issue #290 で導入した起動時 fail-safe の運用手順。`NODE_ENV=production` かつ `AUTH_MODE !== "firebase"` の状態で API サービスがロードされると、`services/api/src/middleware/tenant-auth.ts` と `services/api/src/middleware/super-admin.ts` がモジュールトップレベルで `Error` を throw し、Cloud Run インスタンスは起動失敗する。
+Issue #290 で導入した起動時 fail-safe の運用手順。**本番 runtime** と判定され、かつ `AUTH_MODE !== "firebase"` の状態で API サービスがロードされると、`services/api/src/middleware/tenant-auth.ts` と `services/api/src/middleware/super-admin.ts` がモジュールトップレベルで `Error` を throw し、Cloud Run インスタンスは起動失敗する。
+
+### 本番 runtime 判定 (Issue #290 codex 指摘反映)
+
+以下のいずれかを満たすと「本番」と判定される（defense-in-depth）:
+
+1. `NODE_ENV` を trim + lowercase で正規化した値が `"production"`
+2. `K_SERVICE` 環境変数が設定されている（Cloud Run が自動注入。[Container Contract](https://cloud.google.com/run/docs/container-contract#services-env-vars) 参照）
+
+→ deploy.yml で `NODE_ENV=production` を明示し忘れても、Cloud Run 上では `K_SERVICE` で自動検知される。
 
 ## なぜこの fail-safe が必要か
 

--- a/docs/runbook/auth-mode-production-check.md
+++ b/docs/runbook/auth-mode-production-check.md
@@ -1,0 +1,54 @@
+# Runbook: 本番 AUTH_MODE=firebase 確認手順
+
+Issue #290 で導入した起動時 fail-safe の運用手順。`NODE_ENV=production` かつ `AUTH_MODE !== "firebase"` の状態で API サービスがロードされると、`services/api/src/middleware/tenant-auth.ts` と `services/api/src/middleware/super-admin.ts` がモジュールトップレベルで `Error` を throw し、Cloud Run インスタンスは起動失敗する。
+
+## なぜこの fail-safe が必要か
+
+`AUTH_MODE` のデフォルト値は `"dev"`（ヘッダ疑似認証: `X-User-Email` を無検証で信頼）。本番環境で環境変数の設定漏れ / IaC ドリフト / Cloud Run リビジョン切り戻しなどで `AUTH_MODE` が欠落すると、`email_verified` / `sign_in_provider` / `allowed_emails` 境界（ADR-031 Issue #286 / #294）が**全てバイパス**され、誰でも任意の email で認証可能になる。
+
+この事故を防ぐため、モジュールロード時に fail-fast で検知する。
+
+## 本番デプロイ前チェックリスト
+
+### 1. Cloud Run 環境変数の確認
+
+```bash
+gcloud run services describe api \
+  --region asia-northeast1 \
+  --format='value(spec.template.spec.containers[0].env)' \
+  | grep -E "AUTH_MODE|NODE_ENV"
+```
+
+期待値:
+- `AUTH_MODE=firebase`
+- `NODE_ENV=production`
+
+### 2. IaC 設定との一致確認
+
+`cloudbuild.yaml` / `deploy/cloud-run-*.yaml` / Terraform 等で `AUTH_MODE=firebase` が明示されているか確認。**デフォルト依存は禁止**（設定漏れで dev にフォールバックすると fail-safe が発火し起動失敗するため、明示設定が必須）。
+
+### 3. リビジョン切り戻し時の注意
+
+Cloud Run の UI / gcloud で旧リビジョンにロールバックした際、そのリビジョンに `AUTH_MODE=firebase` が設定されていなかった場合は起動失敗する。リビジョン作成時点で必ず `AUTH_MODE=firebase` を明示していること。
+
+## 起動失敗時の挙動
+
+`Error: FATAL: AUTH_MODE must be "firebase" in production (got "dev"). ...` がログに出力され、Cloud Run インスタンスは ready にならない。トラフィックは直前の正常リビジョンに維持されるため、サービス停止は発生しない（新規リビジョン作成が失敗する）。
+
+## 復旧手順
+
+1. Cloud Run のリビジョン設定で `AUTH_MODE=firebase` を追加して新リビジョンをデプロイ
+2. 新リビジョンが healthy 100% になったことを確認
+3. 旧（失敗）リビジョンを削除
+
+## 開発環境
+
+`NODE_ENV` が `"production"` **以外**（`"development"`, `"test"`, 未設定など）の場合、この fail-safe は発動しない。ローカル / CI / staging では従来通り `AUTH_MODE=dev` で起動可能。
+
+## 関連
+
+- ADR-031（認証・認可・テナント解決の責務分離 + GCIP マルチテナント）
+- Issue #286 / PR #288（email_verified / sign_in_provider 必須化）
+- Issue #289 / PR #291（super-admin 経路への同等ガード）
+- Issue #294 / PR #301（help-role.ts / tenants.ts への境界統一）
+- Issue #290（本 runbook の元 Issue、起動時 assertion）

--- a/services/api/src/middleware/__tests__/auth-mode-production-assertion.test.ts
+++ b/services/api/src/middleware/__tests__/auth-mode-production-assertion.test.ts
@@ -1,0 +1,98 @@
+/**
+ * 本番誤有効化 fail-safe (Issue #290) の起動時 assertion テスト
+ *
+ * 対象:
+ *   - services/api/src/middleware/tenant-auth.ts
+ *   - services/api/src/middleware/super-admin.ts
+ *
+ * 狙い:
+ *   NODE_ENV=production 下で AUTH_MODE が "firebase" でないままモジュールが
+ *   ロードされた場合、ヘッダ疑似認証が無検証で信頼され allowed_emails 境界
+ *   (ADR-031 Issue #286 / #294) がすべてバイパスされる。これを Cloud Run
+ *   起動時に fail-fast で検知するため、モジュールトップレベルで Error を
+ *   throw する。開発/テスト環境 (NODE_ENV !== "production") では従来通り
+ *   AUTH_MODE=dev でも起動可能であることを保証する。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Firebase Admin SDK は import されるだけでネットワーク初期化しないようモックする。
+vi.mock("firebase-admin/app", () => ({
+  getApps: () => [{ name: "[DEFAULT]" }],
+  initializeApp: vi.fn(),
+  cert: vi.fn(),
+}));
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: vi.fn(),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: vi.fn(),
+}));
+
+describe.each([
+  { label: "tenant-auth.ts", modulePath: "../tenant-auth.js" },
+  { label: "super-admin.ts", modulePath: "../super-admin.js" },
+])("$label production fail-safe (Issue #290)", ({ modulePath }) => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("NODE_ENV=production + AUTH_MODE=dev なら import 時に Error を throw", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("AUTH_MODE", "dev");
+
+    await expect(import(modulePath)).rejects.toThrow(
+      /AUTH_MODE must be "firebase" in production/
+    );
+  });
+
+  it("NODE_ENV=production + AUTH_MODE='' (空文字) でも throw", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    // vi.stubEnv は undefined 注入ができないため空文字を使用。
+    // `?? "dev"` は undefined/null のみフォールバック対象（空文字は通過）なので
+    // authMode === "" のまま評価され、"" !== "firebase" で拒否される。
+    // つまり本ケースは「AUTH_MODE を明示的に空文字に設定した」IaC ミス相当を
+    // 検証しており、Cloud Run で `env.AUTH_MODE.value: ""` が起きても
+    // fail-safe が働くことを保証する。
+    // ※ 真の未設定 (delete process.env.AUTH_MODE) の場合は authMode が "dev"
+    //   にフォールバックし、別テスト（最初のケース "AUTH_MODE=dev"）で同等にカバー。
+    vi.stubEnv("AUTH_MODE", "");
+
+    await expect(import(modulePath)).rejects.toThrow(
+      /AUTH_MODE must be "firebase" in production/
+    );
+  });
+
+  it("NODE_ENV=production + AUTH_MODE=firebase は起動成功", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("AUTH_MODE", "firebase");
+
+    await expect(import(modulePath)).resolves.toBeDefined();
+  });
+
+  it("NODE_ENV=development + AUTH_MODE=dev は起動成功（開発体験保護）", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("AUTH_MODE", "dev");
+
+    await expect(import(modulePath)).resolves.toBeDefined();
+  });
+
+  it("NODE_ENV=test + AUTH_MODE=dev は起動成功（CI / vitest 既定環境）", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("AUTH_MODE", "dev");
+
+    await expect(import(modulePath)).resolves.toBeDefined();
+  });
+
+  it("NODE_ENV 未設定 + AUTH_MODE=dev は起動成功（production 明示でない限り通す）", async () => {
+    vi.stubEnv("NODE_ENV", "");
+    vi.stubEnv("AUTH_MODE", "dev");
+
+    await expect(import(modulePath)).resolves.toBeDefined();
+  });
+});

--- a/services/api/src/middleware/__tests__/auth-mode-production-assertion.test.ts
+++ b/services/api/src/middleware/__tests__/auth-mode-production-assertion.test.ts
@@ -92,7 +92,47 @@ describe.each([
   it("NODE_ENV 未設定 + AUTH_MODE=dev は起動成功（production 明示でない限り通す）", async () => {
     vi.stubEnv("NODE_ENV", "");
     vi.stubEnv("AUTH_MODE", "dev");
+    vi.stubEnv("K_SERVICE", "");
 
     await expect(import(modulePath)).resolves.toBeDefined();
+  });
+
+  // Issue #290 codex 指摘 HIGH: deploy.yml が NODE_ENV=production を設定していない時代の
+  // 回帰防止。Cloud Run は K_SERVICE を自動注入するため、NODE_ENV 欠落でも本番と判定する。
+  it("K_SERVICE 設定済み (Cloud Run 自動注入) + AUTH_MODE=dev なら throw", async () => {
+    vi.stubEnv("NODE_ENV", "");
+    vi.stubEnv("AUTH_MODE", "dev");
+    vi.stubEnv("K_SERVICE", "api");
+
+    await expect(import(modulePath)).rejects.toThrow(
+      /AUTH_MODE must be "firebase" in production/
+    );
+  });
+
+  it("K_SERVICE 設定済み + AUTH_MODE=firebase なら起動成功", async () => {
+    vi.stubEnv("NODE_ENV", "");
+    vi.stubEnv("AUTH_MODE", "firebase");
+    vi.stubEnv("K_SERVICE", "api");
+
+    await expect(import(modulePath)).resolves.toBeDefined();
+  });
+
+  // silent-failure-hunter 指摘 M-1: NODE_ENV 文字列バリエーション耐性
+  it("NODE_ENV='Production' (大文字始まり) + AUTH_MODE=dev でも throw (正規化)", async () => {
+    vi.stubEnv("NODE_ENV", "Production");
+    vi.stubEnv("AUTH_MODE", "dev");
+
+    await expect(import(modulePath)).rejects.toThrow(
+      /AUTH_MODE must be "firebase" in production/
+    );
+  });
+
+  it("NODE_ENV='production ' (末尾空白) + AUTH_MODE=dev でも throw (trim)", async () => {
+    vi.stubEnv("NODE_ENV", "production ");
+    vi.stubEnv("AUTH_MODE", "dev");
+
+    await expect(import(modulePath)).rejects.toThrow(
+      /AUTH_MODE must be "firebase" in production/
+    );
   });
 });

--- a/services/api/src/middleware/super-admin.ts
+++ b/services/api/src/middleware/super-admin.ts
@@ -93,6 +93,18 @@ async function recordSuperAdminAuthEvent(
 
 const authMode = process.env.AUTH_MODE ?? "dev";
 
+// Issue #290 / ADR-031: NODE_ENV=production では AUTH_MODE=firebase を必須化。
+// super-admin 経路も dev モードでは X-User-Email を無検証で信頼するため、同等の
+// fail-fast ガードが必要。tenant-auth.ts と独立モジュールのため両方で assertion する。
+// 詳細: docs/runbook/auth-mode-production-check.md
+if (process.env.NODE_ENV === "production" && authMode !== "firebase") {
+  throw new Error(
+    `FATAL: AUTH_MODE must be "firebase" in production (got "${authMode}"). ` +
+      `Super-admin endpoints would accept unverified X-User-Email headers. ` +
+      `Check Cloud Run env vars or IaC configuration (docs/runbook/auth-mode-production-check.md).`
+  );
+}
+
 // 環境変数からのスーパー管理者（フォールバック/ブートストラップ用）
 const envSuperAdminEmails: string[] = (process.env.SUPER_ADMIN_EMAILS ?? "")
   .split(",")

--- a/services/api/src/middleware/super-admin.ts
+++ b/services/api/src/middleware/super-admin.ts
@@ -93,16 +93,25 @@ async function recordSuperAdminAuthEvent(
 
 const authMode = process.env.AUTH_MODE ?? "dev";
 
-// Issue #290 / ADR-031: NODE_ENV=production では AUTH_MODE=firebase を必須化。
+// Issue #290 / ADR-031: 本番 runtime では AUTH_MODE=firebase を必須化。
 // super-admin 経路も dev モードでは X-User-Email を無検証で信頼するため、同等の
 // fail-fast ガードが必要。tenant-auth.ts と独立モジュールのため両方で assertion する。
+// 本番 runtime 判定は tenant-auth.ts と同じロジック: NODE_ENV 正規化 + Cloud Run
+// の K_SERVICE 自動注入を併用し、どちらか一方でも本番と判定されたら発火する。
 // 詳細: docs/runbook/auth-mode-production-check.md
-if (process.env.NODE_ENV === "production" && authMode !== "firebase") {
+if (isProductionRuntime() && authMode !== "firebase") {
   throw new Error(
     `FATAL: AUTH_MODE must be "firebase" in production (got "${authMode}"). ` +
       `Super-admin endpoints would accept unverified X-User-Email headers. ` +
       `Check Cloud Run env vars or IaC configuration (docs/runbook/auth-mode-production-check.md).`
   );
+}
+
+function isProductionRuntime(): boolean {
+  const nodeEnv = process.env.NODE_ENV?.trim().toLowerCase();
+  if (nodeEnv === "production") return true;
+  if (typeof process.env.K_SERVICE === "string" && process.env.K_SERVICE.length > 0) return true;
+  return false;
 }
 
 // 環境変数からのスーパー管理者（フォールバック/ブートストラップ用）

--- a/services/api/src/middleware/tenant-auth.ts
+++ b/services/api/src/middleware/tenant-auth.ts
@@ -21,6 +21,19 @@ declare global {
 
 const authMode = process.env.AUTH_MODE ?? "dev";
 
+// Issue #290 / ADR-031: NODE_ENV=production では AUTH_MODE=firebase を必須化。
+// デフォルト値 "dev" のまま本番デプロイすると、ヘッダ疑似認証 (X-User-Email) が
+// 無検証で信頼されるため、email_verified / sign_in_provider / allowed_emails
+// 境界 (Issue #286 / #294) が全てバイパスされる。環境変数欠落 / IaC ドリフト /
+// Cloud Run リビジョン切り戻しによる欠落を、モジュールロード時に fail-fast で検知する。
+if (process.env.NODE_ENV === "production" && authMode !== "firebase") {
+  throw new Error(
+    `FATAL: AUTH_MODE must be "firebase" in production (got "${authMode}"). ` +
+      `This would allow header-based authentication bypass. ` +
+      `Check Cloud Run env vars or IaC configuration (docs/runbook/auth-mode-production-check.md).`
+  );
+}
+
 // Firebase Admin SDK初期化（firebase モードの場合のみ）
 if (authMode === "firebase" && getApps().length === 0) {
   const projectId = process.env.FIREBASE_PROJECT_ID || process.env.GCLOUD_PROJECT;

--- a/services/api/src/middleware/tenant-auth.ts
+++ b/services/api/src/middleware/tenant-auth.ts
@@ -21,17 +21,31 @@ declare global {
 
 const authMode = process.env.AUTH_MODE ?? "dev";
 
-// Issue #290 / ADR-031: NODE_ENV=production では AUTH_MODE=firebase を必須化。
+// Issue #290 / ADR-031: 本番 runtime では AUTH_MODE=firebase を必須化。
 // デフォルト値 "dev" のまま本番デプロイすると、ヘッダ疑似認証 (X-User-Email) が
 // 無検証で信頼されるため、email_verified / sign_in_provider / allowed_emails
 // 境界 (Issue #286 / #294) が全てバイパスされる。環境変数欠落 / IaC ドリフト /
 // Cloud Run リビジョン切り戻しによる欠落を、モジュールロード時に fail-fast で検知する。
-if (process.env.NODE_ENV === "production" && authMode !== "firebase") {
+//
+// 本番 runtime 判定:
+//   - NODE_ENV を trim + lowercase で正規化（"Production " 末尾空白/大文字ケース耐性）
+//   - かつ Cloud Run が自動注入する K_SERVICE を併用（NODE_ENV 未設定の IaC でも発火）
+//     参考: https://cloud.google.com/run/docs/container-contract#services-env-vars
+//   - どちらも検出しない場合のみローカル/CI とみなして assertion をスキップ
+if (isProductionRuntime() && authMode !== "firebase") {
   throw new Error(
     `FATAL: AUTH_MODE must be "firebase" in production (got "${authMode}"). ` +
       `This would allow header-based authentication bypass. ` +
       `Check Cloud Run env vars or IaC configuration (docs/runbook/auth-mode-production-check.md).`
   );
+}
+
+function isProductionRuntime(): boolean {
+  const nodeEnv = process.env.NODE_ENV?.trim().toLowerCase();
+  if (nodeEnv === "production") return true;
+  // Cloud Run は起動時に K_SERVICE を必ず注入する。NODE_ENV 設定漏れ時の保険。
+  if (typeof process.env.K_SERVICE === "string" && process.env.K_SERVICE.length > 0) return true;
+  return false;
 }
 
 // Firebase Admin SDK初期化（firebase モードの場合のみ）


### PR DESCRIPTION
## Summary
- `tenant-auth.ts` / `super-admin.ts` のモジュールトップレベルで `isProductionRuntime() && AUTH_MODE !== "firebase"` を検知して Error を throw し、Cloud Run の起動を fail-fast させる。
- **本番 runtime 判定**: `NODE_ENV` を `.trim().toLowerCase()` で正規化した `"production"` 一致、または Cloud Run 自動注入の `K_SERVICE` 存在、のいずれか（defense-in-depth）。
- **dev モードでは `X-User-Email` が無検証で信頼される**ため、環境変数欠落 / IaC ドリフト / リビジョン切り戻しで AUTH_MODE が "dev" に落ちると allowed_emails 境界 (Issue #286 / #294) がすべてバイパスされる。この事故を起動時に検知する。
- `docs/runbook/auth-mode-production-check.md` 新設 (本番デプロイチェックリスト + 本番 runtime 判定ロジック + 復旧手順)。

## Acceptance Criteria
- [x] NODE_ENV=production + AUTH_MODE=dev → モジュール import 時に throw
- [x] NODE_ENV="Production"（大文字） / "production " (末尾空白) でも throw（正規化）
- [x] **NODE_ENV 未設定 + K_SERVICE 設定済み + AUTH_MODE=dev → throw**（Cloud Run 実挙動、codex HIGH 回帰防止）
- [x] K_SERVICE 設定済み + AUTH_MODE=firebase → 起動成功
- [x] NODE_ENV=development / test / 未設定 + AUTH_MODE=dev + K_SERVICE="" → 起動成功（開発/CI 体験保護）
- [x] AUTH_MODE='' (空文字, IaC ミス想定) 本番 runtime → throw
- [x] super-admin.ts にも同等 assertion + `isProductionRuntime()` を適用（モジュール独立のため重複許容）
- [x] 本番デプロイ runbook 整備 + 本番 runtime 判定の明文化

## 設計判断
- **DRY より独立性を優先**: tenant-auth.ts と super-admin.ts で同一 `isProductionRuntime()` + assertion を重複配置。共通モジュール化は循環依存リスク + テスト時の `vi.resetModules()` 対応複雑化のため現状見送り。3 つ目以降が出た時点で共通化を検討。
- **本番 runtime 判定 (codex HIGH 指摘反映)**: 当初は `NODE_ENV === "production"` のみだったが、現行 `.github/workflows/deploy.yml:83` に `NODE_ENV=production` が未設定で assertion が発火しない抜け穴を codex セカンドオピニオンで発見。Cloud Run 自動注入の `K_SERVICE` を併用して本番検知を担保。
- **NODE_ENV の正規化** (silent-failure-hunter M-1): `.trim().toLowerCase()` で IaC の人為ミス（大文字始まり・末尾空白）耐性。
- **deploy.yml 更新は別 PR**: 本コミットで K_SERVICE フォールバックが入ったため HIGH は解消。deploy.yml に `NODE_ENV=production` を明示する変更は defense-in-depth として follow-up Issue で対応予定。

## Test plan
- [x] `npm test --workspace=@lms-279/api` → 536/536 PASS（新規 20 ケース追加）
  - describe.each で tenant-auth.ts / super-admin.ts を並列検証、各 10 シナリオ (計 20)
  - 網羅: NODE_ENV 4 ケース（production/Production/production+trim/dev/test/未設定）× AUTH_MODE 3 ケース（dev/空文字/firebase）+ K_SERVICE 2 ケース（有/無）
- [x] `npm run lint` → PASS
- [x] `npm run type-check` → 全ワークスペース PASS
- [ ] デプロイ後に Cloud Run のログで "FATAL: AUTH_MODE ..." が出ていないこと、起動 healthcheck が正常であることを確認

## Quality Gate
- [x] code-reviewer: ブロッカーなし、MEDIUM 2 件反映済み（runbook URL 統一 / テストコメント誤記修正）
- [x] silent-failure-hunter: HIGH なし、MEDIUM 1 件反映済み（NODE_ENV 正規化）
- [x] **codex セカンドオピニオン HIGH**: deploy.yml 抜け穴 → K_SERVICE 併用で修正済み、追加テストで回帰防止

## 関連
- Closes #290
- Parent: #272 (ADR-031 Phase 3 境界強化)
- runbook: `docs/runbook/auth-mode-production-check.md`
- 補足 1: deploy.yml に `NODE_ENV=production` を明示する defense-in-depth 対応は別 PR で対応予定（hook が今回の編集をブロックしたため、かつ K_SERVICE フォールバックで HIGH は解消済み）
- 補足 2: #290 コメントで提起された PR #298 silent-failure H-3 (super-admin.ts の Firestore transient/permanent 分離) は**本 PR スコープ外**。別途対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)