### PR TITLE
feat(deploy): API ENV_VARS に NODE_ENV=production を明示 (Issue #290 follow-up)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,10 @@ jobs:
       - name: Deploy API to Cloud Run
         run: |
           # Build env vars string
-          ENV_VARS="DEMO_ENABLED=true,AUTH_MODE=firebase,CORS_ORIGIN=https://web-3zcica5euq-an.a.run.app,GOOGLE_WORKSPACE_ADMIN_EMAIL=system@279279.net"
+          # NODE_ENV=production は Issue #290 fail-safe (tenant-auth.ts/super-admin.ts の
+          # isProductionRuntime) の二重防御として明示。K_SERVICE 自動注入が効かないデプロイ
+          # 経路（ローカル再現等）でも本番判定が効くようにする。
+          ENV_VARS="NODE_ENV=production,DEMO_ENABLED=true,AUTH_MODE=firebase,CORS_ORIGIN=https://web-3zcica5euq-an.a.run.app,GOOGLE_WORKSPACE_ADMIN_EMAIL=system@279279.net"
           if [ -n "${{ secrets.SUPER_ADMIN_EMAILS }}" ]; then
             ENV_VARS="${ENV_VARS},SUPER_ADMIN_EMAILS=${{ secrets.SUPER_ADMIN_EMAILS }}"
           fi


### PR DESCRIPTION
## Summary
Issue #290（AUTH_MODE=dev fail-safe）で tenant-auth.ts / super-admin.ts に導入した `isProductionRuntime()` は `NODE_ENV=production` または `K_SERVICE` のいずれかで本番判定する fail-safe。K_SERVICE は Cloud Run が自動注入するため現状も有効だが、deploy.yml の `ENV_VARS` に `NODE_ENV=production` を明示して defense-in-depth を強化する。

## Why
- PR #302 merge 時点で `K_SERVICE` 依存の本番判定は効いているが、**ローカル再現・他デプロイ経路**（例: `gcloud run deploy` を CI 外から手動実行、将来的な GKE 移行等）では `K_SERVICE` が注入されない or 予期しない値になりうる
- `NODE_ENV=production` を明示しておけば二重防御。変更コストほぼゼロ（1 行追加）、副作用なし
- ログ/メトリクス側で `NODE_ENV` を dim にするライブラリにも parity で効く

## Scope
- `.github/workflows/deploy.yml` の API service deploy-step のみ
- web / notification はサーバサイド認証を持たないため対象外（本 PR では触らない）

## Test plan
- [x] Lint PASS (`npm run lint`)
- [x] YAML diff が意図通り（NODE_ENV=production 先頭追加 + コメントのみ）
- [ ] main マージ → API デプロイ後、Cloud Run コンソール or 以下で反映確認：
  ```
  gcloud run services describe api --region=asia-northeast1 \
    --format='value(spec.template.spec.containers[0].env)' | grep NODE_ENV
  ```

## Related
- Closes: #290 の follow-up（起票は無し、既存 Issue の補強）
- ベース PR: #302 (feat(auth): NODE_ENV=production で AUTH_MODE=firebase を必須化)
- ロジック側: `services/api/src/middleware/tenant-auth.ts:43-47`, `super-admin.ts:110-114`

🤖 Generated with [Claude Code](https://claude.com/claude-code)