### PR TITLE
feat(super-admin): platform_auth_error_logs 読み取り API 追加 (Issue #299)

### DIFF
--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -120,8 +120,8 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 #### Phase 1 の制約（次 Issue で拡張予定）
 - ~~`platform_auth_error_logs` を **admin UI から参照する経路は未実装**。Phase 1 では Cloud Logging（`logger.warn/error` の構造化出力）経由で確認する前提~~
 - ~~`getPlatformAuthErrorLogs()` / super-admin 画面 UI は別 Issue で追加（PR #298 code-reviewer H1 指摘）~~
-- **Issue #299 で解消（2026-04-22）**: `DataSource.getPlatformAuthErrorLogs()` を I/F / Firestore / InMemory の 3 実装に追加し、`GET /api/v2/super/platform/auth-errors` (super-admin のみ) で admin API 経由の読み取りが可能になった。FE 管理画面 UI は引き続き別 Issue
-- `SuperAdminFirestoreUnavailableError` の transient (`unavailable`/`deadline-exceeded`) と permanent (`permission-denied` 等) の区別は現状未実装。すべて 503 を返すが、permanent は 500 相当（別 Issue 推奨）
+- **Issue #299 で解消（2026-04-22）**: `DataSource.getPlatformAuthErrorLogs()` を I/F / Firestore / InMemory の 3 実装に追加し、`GET /api/v2/super/platform/auth-errors` (super-admin のみ) で admin API 経由の読み取りが可能になった。FE 管理画面 UI は引き続き別 Issue。Firestore 複合 index `(email ASC, occurredAt DESC)` を宣言し、`email` equality + `occurredAt` range/orderBy の組み合わせクエリに対応
+- `SuperAdminFirestoreUnavailableError` の transient (`unavailable`/`deadline-exceeded`) と permanent (`permission-denied` 等) の区別は現状未実装。すべて 503 を返すが、permanent は 500 相当（**Issue #310 で対応予定**。`/platform/auth-errors` も同じ事情で一律 500 `fetch_failed` を返す）
 - `tenant-auth.ts:checkSuperAdmin` が `SuperAdminFirestoreUnavailableError` も false fallback に潰している点（Issue #293 の silent 権限剥奪を tenant 経路では部分的に残す）も別 Issue で対応
 
 ### UID保持戦略

--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -118,8 +118,9 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 - `firebaseErrorCode: string | null`（403 等の分岐では null、catch 節で Firebase SDK エラーコードを格納）
 
 #### Phase 1 の制約（次 Issue で拡張予定）
-- `platform_auth_error_logs` を **admin UI から参照する経路は未実装**。Phase 1 では Cloud Logging（`logger.warn/error` の構造化出力）経由で確認する前提
-- `getPlatformAuthErrorLogs()` / super-admin 画面 UI は別 Issue で追加（PR #298 code-reviewer H1 指摘）
+- ~~`platform_auth_error_logs` を **admin UI から参照する経路は未実装**。Phase 1 では Cloud Logging（`logger.warn/error` の構造化出力）経由で確認する前提~~
+- ~~`getPlatformAuthErrorLogs()` / super-admin 画面 UI は別 Issue で追加（PR #298 code-reviewer H1 指摘）~~
+- **Issue #299 で解消（2026-04-22）**: `DataSource.getPlatformAuthErrorLogs()` を I/F / Firestore / InMemory の 3 実装に追加し、`GET /api/v2/super/platform/auth-errors` (super-admin のみ) で admin API 経由の読み取りが可能になった。FE 管理画面 UI は引き続き別 Issue
 - `SuperAdminFirestoreUnavailableError` の transient (`unavailable`/`deadline-exceeded`) と permanent (`permission-denied` 等) の区別は現状未実装。すべて 503 を返すが、permanent は 500 相当（別 Issue 推奨）
 - `tenant-auth.ts:checkSuperAdmin` が `SuperAdminFirestoreUnavailableError` も false fallback に潰している点（Issue #293 の silent 権限剥奪を tenant 経路では部分的に残す）も別 Issue で対応
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -299,3 +299,48 @@
   }
 }
 ```
+
+
+### プラットフォーム認証エラーログ（Super Admin）
+
+ベースURL: `/api/v2/super/`
+
+super-admin 経路の認証拒否（tenant スコープ外）を root コレクション `platform_auth_error_logs` に記録し、同ルートから参照する。tenant-scoped `/admin/auth-errors` と分離されている（ADR-031）。
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/platform/auth-errors` | プラットフォーム認証エラーログ一覧取得（super-admin のみ） |
+
+#### クエリパラメータ
+- `email`（任意）: メールアドレス完全一致フィルタ
+- `startDate`（任意）: ISO 8601 日時。不正値は 400 `invalid_start_date`
+- `endDate`（任意）: ISO 8601 日時。不正値は 400 `invalid_end_date`。`startDate > endDate` は空配列を返す
+- `limit`（任意）: 1〜500（デフォルト 100、範囲外は clamp、不正値は 100）
+
+```json
+// GET /platform/auth-errors レスポンス（200）
+{
+  "platformAuthErrorLogs": [
+    {
+      "id": "abc123",
+      "email": "denied@example.com",
+      "tenantId": "__platform__",
+      "errorType": "super_admin_denied",
+      "reason": "not_super_admin",
+      "errorMessage": "Email not registered as super admin",
+      "path": "/api/v2/super/tenants",
+      "method": "GET",
+      "userAgent": null,
+      "ipAddress": null,
+      "firebaseErrorCode": null,
+      "occurredAt": "2026-04-22T12:00:00.000Z"
+    }
+  ]
+}
+```
+
+#### 認可
+- `superAdminAuthMiddleware` 配下。非 super-admin は 403 `{ error: "forbidden" }`
+- 認証欠落は 401 `{ error: "unauthorized" }`
+
+関連 Issue: #292（記録側）、#299（読み取り側）

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -172,6 +172,14 @@
       ]
     },
     {
+      "collectionGroup": "platform_auth_error_logs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "email", "order": "ASCENDING" },
+        { "fieldPath": "occurredAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "lesson_sessions",
       "queryScope": "COLLECTION",
       "fields": [

--- a/services/api/src/datasource/__tests__/firestore-platform-auth-error-log.test.ts
+++ b/services/api/src/datasource/__tests__/firestore-platform-auth-error-log.test.ts
@@ -115,3 +115,117 @@ describe("FirestoreDataSource.createPlatformAuthErrorLog (Issue #292)", () => {
     expect(result.reason).toBe("not_super_admin");
   });
 });
+
+/**
+ * Issue #299: FirestoreDataSource.getPlatformAuthErrorLogs の直接テスト
+ *
+ * 確認対象（AC4 Firestore 実装は root collection 参照、tenant 非参照）:
+ *   - 読み取り先が `platform_auth_error_logs`（root コレクション）であること
+ *   - `tenants/` プレフィックス配下を参照していないこと
+ *   - orderBy("occurredAt", "desc") が呼ばれること
+ *   - filter (email / startDate / endDate / limit) で where/limit が呼ばれること
+ *   - Firestore Timestamp → ISO string 変換が通ること
+ */
+function buildMockQueryDb(docs: Array<{ id: string; data: Record<string, unknown> }>) {
+  const snapshot = {
+    docs: docs.map(({ id, data }) => ({
+      id,
+      data: () => data,
+    })),
+  };
+  const limitMock = vi.fn().mockReturnThis();
+  const whereMock = vi.fn().mockReturnThis();
+  const orderByMock = vi.fn().mockReturnThis();
+  const getMock = vi.fn().mockResolvedValue(snapshot);
+  const query = {
+    where: whereMock,
+    orderBy: orderByMock,
+    limit: limitMock,
+    get: getMock,
+  };
+  // orderBy is the entry point; all chain methods return `query`
+  const collectionMock = vi.fn().mockReturnValue(query);
+  const db = { collection: collectionMock } as unknown as Firestore;
+  return { db, collectionMock, whereMock, orderByMock, limitMock, getMock };
+}
+
+describe("FirestoreDataSource.getPlatformAuthErrorLogs (Issue #299)", () => {
+  it("ルートコレクション `platform_auth_error_logs` を参照する（tenant 非参照）", async () => {
+    const mock = buildMockQueryDb([]);
+    const ds = new FirestoreDataSource(mock.db, "acme");
+    await ds.getPlatformAuthErrorLogs();
+
+    expect(mock.collectionMock).toHaveBeenCalledTimes(1);
+    expect(mock.collectionMock).toHaveBeenCalledWith("platform_auth_error_logs");
+    const collectionCalls = mock.collectionMock.mock.calls.map((c) => c[0] as string);
+    expect(collectionCalls.some((name) => name.startsWith("tenants/"))).toBe(false);
+  });
+
+  it("orderBy(occurredAt desc) + limit(デフォルト 100) を呼ぶ", async () => {
+    const mock = buildMockQueryDb([]);
+    const ds = new FirestoreDataSource(mock.db, "__platform__");
+    await ds.getPlatformAuthErrorLogs();
+
+    expect(mock.orderByMock).toHaveBeenCalledWith("occurredAt", "desc");
+    expect(mock.limitMock).toHaveBeenCalledWith(100);
+  });
+
+  it("email filter で where('email', '==', X) を呼ぶ", async () => {
+    const mock = buildMockQueryDb([]);
+    const ds = new FirestoreDataSource(mock.db, "__platform__");
+    await ds.getPlatformAuthErrorLogs({ email: "denied@example.com" });
+
+    expect(mock.whereMock).toHaveBeenCalledWith("email", "==", "denied@example.com");
+  });
+
+  it("startDate/endDate filter で where('occurredAt', '>=' | '<=', Timestamp) を呼ぶ", async () => {
+    const mock = buildMockQueryDb([]);
+    const ds = new FirestoreDataSource(mock.db, "__platform__");
+    const startDate = new Date("2026-04-20T00:00:00.000Z");
+    const endDate = new Date("2026-04-23T00:00:00.000Z");
+    await ds.getPlatformAuthErrorLogs({ startDate, endDate });
+
+    const occurredAtCalls = mock.whereMock.mock.calls.filter((c) => c[0] === "occurredAt");
+    expect(occurredAtCalls).toHaveLength(2);
+    expect(occurredAtCalls[0][1]).toBe(">=");
+    expect(occurredAtCalls[0][2]).toBeInstanceOf(Timestamp);
+    expect(occurredAtCalls[1][1]).toBe("<=");
+    expect(occurredAtCalls[1][2]).toBeInstanceOf(Timestamp);
+  });
+
+  it("limit 明示指定で limit(N) を呼ぶ", async () => {
+    const mock = buildMockQueryDb([]);
+    const ds = new FirestoreDataSource(mock.db, "__platform__");
+    await ds.getPlatformAuthErrorLogs({ limit: 50 });
+
+    expect(mock.limitMock).toHaveBeenCalledWith(50);
+  });
+
+  it("Timestamp を ISO string に変換して AuthErrorLog を返す", async () => {
+    const mock = buildMockQueryDb([
+      {
+        id: "log-1",
+        data: {
+          email: "denied@example.com",
+          tenantId: "__platform__",
+          errorType: "super_admin_denied",
+          reason: "not_super_admin",
+          errorMessage: "msg",
+          path: "/admin",
+          method: "GET",
+          userAgent: "curl",
+          ipAddress: "10.0.0.1",
+          firebaseErrorCode: null,
+          occurredAt: Timestamp.fromDate(new Date("2026-04-22T12:00:00.000Z")),
+        },
+      },
+    ]);
+    const ds = new FirestoreDataSource(mock.db, "__platform__");
+    const logs = await ds.getPlatformAuthErrorLogs();
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].id).toBe("log-1");
+    expect(logs[0].email).toBe("denied@example.com");
+    expect(logs[0].occurredAt).toBe("2026-04-22T12:00:00.000Z");
+  });
+});

--- a/services/api/src/datasource/__tests__/in-memory.test.ts
+++ b/services/api/src/datasource/__tests__/in-memory.test.ts
@@ -839,5 +839,25 @@ describe("InMemoryDataSource", () => {
       const logs = await ds.getPlatformAuthErrorLogs();
       expect(logs).toEqual([]);
     });
+
+    it("NaN startDate は throw（silent drop を防ぐ）", async () => {
+      await expect(
+        ds.getPlatformAuthErrorLogs({ startDate: new Date("invalid") })
+      ).rejects.toThrow(/invalid startDate/);
+    });
+
+    it("NaN endDate は throw（silent drop を防ぐ）", async () => {
+      await expect(
+        ds.getPlatformAuthErrorLogs({ endDate: new Date("invalid") })
+      ).rejects.toThrow(/invalid endDate/);
+    });
+
+    it("limit < 1 はデフォルト 100 にフォールバック", async () => {
+      for (let i = 0; i < 3; i++) {
+        await ds.createPlatformAuthErrorLog({ ...baseLog, occurredAt: `2026-04-22T1${i}:00:00.000Z` });
+      }
+      const logs = await ds.getPlatformAuthErrorLogs({ limit: -1 });
+      expect(logs).toHaveLength(3); // 3 件 < 100 なので全件
+    });
   });
 });

--- a/services/api/src/datasource/__tests__/in-memory.test.ts
+++ b/services/api/src/datasource/__tests__/in-memory.test.ts
@@ -747,4 +747,97 @@ describe("InMemoryDataSource", () => {
       expect(result).toBe(false);
     });
   });
+
+  // -----------------------------------------------
+  // PlatformAuthErrorLog (Issue #299)
+  // -----------------------------------------------
+
+  describe("PlatformAuthErrorLog", () => {
+    let ds: InMemoryDataSource;
+
+    const baseLog = {
+      email: "denied@example.com",
+      tenantId: "__platform__",
+      errorType: "super_admin_denied",
+      reason: "not_super_admin" as string | null,
+      errorMessage: "not registered",
+      path: "/api/v2/super/tenants",
+      method: "GET",
+      userAgent: null as string | null,
+      ipAddress: null as string | null,
+      firebaseErrorCode: null as string | null,
+      occurredAt: "2026-04-22T12:00:00.000Z",
+    };
+
+    beforeEach(() => {
+      ds = new InMemoryDataSource({ readOnly: false });
+    });
+
+    it("createPlatformAuthErrorLog で書いた log が getPlatformAuthErrorLogs で読める（read-after-write）", async () => {
+      await ds.createPlatformAuthErrorLog(baseLog);
+      const logs = await ds.getPlatformAuthErrorLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0].email).toBe("denied@example.com");
+      expect(logs[0].id).toMatch(/^platform-auth-error-/);
+    });
+
+    it("getPlatformAuthErrorLogs は occurredAt 降順で返す", async () => {
+      await ds.createPlatformAuthErrorLog({ ...baseLog, occurredAt: "2026-04-22T10:00:00.000Z" });
+      await ds.createPlatformAuthErrorLog({ ...baseLog, occurredAt: "2026-04-22T12:00:00.000Z" });
+      await ds.createPlatformAuthErrorLog({ ...baseLog, occurredAt: "2026-04-22T11:00:00.000Z" });
+
+      const logs = await ds.getPlatformAuthErrorLogs();
+      expect(logs.map((l) => l.occurredAt)).toEqual([
+        "2026-04-22T12:00:00.000Z",
+        "2026-04-22T11:00:00.000Z",
+        "2026-04-22T10:00:00.000Z",
+      ]);
+    });
+
+    it("email filter は完全一致", async () => {
+      await ds.createPlatformAuthErrorLog({ ...baseLog, email: "a@example.com" });
+      await ds.createPlatformAuthErrorLog({ ...baseLog, email: "b@example.com" });
+
+      const logs = await ds.getPlatformAuthErrorLogs({ email: "a@example.com" });
+      expect(logs).toHaveLength(1);
+      expect(logs[0].email).toBe("a@example.com");
+    });
+
+    it("startDate/endDate filter は inclusive で範囲外を除外", async () => {
+      await ds.createPlatformAuthErrorLog({ ...baseLog, occurredAt: "2026-04-20T00:00:00.000Z" });
+      await ds.createPlatformAuthErrorLog({ ...baseLog, occurredAt: "2026-04-21T00:00:00.000Z" });
+      await ds.createPlatformAuthErrorLog({ ...baseLog, occurredAt: "2026-04-23T00:00:00.000Z" });
+
+      const logs = await ds.getPlatformAuthErrorLogs({
+        startDate: new Date("2026-04-21T00:00:00.000Z"),
+        endDate: new Date("2026-04-22T00:00:00.000Z"),
+      });
+      expect(logs).toHaveLength(1);
+      expect(logs[0].occurredAt).toBe("2026-04-21T00:00:00.000Z");
+    });
+
+    it("startDate > endDate は空配列", async () => {
+      await ds.createPlatformAuthErrorLog({ ...baseLog, occurredAt: "2026-04-22T00:00:00.000Z" });
+      const logs = await ds.getPlatformAuthErrorLogs({
+        startDate: new Date("2026-04-25T00:00:00.000Z"),
+        endDate: new Date("2026-04-20T00:00:00.000Z"),
+      });
+      expect(logs).toEqual([]);
+    });
+
+    it("limit で件数制限（降順で最新を残す）", async () => {
+      for (let i = 0; i < 5; i++) {
+        await ds.createPlatformAuthErrorLog({ ...baseLog, occurredAt: `2026-04-22T1${i}:00:00.000Z` });
+      }
+      const logs = await ds.getPlatformAuthErrorLogs({ limit: 2 });
+      expect(logs).toHaveLength(2);
+      expect(logs[0].occurredAt).toBe("2026-04-22T14:00:00.000Z");
+      expect(logs[1].occurredAt).toBe("2026-04-22T13:00:00.000Z");
+    });
+
+    it("空結果時は空配列を返す", async () => {
+      const logs = await ds.getPlatformAuthErrorLogs();
+      expect(logs).toEqual([]);
+    });
+  });
 });

--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -610,7 +610,10 @@ export class FirestoreDataSource implements DataSource {
   /**
    * プラットフォーム（テナント非依存）認証エラーログを取得 (Issue #299)
    * ルートコレクション `platform_auth_error_logs` から `occurredAt desc` で取得。
-   * tenant 用 `auth_error_logs` (collection path は `this.collection(...)` 経由) には一切触らない。
+   * tenant-scoped `auth_error_logs` には触らない（境界を混ぜない）。
+   *
+   * 複合 index: `(email ASC, occurredAt DESC)` を `firestore.indexes.json` に宣言。
+   * `email` equality + `occurredAt` range/orderBy の組み合わせに必要。
    */
   async getPlatformAuthErrorLogs(filter?: AuthErrorLogFilter): Promise<AuthErrorLog[]> {
     let query = this.db.collection("platform_auth_error_logs").orderBy("occurredAt", "desc");

--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -607,6 +607,35 @@ export class FirestoreDataSource implements DataSource {
     return { ...data, id: docRef.id };
   }
 
+  /**
+   * プラットフォーム（テナント非依存）認証エラーログを取得 (Issue #299)
+   * ルートコレクション `platform_auth_error_logs` から `occurredAt desc` で取得。
+   * tenant 用 `auth_error_logs` (collection path は `this.collection(...)` 経由) には一切触らない。
+   */
+  async getPlatformAuthErrorLogs(filter?: AuthErrorLogFilter): Promise<AuthErrorLog[]> {
+    let query = this.db.collection("platform_auth_error_logs").orderBy("occurredAt", "desc");
+
+    if (filter?.email) {
+      query = query.where("email", "==", filter.email);
+    }
+    if (filter?.startDate) {
+      query = query.where("occurredAt", ">=", Timestamp.fromDate(filter.startDate));
+    }
+    if (filter?.endDate) {
+      query = query.where("occurredAt", "<=", Timestamp.fromDate(filter.endDate));
+    }
+
+    const limit = filter?.limit ?? 100;
+    query = query.limit(limit);
+
+    const snapshot = await query.get();
+    return mapDocsResilient(
+      snapshot.docs,
+      (id, data) => this.toAuthErrorLog(id, data),
+      "PlatformAuthErrorLog",
+    );
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private toAuthErrorLog(id: string, data: any): AuthErrorLog {
     return {

--- a/services/api/src/datasource/in-memory.ts
+++ b/services/api/src/datasource/in-memory.ts
@@ -599,8 +599,8 @@ export class InMemoryDataSource implements DataSource {
 
   /**
    * プラットフォーム（テナント非依存）認証エラーログを作成 (Issue #292)
-   * Issue #299 以降は in-memory 配列に push して `getPlatformAuthErrorLogs`
-   * で読み取れるようにする（統合テストで read-after-write を再現するため）。
+   * 統合テストで read-after-write を再現するため、配列に push して
+   * `getPlatformAuthErrorLogs` から読める状態にする。
    */
   async createPlatformAuthErrorLog(data: Omit<AuthErrorLog, "id">): Promise<AuthErrorLog> {
     this.throwIfReadOnly();
@@ -616,8 +616,19 @@ export class InMemoryDataSource implements DataSource {
    * プラットフォーム（テナント非依存）認証エラーログを取得 (Issue #299)
    * in-memory 配列から occurredAt 降順で返す。tenant-scoped `auth_error_logs`
    * には触らない。
+   *
+   * 無効な Date (`new Date("invalid")` で `NaN`) は route 層で 400 にしているが、
+   * 直接呼び出し経路での silent drop（`NaN >= NaN` が常に false で結果が空配列化）
+   * を防ぐため、DataSource 層でも明示的に throw する。
    */
   async getPlatformAuthErrorLogs(filter?: AuthErrorLogFilter): Promise<AuthErrorLog[]> {
+    if (filter?.startDate && Number.isNaN(filter.startDate.getTime())) {
+      throw new Error("InMemoryDataSource.getPlatformAuthErrorLogs: invalid startDate (NaN)");
+    }
+    if (filter?.endDate && Number.isNaN(filter.endDate.getTime())) {
+      throw new Error("InMemoryDataSource.getPlatformAuthErrorLogs: invalid endDate (NaN)");
+    }
+
     let result = [...this.platformAuthErrorLogs];
 
     if (filter?.email) {
@@ -634,8 +645,8 @@ export class InMemoryDataSource implements DataSource {
 
     result.sort((a, b) => new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime());
 
-    // route 層で clamp 済みの値が渡る前提だが、直接呼び出し経路の誤用（負数で
-    // slice(0, -1) → 末尾1件欠落）を防ぐため DataSource 内でもガードする。
+    // 直接呼び出し経路の誤用（負数で slice(0, -1) → 末尾1件欠落）を防ぐため
+    // DataSource 内でも limit をガードする。route 経由では既に clamp 済み。
     const rawLimit = filter?.limit ?? 100;
     const limit = rawLimit < 1 ? 100 : rawLimit;
     return result.slice(0, limit);

--- a/services/api/src/datasource/in-memory.ts
+++ b/services/api/src/datasource/in-memory.ts
@@ -634,7 +634,10 @@ export class InMemoryDataSource implements DataSource {
 
     result.sort((a, b) => new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime());
 
-    const limit = filter?.limit ?? 100;
+    // route 層で clamp 済みの値が渡る前提だが、直接呼び出し経路の誤用（負数で
+    // slice(0, -1) → 末尾1件欠落）を防ぐため DataSource 内でもガードする。
+    const rawLimit = filter?.limit ?? 100;
+    const limit = rawLimit < 1 ? 100 : rawLimit;
     return result.slice(0, limit);
   }
 

--- a/services/api/src/datasource/in-memory.ts
+++ b/services/api/src/datasource/in-memory.ts
@@ -194,6 +194,7 @@ export class InMemoryDataSource implements DataSource {
   private users: User[] = [...initialUsers];
   private notificationPolicies: NotificationPolicy[] = [...initialNotificationPolicies];
   private allowedEmails: AllowedEmail[] = [...initialAllowedEmails];
+  private platformAuthErrorLogs: AuthErrorLog[] = [];
   private userSettings: Map<string, UserSettings> = new Map();
   private videos: Video[] = [];
   private videoEvents: VideoEvent[] = [];
@@ -598,14 +599,43 @@ export class InMemoryDataSource implements DataSource {
 
   /**
    * プラットフォーム（テナント非依存）認証エラーログを作成 (Issue #292)
-   * InMemory ではテスト時の spy 対象として返却のみ行う（永続化なし）。
+   * Issue #299 以降は in-memory 配列に push して `getPlatformAuthErrorLogs`
+   * で読み取れるようにする（統合テストで read-after-write を再現するため）。
    */
   async createPlatformAuthErrorLog(data: Omit<AuthErrorLog, "id">): Promise<AuthErrorLog> {
     this.throwIfReadOnly();
-    return {
+    const log: AuthErrorLog = {
       ...data,
       id: InMemoryDataSource.uniqueId("platform-auth-error"),
     };
+    this.platformAuthErrorLogs.push(log);
+    return log;
+  }
+
+  /**
+   * プラットフォーム（テナント非依存）認証エラーログを取得 (Issue #299)
+   * in-memory 配列から occurredAt 降順で返す。tenant-scoped `auth_error_logs`
+   * には触らない。
+   */
+  async getPlatformAuthErrorLogs(filter?: AuthErrorLogFilter): Promise<AuthErrorLog[]> {
+    let result = [...this.platformAuthErrorLogs];
+
+    if (filter?.email) {
+      result = result.filter((log) => log.email === filter.email);
+    }
+    if (filter?.startDate) {
+      const startMs = filter.startDate.getTime();
+      result = result.filter((log) => new Date(log.occurredAt).getTime() >= startMs);
+    }
+    if (filter?.endDate) {
+      const endMs = filter.endDate.getTime();
+      result = result.filter((log) => new Date(log.occurredAt).getTime() <= endMs);
+    }
+
+    result.sort((a, b) => new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime());
+
+    const limit = filter?.limit ?? 100;
+    return result.slice(0, limit);
   }
 
   // User Settings

--- a/services/api/src/datasource/interface.ts
+++ b/services/api/src/datasource/interface.ts
@@ -133,6 +133,18 @@ export interface DataSource {
    */
   createPlatformAuthErrorLog(data: Omit<AuthErrorLog, "id">): Promise<AuthErrorLog>;
 
+  /**
+   * プラットフォーム（テナント非依存）認証エラーログを取得 (Issue #299)
+   *
+   * ルートコレクション `platform_auth_error_logs` を `occurredAt` 降順で返す。
+   * tenant スコープの `auth_error_logs` には触らない（境界を混ぜない）。
+   * super-admin 専用 API (`GET /api/v2/super/platform/auth-errors`) から呼び出される。
+   *
+   * filter の `email` / `startDate` / `endDate` / `limit` は `getAuthErrorLogs` と同じ意味論。
+   * `startDate > endDate` の場合は空配列を返す（400 を返さず、クライアント側の意図に委ねる）。
+   */
+  getPlatformAuthErrorLogs(filter?: AuthErrorLogFilter): Promise<AuthErrorLog[]>;
+
   // User Settings
   getUserSettings(userId: string): Promise<UserSettings | null>;
   upsertUserSettings(userId: string, data: Partial<UserSettings>): Promise<UserSettings>;

--- a/services/api/src/routes/__tests__/super-admin-platform-auth-errors.test.ts
+++ b/services/api/src/routes/__tests__/super-admin-platform-auth-errors.test.ts
@@ -181,10 +181,8 @@ describe("GET /api/v2/super/platform/auth-errors (Issue #299)", () => {
     expect(res.body.platformAuthErrorLogs).toEqual([]);
   });
 
-  it("AC9: limit 上限 (500) 超過は clamp", async () => {
+  it("AC9: limit 明示指定 (1) で 1 件のみ返る", async () => {
     // super@example.com は env fast path で super-admin 判定される
-    // limit=501 が clamp されていることは query で確認（500 件以上は生成コストが高いのでロジック確認のみ）
-    // ds に 3 件だけ入れ、limit=1 で 1 件返ることを確認（clamp の逆方向）
     await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-22T10:00:00.000Z" }));
     await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-22T11:00:00.000Z" }));
     await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-22T12:00:00.000Z" }));
@@ -196,6 +194,23 @@ describe("GET /api/v2/super/platform/auth-errors (Issue #299)", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.platformAuthErrorLogs).toHaveLength(1);
+  });
+
+  it("AC9: limit=501 は 500 に clamp される（HTTP 端点）", async () => {
+    // 501 件作成して clamp 動作を実測
+    for (let i = 0; i < 501; i++) {
+      const hour = String(Math.floor(i / 60)).padStart(2, "0");
+      const min = String(i % 60).padStart(2, "0");
+      await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: `2026-04-22T${hour}:${min}:00.000Z` }));
+    }
+
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors?limit=501")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body.platformAuthErrorLogs).toHaveLength(500);
   });
 
   it("AC9: limit 不正値 (文字列 abc) は 100 にフォールバック", async () => {
@@ -236,7 +251,7 @@ describe("GET /api/v2/super/platform/auth-errors (Issue #299)", () => {
 
   it("AC12: response は PII (email) を含むが、super-admin のみアクセス可能 (AC3 の裏付け)", async () => {
     // super@example.com は env fast path で super-admin 判定される
-    await ds.createPlatformAuthErrorLog(makeLog({ email: "pii@example.com" }));
+    await ds.createPlatformAuthErrorLog(makeLog({ email: "pii@example.com", firebaseErrorCode: "auth/id-token-revoked" }));
 
     const app = await buildApp(ds);
     const res = await supertest(app)
@@ -246,6 +261,24 @@ describe("GET /api/v2/super/platform/auth-errors (Issue #299)", () => {
     expect(res.status).toBe(200);
     const logs = res.body.platformAuthErrorLogs as AuthErrorLog[];
     expect(logs[0].email).toBe("pii@example.com");
-    expect(logs[0].firebaseErrorCode).toBeDefined();
+    expect(logs[0].firebaseErrorCode).toBe("auth/id-token-revoked");
+  });
+
+  it("DataSource 障害時は 500 fetch_failed を返す（evaluator 指摘）", async () => {
+    // super@example.com は env fast path で super-admin 判定される
+    // getPlatformAuthErrorLogs を reject させる
+    const brokenDs = {
+      ...ds,
+      getPlatformAuthErrorLogs: vi.fn().mockRejectedValue(new Error("Firestore unavailable")),
+      createPlatformAuthErrorLog: ds.createPlatformAuthErrorLog.bind(ds),
+    } as unknown as InMemoryDataSource;
+
+    const app = await buildApp(brokenDs);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("fetch_failed");
   });
 });

--- a/services/api/src/routes/__tests__/super-admin-platform-auth-errors.test.ts
+++ b/services/api/src/routes/__tests__/super-admin-platform-auth-errors.test.ts
@@ -1,0 +1,251 @@
+/**
+ * GET /api/v2/super/platform/auth-errors (routes/super-admin.ts) の統合テスト
+ *
+ * Issue #299: platform_auth_error_logs の admin UI/API 読み取り経路追加
+ *
+ * 確認対象:
+ *   - AC2: super-admin は 200 + { platformAuthErrorLogs: [...] } を日時降順で取得
+ *   - AC3: 非 super-admin は 403 (既存 superAdminAuthMiddleware 経由)
+ *   - AC5: filter (email / startDate / endDate / limit) が機能
+ *   - AC6: invalid startDate → 400 invalid_start_date
+ *   - AC7: invalid endDate → 400 invalid_end_date
+ *   - AC8: startDate > endDate → 空配列（400 を返さない）
+ *   - AC9: limit clamp (1-500, デフォルト 100, 不正値は 100)
+ *   - AC10: 空結果 → 200 + { platformAuthErrorLogs: [] }
+ *   - AC12: PII (email) は super-admin のみに返す（AC3 の裏付け）
+ *
+ * dev モード (X-User-Email ヘッダ + isSuperAdmin mock) で境界を検証する。
+ * Firebase モードは既存の tenants.test.ts / help-role.test.ts と同じパターンで
+ * verifyIdToken が走るため、本テストはスコープ外とする（別 Issue 起票可）。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import supertest from "supertest";
+import { InMemoryDataSource } from "../../datasource/in-memory.js";
+import type { AuthErrorLog } from "../../types/entities.js";
+
+const PLATFORM_TENANT_ID = "__platform__";
+
+// firebase-admin/firestore を mock: superAdmins コレクションは空で返す
+// → isSuperAdmin の env fast path (SUPER_ADMIN_EMAILS) のみで判定させる
+const mockGetDocs = vi.fn().mockResolvedValue({ docs: [] });
+vi.mock("firebase-admin/firestore", () => {
+  const makeFirestore = () => ({
+    collection: () => ({
+      get: mockGetDocs,
+    }),
+  });
+  return {
+    getFirestore: () => makeFirestore(),
+    Timestamp: {
+      fromDate: (d: Date) => ({ toDate: () => d, seconds: Math.floor(d.getTime() / 1000), nanoseconds: 0 }),
+    },
+  };
+});
+
+// vi.resetModules() 後に platform-datasource の cached も null に戻るため、
+// 各 test で buildApp 内で dynamic import + 注入する必要がある（module singleton の罠）。
+async function buildApp(ds: InMemoryDataSource) {
+  const { superAdminRouter } = await import("../super-admin.js");
+  const { setPlatformDataSourceForTest } = await import("../../middleware/platform-datasource.js");
+  setPlatformDataSourceForTest(ds);
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v2/super", superAdminRouter);
+  return app;
+}
+
+function makeLog(overrides: Partial<AuthErrorLog> = {}): Omit<AuthErrorLog, "id"> {
+  return {
+    email: "denied@example.com",
+    tenantId: PLATFORM_TENANT_ID,
+    errorType: "super_admin_denied",
+    reason: "not_super_admin",
+    errorMessage: "Email not registered as super admin",
+    path: "/api/v2/super/tenants",
+    method: "GET",
+    userAgent: null,
+    ipAddress: null,
+    firebaseErrorCode: null,
+    occurredAt: "2026-04-22T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("GET /api/v2/super/platform/auth-errors (Issue #299)", () => {
+  let ds: InMemoryDataSource;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("AUTH_MODE", "dev");
+    // env fast path で super@example.com を super-admin として認識させる
+    vi.stubEnv("SUPER_ADMIN_EMAILS", "super@example.com");
+    mockGetDocs.mockResolvedValue({ docs: [] });
+    ds = new InMemoryDataSource({ readOnly: false });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    const { setPlatformDataSourceForTest } = await import("../../middleware/platform-datasource.js");
+    setPlatformDataSourceForTest(null);
+  });
+
+  it("AC3: X-User-Email ヘッダ欠落時は 401 (superAdminAuthMiddleware)", async () => {
+    const app = await buildApp(ds);
+    const res = await supertest(app).get("/api/v2/super/platform/auth-errors");
+    expect(res.status).toBe(401);
+  });
+
+  it("AC3: 非 super-admin (env/Firestore どちらにも無い) は 403", async () => {
+    // notadmin@example.com は env に無く、Firestore mock も空 → false
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors")
+      .set("X-User-Email", "notadmin@example.com");
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("forbidden");
+  });
+
+  it("AC10: super-admin で空結果時は 200 + 空配列", async () => {
+    // super@example.com は env fast path で super-admin 判定される
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors")
+      .set("X-User-Email", "super@example.com");
+    expect(res.status).toBe(200);
+    expect(res.body.platformAuthErrorLogs).toEqual([]);
+  });
+
+  it("AC2: super-admin は日時降順でログリストを取得（createPlatformAuthErrorLog で書いた分が読める）", async () => {
+    // super@example.com は env fast path で super-admin 判定される
+    await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-22T10:00:00.000Z", email: "a@example.com" }));
+    await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-22T12:00:00.000Z", email: "b@example.com" }));
+    await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-22T11:00:00.000Z", email: "c@example.com" }));
+
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(200);
+    const logs = res.body.platformAuthErrorLogs as AuthErrorLog[];
+    expect(logs).toHaveLength(3);
+    expect(logs[0].email).toBe("b@example.com"); // 12:00
+    expect(logs[1].email).toBe("c@example.com"); // 11:00
+    expect(logs[2].email).toBe("a@example.com"); // 10:00
+  });
+
+  it("AC5: email フィルタで指定したメールのみ返る", async () => {
+    // super@example.com は env fast path で super-admin 判定される
+    await ds.createPlatformAuthErrorLog(makeLog({ email: "a@example.com" }));
+    await ds.createPlatformAuthErrorLog(makeLog({ email: "b@example.com" }));
+
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors?email=a@example.com")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(200);
+    const logs = res.body.platformAuthErrorLogs as AuthErrorLog[];
+    expect(logs).toHaveLength(1);
+    expect(logs[0].email).toBe("a@example.com");
+  });
+
+  it("AC5: startDate/endDate フィルタで日時範囲が効く", async () => {
+    // super@example.com は env fast path で super-admin 判定される
+    await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-20T00:00:00.000Z" }));
+    await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-22T00:00:00.000Z" }));
+    await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-24T00:00:00.000Z" }));
+
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors?startDate=2026-04-21T00:00:00.000Z&endDate=2026-04-23T00:00:00.000Z")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(200);
+    const logs = res.body.platformAuthErrorLogs as AuthErrorLog[];
+    expect(logs).toHaveLength(1);
+    expect(logs[0].occurredAt).toBe("2026-04-22T00:00:00.000Z");
+  });
+
+  it("AC8: startDate > endDate の場合は空配列を返す（400 ではない）", async () => {
+    // super@example.com は env fast path で super-admin 判定される
+    await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-22T00:00:00.000Z" }));
+
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors?startDate=2026-04-25T00:00:00.000Z&endDate=2026-04-20T00:00:00.000Z")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body.platformAuthErrorLogs).toEqual([]);
+  });
+
+  it("AC9: limit 上限 (500) 超過は clamp", async () => {
+    // super@example.com は env fast path で super-admin 判定される
+    // limit=501 が clamp されていることは query で確認（500 件以上は生成コストが高いのでロジック確認のみ）
+    // ds に 3 件だけ入れ、limit=1 で 1 件返ることを確認（clamp の逆方向）
+    await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-22T10:00:00.000Z" }));
+    await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-22T11:00:00.000Z" }));
+    await ds.createPlatformAuthErrorLog(makeLog({ occurredAt: "2026-04-22T12:00:00.000Z" }));
+
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors?limit=1")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body.platformAuthErrorLogs).toHaveLength(1);
+  });
+
+  it("AC9: limit 不正値 (文字列 abc) は 100 にフォールバック", async () => {
+    // super@example.com は env fast path で super-admin 判定される
+    await ds.createPlatformAuthErrorLog(makeLog());
+
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors?limit=abc")
+      .set("X-User-Email", "super@example.com");
+
+    // 100 デフォルトでフォールバック → 1件存在
+    expect(res.status).toBe(200);
+    expect(res.body.platformAuthErrorLogs).toHaveLength(1);
+  });
+
+  it("AC6: invalid startDate は 400 invalid_start_date", async () => {
+    // super@example.com は env fast path で super-admin 判定される
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors?startDate=not-a-date")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_start_date");
+  });
+
+  it("AC7: invalid endDate は 400 invalid_end_date", async () => {
+    // super@example.com は env fast path で super-admin 判定される
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors?endDate=also-not-a-date")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_end_date");
+  });
+
+  it("AC12: response は PII (email) を含むが、super-admin のみアクセス可能 (AC3 の裏付け)", async () => {
+    // super@example.com は env fast path で super-admin 判定される
+    await ds.createPlatformAuthErrorLog(makeLog({ email: "pii@example.com" }));
+
+    const app = await buildApp(ds);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(200);
+    const logs = res.body.platformAuthErrorLogs as AuthErrorLog[];
+    expect(logs[0].email).toBe("pii@example.com");
+    expect(logs[0].firebaseErrorCode).toBeDefined();
+  });
+});

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -789,11 +789,21 @@ router.get("/platform/auth-errors", async (req: Request, res: Response) => {
       })),
     });
   } catch (e) {
-    // 既存 super-admin ハンドラと同じく logger.error + 500 で返す。
-    // Firestore 障害時のレスポンス形式を保証する（Issue #299 evaluator 指摘）。
+    // Firestore 障害時のレスポンス形式を保証する（AC: 500 fetch_failed）。
+    // transient (UNAVAILABLE/DEADLINE_EXCEEDED) と permanent の分離は
+    // ADR-031 Phase 1 制約で別 Issue 対応予定。現状は一律 500 を返す。
+    // ログは errorType + firebaseErrorCode + 入力パラメータで再現性を確保する
+    // （`/admins/:email` DELETE と同等の構造化レベル）。
+    const err = e as { code?: string } | undefined;
     logger.error("Failed to fetch platform auth error logs", {
+      errorType: "platform_auth_errors_fetch_failed",
       error: e instanceof Error ? e : new Error(String(e)),
+      firebaseErrorCode: typeof err?.code === "string" ? err.code : null,
       operatorEmail: req.superAdmin?.email,
+      filterEmail: email ?? null,
+      filterStartDate: startDateStr ?? null,
+      filterEndDate: endDateStr ?? null,
+      filterLimit: limit,
     });
     res.status(500).json({
       error: "fetch_failed",

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -28,6 +28,7 @@ import { masterRouter } from "./super-admin-master.js";
 import { calculateDefaultDeadlines } from "../services/enrollment.js";
 import { generateTenantId, normalizeEmail } from "../utils/tenant-id.js";
 import { logger } from "../utils/logger.js";
+import { getPlatformDataSource } from "../middleware/platform-datasource.js";
 
 const router = Router();
 
@@ -711,6 +712,80 @@ router.delete("/admins/:email", async (req: Request, res: Response) => {
 
   res.json({
     message: "スーパー管理者を削除しました。",
+  });
+});
+
+// ============================================================
+// プラットフォーム認証エラーログ (Issue #299)
+// ============================================================
+
+/**
+ * プラットフォーム認証エラーログ一覧取得
+ * GET /api/v2/super/platform/auth-errors
+ *
+ * super-admin 経路の認証拒否ログ（ルートコレクション `platform_auth_error_logs`）を
+ * occurredAt 降順で返す。tenant-scoped `auth_error_logs` には触らない（境界分離）。
+ *
+ * クエリパラメータ:
+ *   - email: メールアドレス完全一致フィルタ
+ *   - startDate: 開始日時（ISO 8601）
+ *   - endDate: 終了日時（ISO 8601）— startDate > endDate の場合は空配列を返す
+ *   - limit: 1〜500 (デフォルト 100, 範囲外は clamp)
+ */
+router.get("/platform/auth-errors", async (req: Request, res: Response) => {
+  const email = req.query.email as string | undefined;
+  const startDateStr = req.query.startDate as string | undefined;
+  const endDateStr = req.query.endDate as string | undefined;
+  const limitStr = req.query.limit as string | undefined;
+
+  const startDate = startDateStr ? new Date(startDateStr) : undefined;
+  const endDate = endDateStr ? new Date(endDateStr) : undefined;
+
+  if (startDateStr && Number.isNaN(startDate!.getTime())) {
+    res.status(400).json({
+      error: "invalid_start_date",
+      message: "startDate must be a valid ISO 8601 date",
+    });
+    return;
+  }
+  if (endDateStr && Number.isNaN(endDate!.getTime())) {
+    res.status(400).json({
+      error: "invalid_end_date",
+      message: "endDate must be a valid ISO 8601 date",
+    });
+    return;
+  }
+
+  let limit = limitStr ? parseInt(limitStr, 10) : 100;
+  if (Number.isNaN(limit) || limit < 1) {
+    limit = 100;
+  } else if (limit > 500) {
+    limit = 500;
+  }
+
+  const ds = getPlatformDataSource();
+  const logs = await ds.getPlatformAuthErrorLogs({
+    email,
+    startDate,
+    endDate,
+    limit,
+  });
+
+  res.json({
+    platformAuthErrorLogs: logs.map((log) => ({
+      id: log.id,
+      email: log.email,
+      tenantId: log.tenantId,
+      errorType: log.errorType,
+      reason: log.reason,
+      errorMessage: log.errorMessage,
+      path: log.path,
+      method: log.method,
+      userAgent: log.userAgent,
+      ipAddress: log.ipAddress,
+      firebaseErrorCode: log.firebaseErrorCode,
+      occurredAt: log.occurredAt,
+    })),
   });
 });
 

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -763,30 +763,43 @@ router.get("/platform/auth-errors", async (req: Request, res: Response) => {
     limit = 500;
   }
 
-  const ds = getPlatformDataSource();
-  const logs = await ds.getPlatformAuthErrorLogs({
-    email,
-    startDate,
-    endDate,
-    limit,
-  });
+  try {
+    const ds = getPlatformDataSource();
+    const logs = await ds.getPlatformAuthErrorLogs({
+      email,
+      startDate,
+      endDate,
+      limit,
+    });
 
-  res.json({
-    platformAuthErrorLogs: logs.map((log) => ({
-      id: log.id,
-      email: log.email,
-      tenantId: log.tenantId,
-      errorType: log.errorType,
-      reason: log.reason,
-      errorMessage: log.errorMessage,
-      path: log.path,
-      method: log.method,
-      userAgent: log.userAgent,
-      ipAddress: log.ipAddress,
-      firebaseErrorCode: log.firebaseErrorCode,
-      occurredAt: log.occurredAt,
-    })),
-  });
+    res.json({
+      platformAuthErrorLogs: logs.map((log) => ({
+        id: log.id,
+        email: log.email,
+        tenantId: log.tenantId,
+        errorType: log.errorType,
+        reason: log.reason,
+        errorMessage: log.errorMessage,
+        path: log.path,
+        method: log.method,
+        userAgent: log.userAgent,
+        ipAddress: log.ipAddress,
+        firebaseErrorCode: log.firebaseErrorCode,
+        occurredAt: log.occurredAt,
+      })),
+    });
+  } catch (e) {
+    // 既存 super-admin ハンドラと同じく logger.error + 500 で返す。
+    // Firestore 障害時のレスポンス形式を保証する（Issue #299 evaluator 指摘）。
+    logger.error("Failed to fetch platform auth error logs", {
+      error: e instanceof Error ? e : new Error(String(e)),
+      operatorEmail: req.superAdmin?.email,
+    });
+    res.status(500).json({
+      error: "fetch_failed",
+      message: "認証エラーログの取得に失敗しました。再度お試しください。",
+    });
+  }
 });
 
 // ============================================================


### PR DESCRIPTION
## Summary
Issue #292 で super-admin 経路の認証拒否を root コレクション `platform_auth_error_logs` に記録する仕組みが実装されたが、admin API 経由の読み取り経路が未実装で Cloud Logging 参照に依存していた。

本 PR で `DataSource.getPlatformAuthErrorLogs` を追加し、`GET /api/v2/super/platform/auth-errors`（super-admin 限定）で参照可能にする。ADR-031 Phase 1 制約の「admin UI 未実装」を解消。

## 設計
- ルート `/api/v2/super/platform/auth-errors`（super-admin.ts flat 構造と一貫）
- Response key `platformAuthErrorLogs`（tenant-scoped `authErrorLogs` と明示分離）
- `AuthErrorLogFilter` には `tenantId` が無いため、tenant / platform スコープ混在が構造的に防がれる
- `getPlatformDataSource()` singleton 経由でアクセス、tenant DataSource とは独立

## Changes (10 files, +740/-31 lines)

### 実装
- `datasource/interface.ts`: `getPlatformAuthErrorLogs(filter?)` 追加
- `datasource/firestore.ts`: root collection から orderBy/where/limit で取得
- `datasource/in-memory.ts`: `platformAuthErrorLogs` 配列 + create push + get 実装 + limit<1 ガード
- `routes/super-admin.ts`: `GET /platform/auth-errors` 追加（try-catch で 500 fetch_failed 保証）
- `firestore.indexes.json`: `(email ASC, occurredAt DESC)` 複合 index 追加

### テスト (+2 AC = 13 AC 全網羅)
- `routes/__tests__/super-admin-platform-auth-errors.test.ts` (新規, 14 tests)
  - AC2/3/5/6/7/8/9/10/12 + limit=501 HTTP端点 + 500 fetch_failed
- `datasource/__tests__/firestore-platform-auth-error-log.test.ts` (拡張)
  - root collection 参照、orderBy/where/limit 呼び出し確認、Timestamp→ISO変換
- `datasource/__tests__/in-memory.test.ts` (+7 tests)

### ドキュメント
- `docs/adr/ADR-031-gcip-multi-tenancy.md`: Phase 1 制約の解消を追記
- `docs/api.md`: Super Admin プラットフォーム認証エラーログ API 追加

## Acceptance Criteria (Evaluator 分離プロトコル 検証済)

| # | 基準 | 判定 |
|---|------|------|
| AC1 | 3 実装に `getPlatformAuthErrorLogs` 追加 | ✅ |
| AC2 | 200 + 日時降順 | ✅ |
| AC3 | 非 super-admin → 403 | ✅ |
| AC4 | Firestore: root collection 参照、tenant 非参照 | ✅ |
| AC5 | filter (email/date/limit) 機能 | ✅ |
| AC6/7 | invalid date → 400 | ✅ |
| AC8 | startDate > endDate → 空配列 | ✅ |
| AC9 | limit clamp (1-500) + HTTP端点テスト | ✅ |
| AC10 | 空結果 → 200 + 空配列 | ✅ |
| AC11 | Firestore Timestamp/ISO 変換整合 | ✅ |
| AC12 | PII は super-admin のみ | ✅ |
| AC13 | ADR-031 + docs/api.md 更新 | ✅ |

## Test plan
- [x] Lint PASS
- [x] Type check PASS (4 workspaces)
- [x] Unit/Integration tests PASS (api: 568, web: 33)
- [x] Evaluator 分離プロトコル (5ファイル以上該当): APPROVE_WITH_REVISIONS → 指摘反映済
- [x] Codex セカンドオピニオン (plan phase): APPROVE_WITH_REVISIONS → AC 拡充で反映
- [ ] main マージ後、本番デプロイで `firestore.indexes.json` を手動反映 (`firebase deploy --only firestore:indexes`)

## 注意: Firestore Index 手動デプロイ必要
CI/CD は service コンテナのみデプロイし、`firestore.indexes.json` は含まない（`rules/firebase.md` 参照）。マージ後に以下を実行：
```
firebase deploy --only firestore:indexes --project=lms-279 --non-interactive
```
※ GitHub Actions には `deploy-firestore-indexes` job があり自動実行される（`.github/workflows/deploy.yml:18-46`）

## Related
- Closes: #299
- 元 Issue: #292 (記録側)
- ADR: #031 (allowed_emails 境界)
- Evaluator 指摘: try-catch 追加 / limit=501 端点 / InMemory clamp guard → 全反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)