### PR TITLE
feat(public): 認証不要 Public tenant-info endpoint 追加 (Sub-Issue B)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -305,7 +305,7 @@
 
 ベースURL: `/api/v2/public/`
 
-ADR-031 Phase 3 Sub-Issue B。FE が GCIP 経路のログイン前に `auth.tenantId` へ `gcipTenantId` をセットするための認証不要エンドポイント。
+FE が GCIP 経路のログイン前に `auth.tenantId` へ `gcipTenantId` をセットするための認証不要エンドポイント（ADR-031）。
 
 | メソッド | パス | 説明 |
 |---------|------|------|
@@ -318,7 +318,6 @@ ADR-031 Phase 3 Sub-Issue B。FE が GCIP 経路のログイン前に `auth.tena
 {
   "tenant": {
     "id": "test-tenant",
-    "name": "Test Organization",
     "status": "active",
     "gcipTenantId": "tenant-gcip-xyz",
     "useGcip": true
@@ -328,15 +327,15 @@ ADR-031 Phase 3 Sub-Issue B。FE が GCIP 経路のログイン前に `auth.tena
 
 #### セキュリティ設計
 
-- **情報漏洩防止**: `ownerId` / `ownerEmail` / `userCount` / `createdAt` / `updatedAt` は含めない
-- **Enumeration 防止**: 未登録 / `RESERVED_TENANT_IDS` / 不正フォーマットは全て `404 tenant_not_found` で統一
+- **情報漏洩防止**: `name` / `ownerId` / `ownerEmail` / `userCount` / `createdAt` / `updatedAt` は含めない（顧客名の enumeration 漏洩防止）
+- **Enumeration 防止**: 未登録 / `RESERVED_TENANT_IDS` / 不正フォーマットは全て同一の `404 tenant_not_found` + 同一 `Cache-Control` を返す
 - **suspended テナント**: 200 で返却し `status: "suspended"` を含める（FE はメンテ画面切替に使用）
 - **status の fail-closed 判定**: `"active"` / `"suspended"` 以外の値（データ破損・未設定）は `suspended` にフォールバック（active 漏洩防止）
 - **レート制限**: `authLimiter` 流用（10 req/min/IP）
-- **Firestore 障害時**: `503 firestore_unavailable`（silent 空応答にしない）
-- **HTTP キャッシュ**: 成功時 `Cache-Control: public, max-age=60, stale-while-revalidate=300`、404 時 `public, max-age=30`、503 時 `no-store`（障害回復後に古い応答を再提示しない）
+- **Firestore 障害時**: `503 firestore_unavailable` + `Cache-Control: no-store` + 構造化 `logger.error` でアラート可能
+- **HTTP キャッシュ**: 200 / 404 とも `Cache-Control: public, max-age=60`（header 差分で存在有無が推測されないよう統一）、503 は `no-store`
 
-関連: ADR-031、Issue #320、親 Issue #272
+関連: ADR-031
 
 ### プラットフォーム認証エラーログ（Super Admin）
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -301,6 +301,43 @@
 ```
 
 
+### 公開テナント情報（認証不要）
+
+ベースURL: `/api/v2/public/`
+
+ADR-031 Phase 3 Sub-Issue B。FE が GCIP 経路のログイン前に `auth.tenantId` へ `gcipTenantId` をセットするための認証不要エンドポイント。
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/tenants/:tenantId` | テナントの公開情報取得（認証不要） |
+
+#### レスポンス
+
+```json
+// GET /public/tenants/:tenantId (200)
+{
+  "tenant": {
+    "id": "test-tenant",
+    "name": "Test Organization",
+    "status": "active",
+    "gcipTenantId": "tenant-gcip-xyz",
+    "useGcip": true
+  }
+}
+```
+
+#### セキュリティ設計
+
+- **情報漏洩防止**: `ownerId` / `ownerEmail` / `userCount` / `createdAt` / `updatedAt` は含めない
+- **Enumeration 防止**: 未登録 / `RESERVED_TENANT_IDS` / 不正フォーマットは全て `404 tenant_not_found` で統一
+- **suspended テナント**: 200 で返却し `status: "suspended"` を含める（FE はメンテ画面切替に使用）
+- **status の fail-closed 判定**: `"active"` / `"suspended"` 以外の値（データ破損・未設定）は `suspended` にフォールバック（active 漏洩防止）
+- **レート制限**: `authLimiter` 流用（10 req/min/IP）
+- **Firestore 障害時**: `503 firestore_unavailable`（silent 空応答にしない）
+- **HTTP キャッシュ**: 成功時 `Cache-Control: public, max-age=60, stale-while-revalidate=300`、404 時 `public, max-age=30`、503 時 `no-store`（障害回復後に古い応答を再提示しない）
+
+関連: ADR-031、Issue #320、親 Issue #272
+
 ### プラットフォーム認証エラーログ（Super Admin）
 
 ベースURL: `/api/v2/super/`

--- a/packages/shared-types/src/tenant.ts
+++ b/packages/shared-types/src/tenant.ts
@@ -50,21 +50,24 @@ export interface SuperTenantDetailResponse {
 }
 
 /**
- * 認証不要の公開テナント情報（ADR-031 Phase 3 / Sub-Issue B）
+ * 認証不要の公開テナント情報（ADR-031）
  *
  * `GET /api/v2/public/tenants/:tenantId` のレスポンスボディ。
  * FE が GCIP 経路のログイン前に `auth.tenantId` へ `gcipTenantId` をセットするために使用する。
  *
- * 情報漏洩防止のため、`ownerId` / `ownerEmail` / `userCount` /
- * `createdAt` / `updatedAt` は**意図的に含めない**。
+ * 認証不要エンドポイントのため、テナントの識別情報（`name`）・所有者 PII
+ * （`ownerId` / `ownerEmail`）・利用規模（`userCount`）・運用時刻
+ * （`createdAt` / `updatedAt`）は**意図的に含めない**。新フィールド追加時は
+ * 同じ threat model で可否を判断する。
+ *
+ * `status` は `"active"` / `"suspended"` のいずれか。サーバー側でデータ破損時に
+ * `"suspended"` へフェイルクローズする（詳細 ADR-031）。FE は `"active"` 以外を
+ * 全てメンテナンス扱いにしてよい。
  */
 export interface PublicTenantInfo {
   id: string;
-  name: string;
   status: TenantStatus;
-  /** GCIP Tenant ID（ADR-031 Phase 3）。非 GCIP 経路の場合は null */
   gcipTenantId: string | null;
-  /** GCIP 経路を有効化するか（ADR-031 Phase 3、feature flag） */
   useGcip: boolean;
 }
 

--- a/packages/shared-types/src/tenant.ts
+++ b/packages/shared-types/src/tenant.ts
@@ -48,3 +48,26 @@ export interface SuperTenantDetailResponse {
     lessonCount: number;
   };
 }
+
+/**
+ * 認証不要の公開テナント情報（ADR-031 Phase 3 / Sub-Issue B）
+ *
+ * `GET /api/v2/public/tenants/:tenantId` のレスポンスボディ。
+ * FE が GCIP 経路のログイン前に `auth.tenantId` へ `gcipTenantId` をセットするために使用する。
+ *
+ * 情報漏洩防止のため、`ownerId` / `ownerEmail` / `userCount` /
+ * `createdAt` / `updatedAt` は**意図的に含めない**。
+ */
+export interface PublicTenantInfo {
+  id: string;
+  name: string;
+  status: TenantStatus;
+  /** GCIP Tenant ID（ADR-031 Phase 3）。非 GCIP 経路の場合は null */
+  gcipTenantId: string | null;
+  /** GCIP 経路を有効化するか（ADR-031 Phase 3、feature flag） */
+  useGcip: boolean;
+}
+
+export interface PublicTenantInfoResponse {
+  tenant: PublicTenantInfo;
+}

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -16,6 +16,7 @@ import { createSharedRouter } from "./routes/shared/index.js";
 import { tenantsRouter } from "./routes/tenants.js";
 import { superAdminRouter } from "./routes/super-admin.js";
 import { helpRoleRouter } from "./routes/help-role.js";
+import { publicRouter } from "./routes/public.js";
 import { logger } from "./utils/logger.js";
 import { getFirestore } from "firebase-admin/firestore";
 
@@ -127,6 +128,10 @@ if (process.env.E2E_TEST_ENABLED === "true") {
   });
 }
 
+// 認証不要の公開API（ADR-031 Phase 3 / Sub-Issue B）
+// FE ログイン前テナント解決（gcipTenantId 取得）用。rate limit 適用必須。
+app.use("/api/v2/public", authLimiter, publicRouter);
+
 // テナント登録API（認証のみ、テナントコンテキスト不要）
 app.use("/api/v2/tenants", authLimiter, tenantsRouter);
 
@@ -157,6 +162,7 @@ const server = app.listen(port, () => {
     port,
     routes: [
       "/health, /healthz, /api/health",
+      "/api/v2/public/*",
       "/api/v2/tenants",
       "/api/v2/super/*",
       "/api/v2/:tenant/*",

--- a/services/api/src/routes/__tests__/public.test.ts
+++ b/services/api/src/routes/__tests__/public.test.ts
@@ -1,0 +1,369 @@
+/**
+ * GET /api/v2/public/tenants/:tenantId (routes/public.ts) の統合テスト
+ *
+ * ADR-031 Phase 3 Sub-Issue B: 認証不要の公開テナント情報 endpoint。
+ *
+ * 検証対象:
+ *   - 正常系: active / suspended の両方で 200 を返す
+ *   - 404: 未登録 / RESERVED_TENANT_IDS / 不正フォーマット（enumeration 防止のため同一レスポンス）
+ *   - 503: Firestore 障害時
+ *   - 情報漏洩防止: ownerId / ownerEmail / createdAt / updatedAt が含まれない
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import supertest from "supertest";
+
+const mockDocGet = vi.fn();
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: () => ({
+    collection: (_name: string) => ({
+      doc: (_id: string) => ({
+        get: () => mockDocGet(),
+      }),
+    }),
+  }),
+}));
+
+async function buildApp() {
+  const { publicRouter } = await import("../public.js");
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v2/public", publicRouter);
+  return app;
+}
+
+function makeSnapshot(data: Record<string, unknown> | null) {
+  return {
+    exists: data !== null,
+    data: () => data,
+  };
+}
+
+describe("GET /api/v2/public/tenants/:tenantId", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockDocGet.mockReset();
+  });
+
+  describe("正常系 (AC-1, AC-5)", () => {
+    it("active テナントで 200 + PublicTenantInfo を返す", async () => {
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({
+          name: "Test Tenant",
+          status: "active",
+          gcipTenantId: "gcip-xyz",
+          useGcip: true,
+          ownerId: "uid-owner",
+          ownerEmail: "owner@example.com",
+          createdAt: new Date("2026-01-01"),
+          updatedAt: new Date("2026-02-01"),
+        })
+      );
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/test-tenant");
+
+      expect(res.status).toBe(200);
+      expect(res.body.tenant).toEqual({
+        id: "test-tenant",
+        name: "Test Tenant",
+        status: "active",
+        gcipTenantId: "gcip-xyz",
+        useGcip: true,
+      });
+    });
+
+    it("suspended テナントでも 200 を返す（FE がメンテ画面切替判断に使用）", async () => {
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({
+          name: "Paused Tenant",
+          status: "suspended",
+          gcipTenantId: null,
+          useGcip: false,
+        })
+      );
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/paused-tenant");
+
+      expect(res.status).toBe(200);
+      expect(res.body.tenant.status).toBe("suspended");
+      expect(res.body.tenant.gcipTenantId).toBeNull();
+      expect(res.body.tenant.useGcip).toBe(false);
+    });
+
+    it("gcipTenantId が未設定のテナント（非 GCIP 経路）でも 200 を返す", async () => {
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({
+          name: "Legacy Tenant",
+          status: "active",
+          gcipTenantId: null,
+          useGcip: false,
+        })
+      );
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/legacy");
+
+      expect(res.status).toBe(200);
+      expect(res.body.tenant.gcipTenantId).toBeNull();
+      expect(res.body.tenant.useGcip).toBe(false);
+    });
+  });
+
+  describe("情報漏洩防止 (AC-2)", () => {
+    it("レスポンスに ownerId / ownerEmail / createdAt / updatedAt / userCount が含まれない", async () => {
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({
+          name: "Test",
+          status: "active",
+          gcipTenantId: null,
+          useGcip: false,
+          ownerId: "uid-owner",
+          ownerEmail: "owner@example.com",
+          userCount: 42,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+      );
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/test");
+
+      expect(res.status).toBe(200);
+      const tenantKeys = Object.keys(res.body.tenant).sort();
+      expect(tenantKeys).toEqual(["gcipTenantId", "id", "name", "status", "useGcip"]);
+    });
+  });
+
+  describe("404 系 (AC-3, AC-4)", () => {
+    it("未登録 tenantId は 404 tenant_not_found", async () => {
+      mockDocGet.mockResolvedValue(makeSnapshot(null));
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/nonexistent");
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("tenant_not_found");
+    });
+
+    it("RESERVED_TENANT_IDS (admin) は Firestore を呼ばず 404", async () => {
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/admin");
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("tenant_not_found");
+      expect(mockDocGet).not.toHaveBeenCalled();
+    });
+
+    it("RESERVED_TENANT_IDS (super) も 404", async () => {
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/super");
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("tenant_not_found");
+      expect(mockDocGet).not.toHaveBeenCalled();
+    });
+
+    it("RESERVED_TENANT_IDS (public) も 404（URL prefix と同名の回避）", async () => {
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/public");
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("tenant_not_found");
+      expect(mockDocGet).not.toHaveBeenCalled();
+    });
+
+    it("不正フォーマット (大文字混入) は Firestore を呼ばず 404", async () => {
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/BadCase");
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("tenant_not_found");
+      expect(mockDocGet).not.toHaveBeenCalled();
+    });
+
+    it("不正フォーマット (記号混入) は Firestore を呼ばず 404", async () => {
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/invalid%20id");
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("tenant_not_found");
+      expect(mockDocGet).not.toHaveBeenCalled();
+    });
+
+    it("snapshot が存在するがデータが undefined の場合も 404", async () => {
+      mockDocGet.mockResolvedValue({ exists: true, data: () => undefined });
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/stale");
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("tenant_not_found");
+    });
+  });
+
+  describe("503 系 (AC-7)", () => {
+    it("Firestore が throw した場合 503 firestore_unavailable", async () => {
+      mockDocGet.mockRejectedValue(new Error("firestore timeout"));
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/test");
+
+      expect(res.status).toBe(503);
+      expect(res.body.error).toBe("firestore_unavailable");
+    });
+
+    it("503 時は Cache-Control: no-store を付与（障害回復後に古い応答を返さない）", async () => {
+      mockDocGet.mockRejectedValue(new Error("firestore timeout"));
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/test");
+
+      expect(res.status).toBe(503);
+      expect(res.headers["cache-control"]).toBe("no-store");
+    });
+  });
+
+  describe("データ正規化（fail-closed）", () => {
+    it("status が不正値の場合は suspended にフェイルクローズ（active 漏洩防止）", async () => {
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({
+          name: "Test",
+          status: "unknown_status",
+          gcipTenantId: null,
+          useGcip: false,
+        })
+      );
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/test");
+
+      expect(res.status).toBe(200);
+      expect(res.body.tenant.status).toBe("suspended");
+    });
+
+    it("status が欠落している場合も suspended にフェイルクローズ", async () => {
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({
+          name: "Test",
+          gcipTenantId: null,
+          useGcip: false,
+        })
+      );
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/test");
+
+      expect(res.status).toBe(200);
+      expect(res.body.tenant.status).toBe("suspended");
+    });
+
+    it("gcipTenantId が非 string の場合は null（parseTenantGcipFields 経由）", async () => {
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({
+          name: "Test",
+          status: "active",
+          gcipTenantId: 12345,
+          useGcip: true,
+        })
+      );
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/test");
+
+      expect(res.status).toBe(200);
+      expect(res.body.tenant.gcipTenantId).toBeNull();
+    });
+
+    it("name が欠落している場合は空文字列にフォールバック（data 破損可視化のため warn）", async () => {
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({
+          status: "active",
+          gcipTenantId: null,
+          useGcip: false,
+        })
+      );
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/test");
+
+      expect(res.status).toBe(200);
+      expect(res.body.tenant.name).toBe("");
+    });
+
+    it("name が非 string の場合も空文字列にフォールバック", async () => {
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({
+          name: 42,
+          status: "active",
+          gcipTenantId: null,
+          useGcip: false,
+        })
+      );
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/test");
+
+      expect(res.status).toBe(200);
+      expect(res.body.tenant.name).toBe("");
+    });
+
+    it("useGcip が truthy だが非 boolean の場合は false", async () => {
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({
+          name: "Test",
+          status: "active",
+          gcipTenantId: "gcip-x",
+          useGcip: "true",
+        })
+      );
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/test");
+
+      expect(res.status).toBe(200);
+      expect(res.body.tenant.useGcip).toBe(false);
+    });
+  });
+
+  describe("HTTP キャッシュヘッダ", () => {
+    it("成功時は Cache-Control: public, max-age=60, stale-while-revalidate=300 を付与", async () => {
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({
+          name: "Test",
+          status: "active",
+          gcipTenantId: null,
+          useGcip: false,
+        })
+      );
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/test");
+
+      expect(res.status).toBe(200);
+      expect(res.headers["cache-control"]).toBe(
+        "public, max-age=60, stale-while-revalidate=300"
+      );
+    });
+
+    it("404 時は Cache-Control: public, max-age=30 を付与（enumeration 攻撃時の Firestore read 抑制）", async () => {
+      mockDocGet.mockResolvedValue(makeSnapshot(null));
+
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/nonexistent");
+
+      expect(res.status).toBe(404);
+      expect(res.headers["cache-control"]).toBe("public, max-age=30");
+    });
+
+    it("RESERVED_TENANT_IDS の 404 にも Cache-Control を付与", async () => {
+      const app = await buildApp();
+      const res = await supertest(app).get("/api/v2/public/tenants/admin");
+
+      expect(res.status).toBe(404);
+      expect(res.headers["cache-control"]).toBe("public, max-age=30");
+    });
+  });
+});

--- a/services/api/src/routes/__tests__/public.test.ts
+++ b/services/api/src/routes/__tests__/public.test.ts
@@ -1,13 +1,16 @@
 /**
  * GET /api/v2/public/tenants/:tenantId (routes/public.ts) の統合テスト
  *
- * ADR-031 Phase 3 Sub-Issue B: 認証不要の公開テナント情報 endpoint。
+ * 認証不要の公開テナント情報 endpoint（ADR-031）。
  *
  * 検証対象:
  *   - 正常系: active / suspended の両方で 200 を返す
- *   - 404: 未登録 / RESERVED_TENANT_IDS / 不正フォーマット（enumeration 防止のため同一レスポンス）
- *   - 503: Firestore 障害時
- *   - 情報漏洩防止: ownerId / ownerEmail / createdAt / updatedAt が含まれない
+ *   - 404: 未登録 / RESERVED_TENANT_IDS / 不正フォーマット全経路が
+ *     body / headers 完全一致（enumeration 防止の回帰防止）
+ *   - 503: Firestore 障害時に logger.error + Cache-Control: no-store
+ *   - 情報漏洩防止: 応答は id / status / gcipTenantId / useGcip のみ
+ *   - 観測性: status / name / 503 path で logger.warn/error が発火する契約
+ *   - Wiring: authLimiter が publicRouter の前段に mount されている
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import express from "express";
@@ -46,8 +49,8 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
     mockDocGet.mockReset();
   });
 
-  describe("正常系 (AC-1, AC-5)", () => {
-    it("active テナントで 200 + PublicTenantInfo を返す", async () => {
+  describe("正常系", () => {
+    it("active テナントで 200 + id/status/gcipTenantId/useGcip を返す", async () => {
       mockDocGet.mockResolvedValue(
         makeSnapshot({
           name: "Test Tenant",
@@ -67,7 +70,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
       expect(res.status).toBe(200);
       expect(res.body.tenant).toEqual({
         id: "test-tenant",
-        name: "Test Tenant",
         status: "active",
         gcipTenantId: "gcip-xyz",
         useGcip: true,
@@ -77,7 +79,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
     it("suspended テナントでも 200 を返す（FE がメンテ画面切替判断に使用）", async () => {
       mockDocGet.mockResolvedValue(
         makeSnapshot({
-          name: "Paused Tenant",
           status: "suspended",
           gcipTenantId: null,
           useGcip: false,
@@ -96,7 +97,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
     it("gcipTenantId が未設定のテナント（非 GCIP 経路）でも 200 を返す", async () => {
       mockDocGet.mockResolvedValue(
         makeSnapshot({
-          name: "Legacy Tenant",
           status: "active",
           gcipTenantId: null,
           useGcip: false,
@@ -112,11 +112,11 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
     });
   });
 
-  describe("情報漏洩防止 (AC-2)", () => {
-    it("レスポンスに ownerId / ownerEmail / createdAt / updatedAt / userCount が含まれない", async () => {
+  describe("情報漏洩防止", () => {
+    it("応答に name / ownerId / ownerEmail / createdAt / updatedAt / userCount が含まれない", async () => {
       mockDocGet.mockResolvedValue(
         makeSnapshot({
-          name: "Test",
+          name: "Corporate Acme",
           status: "active",
           gcipTenantId: null,
           useGcip: false,
@@ -132,12 +132,17 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
       const res = await supertest(app).get("/api/v2/public/tenants/test");
 
       expect(res.status).toBe(200);
-      const tenantKeys = Object.keys(res.body.tenant).sort();
-      expect(tenantKeys).toEqual(["gcipTenantId", "id", "name", "status", "useGcip"]);
+      expect(Object.keys(res.body).sort()).toEqual(["tenant"]);
+      expect(Object.keys(res.body.tenant).sort()).toEqual([
+        "gcipTenantId",
+        "id",
+        "status",
+        "useGcip",
+      ]);
     });
   });
 
-  describe("404 系 (AC-3, AC-4)", () => {
+  describe("404 経路の完全等価性（enumeration 防止）", () => {
     it("未登録 tenantId は 404 tenant_not_found", async () => {
       mockDocGet.mockResolvedValue(makeSnapshot(null));
 
@@ -153,7 +158,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
       const res = await supertest(app).get("/api/v2/public/tenants/admin");
 
       expect(res.status).toBe(404);
-      expect(res.body.error).toBe("tenant_not_found");
       expect(mockDocGet).not.toHaveBeenCalled();
     });
 
@@ -162,7 +166,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
       const res = await supertest(app).get("/api/v2/public/tenants/super");
 
       expect(res.status).toBe(404);
-      expect(res.body.error).toBe("tenant_not_found");
       expect(mockDocGet).not.toHaveBeenCalled();
     });
 
@@ -171,7 +174,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
       const res = await supertest(app).get("/api/v2/public/tenants/public");
 
       expect(res.status).toBe(404);
-      expect(res.body.error).toBe("tenant_not_found");
       expect(mockDocGet).not.toHaveBeenCalled();
     });
 
@@ -180,7 +182,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
       const res = await supertest(app).get("/api/v2/public/tenants/BadCase");
 
       expect(res.status).toBe(404);
-      expect(res.body.error).toBe("tenant_not_found");
       expect(mockDocGet).not.toHaveBeenCalled();
     });
 
@@ -189,7 +190,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
       const res = await supertest(app).get("/api/v2/public/tenants/invalid%20id");
 
       expect(res.status).toBe(404);
-      expect(res.body.error).toBe("tenant_not_found");
       expect(mockDocGet).not.toHaveBeenCalled();
     });
 
@@ -202,10 +202,33 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
       expect(res.status).toBe(404);
       expect(res.body.error).toBe("tenant_not_found");
     });
+
+    it("全 404 経路で body / Cache-Control / status が完全一致（enumeration 防止の回帰防止）", async () => {
+      const app = await buildApp();
+
+      mockDocGet.mockResolvedValue(makeSnapshot(null));
+      const notFound = await supertest(app).get("/api/v2/public/tenants/nonexistent");
+
+      mockDocGet.mockReset();
+      const reserved = await supertest(app).get("/api/v2/public/tenants/admin");
+
+      mockDocGet.mockReset();
+      const badFormat = await supertest(app).get("/api/v2/public/tenants/BadCase");
+
+      mockDocGet.mockReset();
+      mockDocGet.mockResolvedValueOnce({ exists: true, data: () => undefined });
+      const staleDoc = await supertest(app).get("/api/v2/public/tenants/stale");
+
+      for (const other of [reserved, badFormat, staleDoc]) {
+        expect(other.status).toBe(notFound.status);
+        expect(other.body).toEqual(notFound.body);
+        expect(other.headers["cache-control"]).toBe(notFound.headers["cache-control"]);
+      }
+    });
   });
 
-  describe("503 系 (AC-7)", () => {
-    it("Firestore が throw した場合 503 firestore_unavailable", async () => {
+  describe("503 系", () => {
+    it("Firestore が throw した場合 503 firestore_unavailable + Cache-Control: no-store", async () => {
       mockDocGet.mockRejectedValue(new Error("firestore timeout"));
 
       const app = await buildApp();
@@ -213,15 +236,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
 
       expect(res.status).toBe(503);
       expect(res.body.error).toBe("firestore_unavailable");
-    });
-
-    it("503 時は Cache-Control: no-store を付与（障害回復後に古い応答を返さない）", async () => {
-      mockDocGet.mockRejectedValue(new Error("firestore timeout"));
-
-      const app = await buildApp();
-      const res = await supertest(app).get("/api/v2/public/tenants/test");
-
-      expect(res.status).toBe(503);
       expect(res.headers["cache-control"]).toBe("no-store");
     });
   });
@@ -230,7 +244,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
     it("status が不正値の場合は suspended にフェイルクローズ（active 漏洩防止）", async () => {
       mockDocGet.mockResolvedValue(
         makeSnapshot({
-          name: "Test",
           status: "unknown_status",
           gcipTenantId: null,
           useGcip: false,
@@ -247,7 +260,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
     it("status が欠落している場合も suspended にフェイルクローズ", async () => {
       mockDocGet.mockResolvedValue(
         makeSnapshot({
-          name: "Test",
           gcipTenantId: null,
           useGcip: false,
         })
@@ -263,7 +275,6 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
     it("gcipTenantId が非 string の場合は null（parseTenantGcipFields 経由）", async () => {
       mockDocGet.mockResolvedValue(
         makeSnapshot({
-          name: "Test",
           status: "active",
           gcipTenantId: 12345,
           useGcip: true,
@@ -277,43 +288,9 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
       expect(res.body.tenant.gcipTenantId).toBeNull();
     });
 
-    it("name が欠落している場合は空文字列にフォールバック（data 破損可視化のため warn）", async () => {
-      mockDocGet.mockResolvedValue(
-        makeSnapshot({
-          status: "active",
-          gcipTenantId: null,
-          useGcip: false,
-        })
-      );
-
-      const app = await buildApp();
-      const res = await supertest(app).get("/api/v2/public/tenants/test");
-
-      expect(res.status).toBe(200);
-      expect(res.body.tenant.name).toBe("");
-    });
-
-    it("name が非 string の場合も空文字列にフォールバック", async () => {
-      mockDocGet.mockResolvedValue(
-        makeSnapshot({
-          name: 42,
-          status: "active",
-          gcipTenantId: null,
-          useGcip: false,
-        })
-      );
-
-      const app = await buildApp();
-      const res = await supertest(app).get("/api/v2/public/tenants/test");
-
-      expect(res.status).toBe(200);
-      expect(res.body.tenant.name).toBe("");
-    });
-
     it("useGcip が truthy だが非 boolean の場合は false", async () => {
       mockDocGet.mockResolvedValue(
         makeSnapshot({
-          name: "Test",
           status: "active",
           gcipTenantId: "gcip-x",
           useGcip: "true",
@@ -329,41 +306,93 @@ describe("GET /api/v2/public/tenants/:tenantId", () => {
   });
 
   describe("HTTP キャッシュヘッダ", () => {
-    it("成功時は Cache-Control: public, max-age=60, stale-while-revalidate=300 を付与", async () => {
+    it("200 / 404 の Cache-Control が同一（public, max-age=60）", async () => {
+      const app = await buildApp();
+
       mockDocGet.mockResolvedValue(
         makeSnapshot({
-          name: "Test",
           status: "active",
           gcipTenantId: null,
           useGcip: false,
         })
       );
+      const found = await supertest(app).get("/api/v2/public/tenants/found");
 
-      const app = await buildApp();
-      const res = await supertest(app).get("/api/v2/public/tenants/test");
-
-      expect(res.status).toBe(200);
-      expect(res.headers["cache-control"]).toBe(
-        "public, max-age=60, stale-while-revalidate=300"
-      );
-    });
-
-    it("404 時は Cache-Control: public, max-age=30 を付与（enumeration 攻撃時の Firestore read 抑制）", async () => {
+      mockDocGet.mockReset();
       mockDocGet.mockResolvedValue(makeSnapshot(null));
+      const notFound = await supertest(app).get("/api/v2/public/tenants/missing");
+
+      expect(found.headers["cache-control"]).toBe("public, max-age=60");
+      expect(notFound.headers["cache-control"]).toBe("public, max-age=60");
+    });
+  });
+
+  describe("観測性（logger 契約）", () => {
+    it("status 不正値で logger.warn が errorType=tenant_status_invalid で呼ばれる", async () => {
+      const { logger } = await import("../../utils/logger.js");
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({ status: "bogus", gcipTenantId: null, useGcip: false })
+      );
 
       const app = await buildApp();
-      const res = await supertest(app).get("/api/v2/public/tenants/nonexistent");
+      await supertest(app).get("/api/v2/public/tenants/test");
 
-      expect(res.status).toBe(404);
-      expect(res.headers["cache-control"]).toBe("public, max-age=30");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("status"),
+        expect.objectContaining({
+          errorType: "tenant_status_invalid",
+          tenantId: "test",
+          actualValue: "bogus",
+        })
+      );
+      warnSpy.mockRestore();
     });
 
-    it("RESERVED_TENANT_IDS の 404 にも Cache-Control を付与", async () => {
-      const app = await buildApp();
-      const res = await supertest(app).get("/api/v2/public/tenants/admin");
+    it("503 経路で logger.error が firestoreErrorCode 付きで呼ばれる", async () => {
+      const { logger } = await import("../../utils/logger.js");
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
 
-      expect(res.status).toBe(404);
-      expect(res.headers["cache-control"]).toBe("public, max-age=30");
+      const firestoreErr = Object.assign(new Error("IAM"), { code: "permission-denied" });
+      mockDocGet.mockRejectedValue(firestoreErr);
+
+      const app = await buildApp();
+      await supertest(app).get("/api/v2/public/tenants/test");
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Firestore"),
+        expect.objectContaining({
+          errorType: "public_tenant_firestore_error",
+          tenantId: "test",
+          firestoreErrorCode: "permission-denied",
+        })
+      );
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe("Wiring (authLimiter が mount されている)", () => {
+    it("authLimiter 配下では 11 リクエスト目で 429 を返す", async () => {
+      // 実際の index.ts と同じ middleware 順序を再現して実挙動で wiring を確認する。
+      const { authLimiter } = await import("../../middleware/rate-limiter.js");
+      const { publicRouter } = await import("../public.js");
+      const app = express();
+      app.use(express.json());
+      app.use("/api/v2/public", authLimiter, publicRouter);
+
+      mockDocGet.mockResolvedValue(
+        makeSnapshot({ status: "active", gcipTenantId: null, useGcip: false })
+      );
+
+      const agent = supertest.agent(app);
+      for (let i = 0; i < 10; i++) {
+        const ok = await agent.get("/api/v2/public/tenants/test");
+        expect(ok.status).toBe(200);
+      }
+
+      const overflow = await agent.get("/api/v2/public/tenants/test");
+      expect(overflow.status).toBe(429);
     });
   });
 });

--- a/services/api/src/routes/public.ts
+++ b/services/api/src/routes/public.ts
@@ -1,5 +1,5 @@
 /**
- * 認証不要の公開 API（ADR-031: GCIP マルチテナント対応の一部）
+ * 認証不要の公開 API（ADR-031: GCIP マルチテナント対応）
  *
  * `GET /api/v2/public/tenants/:tenantId`
  *   FE が GCIP 経路のログイン前に `auth.tenantId` へ GCIP Tenant ID を
@@ -22,15 +22,48 @@ const ALLOWED_STATUSES = new Set<TenantStatus>(["active", "suspended"]);
 
 /** 認証不要 endpoint の HTTP キャッシュ方針
  *
- * 公開情報のみで機密は含まれないため、ブラウザ / CDN での短期キャッシュを許可し
- * Firestore read と hot-path レイテンシを抑制する。値が変わるのは super-admin の
- * 操作時のみのため、60 秒の max-age と 300 秒の SWR で UX 影響なし。
+ * 200 と 404 は同一の `Cache-Control` を返し、header から存在有無が推測
+ * できないようにする。503 は `no-store` で障害回復後に古い応答を再提示しない。
+ * `stale-while-revalidate` は付与しない（super-admin の suspend 操作が
+ * 最大 SWR 期間分遅延するのを避けるため）。
  */
-const CACHE_CONTROL_FOUND = "public, max-age=60, stale-while-revalidate=300";
-const CACHE_CONTROL_NOT_FOUND = "public, max-age=30";
+const CACHE_CONTROL_DEFAULT = "public, max-age=60";
+const CACHE_CONTROL_UNAVAILABLE = "no-store";
+
+/**
+ * 公開レスポンス用テナント情報の構築。
+ *
+ * ここを単一の audit point として、`TenantMetadata` から外に出してよい
+ * フィールドだけを明示的に pick する。新しい `TenantMetadata` フィールドが
+ * 追加されても、この関数を通過しない限り公開 response には含まれない。
+ * `status` は fail-closed: 想定外の値はすべて `"suspended"` に正規化する。
+ */
+function toPublicTenantInfo(
+  tenantId: string,
+  data: Partial<TenantMetadata>
+): PublicTenantInfo {
+  const rawStatus = data.status;
+  let status: TenantStatus;
+  if (typeof rawStatus === "string" && ALLOWED_STATUSES.has(rawStatus)) {
+    status = rawStatus;
+  } else {
+    logger.warn("Tenant status has invalid value; falling back to suspended", {
+      errorType: "tenant_status_invalid",
+      tenantId,
+      actualValue: typeof rawStatus === "string" ? rawStatus : typeof rawStatus,
+    });
+    status = "suspended";
+  }
+
+  return {
+    id: tenantId,
+    status,
+    ...parseTenantGcipFields({ ...data, id: tenantId }),
+  };
+}
 
 function sendNotFound(res: Response): void {
-  res.set("Cache-Control", CACHE_CONTROL_NOT_FOUND);
+  res.set("Cache-Control", CACHE_CONTROL_DEFAULT);
   res.status(404).json({
     error: "tenant_not_found",
     message: "Tenant not found",
@@ -56,12 +89,21 @@ router.get("/tenants/:tenantId", async (req: Request, res: Response) => {
   try {
     snapshot = await db.collection("tenants").doc(tenantId).get();
   } catch (err) {
-    logger.warn("Public tenant lookup failed (Firestore error)", {
+    // 5xx は運用上のインシデント（IAM regression / quota / 一時障害 等）に
+    // 相当するため error 重大度で記録し、SDK の構造化エラー情報を保持する。
+    const firestoreErrorCode =
+      err && typeof err === "object" && "code" in err
+        ? ((err as { code?: unknown }).code ?? null)
+        : null;
+    logger.error("Public tenant lookup failed (Firestore error)", {
+      errorType: "public_tenant_firestore_error",
       tenantId,
-      error: String(err),
+      firestoreErrorCode,
+      errorMessage: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
     });
     // 障害回復後に古い 503 が CDN/ブラウザで再提示されないよう明示的にキャッシュ無効化
-    res.set("Cache-Control", "no-store");
+    res.set("Cache-Control", CACHE_CONTROL_UNAVAILABLE);
     res.status(503).json({
       error: "firestore_unavailable",
       message: "Tenant directory is temporarily unavailable. Please retry.",
@@ -80,42 +122,9 @@ router.get("/tenants/:tenantId", async (req: Request, res: Response) => {
     return;
   }
 
-  // status は fail-closed で判定する。`active` への silent fallback は
-  // データ破損時に suspended テナントが active として漏洩するリスクがあるため、
-  // 想定外の値はすべて suspended 扱いでメンテ状態を返す。
-  const rawStatus = data.status;
-  let status: TenantStatus;
-  if (typeof rawStatus === "string" && ALLOWED_STATUSES.has(rawStatus)) {
-    status = rawStatus;
-  } else {
-    logger.warn("Tenant status has invalid value; falling back to suspended", {
-      errorType: "tenant_status_invalid",
-      tenantId,
-      actualValue: typeof rawStatus === "string" ? rawStatus : typeof rawStatus,
-    });
-    status = "suspended";
-  }
+  const tenant = toPublicTenantInfo(tenantId, data);
 
-  let name: string;
-  if (typeof data.name === "string") {
-    name = data.name;
-  } else {
-    logger.warn("Tenant name has invalid value; falling back to empty string", {
-      errorType: "tenant_name_invalid",
-      tenantId,
-      actualType: typeof data.name,
-    });
-    name = "";
-  }
-
-  const tenant: PublicTenantInfo = {
-    id: tenantId,
-    name,
-    status,
-    ...parseTenantGcipFields({ ...data, id: tenantId }),
-  };
-
-  res.set("Cache-Control", CACHE_CONTROL_FOUND);
+  res.set("Cache-Control", CACHE_CONTROL_DEFAULT);
   const response: PublicTenantInfoResponse = { tenant };
   res.status(200).json(response);
 });

--- a/services/api/src/routes/public.ts
+++ b/services/api/src/routes/public.ts
@@ -1,0 +1,123 @@
+/**
+ * 認証不要の公開 API（ADR-031: GCIP マルチテナント対応の一部）
+ *
+ * `GET /api/v2/public/tenants/:tenantId`
+ *   FE が GCIP 経路のログイン前に `auth.tenantId` へ GCIP Tenant ID を
+ *   セットするために使用する。認証不要のためレスポンスフィールドは最小化し、
+ *   存在チェックと予約語チェックは同一レスポンスで返す（enumeration 防止）。
+ */
+
+import { Router, Request, Response } from "express";
+import { getFirestore } from "firebase-admin/firestore";
+import type { PublicTenantInfo, PublicTenantInfoResponse } from "@lms-279/shared-types";
+import type { TenantMetadata, TenantStatus } from "../types/tenant.js";
+import { RESERVED_TENANT_IDS, parseTenantGcipFields } from "../utils/tenant-id.js";
+import { logger } from "../utils/logger.js";
+
+const router = Router();
+
+/** tenantId の許容形式: 小文字英数字・アンダースコア・ハイフン、1〜64 文字 */
+const TENANT_ID_PATTERN = /^[a-z0-9_-]{1,64}$/;
+const ALLOWED_STATUSES = new Set<TenantStatus>(["active", "suspended"]);
+
+/** 認証不要 endpoint の HTTP キャッシュ方針
+ *
+ * 公開情報のみで機密は含まれないため、ブラウザ / CDN での短期キャッシュを許可し
+ * Firestore read と hot-path レイテンシを抑制する。値が変わるのは super-admin の
+ * 操作時のみのため、60 秒の max-age と 300 秒の SWR で UX 影響なし。
+ */
+const CACHE_CONTROL_FOUND = "public, max-age=60, stale-while-revalidate=300";
+const CACHE_CONTROL_NOT_FOUND = "public, max-age=30";
+
+function sendNotFound(res: Response): void {
+  res.set("Cache-Control", CACHE_CONTROL_NOT_FOUND);
+  res.status(404).json({
+    error: "tenant_not_found",
+    message: "Tenant not found",
+  });
+}
+
+router.get("/tenants/:tenantId", async (req: Request, res: Response) => {
+  const rawTenantId = req.params.tenantId;
+  const tenantId = Array.isArray(rawTenantId) ? rawTenantId[0] : rawTenantId;
+
+  if (
+    typeof tenantId !== "string" ||
+    !TENANT_ID_PATTERN.test(tenantId) ||
+    RESERVED_TENANT_IDS.has(tenantId)
+  ) {
+    sendNotFound(res);
+    return;
+  }
+
+  const db = getFirestore();
+
+  let snapshot;
+  try {
+    snapshot = await db.collection("tenants").doc(tenantId).get();
+  } catch (err) {
+    logger.warn("Public tenant lookup failed (Firestore error)", {
+      tenantId,
+      error: String(err),
+    });
+    // 障害回復後に古い 503 が CDN/ブラウザで再提示されないよう明示的にキャッシュ無効化
+    res.set("Cache-Control", "no-store");
+    res.status(503).json({
+      error: "firestore_unavailable",
+      message: "Tenant directory is temporarily unavailable. Please retry.",
+    });
+    return;
+  }
+
+  if (!snapshot.exists) {
+    sendNotFound(res);
+    return;
+  }
+
+  const data = snapshot.data() as Partial<TenantMetadata> | undefined;
+  if (!data) {
+    sendNotFound(res);
+    return;
+  }
+
+  // status は fail-closed で判定する。`active` への silent fallback は
+  // データ破損時に suspended テナントが active として漏洩するリスクがあるため、
+  // 想定外の値はすべて suspended 扱いでメンテ状態を返す。
+  const rawStatus = data.status;
+  let status: TenantStatus;
+  if (typeof rawStatus === "string" && ALLOWED_STATUSES.has(rawStatus)) {
+    status = rawStatus;
+  } else {
+    logger.warn("Tenant status has invalid value; falling back to suspended", {
+      errorType: "tenant_status_invalid",
+      tenantId,
+      actualValue: typeof rawStatus === "string" ? rawStatus : typeof rawStatus,
+    });
+    status = "suspended";
+  }
+
+  let name: string;
+  if (typeof data.name === "string") {
+    name = data.name;
+  } else {
+    logger.warn("Tenant name has invalid value; falling back to empty string", {
+      errorType: "tenant_name_invalid",
+      tenantId,
+      actualType: typeof data.name,
+    });
+    name = "";
+  }
+
+  const tenant: PublicTenantInfo = {
+    id: tenantId,
+    name,
+    status,
+    ...parseTenantGcipFields({ ...data, id: tenantId }),
+  };
+
+  res.set("Cache-Control", CACHE_CONTROL_FOUND);
+  const response: PublicTenantInfoResponse = { tenant };
+  res.status(200).json(response);
+});
+
+export { router as publicRouter };


### PR DESCRIPTION
## Summary

- ADR-031 Phase 3 Sub-Issue B: FE が GCIP 経路のログイン前に `auth.tenantId` へ `gcipTenantId` をセットするための認証不要エンドポイントを新設
- `GET /api/v2/public/tenants/:tenantId` を追加し、`shared-types` に `PublicTenantInfo` 型を同梱
- 情報漏洩防止・enumeration 防止・fail-closed status・HTTP キャッシュ戦略を実装

Closes #320
Refs: #272 (Phase 3 親 Issue)

## 実装概要

### 追加エンドポイント
```
GET /api/v2/public/tenants/:tenantId
  → 200: { tenant: { id, name, status, gcipTenantId, useGcip } }
  → 404: tenant_not_found（未登録/RESERVED/不正フォーマット統一）
  → 503: firestore_unavailable
```

### セキュリティ設計
- **情報漏洩防止**: `ownerId` / `ownerEmail` / `userCount` / `createdAt` / `updatedAt` は含めない
- **Enumeration 防止**: 未登録 / `RESERVED_TENANT_IDS` / 不正フォーマットは全て同一 404
- **fail-closed status**: `"active"` / `"suspended"` 以外は `suspended` にフォールバック（active 漏洩防止）
- **HTTP キャッシュ**: 200=60s+SWR300s / 404=30s / 503=no-store
- **レート制限**: 既存 `authLimiter` 流用（10 req/min/IP）
- **観測性**: status / name / gcipTenantId / useGcip の不正値で `logger.warn`

### ファイル構成（5 ファイル + 新規 test）
| ファイル | 種別 | 変更 |
|---|---|---|
| `services/api/src/routes/public.ts` | 新規 | public endpoint 実装 |
| `services/api/src/routes/__tests__/public.test.ts` | 新規 | 22 テスト |
| `services/api/src/index.ts` | 修正 | publicRouter マウント |
| `packages/shared-types/src/tenant.ts` | 修正 | PublicTenantInfo 型追加 |
| `docs/api.md` | 修正 | API ドキュメント追記 |

## 品質ゲート（CLAUDE.md Quality Gate 準拠）

| ゲート | 結果 |
|---|---|
| `/impl-plan` (3+ ステップ + 5+ ファイル) | ✅ AC 10 件策定 |
| `/simplify` (reuse + quality + efficiency 3 並列) | ✅ HIGH 2 件（parseTenantGcipFields 再利用 + fail-closed status）+ MEDIUM 2 件（sendNotFound helper + Cache-Control）反映 |
| `/safe-refactor` (3+ ファイル) | ✅ 冗長型キャスト削除 |
| **Evaluator 分離** (5+ ファイル + 新機能) | ✅ APPROVE_WITH_REVISIONS → MEDIUM 2 件（503 no-store + name warn）+ LOW 1 件（コメント修正）反映 |
| CI (Type Check / Test / Lint) | ✅ 型チェック PASS、API 630 テスト PASS、lint クリーン |

## Acceptance Criteria 検証

| # | 基準 | 結果 |
|---|---|---|
| 1 | 200 + 5 フィールド返却 | ✅ PASS |
| 2 | 情報漏洩防止（ownerId 等含まない） | ✅ PASS |
| 3 | 未登録 → 404 tenant_not_found | ✅ PASS |
| 4 | RESERVED_TENANT_IDS → 404 | ✅ PASS |
| 5 | suspended テナント → 200 | ✅ PASS |
| 6 | authLimiter 10 req/min/IP | ✅ PASS |
| 7 | Firestore 障害 → 503 | ✅ PASS |
| 8 | shared-types 型追加 | ✅ PASS |
| 9 | docs/api.md 更新 | ✅ PASS |
| 10 | lint/type-check/test 全 PASS | ✅ PASS |

## Test plan

- [x] `npm run type-check` 全ワークスペース PASS
- [x] `npm run test -w @lms-279/api` 630 件全 PASS（22 件が本 PR 新規追加）
- [x] `npm run build -w @lms-279/api` 成功
- [x] `npm run build -w @lms-279/shared-types` 成功
- [x] `npx eslint` 変更ファイルで違反なし
- [ ] 本番デプロイ後、`curl /api/v2/public/tenants/<存在する tenant id>` で 200 確認
- [ ] `curl /api/v2/public/tenants/nonexistent` で 404 + Cache-Control 確認

## 依存関係

- 前提 PR: #314（Tenant schema + gcipTenantId/useGcip）✅ マージ済
- 後続 Sub-Issue:
  - F: FE `auth.tenantId` + ログイン前テナント解決（本 PR が前提）
  - E: BE GCIP 経路の tenant 整合性チェック（#313 + #316 が前提、本 PR と独立）

🤖 Generated with [Claude Code](https://claude.com/claude-code)