### PR TITLE
feat(auth): DELETE /super/admins を fail-closed 化 (Issue #296)

### DIFF
--- a/services/api/src/middleware/__tests__/get-all-super-admins-strict.test.ts
+++ b/services/api/src/middleware/__tests__/get-all-super-admins-strict.test.ts
@@ -1,0 +1,154 @@
+/**
+ * getAllSuperAdminsStrict / getAllSuperAdmins の fail-closed / silent fallback
+ * 挙動を検証する単体テスト (Issue #296)。
+ *
+ * 方針:
+ *   - getAllSuperAdminsStrict: Firestore 障害時に SuperAdminFirestoreUnavailableError
+ *     を throw する（破壊的操作のための fail-closed 版）
+ *   - getAllSuperAdmins: Firestore 障害時も env 分を silent fallback で返す
+ *     （一覧表示の可用性維持、UX 優先）
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockFirestoreGet = vi.fn();
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: () => ({
+    verifyIdToken: vi.fn(),
+  }),
+}));
+
+vi.mock("firebase-admin/app", () => ({
+  getApps: () => [{ name: "[DEFAULT]" }],
+  initializeApp: vi.fn(),
+  cert: vi.fn(),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: () => ({
+    collection: () => ({
+      get: mockFirestoreGet,
+    }),
+  }),
+}));
+
+describe("getAllSuperAdminsStrict (Issue #296 fail-closed)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("AUTH_MODE", "firebase");
+    vi.stubEnv("SUPER_ADMIN_EMAILS", "env-admin@example.com");
+    mockFirestoreGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("Firestore 成功時は env + firestore の admins を返す", async () => {
+    const { getAllSuperAdminsStrict } = await import("../super-admin.js");
+
+    mockFirestoreGet.mockResolvedValue({
+      docs: [
+        {
+          id: "firestore-admin@example.com",
+          data: () => ({ addedAt: "2026-04-01T00:00:00Z", addedBy: "system" }),
+        },
+      ],
+    });
+
+    const admins = await getAllSuperAdminsStrict();
+    expect(admins).toEqual([
+      { email: "env-admin@example.com", source: "env" },
+      {
+        email: "firestore-admin@example.com",
+        source: "firestore",
+        addedAt: "2026-04-01T00:00:00Z",
+        addedBy: "system",
+      },
+    ]);
+  });
+
+  it("Firestore 障害時は SuperAdminFirestoreUnavailableError を throw する (fail-closed)", async () => {
+    const { getAllSuperAdminsStrict, SuperAdminFirestoreUnavailableError } =
+      await import("../super-admin.js");
+
+    mockFirestoreGet.mockRejectedValue(
+      Object.assign(new Error("service unavailable"), { code: "unavailable" })
+    );
+
+    await expect(getAllSuperAdminsStrict()).rejects.toBeInstanceOf(
+      SuperAdminFirestoreUnavailableError
+    );
+  });
+
+  it("env と firestore で重複した email は env 優先で firestore 側を除外する", async () => {
+    const { getAllSuperAdminsStrict } = await import("../super-admin.js");
+
+    mockFirestoreGet.mockResolvedValue({
+      docs: [
+        {
+          id: "env-admin@example.com",
+          data: () => ({ addedAt: "2026-04-01T00:00:00Z" }),
+        },
+        {
+          id: "firestore-only@example.com",
+          data: () => ({ addedAt: "2026-04-02T00:00:00Z" }),
+        },
+      ],
+    });
+
+    const admins = await getAllSuperAdminsStrict();
+    expect(admins).toHaveLength(2);
+    expect(admins[0]).toEqual({ email: "env-admin@example.com", source: "env" });
+    expect(admins[1].email).toBe("firestore-only@example.com");
+  });
+});
+
+describe("getAllSuperAdmins (Issue #296 silent fallback 継続)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("AUTH_MODE", "firebase");
+    vi.stubEnv("SUPER_ADMIN_EMAILS", "env-admin@example.com");
+    mockFirestoreGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("Firestore 障害時も env 分だけを silent fallback で返す (既存挙動、一覧取得の可用性維持)", async () => {
+    const { getAllSuperAdmins } = await import("../super-admin.js");
+
+    mockFirestoreGet.mockRejectedValue(
+      Object.assign(new Error("service unavailable"), { code: "unavailable" })
+    );
+
+    // 破壊的挙動ではないのでエラーを投げず、env admin のみ返す
+    const admins = await getAllSuperAdmins();
+    expect(admins).toEqual([{ email: "env-admin@example.com", source: "env" }]);
+  });
+
+  it("Firestore 成功時は env + firestore の admins を返す", async () => {
+    const { getAllSuperAdmins } = await import("../super-admin.js");
+
+    mockFirestoreGet.mockResolvedValue({
+      docs: [
+        {
+          id: "firestore-admin@example.com",
+          data: () => ({ addedAt: "2026-04-01T00:00:00Z", addedBy: "system" }),
+        },
+      ],
+    });
+
+    const admins = await getAllSuperAdmins();
+    expect(admins).toEqual([
+      { email: "env-admin@example.com", source: "env" },
+      {
+        email: "firestore-admin@example.com",
+        source: "firestore",
+        addedAt: "2026-04-01T00:00:00Z",
+        addedBy: "system",
+      },
+    ]);
+  });
+});

--- a/services/api/src/middleware/super-admin.ts
+++ b/services/api/src/middleware/super-admin.ts
@@ -220,7 +220,7 @@ export async function addSuperAdmin(email: string, addedBy: string): Promise<voi
     addedBy,
     addedAt: new Date().toISOString(),
   });
-  console.log(`Super admin added: ${normalizedEmail} by ${addedBy}`);
+  logger.info("Super admin added", { email: normalizedEmail, addedBy });
 }
 
 /**
@@ -230,51 +230,92 @@ export async function removeSuperAdmin(email: string): Promise<void> {
   const db = getFirestore();
   const normalizedEmail = email.toLowerCase();
   await db.collection("superAdmins").doc(normalizedEmail).delete();
-  console.log(`Super admin removed: ${normalizedEmail}`);
+  logger.info("Super admin removed", { email: normalizedEmail });
 }
 
-/**
- * 全スーパー管理者一覧を取得（環境変数 + Firestore）
- */
-export async function getAllSuperAdmins(): Promise<Array<{
+export type SuperAdminRecord = {
   email: string;
   source: "env" | "firestore";
   addedAt?: string;
   addedBy?: string;
-}>> {
-  const result: Array<{
-    email: string;
-    source: "env" | "firestore";
-    addedAt?: string;
-    addedBy?: string;
-  }> = [];
+};
 
-  // 環境変数からの管理者
+/**
+ * env + Firestore snapshot からスーパー管理者一覧を構築する private helper。
+ *
+ * Issue #296: `getAllSuperAdmins` (silent fallback) と `getAllSuperAdminsStrict`
+ * (fail-closed) で内部ループが完全一致していた負債を解消する共通化。catch の
+ * 扱いだけを各公開関数で変え、ループ本体の同期漏れリスクをなくす。
+ */
+function buildSuperAdminList(
+  snapshot: FirebaseFirestore.QuerySnapshot
+): SuperAdminRecord[] {
+  const result: SuperAdminRecord[] = [];
+
   for (const email of envSuperAdminEmails) {
     result.push({ email, source: "env" });
   }
 
-  // Firestoreからの管理者
-  try {
-    const db = getFirestore();
-    const snapshot = await db.collection("superAdmins").get();
-    for (const doc of snapshot.docs) {
-      const data = doc.data();
-      // 環境変数と重複していない場合のみ追加
-      if (!envSuperAdminEmails.includes(doc.id)) {
-        result.push({
-          email: doc.id,
-          source: "firestore",
-          addedAt: data.addedAt,
-          addedBy: data.addedBy,
-        });
-      }
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    // 環境変数と重複していない場合のみ追加（env 側を優先）
+    if (!envSuperAdminEmails.includes(doc.id)) {
+      result.push({
+        email: doc.id,
+        source: "firestore",
+        addedAt: data.addedAt,
+        addedBy: data.addedBy,
+      });
     }
-  } catch (error) {
-    console.error("Failed to fetch super admins from Firestore:", error);
   }
 
   return result;
+}
+
+/**
+ * 全スーパー管理者一覧を取得（環境変数 + Firestore）
+ *
+ * Issue #296: Firestore 障害時の挙動は「silent fallback（env 分のみ返却）」を
+ * 維持する（UI 一覧表示の可用性優先）。ただし破壊的操作（削除 / 追加）では
+ * silent に env 以外が消えた状態で find() に通すと 404 誤認事故につながるため、
+ * そちら用には {@link getAllSuperAdminsStrict} を使う。
+ *
+ * console.error から logger.error に移行し、Issue #292 の構造化ログ形式に揃える
+ * （firebaseErrorCode / errorMessage を Cloud Logging で串刺し可能）。
+ */
+export async function getAllSuperAdmins(): Promise<SuperAdminRecord[]> {
+  try {
+    const db = getFirestore();
+    const snapshot = await db.collection("superAdmins").get();
+    return buildSuperAdminList(snapshot);
+  } catch (error) {
+    const err = error as { code?: unknown; message?: unknown };
+    logger.error("Failed to fetch super admins from Firestore (silent fallback)", {
+      errorType: "super_admin_list_firestore_fallback",
+      firebaseErrorCode: typeof err.code === "string" ? err.code : null,
+      errorMessage: typeof err.message === "string" ? err.message : String(error),
+    });
+    // env 分だけで一覧を返す（UI ロード失敗回避のための UX 優先）
+    return envSuperAdminEmails.map((email) => ({ email, source: "env" }) as const);
+  }
+}
+
+/**
+ * 全スーパー管理者一覧を fail-closed で取得する（Issue #296）。
+ *
+ * Firestore 障害時に {@link SuperAdminFirestoreUnavailableError} を throw する。
+ * 破壊的操作（削除・追加）の前段で「env 分のみ」に縮退した状態で find() に
+ * 通すと、実在する firestore admin を 404 で「見つからない」と誤認させ
+ * インシデント時に危険な操作判断につながるため、これらの経路では本関数を使う。
+ */
+export async function getAllSuperAdminsStrict(): Promise<SuperAdminRecord[]> {
+  try {
+    const db = getFirestore();
+    const snapshot = await db.collection("superAdmins").get();
+    return buildSuperAdminList(snapshot);
+  } catch (error) {
+    throw new SuperAdminFirestoreUnavailableError(error);
+  }
 }
 
 /**

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -626,7 +626,19 @@ router.post("/admins", async (req: Request, res: Response) => {
  * 取得し、Firestore 障害時は 503 を返して再試行を促す。
  */
 router.delete("/admins/:email", async (req: Request, res: Response) => {
-  const email = decodeURIComponent(req.params.email as string);
+  // Issue #296 silent-failure-hunter H-2: decodeURIComponent は不正入力
+  // ("%" 単体など) で URIError を投げる。構造化ログなしに 500 に落とさず
+  // 400 で早期返却する。
+  let email: string;
+  try {
+    email = decodeURIComponent(req.params.email as string);
+  } catch {
+    res.status(400).json({
+      error: "invalid_email",
+      message: "メールアドレスの形式が正しくありません。",
+    });
+    return;
+  }
 
   let admins: SuperAdminRecord[];
   try {
@@ -645,7 +657,23 @@ router.delete("/admins/:email", async (req: Request, res: Response) => {
       });
       return;
     }
-    throw error;
+    // Issue #296 silent-failure-hunter H-1: 想定外例外が Express default
+    // handler に素通しで流れると、operatorEmail / targetEmail / errorType が
+    // Cloud Logging から串刺しできず削除操作の証跡が欠落する。構造化ログを
+    // 残したうえで 500 を明示返却する (error handler への委譲は行わない)。
+    const err = error as { code?: unknown };
+    logger.error("Super admin DELETE unexpected failure", {
+      errorType: "super_admin_delete_internal_error",
+      operatorEmail: req.superAdmin?.email,
+      targetEmail: email,
+      firebaseErrorCode: typeof err.code === "string" ? err.code : null,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({
+      error: "internal_error",
+      message: "削除中にエラーが発生しました。再度お試しください。",
+    });
+    return;
   }
 
   const targetAdmin = admins.find((a) => a.email === email.toLowerCase());

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -17,8 +17,11 @@ import type { SuperAttendanceResponse, SuperStudentProgressResponse, TenantEnrol
 import {
   superAdminAuthMiddleware,
   getAllSuperAdmins,
+  getAllSuperAdminsStrict,
   addSuperAdmin,
   removeSuperAdmin,
+  SuperAdminFirestoreUnavailableError,
+  type SuperAdminRecord,
 } from "../middleware/super-admin.js";
 import type { TenantMetadata, TenantStatus } from "../types/tenant.js";
 import { masterRouter } from "./super-admin-master.js";
@@ -615,11 +618,36 @@ router.post("/admins", async (req: Request, res: Response) => {
 /**
  * スーパー管理者を削除
  * DELETE /api/v2/super/admins/:email
+ *
+ * Issue #296: Firestore 障害中に silent fallback で「env 分のみ」の一覧と
+ * `.find()` を組み合わせると、実在する firestore admin が 404 誤認され、
+ * オペレータが「既に削除済」と判断して二重操作や対象取り違えを起こす事故
+ * リスクがある。破壊的操作なので getAllSuperAdminsStrict で fail-closed に
+ * 取得し、Firestore 障害時は 503 を返して再試行を促す。
  */
 router.delete("/admins/:email", async (req: Request, res: Response) => {
   const email = decodeURIComponent(req.params.email as string);
 
-  const admins = await getAllSuperAdmins();
+  let admins: SuperAdminRecord[];
+  try {
+    admins = await getAllSuperAdminsStrict();
+  } catch (error) {
+    if (error instanceof SuperAdminFirestoreUnavailableError) {
+      logger.error("Super admin DELETE blocked by Firestore unavailability", {
+        errorType: "super_admin_delete_firestore_unavailable",
+        firebaseErrorCode: error.code ?? null,
+        operatorEmail: req.superAdmin?.email,
+        targetEmail: email,
+      });
+      res.status(503).json({
+        error: "service_unavailable",
+        message: "一時的に利用できません。再度お試しください。",
+      });
+      return;
+    }
+    throw error;
+  }
+
   const targetAdmin = admins.find((a) => a.email === email.toLowerCase());
 
   if (!targetAdmin) {
@@ -648,7 +676,10 @@ router.delete("/admins/:email", async (req: Request, res: Response) => {
 
   await removeSuperAdmin(email);
 
-  console.log(`[SuperAdmin] Admin removed: ${email} by ${req.superAdmin?.email}`);
+  logger.info("Super admin removed", {
+    operatorEmail: req.superAdmin?.email,
+    targetEmail: email,
+  });
 
   res.json({
     message: "スーパー管理者を削除しました。",


### PR DESCRIPTION
## Summary
- Firestore 障害時に `getAllSuperAdmins` が silent fallback で env admin のみを返すため、`DELETE /api/v2/super/admins/:email` の `.find()` で実在する firestore admin が **404「見つからない」と誤認される**事故リスクを解消。
- 破壊的操作のみ `getAllSuperAdminsStrict` を使って 503 を返し、一覧取得 (`GET /admins`) は既存の silent fallback を維持（UI 可用性優先）。
- API 契約 (`{ admins: SuperAdminRecord[] }`) は変更なし → Web 側の改修不要。

## 設計判断 (選択肢 C を採用)
| 経路 | 挙動 | 理由 |
|------|------|------|
| GET /admins | silent fallback 維持 (env 分のみ返却) | 一覧表示の可用性優先 |
| DELETE /admins/:email | fail-closed (503 で拒否) | 実在する admin を 404 誤認して削除/放置する事故を防止 |
| POST /admins | 変更なし | addSuperAdmin の write が Firestore 失敗で例外を上位に流す既存挙動 |

選択肢 A (一覧取得も fail-closed) は UI ロード失敗のインパクトが大きいため不採用。選択肢 B (degraded フラグ) は API 契約変更により Web 側改修が必要でスコープ増のため不採用。

## 実装
- **新関数**: `getAllSuperAdminsStrict()` — Firestore 障害時 `SuperAdminFirestoreUnavailableError` throw
- **共通化**: `buildSuperAdminList(snapshot)` を private helper に抽出し、silent / strict 両関数のループ本体重複を解消 (code-reviewer DRY 指摘反映)
- **logger 統一**: `getAllSuperAdmins` catch / `addSuperAdmin` / `removeSuperAdmin` / DELETE 成功ログを `console.*` → `logger.*` に置換、Issue #292 形式の構造化ログに (Cloud Logging 串刺し可能)
- **DELETE route**: try/catch で 503 返却、`admins: SuperAdminRecord[]` 型明示

## Acceptance Criteria
- [x] 設計判断 (選択肢 C) を PR body / コードコメントに記録
- [x] `getAllSuperAdmins` の silent fallback 維持 / `getAllSuperAdminsStrict` の fail-closed 挙動
- [x] DELETE /admins が Firestore 障害時 503 返却
- [x] 新規ユニットテスト 5 ケース (silent / strict 両挙動、重複時 env 優先)
- [x] UI 側対応: API 契約維持のため改修不要

## Test plan
- [x] `npm test --workspace=@lms-279/api` → 541/541 PASS
- [x] 新規 `get-all-super-admins-strict.test.ts` → 5/5 PASS
- [x] `npm run lint` → PASS
- [x] `npm run type-check` → 全ワークスペース PASS
- [ ] デプロイ後に Firestore 障害シミュレーション時のログ (`errorType: super_admin_list_firestore_fallback` / `super_admin_delete_firestore_unavailable`) を Cloud Logging で確認

## Quality Gate
- [x] code-reviewer: HIGH 1 件 (console.log 残存) + MEDIUM 1 件 (DRY) + LOW 1 件 (型) をすべて反映済み
- [x] 関連 PR: #295 (Issue #293) でリリース済みの `superAdminAuthMiddleware` の fail-closed と同じパターン
- [x] スコープ外の LOW 指摘 (student-progress PATCH / export-sheets の console.* 残存 / shared-types 移行 / DELETE integration テスト) は**別 Issue で対応**

## 関連
- Closes #296
- Parent: PR #295 (Issue #293) で `superAdminAuthMiddleware` を fail-closed 化した延長線
- 関連: Issue #292 (構造化ログ) のパターンを流用

🤖 Generated with [Claude Code](https://claude.com/claude-code)