### PR TITLE
docs(handoff): Session 10 (2026-04-23) ハンドオフ更新

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,14 +1,13 @@
-# Session Handoff — 2026-04-23 (Session 9)
+# Session Handoff — 2026-04-23 (Session 10)
 
 ## TL;DR
 
-**ADR-031 Phase 3 Sub-Issue B 完了**。認証不要 Public tenant-info endpoint `GET /api/v2/public/tenants/:tenantId` を新設。FE が GCIP 経路のログイン前に `auth.tenantId` へ `gcipTenantId` をセットするための入口。Quality Gate 6 層（impl-plan / simplify / safe-refactor / Evaluator / review-pr 6エージェント / codex review）を通過し、`/review-pr` で検出された**情報漏洩リスク**（`name` 露出で顧客名 enumeration 可能）を初期実装から除去。Issue net **0** (#320 起票→同 PR で close、Session 7/8 合意の「実装直前起票」方針を継続)。Codex 最終判定 BLOCKING なし、merge 可能水準。
+**Issue #272 ブランディング検証トラック進行中（Google 側審査待ち）**。Session 9 で Firebase Hosting 公開 (`/privacy` `/terms`) を済ませたが、ブランディング再確認で「ホームページ URL 所有権未確認」エラーが発生。本セッションで Search Console にプロパティ追加 + HTML ファイル検証 (PR #325) を実施し、**「所有権を証明しました」** を確認 → GCP Auth Platform で「問題は修正した」経路で再審査リクエスト送信済み。現在は Google 側で「ブランディングは現在審査中です」状態、結果メール待ち。**Issue net 0**（既存 #272 への進捗更新のみ、triage 基準 #5 ユーザー明示指示に基づく PR #325 の 2 ファイル追加）。
 
-- **マージ完了** (今セッション): PR #321
-- **新規 Issue**: 1 件 (#320 実装直前起票、同 PR でクローズ)
-- **Close**: 1 件 (#320)
-- **Issue Net**: **0** (実装直前起票パターンにつき scope bloat ではない)
-- **Open 推移**: Session 8 末 7 件 → Session 9 末 7 件 (P0:1 / P2:6)
+- **マージ完了** (今セッション): PR #325
+- **Firebase Hosting Deploy**: 完了（`firebase deploy --only hosting --project lms-279`）
+- **Issue Net**: **0**（Close 0 / 起票 0、既存 #272 への進捗更新のみ）
+- **Open 推移**: Session 9 末 7 件 → Session 10 末 7 件 (P0:1 / P2:6)
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -22,115 +21,108 @@ gh issue list --state open --limit 15
 # 3. main CI が緑であることを確認
 gh run list --branch main --limit 3
 
-# 4. 次セッション最優先候補 (ADR-031 Phase 3 残 Sub-Issue)
+# 4. ブランディング審査結果メール確認（system@279279.net）
+# OK → sayori-maeda@kanjikai.or.jp 再ログイン依頼 → #272 緊急トラッククローズ
+# NG → reject 理由確認 → 是正対応
+
+# 5. 並行で進められる Phase 3 残 Sub-Issue (推奨: D/E 並行 → F)
 gh issue view 272  # Phase 3 親 Issue
-# Sub-Issue D/E/F/G/H は実装直前に起票（Net KPI 維持方針）
 ```
 
 ---
 
-## セッション成果物 (2026-04-23 Session 9)
+## セッション成果物 (2026-04-23 Session 10)
 
 ### マージ完了 PR
 
-| # | Issue | Title | Merge Commit |
-|---|-------|-------|-------------|
-| #321 | #320 | feat(public): 認証不要 Public tenant-info endpoint 追加 (Sub-Issue B) | `2cb7c23` |
+| # | Title | Merge Commit |
+|---|-------|-------------|
+| #325 | feat(legal): Google Search Console 所有権確認ファイルを追加 (Issue #272) | `d82a794` |
 
 ### 起票 Issue
 
-| # | 状態 | タイトル | 理由 |
-|---|------|---------|------|
-| #320 | CLOSED (同 PR で完結) | [P1][Phase 3] Sub-Issue B: Public tenant-info endpoint (ADR-031) | Session 7/8 合意の「実装直前起票」。triage 基準 #5（ユーザー明示）準拠 |
+なし（本セッションは既存 #272 緊急復旧トラックの継続。triage 基準 #5 のユーザー明示指示に基づき PR #325 は Issue 化せず直接実装）
 
-### 主要変更の要点 (PR #321)
+### 主要変更の要点 (PR #325)
 
-- **新規 endpoint** (`services/api/src/routes/public.ts`): `GET /api/v2/public/tenants/:tenantId`（認証不要）
-  - 認証なしで FE が `{ id, status, gcipTenantId, useGcip }` を取得
-  - **初期実装にあった `name` フィールドは `/review-pr` の security 指摘で除去**（enumeration 成功時の顧客名漏洩防止）
-  - `authLimiter` 流用（10 req/min/IP）、`/api/v2/public/*` 配下にマウント
-- **共有型** (`packages/shared-types/src/tenant.ts`):
-  - `PublicTenantInfo` (id / status / gcipTenantId / useGcip)
-  - `PublicTenantInfoResponse` ({ tenant })
-  - JSDoc に threat model（何を意図的に除外するか）を明記
-- **セキュリティ設計**:
-  - **Enumeration 防止**: 未登録 / RESERVED_TENANT_IDS / 不正フォーマットは全て同一の 404 + 同一 Cache-Control
-  - **fail-closed status**: `"active"` / `"suspended"` 以外の値は `suspended` に強制（active 漏洩防止）
-  - **HTTP キャッシュ**: 200 / 404 とも `public, max-age=60`（header 差分で存在有無の識別を防止）、503 は `no-store`
-  - stale-while-revalidate は不採用（super-admin の suspend 操作が SWR 期間分遅延するのを回避）
-- **観測性**:
-  - Firestore エラーは `logger.error` で `errorType: "public_tenant_firestore_error"` + `firestoreErrorCode` / `errorMessage` / `stack` を構造化 → IAM regression を Cloud Logging alert で page 可能
-  - status / name / gcipTenantId / useGcip の不正値は `logger.warn` で観測化
-- **response 構築の単一化**: `toPublicTenantInfo()` helper に集約し「外に出してよいフィールド」を single audit point で管理
-- **テスト追加** (21 件、`routes/__tests__/public.test.ts`):
-  - 正常系 3 / 情報漏洩防止 1 / 404 経路完全等価性 1（回帰防止） / 503 系 1 / データ正規化 4 / HTTP キャッシュ 1 / 観測性 logger spy 2 / authLimiter wiring 1
-- **ドキュメント更新** (`docs/api.md`): 公開テナント情報セクション追加、セキュリティ設計の threat model 明記
+- **新規ファイル** (`public-legal/googled6c8738c607c8446.html`): Google Search Console 発行の所有権確認用 HTML ファイル。内容は Google 仕様通り 1 行 (`google-site-verification: googled6c8738c607c8446.html`)
+- **runbook 更新** (`docs/runbook/firebase-hosting-legal-deploy.md`): Search Console 所有権確認手順を追記。ブランディング検証の前提として Search Console プロパティ検証が必要であることを明記
+- **Deploy**: `firebase deploy --only hosting --project lms-279` で公開 (4 ファイル中 1 ファイル新規 upload)
+
+### ブランディング検証フローの実行結果
+
+| # | ステップ | 結果 |
+|---|---------|------|
+| 1 | Search Console プロパティ追加 (URL プレフィックス: `https://lms-279.firebaseapp.com/`) | ✅ 完了 |
+| 2 | HTML ファイル方式で検証トークン発行 | ✅ `googled6c8738c607c8446.html` |
+| 3 | Firebase Hosting に検証ファイル配置 + deploy (PR #325) | ✅ 完了 |
+| 4 | 動作確認: `/googled6c8738c607c8446.html` → 301 → `/googled6c8738c607c8446` → 200 OK | ✅ curl 検証済 |
+| 5 | Search Console で「確認」→ **「所有権を証明しました」** | ✅ 確認済 |
+| 6 | GCP Auth Platform で「問題は修正した」→ 続行 | ✅ 送信済 |
+| 7 | 確認ステータス = **「ブランディングは現在審査中です」** | 🔄 待機中 |
+
+### 技術的発見: cleanUrls と Search Console 検証の両立
+
+`firebase.json` の `cleanUrls: true` 設定により `/googled6c8738c607c8446.html` は `/googled6c8738c607c8446` に 301 リダイレクトされる。**Search Console の検証クローラーは 301 をフォローして検証成功** することを実証。将来同種の検証が必要な場合もメタタグ方式へのフォールバック不要。
+
+**実測結果** (`curl -sI https://lms-279.firebaseapp.com/googled6c8738c607c8446.html`):
+- 直接アクセス: `HTTP/2 301` + `location: /googled6c8738c607c8446`
+- リダイレクト先: `HTTP/2 200` + `content-type: text/html; charset=utf-8`
+- レスポンスボディ: `google-site-verification: googled6c8738c607c8446.html` (Google 期待形式と完全一致)
 
 ### Quality Gate 検証結果
 
-| ゲート | 結果 |
-|-------|------|
-| `/impl-plan` (3+ ステップ + 5+ ファイル) | ✅ AC 10 件策定、Phase 2.7 完了 |
-| `/simplify` (reuse + quality + efficiency 3 並列) | ✅ HIGH 2 件（parseTenantGcipFields 再利用、fail-closed status）+ MEDIUM 2 件（sendNotFound helper、Cache-Control）反映 |
-| `/safe-refactor` (3+ ファイル) | ✅ 冗長型キャスト削除 |
-| **Evaluator 分離** (5+ ファイル + 新機能) | ✅ APPROVE_WITH_REVISIONS → MEDIUM 2 件（503 no-store、name invalid warn）+ LOW 1 件（コメント）反映 |
-| `/review-pr` 6 エージェント並列 | ✅ **Critical 4 件**（`name` 削除 = 顧客名 enumeration 漏洩防止 / 503 logger.error 昇格 / Cache-Control 統一 / 404 完全等価性テスト）+ **Important 4 件**（warn spy / authLimiter wiring / task-tracking 参照削除 / mapper 集約）反映 |
-| `/codex review` セカンドオピニオン | ✅ **BLOCKING なし**、全 4 焦点（name 削除後の残存リスク / Cloud Logging alert / Cache-Control 副作用 / fail-closed 一貫性）で OK / NICE-TO-HAVE のみ |
-| CI (Build / Lint / Test / Type Check) | ✅ 全 PASS（API 629 テスト、うち public 21 件） |
+PR #325 は 2 ファイル / +19 行 / -0 行の軽微変更 (検証ファイル 1 行 + runbook 追記)。ユーザー明示承認のもと、Quality Gate 発動条件 (3 ファイル+ / 5 ファイル+ / 新機能) 非該当のため手動レビュー済み扱いでマージ。
 
-### `/review-pr` の重要な発見
+| ゲート | 状態 | 備考 |
+|-------|------|------|
+| `/impl-plan` | ⏭️ スキップ | 1-2 ファイル変更、スコープ小さい |
+| `/simplify` (3+ ファイル) | ⏭️ スキップ | 対象外 |
+| `/safe-refactor` (3+ ファイル) | ⏭️ スキップ | 対象外 |
+| Evaluator 分離 (5+ ファイル) | ⏭️ スキップ | 対象外 |
+| `/review-pr` | ⏭️ スキップ | ユーザー明示承認 (feedback_cost_benefit_before_action.md 準拠) |
+| 手動レビュー | ✅ 全項目クリア | security / quality / compatibility / docs |
+| CI (E2E Tests) | ✅ PASS (6m40s, run 24830578363) | |
 
-**初期実装から `name` フィールドを削除した判断**が本セッションで最も重要な修正。security レビューエージェントが以下を指摘:
+### 注意: 検証ファイル削除禁止
 
-- tenantId の enumeration（timing / Cache-Control 差分で可能）に加えて `name` が返ると「顧客名の列挙」が成立
-- FE のログイン前処理に必要なのは `gcipTenantId` / `useGcip` / `status` のみで、`name` は UX 向け add-on
-- `name` 露出は ADR-031 の threat model（ホワイトリスト主義 + ゼロトラスト）と不整合
-
-対応として `PublicTenantInfo` から `name` を除去し、FE は login 前は汎用的な welcome 画面、login 後に personalize する運用とした。`/codex review` のセカンドオピニオンでも "`name` 削除により 'knowing tenantId への状態開示' のみが残り、enumeration 成功時の実害が大幅低下" として妥当性を追認。
-
-### 却下した指摘（エージェント提案の triage）
-
-`/review-pr` と security エージェントから多数の提案があったが、以下は triage 基準（rating ≥ 7 + confidence ≥ 80 + 実害あり）不満たしで本 PR 内修正せず:
-
-| 提案 | 却下理由 |
-|---|---|
-| jitter による timing attack 対策 | `name` 削除で enumeration の実害低下、over-engineering |
-| 専用 `publicTenantLookupLimiter` (5 req/min) | 既存 `authLimiter` で実運用 OK、ROI 低 |
-| CORS `credentials: false` on `/api/v2/public` | pre-existing 全エンドポイント共通パターン、本 PR 責任外 |
-| zod ランタイム検証 | 4 フィールド DTO にはオーバーエンジニアリング |
-| length boundary / path-traversal テスト | 既存 regex で防御済み、suggestion レベル |
-| `id` も削除 | REST convention / FE keying を考慮し保持 |
-
-### Defer 項目 (本 PR スコープ外、handoff へ)
-
-- **`rate-limiter.ts` の 429 応答形式が ADR-010 に非準拠**: pre-existing 問題。`{ error: { code, message } }` のネスト形式で返却中。本 PR では endpoint 固有の 200/404/503 のみフラット化。対応 triage は別 Issue 候補（rating 7 相当、ただし既知の仕様）
-- **Firestore エラーの transient / permanent 分類**: silent-failure エージェントの I1 指摘。現状は全て 503 を返すが `permission-denied` は 500 相当、`unavailable` は 503 + Retry-After が理想。#310 (platform_auth_error_logs の transient / permanent 分離) と同系統の運用課題
+Search Console は定期的に再検証するため、`public-legal/googled6c8738c607c8446.html` は **永続保持**。削除すると所有権検証が無効化されブランディング検証が再度失敗する。
 
 ---
 
 ## 残タスク
 
-### 🔴 P0 残
+### 🔴 P0 Issue #272 (ブランディング検証トラック)
 
-**Issue #272 Phase 3 (GCIP 移行本体)** — 引き続きクリティカルパス。Phase 1.1 (OAuth External 化) + Phase 3 後半 (Identity Platform 有効化) はユーザー側 GCP Console 作業の継続ブロッカー。
+**Google 側審査待ち** (通常数時間〜数日):
+- **結果 OK の場合**:
+  1. `system@279279.net` 宛メール受信確認
+  2. `sayori-maeda@kanjikai.or.jp` さんに再ログイン依頼
+  3. 外部ドメインからの Google ログイン成功確認
+  4. Issue #272 緊急復旧トラック完全クローズ (Phase 1.1 + ブランディング検証完了)
+  5. Phase 3 (GCIP 移行本体) の Sub-Issue D/E/F に着手可能
+- **結果 NG の場合**:
+  1. reject 理由を確認 (ロゴ / プライバシーポリシー / その他)
+  2. 該当の是正対応
+  3. 再申請
 
 ### 🟡 Phase 3 残 Sub-Issue (実装直前起票方針で defer 中)
 
 | Sub-Issue | 内容 | 依存 | 備考 |
 |-----------|------|------|------|
 | **D** | GCIP Tenant 作成スクリプト (`scripts/create-gcip-tenants.ts`) | Sub-Issue A (#312) マージ済 | GCP Identity Platform 未有効化でも dry-run 動作確認可 |
-| **E** | BE GCIP 経路の tenant 整合性チェック (`decodedToken.firebase.tenant` 検証) | Sub-Issue A + #316 マージ済 | code-only、本 PR の public endpoint と独立 |
-| **F** | FE `auth.tenantId` + ログイン前テナント解決 | **Sub-Issue B ✅ (本 PR #321 完了)** | 本 PR の endpoint を FE から呼び出す |
+| **E** | BE GCIP 経路の tenant 整合性チェック (`decodedToken.firebase.tenant` 検証) | Sub-Issue A + #316 マージ済 | code-only、独立 |
+| **F** | FE `auth.tenantId` + ログイン前テナント解決 | Sub-Issue B (#321) マージ済 | Sub-Issue B の public endpoint を FE から呼び出す |
 | **G** | tenant 作成時の GCIP 自動化 | Sub-Issue A + E | E 完了後 |
 | **H** | Staging + カナリア + 全テナント移行 | 全 Sub-Issue | GCP 操作ブロッカー解消後 |
 
-**推奨**: 次セッションは **D / E 並行 → F** の順。D/E は code-only かつ相互独立、F は本 PR の endpoint を FE に組み込む。
+**推奨**: ブランディング審査結果待ちの並行作業として **D / E 並行 → F** の順。D/E は code-only かつ相互独立、F は本 PR #321 の endpoint を FE に組み込む。
 
 **Sub-Issue H tasks.md 明記事項** (Session 8 PR #318 由来、継続):
-- ABORTED (transaction retry 上限超過) 時の HTTP 応答を **401 で許容するか、503 + Retry-After に変更するか** を Staging 環境で明示判断
+- ABORTED (transaction retry 上限超過) 時の HTTP 応答を 401 / 503+Retry-After のどちらにするか Staging で判断
 - `user_email_locks` への書き込み権限 (`roles/datastore.user`) を Admin SDK 経由で確認
 - 同一 email 並行 5 transaction → user 1 件検証
-- 既存重複 user (PR #318 以前の race で発生したもの) の audit script 実装
+- 既存重複 user (PR #318 以前の race で発生) の audit script 実装
 
 ### 🟢 P2 残 (Phase 3 と並行可)
 
@@ -143,40 +135,40 @@ gh issue view 272  # Phase 3 親 Issue
 
 | 項目 | 内容 | 影響 |
 |------|------|------|
-| GCP Console: OAuth 同意画面 External 化 | Issue #272 Phase 1.1 | sayori-maeda@kanjikai.or.jp 再ログイン復旧 + Phase 3 前提 |
+| ブランディング審査結果メール確認 | Google → `system@279279.net` | #272 緊急復旧トラッククローズの前提 |
 | 本番 `normalize-users-email.ts` dry-run / execute | PR #287 マージ済、Phase 3 移行前に推奨 | users.email 大文字/空白混入の正規化 |
 | GCP Identity Platform Essentials+ Tier 有効化 + 費用試算 | Sub-Issue H (Staging) の前提 | MAU 次第で数千円〜数万円/月 |
 | Staging 環境の Identity Platform 有効化 | Sub-Issue H の staging 検証の前提 | - |
 
 ## ADR / ドキュメント状態
 
-- **ADR-031** は Session 8 時点で最新（Sub-Issue H Staging 検証スコープに ABORTED HTTP 応答判断追加済）。本 PR #321 は Sub-Issue B 実装のため As-Is 表に追加の更新なし（Sub-Issue B は ADR-031 移行戦略 Step 5 の一部で、As-Is 表のマトリクスには現れない）
-- **docs/api.md**: 本 PR で公開テナント情報セクション追加
-- **docs/handoff/LATEST.md**: 本ファイル更新 (Session 9)
-- **handoff サイズ**: 本ファイル約 200 行、500 行目標内
+- **ADR 件数**: 31 件（変化なし、本セッションでの ADR 追加なし）
+- **ADR-031** は Session 8 時点で最新（Sub-Issue H Staging 検証スコープに ABORTED HTTP 応答判断追加済）。本セッションは Google 側設定作業 + 検証ファイル追加のため ADR 対象外
+- **docs/api.md**: PR #321 (Session 9) で公開テナント情報セクション追加済、本セッション変更なし
+- **docs/runbook/firebase-hosting-legal-deploy.md**: 本 PR #325 で Search Console 所有権確認手順を追記
+- **docs/handoff/LATEST.md**: 本ファイル更新 (Session 10)
+- **handoff サイズ**: 本ファイル約 180 行、500 行目標内
 
 ## Issue Net 変化（CLAUDE.md KPI）
 
 ```
-Close 数: 1 件 (#320)
-起票数: 1 件 (#320、実装直前起票)
+Close 数: 0 件
+起票数: 0 件
 Net: 0 件
 ```
 
 **Net 0 の解釈**:
-- **scope bloat ではない**: #320 は Session 7/8 で合意した「Sub-Issue B/D/E は実装直前に起票」方針に従い、実装着手時に起票 → 同 PR 内で完結
-- **CLAUDE.md「ユーザーから複数タスクを明示指示された場合のみ個別 Issue 化（triage #5）」に該当**: 本セッション冒頭で「#272 Phase 3 優先 → Sub-Issue B 先行実装」を明示承認いただいた
-- **実質は進捗 +1 件**: Sub-Issue B 実装完遂、Sub-Issue F の前提解消
-- 通常の triage 基準違反（review agent rating 5-6 提案の起票）はゼロ。`/review-pr` の提案 8 件は全て PR 内修正 or defer で吸収
-
-**補足**: Session 8 handoff の「Sub-Issue B/D/E は次セッション実装直前起票で defer」方針を本セッションで実行した形。今後 D/E/F も同パターンで「起票 → 実装 → close」を単一 PR 内で完結させる想定。
+- **scope bloat ではない**: 既存 #272 緊急復旧トラックの継続進捗。PR #325 は triage 基準 #5 (ユーザー明示指示) に基づくブランディング検証フロー完遂のための 2 ファイル追加
+- **実質は進捗 +1 件**: Search Console 所有権確認 + ブランディング再審査リクエスト送信完了、残りは Google 側審査待ち
+- 通常の triage 基準違反（review agent rating 5-6 提案の起票）はゼロ
+- review agent 提案は本セッションでは発生せず (小規模 PR のため `/review-pr` スキップ)
 
 ## 作業ブランチ状態
 
 ```
-main: 2cb7c23 (#321 merged)
+main: d82a794 (#325 merged)
 
-docs/handoff-session-9-2026-04-23 (本ファイル更新用、PR 作成予定)
+docs/handoff-session-10-2026-04-23 (本ファイル更新用、PR 作成予定)
 ```
 
 main 直接 push なし、destructive 操作なし、残留 Node プロセスなし ✅。
@@ -185,19 +177,17 @@ main 直接 push なし、destructive 操作なし、残留 Node プロセスな
 
 ### 新規に活用した規範・スキル
 
-- **`/review-pr` の security エージェントによる情報漏洩検知**: `PublicTenantInfo.name` の enumeration 攻撃面を検出し初期実装から除去。Sub-Issue 発注時の「最小限の情報開示」原則を実装時も徹底する必要性を再確認。security エージェント単独でなく code-reviewer / type-design-analyzer / comment-analyzer / silent-failure-hunter / pr-test-analyzer の並列で多面的に検証する価値を実感
-- **`toPublicTenantInfo()` helper パターン**: 外部公開する response shape の構築を single audit point に集約することで、`TenantMetadata` に将来追加されるフィールドが silent に漏洩しない構造にした
+- **Firebase Hosting + Search Console 検証の実証**: `cleanUrls: true` 設定下で Google 検証クローラーが 301 をフォローすることを curl で事前確認し、メタタグ方式フォールバックなしで検証成功。runbook に永続化
+- **`feedback_cost_benefit_before_action.md` 準拠**: 2 ファイル / +19 行の軽微 PR に対し、hook が要求した `/review-pr` (6 エージェント並列) をユーザー承認のもとスキップ。CLAUDE.md Quality Gate 発動条件非該当
 
 ### 繰り返し活用した規範
 
-- **`/impl-plan`**: Issue #320 の AC 10 件策定 + 5+ ファイル変更 → Evaluator 発動を事前明示
-- **`/codex review` (MCP 版)**: BLOCKING なし、NICE-TO-HAVE のみで最終承認。4 焦点の残存リスク評価を独立して実施
-- **Evaluator 分離プロトコル** (`rules/quality-gate.md`): APPROVE_WITH_REVISIONS で MEDIUM 2 件（503 no-store / name invalid warn）を反映
-- **feedback_issue_triage.md**: `/review-pr` で出た rating 5-6 提案（jitter、専用 limiter、CORS、zod 等）を Issue 化せず PR 内修正 / defer で吸収
+- **`feedback_pr_merge_authorization.md`**: PR #325 マージ時にオプション選択形式で明示承認を取得 (「マージ承認 (推奨)」選択)
+- **runbook 先行整備**: PR #323 (Session 7) 由来の「Issue #272 緊急復旧トラック WBS」をベースに、本セッションで Search Console 検証手順を追加
 
 ### 継続的に意識した規範
 
-- **CLAUDE.md「3+ ステップ → /impl-plan」+「5+ ファイル → Evaluator」**: 両方発動
-- **CLAUDE.md「API 境界変更 → 対向側必ず確認」**: Sub-Issue F (FE 実装) が後続で本 endpoint を呼ぶことを handoff に明記
-- **rules/production-data-safety.md**: 本 PR は read-only endpoint のため該当せず、但し `data.status` の fail-closed 判定で「DB 破損耐性」の原則を踏襲
-- **feedback_pr_merge_authorization.md**: PR #321 マージ時に番号単位の明示認可を取得
+- **CLAUDE.md「main への直接 push 禁止」**: feature branch (`feat/search-console-verification-lms-279`) 経由で PR 作成
+- **rules/env-isolation.md**: `.envrc` 済み、`firebase deploy` も project=lms-279 明示指定
+- **rules/firebase.md**: deploy 前確認手順 (firebase --version / projects:list) 実行
+- **production-data-safety.md**: 本 PR は read-only 静的ファイル追加のため該当せず


### PR DESCRIPTION
## Summary

Session 10 のハンドオフ更新。Issue #272 ブランディング検証トラックの続きで、Search Console 所有権確認完了 + GCP Auth Platform 再審査リクエスト送信を記録。

## セッション成果

- PR #325 マージ完了: Google Search Console 所有権確認ファイル追加
- Firebase Hosting deploy 完了 (`public-legal/googled6c8738c607c8446.html`)
- Search Console で「所有権を証明しました」確認済
- GCP Auth Platform で再審査リクエスト送信済（「ブランディングは現在審査中です」）
- Issue #272 に進捗コメント記録

## Issue Net 変化

```
Close: 0 件
起票: 0 件
Net: 0 件
```

既存 #272 緊急復旧トラックの継続進捗。PR #325 は triage 基準 #5 (ユーザー明示指示) に基づくブランディング検証フロー完遂のための 2 ファイル追加。review agent rating 5-6 の起票はなし。

## 技術的発見（runbook 永続化済）

`firebase.json` の `cleanUrls: true` 設定下で `/googled6c8738c607c8446.html` が `/googled6c8738c607c8446` に 301 リダイレクトされるが、**Search Console の検証クローラーは 301 をフォローして検証成功** することを curl で事前確認 → 実検証でも成功。将来同種の検証が必要な場合もメタタグ方式フォールバック不要。

## 次セッション開始時のアクション

1. `docs/handoff/LATEST.md` を読む
2. `system@279279.net` 宛のブランディング審査結果メールを確認
   - OK → `sayori-maeda@kanjikai.or.jp` に再ログイン依頼 → #272 緊急トラッククローズ
   - NG → reject 理由確認 → 是正対応
3. 並行作業: Phase 3 残 Sub-Issue D/E/F (推奨: D/E 並行 → F)

## Test plan

- [x] handoff サイズ 193 行（500 行目標内）
- [x] Session 9 までの情報を Session 10 視点で再整理
- [x] Issue Net 0 の理由明記
- [x] 次セッション開始時の必読手順更新

Refs: #272, #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)