### PR TITLE
fix(e2e): playwright test timeout を 60s → 180s に拡大（CI flake 解消）

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,9 +2,10 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
-  // CI の 1 リクエスト当たり 7-9 秒の遅延（要調査、Issue 別起票）で 60秒は不足。
+  // CI の 1 リクエスト当たり 7-9 秒の遅延（Issue #308 で根本調査中）で 60秒は不足。
   // 項目3/7 等のマルチリクエスト test が 60秒を超えて Request context disposed に
   // なるのを回避するため 180秒に拡大。ローカルは fast path で影響なし。
+  // webServer.timeout (60000) は起動タイムアウトで据え置き — test timeout と意図的な差分。
   timeout: 180000,
   retries: 1,
   use: {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
-  timeout: 60000,
+  // CI の 1 リクエスト当たり 7-9 秒の遅延（要調査、Issue 別起票）で 60秒は不足。
+  // 項目3/7 等のマルチリクエスト test が 60秒を超えて Request context disposed に
+  // なるのを回避するため 180秒に拡大。ローカルは fast path で影響なし。
+  timeout: 180000,
   retries: 1,
   use: {
     baseURL: "http://localhost:3000",


### PR DESCRIPTION
## Summary
PR #305 で 409 `session_force_exited` は解消したが、main E2E Tests は別のエラー `apiRequestContext.get: Request context disposed` で failure。Playwright の test timeout 60秒を超過していたため 180秒に拡大する。

## 原因
- PR #305 で pause/play timeout 誤発動は解消済み（`attendance-api.spec.ts:138` の 409 は消失）
- 新たな failure: `attendance-api.spec.ts:151:37` の `request.get(...)` で `Request context disposed`
- CI ログから 1 リクエスト当たり 7-9 秒の遅延（PR #284 allowed_emails 毎リクエスト再チェック以降顕著）
- 項目3（pause/play 状態遷移）/ 項目7（統合シナリオ）は `beforeEach` + 4-6 リクエスト = 60秒に近づく
- Playwright の test timeout 60秒で context が dispose、その後の request は失敗

## 修正
- `e2e/playwright.config.ts` の `timeout: 60000` → `180000`（3分）
- ローカル実行は fast path のため影響なし（1テストあたり通常数秒）

## スコープ外（別 Issue で対応）
**CI リクエスト遅延の根本調査**（P2、性能課題）
- 7-9 秒/request は明らかに異常
- allowed_emails 再チェックの O(n) スキャン / in-memory 初期化時間 / logging オーバーヘッドなどの切り分け
- 別 Issue を本 PR マージと同時に起票予定

## Test plan
- [x] Lint PASS
- [x] Type check PASS
- [ ] main マージ後に E2E Tests workflow が緑になる

## Related
- 先行 PR: #305 (`fix(e2e): PAUSE_TIMEOUT_MS 設定削除で CI フレーク解消`)
- 関連 PR: #284 (`fix(auth): allowed_emails 継続的認可境界の実装`) — CI 遅延の元凶と推定
- 根本原因 Issue（起票予定）: CI リクエスト遅延のプロファイリング

## 注意
CLAUDE.md Debug Protocol「同一機能に対するバグ修正 PR が 3件連続 → 元 PR の設計を再レビュー」に **2件目**。#305 と本 PR でそれぞれ別のエラーを解消しているが、次に新たなエラーが出た場合は allowlist 再チェック全体の設計レビューに入る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)