### PR TITLE
docs(handoff): Session 8 (2026-04-23) ハンドオフ更新

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,14 +1,14 @@
-# Session Handoff — 2026-04-22 (Session 7)
+# Session Handoff — 2026-04-23 (Session 8)
 
 ## TL;DR
 
-**ADR-031 Phase 3 (GCIP マルチテナント移行) 着手 + 2 Sub-Issue 連続 merge**。Issue #272 Phase 3 の実装計画を `/impl-plan` で策定し、9 Sub-Issue に分解。完全独立な Sub-Issue A (Tenant スキーマ拡張) と Sub-Issue C (UID 紐付け原子性 CAS) を並行実装、両方 merge 完了。Quality Gate は **5-6 層検証プロトコル** (impl-plan → simplify → safe-refactor → Evaluator → review-pr 6 並列 → codex review) で、Evaluator REQUEST_CHANGES + Codex APPROVE_WITH_REVISIONS の指摘をすべて反映 or follow-up Issue 化。
+**ADR-031 Phase 3 前提条件 #316 完了**。`findOrCreateTenantUser` の「両方 miss → createUser」経路の並行リクエスト重複 user 作成 race を解消する `findOrCreateUserByEmailAndUid` を atomic 実装 (Firestore: sentinel doc + runTransaction、InMemory: 単一スレッド同期実行)。Quality Gate 5 層 + Codex で `/review-pr` が **Critical type error** (`userId` vs `knownUserId` mismatch) を発見し修正、Codex は IMPORTANT 2件 (ABORTED UX判定 + Firestore 仕様準拠コメント) を反映。Issue net **-1** (#316 close、起票 0)、CLAUDE.md KPI Net ≤ 0 達成。
 
-- **マージ完了** (今セッション): PR #314, PR #315
-- **新規 Issue**: 3 件 (#312 Sub-Issue A / #313 Sub-Issue C / #316 Codex follow-up)
-- **Close**: 2 件 (#312, #313)
-- **Issue Net**: +1（#316 のみ残存、全起票 triage 基準該当）
-- **Open 推移**: Session 6 末 7 件 → Session 7 末 8 件 (P0:1 / P1:1 / P2:6)
+- **マージ完了** (今セッション): PR #318
+- **新規 Issue**: 0 件 (Sub-Issue B/D/E は次セッション「実装直前起票」方針で defer)
+- **Close**: 1 件 (#316)
+- **Issue Net**: **-1** ✅
+- **Open 推移**: Session 7 末 8 件 → Session 8 末 7 件 (P0:1 / P2:6)
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -16,87 +16,91 @@
 # 1. 状況復元
 cat docs/handoff/LATEST.md
 
-# 2. 現在の OPEN Issue（P0: 1 / P1: 1 / P2: 6）
+# 2. 現在の OPEN Issue（P0: 1 / P2: 6）
 gh issue list --state open --limit 15
 
 # 3. main CI が緑であることを確認
 gh run list --branch main --limit 3
 
-# 4. 次セッション候補 Issue のコンテキスト
-gh issue view 316  # Sub-Issue C follow-up (最優先候補)
-gh issue view 272  # Phase 3 親 Issue (進捗トラッキング)
+# 4. 次セッション最優先候補 (ADR-031 Phase 3 残 Sub-Issue)
+gh issue view 272  # Phase 3 親 Issue
+# Sub-Issue B/D/E は実装直前に起票（Session 7 末で合意の Net KPI 維持方針）
 ```
 
 ---
 
-## セッション成果物 (2026-04-22 Session 7)
+## セッション成果物 (2026-04-23 Session 8)
 
 ### マージ完了 PR
 
 | # | Issue | Title | Merge Commit |
 |---|-------|-------|-------------|
-| #314 | #312 | feat(tenant): Tenant スキーマに gcipTenantId + useGcip 追加 | `a7b9116` |
-| #315 | #313 | feat(auth): findOrCreateTenantUser の UID 紐付け原子性 CAS 化 | `24b49b6` |
+| #318 | #316 | feat(auth): findOrCreateTenantUser の初回 create race を atomic 化 | `4c2ecbd` |
 
 ### 起票 Issue
 
-| # | Title | Label | 起票理由（triage 基準） |
-|---|-------|-------|----------------------|
-| #312 | Sub-Issue A: Tenant スキーマ拡張 (gcipTenantId + useGcip) | P1 | **#5 ユーザー明示指示**（`/impl-plan` で分解 + 並行実装合意） |
-| #313 | Sub-Issue C: UID 紐付け原子性 (CAS + 監査) | P1 | **#5 ユーザー明示指示**（同上） |
-| #316 | Sub-Issue C follow-up: 初回 create 経路の並行 race 対応 | P1 | **#4 Codex review rating 7 + confidence 80**（PR #315 レビュー時に発見、ADR-031 §UID保持戦略の未対応部分） |
+なし。Sub-Issue B/D/E は **実装直前に起票** する方針 (Session 7 末で合意) を維持。Session 8 はスコープを #316 単独に絞り Net KPI 達成。
 
-### 主要変更の要点
+### 主要変更の要点 (PR #318)
 
-#### PR #314 (Sub-Issue A: Tenant スキーマ拡張)
-- `TenantMetadata` + `SuperTenantListItem` に `gcipTenantId: string | null` + `useGcip: boolean` 追加
-- 新規テナント作成時の初期値は `{null, false}`（非 GCIP でカナリア展開前）
-- `PATCH /super/tenants/:id` で 2 フィールド更新可能（super-admin のみ）:
-  - 整合性ガード: `useGcip=true` は `gcipTenantId !== null` を要求（400 `gcip_tenant_id_required`）
-  - 前後空白は自動 trim、空文字/whitespace-only は 400 `invalid_gcip_tenant_id`
-  - **Firestore 内一意性検証**: 他テナント重複時 409 `gcip_tenant_id_conflict`（Codex BLOCKING 指摘対応、ADR-031 認証サイロ分離原則）
-- `parseTenantGcipFields` helper で default 値読み取りを 4 箇所で統一（/simplify 指摘反映）
-- 11 テスト追加（バリデーション 4 + POST 初期値 1 + PATCH 正常系 3 + 一意性 2 + Partial Update 1）
-
-#### PR #315 (Sub-Issue C: UID 紐付け原子性 CAS)
-- `DataSource.setUserFirebaseUidIfUnset` を I/F + Firestore (`runTransaction`) + InMemory の 3 実装で追加
-- `SetFirebaseUidResult` discriminated union (4 状態: updated / already_set_same / conflict / not_found)
-- `tenant-auth.ts` の email fallback で `updateUser({firebaseUid})` を CAS 呼び出しに置換
-  - `status: conflict` → 403 `uid_reassignment_blocked`（既存 UID と異なる UID は silent 上書きしない）
-  - `status: not_found` → 403 `uid_cas_user_not_found`（稀: 並行 DELETE）
-  - `TenantAccessDenialReason` union に 2 reason 追加
-- UID 紐付けインシデントは `platform_auth_error_logs` にも tenant 横断で記録（super-admin 監視用、Evaluator BLOCKING 指摘対応）
-- 型不整合 `firebaseUid` 検知 throw + 空文字引数 precondition throw（silent-failure-hunter 指摘反映）
-- `assertCasSuccessOrThrow` + `persistPlatformUidConflictLog` helper 抽出（code-simplifier 指摘反映）
-- 12 テスト追加（DataSource CAS 7 + tenant-auth 5）
+- **DataSource I/F**: `findOrCreateUserByEmailAndUid(email, firebaseUid, defaults)` 追加
+  - 4 状態 discriminated union: `updated` / `already_set_same` / `conflict` / `created`
+  - 構造上 `not_found` は発生しない (query miss なら同 transaction で create するため)
+  - 新型 `FindOrCreateUserResult` / `FindOrCreateUserDefaults`
+- **Firestore 実装** (`services/api/src/datasource/firestore.ts`):
+  - `runTransaction` 内で sentinel doc `tenants/{tid}/user_email_locks/{sha256(email)}` + email query を `Promise.all` で並列 read
+  - create path で sentinel + user を atomic set し、Firestore serializable isolation で並行 transaction を直列化
+  - CAS path では lock doc を read のみで書かない (user doc 自体への `tx.update` が contention target)
+- **InMemory 実装** (`services/api/src/datasource/in-memory.ts`):
+  - メソッド body に `await` を一切置かず、async 関数の同期実行性質で原子化
+  - 「将来 await を追加すると race 復活」の警告コメント明記
+- **middleware/tenant-auth.ts**:
+  - `findOrCreateTenantUser` の email fallback + 新規 create 経路を `findOrCreateUserByEmailAndUid` 単一呼び出しに統合
+  - `assertCasSuccessOrThrow` を **generic assertion predicate** (`asserts result is Exclude<T, conflict|not_found>`) 化し、`SetFirebaseUidResult` / `FindOrCreateUserResult` 両方の失敗分岐を共通処理
+  - super admin 経路: 既存 user に CAS、なければ virtual admin (新規 create はしない)
+- **新規テスト**: 14 件
+  - DataSource (`find-or-create-user-by-email-and-uid.test.ts`): 9 件 (4 状態 + precondition + 並行 race 3 パターン)
+  - Middleware integration (`tenant-auth-atomic-create.test.ts`): 5 件 (初回ログイン / allowlist 未登録 / 異UID race / 同UID race / email 欠落)
+- **ADR-031 As-Is 表更新** (`docs/adr/ADR-031-gcip-multi-tenancy.md` L68): UID 紐付け原子性 ✅ 完了 (Issue #313 + #316)、Sub-Issue H Staging で **ABORTED 時 HTTP 応答 (401 vs 503)** を明示判断するスコープを追加
 
 ### Quality Gate 検証結果
 
-| ゲート | #314 | #315 |
-|-------|------|------|
-| `/simplify` (reuse/quality/efficiency 3 並列) | ✅ helper 抽出 / 整合性コメント強化 | ✅ helper 抽出 / 型不整合 guard |
-| `/safe-refactor` (型安全性・エラー処理) | ✅ gcipTenantId trim 追加 | ✅ 独立 try/catch 確認 |
-| **Evaluator 分離** (5 ファイル+ 新機能) | ✅ APPROVE_WITH_REVISIONS → 反映 | ✅ REQUEST_CHANGES → 反映 |
-| `/review-pr` 6 エージェント並列 | ✅ Critical 2 + Important 2 反映 | ✅ Important 6 反映 |
-| `/codex review` セカンドオピニオン | ✅ BLOCKING 1 (gcipTenantId 一意性) 反映 | ✅ IMPORTANT 1 (初回 create race) → #316 follow-up |
-| CI (Build / Lint / Test / Type Check) | ✅ 全 PASS | ✅ 全 PASS |
+| ゲート | 結果 |
+|-------|------|
+| `/impl-plan` (3+ ステップ + 5+ ファイル) | ✅ AC 10件策定、Phase 2.7 完了 |
+| `/simplify` (reuse + quality + efficiency 3 並列) | ✅ Quality #1 (assertion predicate) + Efficiency #3 (Promise.all) + Reuse minor (JSDoc 正規化責務) 反映 |
+| `/safe-refactor` (型安全性・エラー処理) | ✅ 追加修正不要 |
+| **Evaluator 分離** (5 ファイル+ 新機能) | ✅ APPROVE_WITH_REVISIONS → HIGH 2件 (assertion 順序、ABORTED 文書化) + MEDIUM 1件 (super admin 経路 `casResult.user` 統一) 反映 |
+| `/review-pr` 6 エージェント並列 | ✅ **Critical 型エラー** (`userId` vs `knownUserId` mismatch — 4 エージェントが同指摘) 修正 + comment-analyzer 3件 (`not_found` 矛盾 JSDoc / 孤立 JSDoc / CAS path コメント補足) 反映 |
+| `/codex review` セカンドオピニオン | ✅ BLOCKING なし、IMPORTANT 2件 (ABORTED UX 明示判断 + Firestore 仕様準拠コメント) 反映 |
+| CI (Build / Lint / Test / Type Check) | ✅ 全 SUCCESS |
 
 ### レビュー対応サマリ
 
-#### PR #314 の BLOCKING / Critical 対応
-1. **Evaluator BLOCKING**: AC#7 統合テスト 5 パターン不整合（「true 正常」「Partial Update 保持」未テスト） → 正常系 3 テスト追加
-2. **Evaluator IMPORTANT**: gcipTenantId trim なし保存 → Phase 3 照合整合性のため自動 trim 追加
-3. **comment-analyzer Critical**: PATCH ガード「ケース a」コメント誤記 → 修正
-4. **pr-test-analyzer Critical (rating 8)**: Case (b) 未テスト → 拒否テスト追加
-5. **Codex BLOCKING (REJECT)**: gcipTenantId 一意性制約未実装 → PATCH で Firestore query + 409 拒否 + 2 テスト
+#### Evaluator HIGH/MEDIUM 反映
+1. **HIGH-1 (assertion 順序問題)**: `userId` 算出を `observedUserId` 中間変数として可視化 → /review-pr で削除に再修正
+2. **HIGH-2 (ABORTED 時 HTTP 応答未定義)**: ADR-031 As-Is 表に Sub-Issue H Staging 検証スコープを追記 (Codex IMPORTANT-1 でさらに強化)
+3. **MEDIUM-4 (super admin 経路で `existingByEmail` 使用)**: `casResult.user` 採用に統一 (CAS 後の最新 user)
 
-#### PR #315 の BLOCKING / Important 対応
-1. **Evaluator BLOCKING**: AC#4 `platform_auth_error_logs` 未記録 → `handleTenantAccessDenied` に platform 書き込み追加
-2. **Evaluator Critical**: `not_found` 時の reason 誤マップ → `uid_cas_user_not_found` 専用 reason 追加
-3. **silent-failure-hunter I-2**: 型不整合 firebaseUid の silent 受け入れ → throw + logger.error
-4. **type-design #2 / pr-test #1**: firebaseUid 空文字引数 + テスト → precondition throw + 2 テスト追加
-5. **pr-test #2**: platform 書き込み失敗時の main フロー継続テスト追加
-6. **code-simplifier HIGH**: `assertCasSuccessOrThrow` + `persistPlatformUidConflictLog` helper 抽出
+#### `/review-pr` Critical (4 エージェントが同指摘)
+- **`userId` → `knownUserId` mismatch**: helper シグネチャ変更時に call site 2 箇所を更新漏れ → `tsc --noEmit` で即時 fail。修正 + `observedUserId` 変数削除 (helper 内 fallback に委譲)
+
+#### `/review-pr` comment-analyzer 反映
+- **C-2**: `interface.ts` の `not_found` 言及コメントを構造的除外文言に修正
+- **I-1**: `findOrCreateTenantUser` 上部に孤立していた `buildAuthUser` 用 JSDoc を整理し、`findOrCreateTenantUser` 本体に早期 return 順序明記の JSDoc 追加
+- **I-2**: `firestore.ts` CAS path に「lock doc を書かない理由」コメント追記
+
+#### Codex IMPORTANT 反映
+- **IMPORTANT-1 (ABORTED UX 分類が弱い)**: ADR-031 文言を「Sub-Issue H で 401 vs 503 を **明示判断**」に強化
+- **IMPORTANT-2 (Firestore 仕様コメント)**: 「commit 時に optimistic lock conflict」→「serializable isolation / contention resolution」に正確化、公式 docs URL 追記
+
+### Defer 項目 (本 PR スコープ外、handoff へ)
+
+- **CAS body 4 重複** (`setUserFirebaseUidIfUnset` × 2 + `findOrCreateUserByEmailAndUid` × 2): 既存 `setUserFirebaseUidIfUnset` (#313 マージ済) も touch 必要 → 別 PR で extract
+- **UID hit path (hot path) の `checkSuperAdmin` ∥ `ensureAllowlisted` 並列化**: 本 PR の diff 外 → 別 PR
+- **lock doc TTL/cleanup 自動化**: Issue #276 (Phase 5)
+- **既存重複 user 監査** (Codex SUGGESTION): Phase 3 前提作業として handoff で次セッション候補に追加
+- **Sub-Issue H tasks.md 明記事項**: ABORTED 時 HTTP 応答判断 / lock doc 書き込み権限 / 同一 email 並行 5 transaction → user 1 件検証
 
 ## 品質ゲート結果 (最終)
 
@@ -104,49 +108,52 @@ gh issue view 272  # Phase 3 親 Issue (進捗トラッキング)
 |--------|------|
 | `npm run lint` | ✅ PASS |
 | `npm run type-check` (全 4 workspace) | ✅ PASS |
-| `npm test -w @lms-279/api` (sequential) | ✅ PR #315 ブランチ単独計測: 583 passed (既存 571 + 新規 12)。main の正確な合計は次セッション開始時に `npm test` で再計測 |
-| main CI (PR #314 / #315 両 push 時) | ✅ 全 SUCCESS (Build 53s / Lint 36-38s / Test 55-59s / Type Check 39-42s) |
+| `npm run test` (workspace 単位) | ✅ api 608/608 (既存 583 → 608、+25)、web 33/33 |
+| main CI (PR #318 push 時) | ✅ 全 SUCCESS (Lint / Type Check / Test / Build) |
 
-**Known issue**: ローカル並列テスト実行は flaky (Issue #308 の CI 遅延と同根)。sequential (`--fileParallelism=false`) または単独ファイル実行で全 PASS を確認。CI clean 環境では常時 PASS。
+**Known issue**: ローカル並列テストは flaky (Issue #308 の CI 遅延と同根)。sequential (`--fileParallelism=false`) または workspace 単位実行で全 PASS。CI clean 環境では常時 PASS。
 
 ## main 現状
 
 ```
+4c2ecbd feat(auth): findOrCreateTenantUser の初回 create 経路 race を atomic 化 (Issue #316) (#318)
+50871e9 docs(handoff): Session 7 (2026-04-22) ハンドオフ更新 + ADR-031 UID 原子性対応済み反映 (#317)
 24b49b6 feat(auth): findOrCreateTenantUser の UID 紐付け原子性 CAS 化 (Issue #313) (#315)
 a7b9116 feat(tenant): Tenant スキーマに gcipTenantId + useGcip 追加 (Issue #312) (#314)
-fdbbdc8 docs(handoff): Session 6 (2026-04-22) ハンドオフ更新 (#311)
-094ce4d feat(super-admin): platform_auth_error_logs 読み取り API 追加 (Issue #299) (#309)
 ```
 
-- **working tree**: clean
+- **working tree**: clean (handoff PR ブランチのみ)
 - **残留 Node プロセス**: なし ✅
-- **Deploy to Cloud Run**: PR #315 merge 時に自動実行中（次セッション開始時に CI 状態確認推奨）
+- **Deploy to Cloud Run**: PR #318 merge 時に自動実行 (push 直後の E2E Tests も SUCCESS 確認可能)
 
 ## 次セッションの着手候補（優先度順）
 
 ### 🔴 P0 残
 
-**Issue #272 Phase 3 (GCIP 移行本体)** — 引き続きクリティカルパス。Phase 1.1 + Phase 3 前提作業はユーザー側ブロッカー継続（下記）。
+**Issue #272 Phase 3 (GCIP 移行本体)** — 引き続きクリティカルパス。Phase 1.1 (OAuth External 化) + Phase 3 後半 (Identity Platform 有効化) はユーザー側 GCP Console 作業の継続ブロッカー。
 
-### 🟡 P1 候補 (Phase 3 Sub-Issue、着手可能)
+### 🟡 Phase 3 残 Sub-Issue (実装直前起票方針で defer 中)
 
-以下の表は **2026-04-22 Session 7 終了時点** のスナップショット。起票後は最新状況を `gh issue list -l P1` で確認すること。
+| Sub-Issue | 内容 | 依存 |
+|-----------|------|------|
+| **B** | Public tenant-info endpoint (認証不要、ログイン前テナント解決用) | Sub-Issue A (#312) マージ済 |
+| **D** | GCIP Tenant 作成スクリプト (`scripts/create-gcip-tenants.ts`) | Sub-Issue A (#312) マージ済 |
+| **E** | BE GCIP 経路の tenant 整合性チェック (`decodedToken.firebase.tenant` 検証) | Sub-Issue A + #316 マージ済 |
+| **F** | FE `auth.tenantId` + ログイン前テナント解決 | Sub-Issue B |
+| **G** | tenant 作成時の GCIP 自動化 | Sub-Issue A + E |
+| **H** | Staging + カナリア + 全テナント移行 | 全 Sub-Issue |
 
-| # | Sub-Issue | 内容 | 依存 |
-|---|-----------|------|------|
-| **#316** | Sub-Issue C follow-up | 初回 create 経路の並行 race 対応（sentinel doc / atomic `findOrCreateUserByEmailAndUid`） | Sub-Issue C (#313) マージ済（前提充足） |
-| 未起票 | Sub-Issue B | Public tenant-info endpoint (認証不要、ログイン前テナント解決用) | Sub-Issue A (#312) マージ済 |
-| 未起票 | Sub-Issue D | GCIP Tenant 作成スクリプト (scripts/create-gcip-tenants.ts) | Sub-Issue A (#312) マージ済 |
-| 未起票 | Sub-Issue E | BE GCIP 経路の tenant 整合性チェック (`decodedToken.firebase.tenant` 検証) | Sub-Issue A + C マージ済 |
-| 未起票 | Sub-Issue F | FE `auth.tenantId` + ログイン前テナント解決 | Sub-Issue B |
-| 未起票 | Sub-Issue G | tenant 作成時の GCIP 自動化 | Sub-Issue A + E |
-| 未起票 | Sub-Issue H | Staging + カナリア + 全テナント移行 | 全 Sub-Issue |
+**推奨**: 次セッションは **Sub-Issue B / D 並行 → Sub-Issue E** の順。B/D は #312 のみが前提で完全独立、E は #316 完了で着手可能になった。
 
-**推奨**: 次セッションは **#316 → Sub-Issue B/D 並行 → Sub-Issue E** の順で着手。依存グラフ上のクリティカルパス順。
+**Sub-Issue H tasks.md 明記事項** (本 PR / Codex IMPORTANT-1 由来):
+- ABORTED (transaction retry 上限超過) 時の HTTP 応答を **401 で許容するか、503 + Retry-After に変更するか** を Staging 環境で明示判断
+- `user_email_locks` への書き込み権限 (`roles/datastore.user`) を Admin SDK 経由で確認
+- 同一 email 並行 5 transaction → user 1 件検証
+- 既存重複 user (本 PR 以前の race で発生したもの) の audit script 実装
 
 ### 🟢 P2 残 (Phase 3 と並行可)
 
-- **#308**: E2E CI リクエスト遅延 7-9 秒/request 根本調査（#305/#307 で 2 件連続暫定対処済み。次回 CI 遅延修正 PR が出れば CLAUDE.md Debug Protocol 「同一機能 3 件連続 → 元 PR 再レビュー」発動対象）
+- **#308**: E2E CI リクエスト遅延 7-9 秒/request 根本調査 (#305/#307 で 2 件連続暫定対処済。Debug Protocol 「同一機能 3 件連続 → 元 PR 再レビュー」発動候補)
 - **#310**: platform_auth_error_logs 読み取り時の transient/permanent 分離 (503 vs 500)
 - **#281**: allowed_emails 監査 CLI refactor
 - **#274 / #275 / #276**: Phase 5 allowed_emails 運用改善 (可視化 / UX / セッション失効)
@@ -156,43 +163,36 @@ fdbbdc8 docs(handoff): Session 6 (2026-04-22) ハンドオフ更新 (#311)
 | 項目 | 内容 | 影響 |
 |------|------|------|
 | GCP Console: OAuth 同意画面 External 化 | Issue #272 Phase 1.1 | sayori-maeda@kanjikai.or.jp 再ログイン復旧 + Phase 3 前提 |
-| 本番 `normalize-users-email.ts` dry-run / execute | PR #287 マージ済（Session 5）、Phase 3 移行前に推奨 | users.email 大文字/空白混入の正規化 |
+| 本番 `normalize-users-email.ts` dry-run / execute | PR #287 マージ済 (Session 5)、Phase 3 移行前に推奨 | users.email 大文字/空白混入の正規化 |
 | GCP Identity Platform Essentials+ Tier 有効化 + 費用試算 | Sub-Issue H (Staging) の前提 | MAU 次第で数千円〜数万円/月 |
 | Staging 環境の Identity Platform 有効化 | Sub-Issue H の staging 検証の前提 | - |
 
 ## ADR / ドキュメント状態
 
-- **ADR-031** As-Is 表更新済み（本 handoff PR で更新）:
-  - 「UID 紐付けの原子性」行: 🟡 → ✅（Issue #313 / PR #315 で対応済み、#316 で follow-up 明記）
-  - 「Tenant スキーマ拡張」行: Sub-Issue A 対応済み（PR #314 で追加）
-- **docs/handoff/LATEST.md**: 本ファイル更新 (Session 7)
-- **handoff サイズ**: 本ファイル（500 行以下目標 OK）
+- **ADR-031** As-Is 表更新済み (本 PR #318 内):
+  - 「UID 紐付けの原子性」行: Issue #313 + #316 で完全対応済 ✅、Sub-Issue H Staging 検証スコープに ABORTED HTTP 応答判断追加
+- **docs/handoff/LATEST.md**: 本ファイル更新 (Session 8)
+- **handoff サイズ**: 本ファイル (300 行以下、500 行目標 OK)
 
 ## Issue Net 変化（CLAUDE.md KPI）
 
 ```
-Close 数: 2 件 (#312, #313)
-起票数: 3 件 (#312, #313, #316)
-Net: +1 件 (#316 のみ残存)
+Close 数: 1 件 (#316)
+起票数: 0 件
+Net: -1 件 ✅
 ```
 
-**Net +1 の正当性**:
-- **#312, #313** は同セッション内で起票 → 実装 → close のサイクル完結。`/impl-plan` 分解の成果物として必須の Issue 化（triage #5）
-- **#316** (Codex review IMPORTANT): triage #4 (rating ≥ 7 かつ confidence ≥ 80) 該当。Sub-Issue C スコープ外の新規発見で、ADR-031 §UID保持戦略 の未対応部分を明示化。本来 ADR-031 に暗黙的に含まれていた要件を Issue tracker 上で可視化した形
-
-**rating 5-6 の review agent 提案は全て PR コメント / follow-up タスク / 本 handoff に吸収**:
-- type-design-analyzer Important #1 (exhaustiveness check): 5 状態未満で ROI 低、別 PR
-- silent-failure-hunter I-1 (transient/permanent 分類): 既存 PATCH 全体の課題、ADR 横断対応
-- silent-failure-hunter I-3 (構築/書き込み区別): 運用影響軽微、Phase 5 cleanup
-- pr-test-analyzer Gap #3-5 (rollback / dev モード non-CAS / UID hit 経路): regression 発生頻度低、必要時に後続 PR
-- code-reviewer Important #1 (runTransaction retry JSDoc): doc 追加のみ、別 PR
+**Net -1 達成の要因**:
+- Session 8 開始時にユーザーと「#316 単独完結 + Sub-Issue B/D/E は実装直前起票」スコープに合意 → 起票なしで close 1 を達成
+- `/review-pr` で 6 エージェントが指摘した複数の suggestion (rating 5-6) は全て本 PR 内修正 / handoff defer / PR コメントで吸収、Issue 起票ゼロ
+- `feedback_issue_triage.md` の triage 基準厳守 (Codex IMPORTANT も本 PR 内 ADR 文言追加で吸収)
 
 ## 作業ブランチ状態
 
 ```
-main: 24b49b6 (#315 merged) / a7b9116 (#314 merged)
+main: 4c2ecbd (#318 merged)
 
-docs/handoff-session-7-2026-04-22 (本ファイル更新用、PR 作成予定)
+docs/handoff-session-8-2026-04-23 (本ファイル更新用、PR 作成予定)
 ```
 
 main 直接 push なし、destructive 操作なし、残留 Node プロセスなし ✅。
@@ -200,17 +200,17 @@ main 直接 push なし、destructive 操作なし、残留 Node プロセスな
 ## 参考: 今セッションで使った規範 / スキル
 
 ### 新規に活用した規範・スキル
-- **`/impl-plan`**: Issue #272 Phase 3 を 9 Sub-Issue に分解 + 依存グラフ + AC 策定（本セッションで一番インパクトのあった skill 起動）
-- **`/codex review` (MCP 版)**: PR #314 / #315 両方でセカンドオピニオン取得、実際に BLOCKING 発見（gcipTenantId 一意性、初回 create race）→ 単独 review では見つからない盲点をカバー
-- **Evaluator 分離プロトコル** (`rules/quality-gate.md`): 両 PR で REQUEST_CHANGES / APPROVE_WITH_REVISIONS を受け、すべて反映
+- **`/review-pr` 内の Critical type error 検知**: 4 エージェント (code-reviewer / type-design-analyzer / comment-analyzer / code-simplifier) が同じ `userId` vs `knownUserId` mismatch を独立に検出 → 並列レビューの価値を再確認
+- **`assertCasSuccessOrThrow` の generic assertion predicate** (`asserts result is Exclude<T, conflict|not_found>`) 化: 2 つの異なる union 型 (SetFirebaseUidResult / FindOrCreateUserResult) を共通の失敗分岐 helper で扱う TypeScript パターンの実装
 
 ### 繰り返し活用した規範
-- **`/review-pr`** 6 エージェント並列: code-reviewer / pr-test-analyzer / silent-failure-hunter / type-design-analyzer / comment-analyzer / code-simplifier
-- **`/simplify`** 3 並列 (reuse / quality / efficiency): helper 抽出の判断に活用
-- **`feedback_pr_merge_authorization.md`**: PR 番号単位で明示認可（#314 / #315 個別に承認取得）
-- **`feedback_issue_triage.md`**: Net +1 だが全起票が triage 基準該当、rating 5-6 は吸収
+- **`/impl-plan`**: Issue #316 の AC 10 件策定 + 5+ ファイル変更 → Evaluator 発動を事前明示
+- **`/codex review` (MCP 版)**: BLOCKING はなかったが Firestore 仕様の正確性 (optimistic lock vs serializable isolation) と ABORTED UX 分類弱さを指摘
+- **Evaluator 分離プロトコル** (`rules/quality-gate.md`): APPROVE_WITH_REVISIONS で HIGH 2 件 + MEDIUM 1 件を反映
+- **`feedback_pr_merge_authorization.md`**: PR #318 を AskUserQuestion で個別承認取得後 squash merge
+- **`feedback_issue_triage.md`**: rating 5-6 の review agent 提案 + Codex SUGGESTION を全て本 PR 内修正 / handoff defer / PR コメントに吸収、起票ゼロを実現
 
 ### 学び / 次セッションへの引き継ぎ
-- **pre-push hook flaky**: Issue #308 既知の並列実行 flaky が pre-push quality check でも block 発生。single fork 実行 or retry で解消可能だが、恒久対応は #308 で
-- **ADR-031 As-Is 表の並行更新**: 同じ行を触る PR 複数並行 (A + C) は conflict リスクあり → C 側は ADR 更新を見送り、handoff PR で一括更新のパターンが実用的
-- **Codex セカンドオピニオンの価値**: 5 層レビュー後でも新しい BLOCKING を発見（Sub-Issue A で gcipTenantId 一意性、Sub-Issue C で初回 create race）。大規模 PR では必須と再確認
+- **`/safe-refactor` 後でも `/review-pr` で型エラー発見**: helper シグネチャ rename (`userId` → `knownUserId`) 時に call site 2 箇所を更新漏れ。/safe-refactor 内の `npm run type-check` で本来検知できるはずだったが、ルートからの実行で workspace ごとの tsc が走らず素通り。今後 type-check は **workspace 内 (`cd services/api && npx tsc --noEmit`) で実行する** ことが必要
+- **`/review-pr` の 6 エージェント並列の価値**: 4 エージェントが独立に同じ Critical を検出 → 並列レビューの "redundant by design" が真に効いた事例
+- **Sub-Issue H Staging 検証の重要性**: ABORTED HTTP 応答判断 / lock doc 書き込み権限 / 既存重複 user audit を含めた Staging 検証スコープを次セッションで早めに固める必要


### PR DESCRIPTION
## Summary

Session 8 (2026-04-23) のハンドオフ更新。PR #318 (Issue #316 close) のセッション成果物・Quality Gate 結果・次セッション候補を Session 8 セクションとして反映。

## 主要変更

- `docs/handoff/LATEST.md` を Session 8 内容に更新 (216 行、500 行目標 OK)
- Issue net **-1** 達成 (Close 1: #316 / 起票 0) を明記
- 次セッション候補: ADR-031 Phase 3 残 Sub-Issue B/D 並行 → Sub-Issue E、実装直前起票方針を継続
- Sub-Issue H Staging 検証スコープに以下を明記:
  - ABORTED (transaction retry 上限超過) 時の HTTP 応答 (401 vs 503) 明示判断
  - `user_email_locks` 書き込み権限 (`roles/datastore.user`) 確認
  - 同一 email 並行 5 transaction → user 1 件検証
  - 既存重複 user audit script 実装

## Test plan

- [x] `wc -l docs/handoff/LATEST.md` = 216 (500 行目標 OK)
- [x] 内容整合性: PR #318 / Issue #316 / Session 7 末状態と矛盾なし
- [x] 次セッション必読手順 (`gh issue list` / `gh run list` / `gh issue view 272`) が機械的に実行可能
- [ ] 次セッション開始時に `cat docs/handoff/LATEST.md` で状況復元できるか手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)