### PR TITLE
chore: .firebase/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ sa-key.json
 # Serena (AI agent memories)
 .serena/
 
+# Firebase CLI deploy cache (端末ローカル、コミット対象外)
+.firebase/
+
 # IDE
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary

Session 10 のハンドオフチェックで検出した軽微なクリーンアップ。`firebase deploy` 実行時に生成される `.firebase/` キャッシュディレクトリを `.gitignore` に追加。

## 背景

Issue #272 ブランディング検証で `firebase deploy --only hosting --project lms-279` を実行した結果、`.firebase/hosting.cache` 等の端末ローカルなキャッシュファイルが生成される。これらは:

- Firebase CLI が差分 upload 最適化のために使用
- 各端末ローカルな状態でコミット対象外
- マルチデバイス運用（MacBook Air + Mac mini）で同期するとノイズになる

## 変更内容

| ファイル | 種別 | 内容 |
|---|---|---|
| `.gitignore` | 更新 | `.firebase/` エントリを追加（Serena 等の AI agent memories ブロックの直後に配置） |

## Test plan

- [x] `.gitignore` 構文正しい（diff 3 行追加のみ）
- [x] `git status` で `.firebase/` が untracked リストから消えること（ローカル確認済）
- [x] `.firebase/` 配下のファイルがコミット対象に入らないこと

Refs: Session 10 ハンドオフチェック (#326 後の follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)