### PR TITLE
docs(handoff): Session 5 (2026-04-22) ハンドオフ更新

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,12 +1,12 @@
-# Session Handoff — 2026-04-22 (Session 4)
+# Session Handoff — 2026-04-22 (Session 5)
 
 ## TL;DR
 
-**2 PR マージ達成**。Session 3 の残課題 PR #284 (Issue #278) を rebase 解消して取り込み、P1 #292 の認証拒否ログ構造化を実装。これで **P1 Issue ゼロ化**、P0 は #272 (GCIP 移行 Phase 3) のみ。Session 3 以降の認証強化シリーズは ADR-031 追補で 6 + 3 項目の As-Is 表が全て ✅ / 🟡（未対応は UID 紐付けの原子性のみ）。
+**3 PR 連続マージ達成**。Session 4 の P2 security 系 3 件（#294 / #290 / #296）を全てクローズし、ADR-031「allowed_emails 境界」を `middleware/tenant-auth.ts` + `middleware/super-admin.ts` + `routes/help-role.ts` + `routes/tenants.ts` の **4 経路で統一**。本番誤有効化 fail-safe (NODE_ENV=production + K_SERVICE 併用判定) と DELETE /super/admins の fail-closed 化も反映済み。これで **P2 security 系は残り #290 follow-up のみ**、P0 は #272 (GCIP 移行 Phase 3) が引き続き唯一。
 
-- **マージ完了** (今セッション): PR #284 (Issue #278 Close), PR #298 (Issue #292 Close)
-- **新規 Issue**: #299 (P2 observability, `platform_auth_error_logs` admin UI 読み取り経路)
-- **Issue Net**: -1（Close 2件 / 起票 1件）
+- **マージ完了** (今セッション): PR #301 (#294 Close), PR #302 (#290 Close), PR #303 (#296 Close)
+- **新規 Issue**: 0 件
+- **Issue Net**: -3（Close 3 件 / 起票 0 件）
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -14,58 +14,63 @@
 # 1. 状況復元
 cat docs/handoff/LATEST.md
 
-# 2. 現在の OPEN Issue（P0: 1 / P1: 0 / P2: 8）
+# 2. 現在の OPEN Issue（P0: 1 / P1: 0 / P2: 5）
 gh issue list --state open --limit 15
 
 # 3. ユーザー側作業の確認（GCP Console / 本番 Firestore dry-run など）
-# 必要なら PR/Issue コメントで進捗確認
 ```
 
 ---
 
-## セッション成果物 (2026-04-22 Session 4)
+## セッション成果物 (2026-04-22 Session 5)
 
 ### マージ完了 PR
 
 | # | Issue | Title | Merge Commit |
 |---|-------|-------|-------------|
-| #284 | #278 | fix(auth): allowed_emails 継続的認可境界の実装 | `88a90cb` |
-| #298 | #292 | feat(auth): 認証拒否ログを構造化 + 拒否理由を区別 | `0731191` |
+| #301 | #294 | feat(auth): help-role.ts / tenants.ts に verifyIdToken 境界ガード拡張 | `27b803e` |
+| #302 | #290 | feat(auth): NODE_ENV=production で AUTH_MODE=firebase を必須化 | `1521ef7` |
+| #303 | #296 | feat(auth): DELETE /super/admins を fail-closed 化 + getAllSuperAdminsStrict 追加 | `19580e5` |
 
 ### 主要変更の要点
 
-#### PR #284 (Issue #278): allowed_emails 継続的認可境界
-- Session 3 で conflict していた PR を rebase して取り込み
-- `tenant-auth.ts` の既存ユーザー経路 4 箇所に `ensureAllowlisted` 再チェック追加（firebaseUid / email / x-user-id / x-user-email）
-- スーパー管理者は `checkSuperAdmin` で例外
-- `firestore.ts` / `in-memory.ts` の `createAllowedEmail` に保存時正規化（`.trim().toLowerCase()`）
-- ADR-006 改訂 + ADR-031 As-Is 表を認証強化 5 PR（#287/#288/#291/#295/#284）反映版に統合
-- テスト: `tenant-auth-allowlist-recheck.test.ts` 12 ケース
+#### PR #301 (Issue #294): verifyIdToken 4 経路統一
+- `routes/help-role.ts` と `routes/tenants.ts` の `verifyIdToken` 直接呼び出しに `email_verified=true` / `sign_in_provider="google.com"` / `checkRevoked=true` を追加
+- help-role.ts 不適合時: `helpLevel: "student"` フォールバック（UX 維持）+ `errorType: help_role_guard_failed` / `reason` 構造化ログ
+- tenants.ts 不適合時: 403 で統一文言（ユーザー列挙防止）+ `logger.warn` で `errorType: tenant_creation_denied` / `reason`
+- tenants.ts の `verifyAuthToken` catch/warn を `console.*` → `logger.*` に移行（Issue #292 形式）
+- 新規 integration テスト 14 ケース（`__tests__/help-role.test.ts` + `__tests__/tenants.test.ts`）
+- ADR-031 As-Is 表 + スコープ注記を 4 経路適用済みに更新
 
-#### PR #298 (Issue #292): 認証拒否ログ構造化
-- `AuthErrorLog` スキーマに `reason: string | null` + `firebaseErrorCode: string | null` 追加
-- `TenantAccessDenialReason` (4値) / `SuperAdminDenialReason` (5値) union 型導入
-- `tenant-auth.ts` の全 `TenantAccessDeniedError` throw 箇所に reason 付与、catch 節を `logger.error` + `firebaseErrorCode` 構造化
-- `super-admin.ts` の全 403/401 分岐（firebase 4 + dev 2 + catch）に `logger.warn/error` + reason 付与
-- 新規 `platform-datasource.ts`: `getPlatformDataSource()` singleton + `PLATFORM_TENANT_ID` 定数
-- root コレクション `platform_auth_error_logs` に super-admin 経路の拒否を記録（tenant スコープと分離）
-- ADR-031 追補「認証拒否ログの構造化設計」セクション + 選択肢 A/B/C 採否理由
-- テスト: 新規 `super-admin-auth-logging.test.ts` (9 tests), `tenant-auth-logging.test.ts` (6 tests), `firestore-platform-auth-error-log.test.ts` (4 tests)
+#### PR #302 (Issue #290): 本番誤有効化 fail-safe
+- `middleware/tenant-auth.ts` / `middleware/super-admin.ts` のモジュールトップレベルで `isProductionRuntime() && AUTH_MODE !== "firebase"` を検知して Error throw
+- **本番 runtime 判定**: `NODE_ENV` の `.trim().toLowerCase()` 正規化（Production/末尾空白耐性）**+ Cloud Run 自動注入の `K_SERVICE` 併用** (defense-in-depth)
+  - Codex HIGH 指摘: 現行 `deploy.yml` は `NODE_ENV=production` 未設定 → K_SERVICE フォールバックで抜け穴解消
+- `docs/runbook/auth-mode-production-check.md` 新設（本番デプロイチェックリスト + 本番 runtime 判定 + 復旧手順）
+- 新規テスト 20 ケース（describe.each で 2 モジュール × 10 シナリオ）
+- **follow-up**: `.github/workflows/deploy.yml` への `NODE_ENV=production` 明示追加は PreToolUse hook でブロックされ別 PR に繰り延べ（K_SERVICE フォールバックで HIGH は解消済み）
 
-### `/review-pr` レビュー対応（PR #298）
-- 5 エージェント並列 (silent-failure / test / type-design / code-review / comment)
-- **マージ前対応済み**: CRITICAL 2件 (C-1 silent-failure, comment `firebase_claim_missing` 誤記) + HIGH 4件
-  - `recordSuperAdminAuthEvent` / `handleTenantAccessDenied` の persist 失敗時に元 payload を展開して `logger.error` に残す
-  - `createPlatformAuthErrorLog` の read-after-write 削除
-  - Firestore 直接テスト 4 件追加
-  - 境界値テスト 3 件追加（email 空文字 / firebase 欠落 / ensureAllowlisted 経由）
-- **マージ後フォロー**: Issue #299 起票 + PR #298 コメントで MEDIUM/LOW 10+ 件記録 + Issue #290 にコメント追記
+#### PR #303 (Issue #296): DELETE /super/admins fail-closed 化
+- Firestore 障害時の silent fallback で env admin のみ返却 → DELETE の `.find()` で実在 firestore admin が 404 誤認される事故リスクを解消
+- **採用設計 (選択肢 C)**: GET /admins は silent 維持（UI 可用性）、DELETE /admins は fail-closed（誤判断防止）、API 契約 (`{ admins: SuperAdminRecord[] }`) 変更なし
+- 新関数 `getAllSuperAdminsStrict()`: Firestore 障害時 `SuperAdminFirestoreUnavailableError` throw
+- private helper `buildSuperAdminList(snapshot)` 抽出で silent / strict 両関数のループ重複を解消
+- `addSuperAdmin` / `removeSuperAdmin` / DELETE 成功ログを `console.*` → `logger.*` に統一
+- silent-failure-hunter HIGH 2 件反映:
+  - H-1: DELETE catch の想定外例外に `errorType: super_admin_delete_internal_error` 構造化ログ + 500 明示返却
+  - H-2: `decodeURIComponent` を try で保護し URIError → 400 に変換
+- 新規ユニットテスト 5 ケース
 
-### 新規 Issue 起票 (今セッション)
-
-| # | P | カテゴリ | タイトル | 根拠 |
-|---|---|---------|---------|------|
-| #299 | P2 | observability | `platform_auth_error_logs` の admin UI 読み取り経路追加 | PR #298 code-reviewer H1 (rating 7, confidence 85%) |
+### レビュー対応サマリ
+- **PR #301**: `/review-pr` 5 エージェント (evaluator + code-reviewer + pr-test-analyzer + silent-failure-hunter + comment-analyzer) + `/codex review` = **6 レビュー**
+  - MEDIUM 2 件（logger 統一 / ADR 日付誤記）+ LOW 1 件（tenants.ts コメント誤記）反映済み
+  - Codex GO 判断、4 経路一貫性確認
+- **PR #302**: code-reviewer + silent-failure-hunter + `/codex review`
+  - **Codex HIGH 1 件 (K_SERVICE 抜け穴) 反映**、silent-failure MEDIUM 1 件 (NODE_ENV trim) 反映
+- **PR #303**: code-reviewer + silent-failure-hunter + `/codex review`
+  - code-reviewer HIGH 1 件 (console.log 残存) + MEDIUM 1 件 (DRY 共通化) 反映
+  - silent-failure HIGH 2 件 (throw 構造化ログ + URIError) 反映
+  - Codex GO 判断
 
 ## 品質ゲート結果
 
@@ -73,26 +78,26 @@ gh issue list --state open --limit 15
 |--------|------|
 | `npm run lint` | ✅ PASS |
 | `npm run type-check` | ✅ PASS (4 workspaces) |
-| `npm test` | ✅ API 502 PASS + Web 33 PASS（累積 +20 新規: allowlist-recheck 12 + auth-logging 15 + firestore-platform 4 で整理後実測 502）|
-| CI (PR #284 / #298) | ✅ Lint / Type Check / Test / Build 全 PASS |
-| `/review-pr` 5 エージェント並列 | ✅ CRITICAL/HIGH 全修正、MEDIUM/LOW は triage 後 Issue 化 or コメント |
+| `npm test` | ✅ API 541 PASS + Web 33 PASS（Session 4 比 +39 新規: 14 + 20 + 5）|
+| CI (PR #301 / #302 / #303) | ✅ Lint / Type Check / Test / Build 全 PASS |
+| Quality Gate | ✅ 6 エージェント + Codex セカンドオピニオンで HIGH 全反映 |
 
 ## 次セッションの着手候補 (優先度順)
 
 ### 🔴 P0 残
-1. **Issue #272 Phase 3** (GCIP 移行本体) — `/impl-plan` で計画化が必要（Issue 内に別セッション予定と明記）
+1. **Issue #272 Phase 3** (GCIP 移行本体) — `/impl-plan` で計画化が必要
    - 前提作業: ADR-031 As-Is 表の 🟡「UID 紐付けの原子性」のみ残存
    - ユーザー側作業待ち: Phase 1.1 (GCP Console OAuth External 化) + 本番 `normalize-users-email.ts` dry-run
 
-### 🟢 P2 並行着手可能（Prerequisite なし）
-2. **Issue #294** (P2 security): `help-role.ts` / `tenants.ts` の `verifyIdToken` 直接呼び出しに email_verified / sign_in_provider / checkRevoked 適用（PR #291/#298 と同パターン、着手容易）
-3. **Issue #296** (P2 ux): `getAllSuperAdmins` の Firestore silent fallback で管理 API が誤 404 を返すリスク（PR #298 と関連）
-4. **Issue #299** (P2 observability): `platform_auth_error_logs` admin UI 読み取り経路（今回起票、#272 Phase 3 前に解消推奨）
-5. **Issue #290** (P2 security): AUTH_MODE=dev 起動時 assertion（PR #298 silent-failure H-3 と統合検討可）
-6. **Issue #281** (P2 refactor): allowed_emails 監査 CLI 純粋関数分割
+### 🟢 P2 並行着手可能
+
+2. **#290 follow-up** (小): `.github/workflows/deploy.yml` の ENV_VARS に `NODE_ENV=production` を明示追加（K_SERVICE フォールバックで HIGH は解消済みだが defense-in-depth 推奨。本セッションは PreToolUse hook で未着手）
+3. **Issue #299** (P2 observability): `platform_auth_error_logs` の admin UI 読み取り経路追加（Phase 3 前に解消推奨）
+4. **Issue #281** (P2 refactor): allowed_emails 監査 CLI の純粋関数分割と型強化（独立性高、テスト充実）
+5. **PR #298 H-3** (別 Issue 候補): `super-admin.ts` Firestore transient/permanent 分類（#290 コメントに既出、一律 503 → 分類へ）
 
 ### 🟡 Phase 5
-7. Issue #276 / #275 / #274: Phase 5 運用改善
+6. Issue #276 / #275 / #274: Phase 5 運用改善（allowed_emails 削除時のセッション失効 / 管理画面 UX / 可視化）
 
 ## ブロッカー / ユーザー側タスク（継続）
 
@@ -103,39 +108,43 @@ gh issue list --state open --limit 15
 
 ## ADR / ドキュメント状態
 
-- **ADR-031** 更新済み
-  - PR #284 で As-Is 表を 6 行に拡張（認証モード関係テーブル、UID 紐付け原子性、users email 正規化等）
-  - PR #298 で「認証拒否ログの構造化設計」セクション + 選択肢 A/B/C + Phase 1 の制約（admin UI 読み取り未実装）追補
-- **ADR-006** 更新済み（PR #284: 継続的認可境界の明文化）
-- **CLAUDE.md**: Phase 11 完了、変更なし（#272 Phase 3 未着手）
+- **ADR-031** 更新済み (PR #301)
+  - As-Is 表の「email_verified チェック」「sign_in_provider 制限」「checkRevoked=true」3 行に Issue #294 の `help-role.ts` / `tenants.ts` 拡張を追記
+  - 「適用スコープ注記」を 4 経路（tenant-auth / super-admin / help-role / tenants）すべて適用済みに更新
+  - 共通ヘルパー化は別 Issue で検討予定を明記
+- **docs/runbook/auth-mode-production-check.md** 新設 (PR #302)
+  - 本番 runtime 判定（NODE_ENV 正規化 + K_SERVICE 併用）
+  - Cloud Run 環境変数の確認コマンド + IaC 設定一致確認
+  - リビジョン切り戻し時の注意 + 起動失敗時の挙動 + 復旧手順
+- **CLAUDE.md**: Phase 11 完了、変更なし
 - **handoff サイズ**: 本ファイル（<500 行目標 OK）
 
 ## Issue Net 変化（CLAUDE.md KPI）
 
 ```
-Close 数: 2 件 (#278, #292)
-起票数: 1 件 (#299)
-Net: -1 件
+Close 数: 3 件 (#294, #290, #296)
+起票数: 0 件
+Net: -3 件
 ```
 
-✅ **Net ≤ 0 達成**。rating 5-6 の review agent 提案は全て PR コメント / 既存 Issue 追記で処理（PR #298 コメント参照）。起票した #299 は triage 基準 #1（実害: 記録したログが admin UI から見えない）+ #4（rating 7 confidence 85%）の両方を満たす。
+✅ **Net ≤ 0 達成**。rating 5-6 の review agent 提案は全て PR コメント / 既存 Issue 追記で処理。HIGH 指摘は PR 内で全修正。
 
 ## 作業ブランチ状態
 
 ```
-main: 0731191 feat(auth): 認証拒否ログを構造化 + 拒否理由を区別 (Issue #292) (#298)
+main: 19580e5 feat(auth): DELETE /super/admins を fail-closed 化 (Issue #296) (#303)
 
-docs/handoff-session-4-2026-04-22 (本ファイル更新用、PR 作成予定)
+docs/handoff-session-5-2026-04-22 (本ファイル更新用、PR 作成予定)
 ```
 
 main 直接 push なし、destructive 操作なし、残留 Node プロセスなし ✅。
 
 ## 参考: 今セッションで使った規範 / スキル
 
-- `/impl-plan` — Issue #292 の計画化（Phase 1-5 + Acceptance Criteria + Firestore 記録方式選択肢 A/B/C）
-- `/review-pr` (pr-review-toolkit) — 5 エージェント並列レビュー（silent-failure / test / type-design / code-review / comment）
-- `rules/quality-gate.md` — Evaluator 分離プロトコル発動条件（5 ファイル以上）→ `/review-pr` で代替実施
-- `feedback_pr_merge_authorization.md` — PR 番号単位で明示認可を受けてからマージ（#284, #298 両方ユーザー承認後にマージ）
-- `feedback_issue_triage.md` — 起票は triage 基準を満たす 1 件のみ、rating 5-6 は PR コメント / 既存 Issue 追記で対応
-- `rules/error-handling.md` §1 — エラーハンドラ自体のエラー耐性（recordSuperAdminAuthEvent の catch で元 payload 展開）
-- `rules/error-handling.md` §3 — transient/permanent 分類（Issue #290 関連コメントで記録、別 Issue 化せず統合判断）
+- `/catchup` — セッション開始時の状況確認 + 次のアクション提示
+- `/review-pr` (pr-review-toolkit) — 複数エージェント並列レビュー（PR #301 は 5 + 1 = 6 レビュー）
+- `/codex review` (MCP 版) — 大規模 PR (3 ファイル+ or 200 行+) のセカンドオピニオン。PR #301-#303 すべてで実施し、**PR #302 で Codex 単独 HIGH 発見 (K_SERVICE 抜け穴)**、他エージェントで検出できなかった観点をカバー
+- `rules/quality-gate.md` — Evaluator 分離プロトコル（PR #301 で発動、5 ファイル変更該当）
+- `feedback_pr_merge_authorization.md` — PR 番号単位で明示認可を受けてからマージ（#301/#302/#303 すべてユーザー承認後にマージ）
+- `feedback_issue_triage.md` — 新規起票ゼロで net -3 達成
+- `rules/error-handling.md` §1 — エラーハンドラ自体のエラー耐性（PR #303 の DELETE catch に構造化ログ後 500 返却）


### PR DESCRIPTION
## Summary
Session 5 の成果（3 PR 連続マージ）を `docs/handoff/LATEST.md` に反映。

- **マージ済**: PR #301 (#294), PR #302 (#290), PR #303 (#296)
- **Issue Net**: -3（Close 3 件 / 起票 0 件、CLAUDE.md KPI 準拠）
- **残 follow-up**: #290 の deploy.yml への `NODE_ENV=production` 明示追加（K_SERVICE フォールバックで HIGH 解消済み、defense-in-depth 用）

## Test plan
- [x] ドキュメントのみの変更（コード・設定変更なし）
- [x] 次セッション開始時の手順（`cat docs/handoff/LATEST.md` → `gh issue list`）が記載されていることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)