### PR TITLE
fix(e2e): PAUSE_TIMEOUT_MS 設定削除で CI フレーク解消

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
         AUTH_MODE: "dev",
         PORT: "8080",
         E2E_TEST_ENABLED: "true",
-        PAUSE_TIMEOUT_MS: "5000",
       },
     },
     {

--- a/e2e/tests/attendance-api.spec.ts
+++ b/e2e/tests/attendance-api.spec.ts
@@ -4,8 +4,11 @@
  *
  * e2e-test テナント（InMemoryDataSource, 書き込み可能）を使用。
  * PAUSE_TIMEOUT_MS はデフォルト（15分）を使用する。
- * 項目4（pause_timeout 強制退室）は CI では test.skip 済みのため、
- * 正常遷移テストが CI 遅延で 5秒超過して force-exit が発動するフレークを回避。
+ * 旧 PAUSE_TIMEOUT_MS=5000 設定では CI 遅延により正常遷移テスト
+ * （項目3/項目7）が force-exit を誤発動していたため、デフォルトに戻した。
+ * 項目4（pause_timeout 強制退室）は現在 test.skip 済み。CI で有効化する際は
+ * playwright.config.ts の webServer.env に PAUSE_TIMEOUT_MS=5000 を再注入する
+ * （video-events.ts:17 は起動時1回だけ env を読むため test.use() では届かない）。
  */
 
 import { test, expect } from "@playwright/test";

--- a/e2e/tests/attendance-api.spec.ts
+++ b/e2e/tests/attendance-api.spec.ts
@@ -3,7 +3,9 @@
  * Issue #157: QA手動検証の自動化
  *
  * e2e-test テナント（InMemoryDataSource, 書き込み可能）を使用。
- * PAUSE_TIMEOUT_MS=5000（5秒）でpause timeoutを高速テスト。
+ * PAUSE_TIMEOUT_MS はデフォルト（15分）を使用する。
+ * 項目4（pause_timeout 強制退室）は CI では test.skip 済みのため、
+ * 正常遷移テストが CI 遅延で 5秒超過して force-exit が発動するフレークを回避。
  */
 
 import { test, expect } from "@playwright/test";


### PR DESCRIPTION
## Summary
- main で 2026-04-22 から E2E Tests が 7連続 failure（`88a90cb` / PR #284 以降）
- `tests/attendance-api.spec.ts:138` の pause → play 状態遷移で 409 `session_force_exited` を受領
- `e2e/playwright.config.ts` の `PAUSE_TIMEOUT_MS: "5000"` が CI 遅延で force-exit 誤発動を引き起こしていたため削除

## 原因
PR #284（allowed_emails 継続的認可境界）で tenant-auth.ts の 4 箇所に毎リクエスト allowlist 再チェックを追加 → 各リクエストの処理時間が増加。

`PAUSE_TIMEOUT_MS=5000` は元々 **項目4（pause_timeout による force-exit 発動テスト）を高速化する目的** で設定されていたが、項目4 は Cloud Run デプロイタイミング不安定を理由に `test.skip` 済み（`attendance-api.spec.ts:250`）。したがって短縮設定は機能上不要になっていた。

一方、項目3（pause/play 状態遷移 正常系）および項目7（統合シナリオ）は `pause` → `play` のリクエスト間隔が 5秒を超えると `video-events.ts:180` の超過判定で 409 を返す。CI 環境で allowlist 再チェック追加により処理時間が増え、5秒を超過するケースが発生するようになった。

## 修正
- `e2e/playwright.config.ts`: `PAUSE_TIMEOUT_MS` 環境変数指定を削除（デフォルト 900000ms = 15分を使用）
- `e2e/tests/attendance-api.spec.ts`: ヘッダコメントを「デフォルト使用」へ更新

## 影響範囲
- 項目4（`test.skip` 状態）はそのまま。CI で pause_timeout を発動させる必要が出た際に個別対応
- E2E 全体の正常系テストが CI 遅延の影響を受けずに安定する

## Test plan
- [x] Lint PASS (`npm run lint`)
- [x] Type check PASS (4 workspaces `npm run type-check`)
- [ ] CI: `E2E Tests` workflow が緑になる（マージ前に確認）

## Related
- 失敗開始 commit: 88a90cb (#284)
- main で 7連続 failure: run 24760413832 〜 24763946609

🤖 Generated with [Claude Code](https://claude.com/claude-code)