### PR TITLE
docs(handoff): Session 11 + Issue #272 診断レポート + OAuth runbook 改善

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,13 +1,14 @@
-# Session Handoff — 2026-04-23 (Session 10)
+# Session Handoff — 2026-04-23 (Session 11)
 
 ## TL;DR
 
-**Issue #272 ブランディング検証トラック進行中（Google 側審査待ち）**。Session 9 で Firebase Hosting 公開 (`/privacy` `/terms`) を済ませたが、ブランディング再確認で「ホームページ URL 所有権未確認」エラーが発生。本セッションで Search Console にプロパティ追加 + HTML ファイル検証 (PR #325) を実施し、**「所有権を証明しました」** を確認 → GCP Auth Platform で「問題は修正した」経路で再審査リクエスト送信済み。現在は Google 側で「ブランディングは現在審査中です」状態、結果メール待ち。**Issue net 0**（既存 #272 への進捗更新のみ、triage 基準 #5 ユーザー明示指示に基づく PR #325 の 2 ファイル追加）。
+**Issue #272 緊急復旧トラック: Session 9-10 複雑化の診断完了 + 先方への再ログイン依頼テンプレ送信実施。真の待ちは先方返信（ブランディング審査は非ブロッキング）。**
 
-- **マージ完了** (今セッション): PR #325
-- **Firebase Hosting Deploy**: 完了（`firebase deploy --only hosting --project lms-279`）
-- **Issue Net**: **0**（Close 0 / 起票 0、既存 #272 への進捗更新のみ）
-- **Open 推移**: Session 9 末 7 件 → Session 10 末 7 件 (P0:1 / P2:6)
+Session 11 で Session 9-10 の診断ミスを特定: 2026-04-23 08:14 の Issue #272 コメントで既に OAuth External + 本番環境切替完了、テナント `8vexhzpc` (status=active) + allowed_emails 10 名登録済み（2026/4/21）と記録されていた。**つまりこの時点で先方 `sayori-maeda@kanjikai.or.jp` さんはログイン可能な状態**。しかし Session 9-10 は GCP Console UI の「ホームページ URL 所有権未確認」警告に従って、basic scopes only では本来不要なブランディング審査フロー（4-6 週間）に迷入し、PR #324 (/privacy /terms 公開) + PR #325 (Search Console 所有権確認) を実施。直近 7 日のサーバーログに先方の痕跡なし = **先方には再ログイン依頼も届いていなかった**。Session 11 で runbook §5 ベースの連絡テンプレを先方へ送信、運用教訓を memory・runbook に反映。ブランディング審査は非ブロッキング放置。
+
+- **Issue Net**: **0**（本セッション新規起票・close ともに 0、ドキュメント・memory 整理のみ）
+- **Open 推移**: Session 10 末 7 件 → Session 11 末 7 件 (P0:1 / P2:6)
+- **本セッション成果**: 先方連絡送信 + 教訓整備（個人 memory 3 件 + runbook 追記 + 本ハンドオフ更新 + Issue #272 診断コメント）
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -15,19 +16,62 @@
 # 1. 状況復元
 cat docs/handoff/LATEST.md
 
-# 2. 現在の OPEN Issue（P0: 1 / P2: 6）
+# 2. 🔴 最優先: sayori-maeda さんからの返信確認
+# メール / 業務チャットで返信内容を確認
+# - ✅ ログイン成功 → Issue #272 緊急復旧トラック完全クローズ + コメント
+# - ❌ エラー継続（スクショあり） → Cloud Logging 精査
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND severity>=WARNING' \
+  --project=lms-279 --limit=20 --freshness=1d --format=json
+
+# 3. 現在の OPEN Issue（P0: 1 / P2: 6）
 gh issue list --state open --limit 15
 
-# 3. main CI が緑であることを確認
+# 4. main CI が緑であることを確認
 gh run list --branch main --limit 3
 
-# 4. ブランディング審査結果メール確認（system@279279.net）
-# OK → sayori-maeda@kanjikai.or.jp 再ログイン依頼 → #272 緊急トラッククローズ
-# NG → reject 理由確認 → 是正対応
+# 5. ブランディング審査結果（非ブロッキング・オプション、業務上影響なし）
+# Google → system@279279.net に結果メール (4-6 週間)
+# OK → 警告画面が消える / NG → 業務影響なく再申請任意
 
-# 5. 並行で進められる Phase 3 残 Sub-Issue (推奨: D/E 並行 → F)
-gh issue view 272  # Phase 3 親 Issue
+# 6. 並行で進められる Phase 3 残 Sub-Issue (推奨: D/E 並行 → F)
+gh issue view 272
 ```
+
+---
+
+## セッション成果物 (2026-04-23 Session 11)
+
+### 新規診断: Session 9-10 複雑化の根本原因（5 項目）
+
+| # | 発見 |
+|---|------|
+| 1 | 2026-04-23 08:14 の Issue #272 コメントで既に OAuth External + 本番環境切替完了 + テナント/allowed_emails 10 名登録確認済と記録されていた |
+| 2 | つまりその時点で先方はログイン可能な状態 |
+| 3 | Session 9-10 は GCP Console UI の「ホームページ URL 所有権未確認」警告に従い、basic scopes only では本来不要なブランディング審査フローに迷入 |
+| 4 | runbook `oauth-external-publish.md` §審査の有無 に「basic scopes のみ → 審査不要。Publish 即時反映」と明記されていたが Session 9-10 で読み返されなかった |
+| 5 | 直近 7 日のサーバーログに先方の痕跡なし = 先方は連絡を受けていないから再試行もしていなかった |
+
+### 本セッション実施事項
+
+- ✅ Issue #272 真の原因診断（5 項目）
+- ✅ 先方 `sayori-maeda@kanjikai.or.jp` さんへ再ログイン依頼テンプレ送信（runbook §5 ベース）
+- ✅ `docs/runbook/oauth-external-publish.md` 追記:
+  - §審査の有無 に「⚠️ GCP Console UI の警告に騙されない」節追加、2026-04-23 実例記録
+  - §2.5 新設: Publish 直後の §5 テンプレ送信を明示的チェックボックス化
+- ✅ 個人 memory に教訓 3 件追加（`~/.claude/memory/`）:
+  - `feedback_runbook_first_then_ui.md`: 既存 runbook がある作業は UI 誘導より runbook 記述を優先
+  - `feedback_goal_vs_setup_gap.md`: 技術設定完了 ≠ 業務目的達成、連絡・確認・運用ステップを明示化
+  - `feedback_oauth_basic_scopes_no_review.md`: OAuth basic scopes は審査・ブランディング検証不要
+- ✅ `~/.claude/memory/MEMORY.md` インデックス更新（上記 3 件）
+- ✅ Issue #272 に診断コメント追加（複雑化の経緯を関係者に可視化）
+
+### ブランディング審査の扱い（方針確定）
+
+- **業務上の緊急性: なし**（basic scopes only では「確認されていないアプリ」警告画面が消えるだけ）
+- Session 10 で送信済みの再審査リクエスト（現在「ブランディングは現在審査中」）は **放置で OK**
+- 結果 OK → 警告画面が消える / 結果 NG → 業務影響なく再申請も任意
+- PR #324 (/privacy /terms 公開) + PR #325 (Search Console 所有権確認) は revert 不要、将来の正式ブランディング承認に使える資産として残す
 
 ---
 

--- a/docs/runbook/oauth-external-publish.md
+++ b/docs/runbook/oauth-external-publish.md
@@ -23,6 +23,22 @@ Issue #272 Phase 1.1 の作業手順書。`279279.net` Workspace 組織外のユ
 
 将来 DWD 経由ではなくエンドユーザーに直接 sensitive scopes を要求する方向に変更した場合、その時点で審査が必要になる（所要: 数日〜数週間）。
 
+### ⚠️ GCP Console UI の警告に騙されない（2026-04-23 Issue #272 教訓）
+
+GCP Console で External 化・Publish を実行する際、以下のような警告・誘導が表示される場合があるが、**basic scopes のみ利用する本プロジェクトではすべて無視可**:
+
+- 「ホームページ URL の所有権が未確認です」
+- 「プライバシーポリシーの公開が必要です」
+- 「Search Console での所有権確認が必要です」
+- 「アプリロゴの設定が推奨されます」
+- 「ブランディングは現在審査中です」
+
+これらは **Google Trust & Safety によるブランディング本審査フロー**（4-6 週間）のための要件で、basic scopes のみの運用には**影響しない**。警告を「必須」と誤解して対応してしまうと、不要な審査待ちコースに突入する。
+
+**2026-04-23 実例**: Issue #272 Session 9-10 で、basic scopes only のプロジェクトにも関わらず UI 誘導に従って PR #324（/privacy /terms 公開）、PR #325（Search Console 所有権確認ファイル）を実施 → ブランディング審査 4-6 週間待ちコースに突入。真に必要だったのは **「OAuth Publish 完了 → §5 テンプレで先方に再ログイン依頼」の 1 ステップのみ**だった。
+
+**判断基準**: UI 警告と本 §審査の有無 の記述が食い違う場合、**本 runbook の記述を優先**。UI 誘導に従う前に、他のプロジェクト参加者 / Codex セカンドオピニオンで再確認する。
+
 ## 作業ステップ
 
 ### 1. OAuth 同意画面を External に切り替え
@@ -51,6 +67,15 @@ Issue #272 Phase 1.1 の作業手順書。`279279.net` Workspace 組織外のユ
    - 「Verification is not required for your app because it uses only sensitive scopes that are owned by your project」のような文言が出る
    - 「Do you want to push your app to production?」に対して `Confirm`
 4. `Publishing status` が **`In production`** に変わったことを確認
+
+### 2.5. 🚨 **即時必須アクション**: §5 の連絡テンプレを直ちに送信
+
+**Publish 完了直後に、外部ドメインユーザー（例: `sayori-maeda@kanjikai.or.jp`）へ §5 のテンプレで再ログイン依頼を送信する。**
+
+- [ ] §5 テンプレを先方に送信した
+- [ ] 送信日時を Issue #272 コメントに記録した
+
+これをしないと、技術側は完了しても**業務目的（ユーザーログイン）は未達**のまま放置される。本作業は「R5-R6 OAuth 開放」と「R8 ユーザー再ログイン」の間にある **唯一の人的アクション**で、ここで抜けると Issue が宙に浮く（2026-04-23 実例: OAuth Publish 完了から連絡送信まで 12 時間以上の空白が発生）。
 
 ### 3. Firebase Authorized Domains の確認（Phase 1.2）
 


### PR DESCRIPTION
## Summary

- Session 11 で Issue #272 Session 9-10 複雑化の根本原因を診断 — **2026-04-23 08:14 時点で OAuth 切替・テナント・allowed_emails 全揃っていた**にもかかわらず、GCP Console UI の警告に従って basic scopes only では本来不要なブランディング審査フロー（4-6 週間）に迷入していた
- 真に必要だった「`sayori-maeda@kanjikai.or.jp` さんへの再ログイン依頼テンプレ送信」を本セッションで実施
- 同種の迷入を防ぐため、runbook と ハンドオフに教訓を反映

## 変更内容

### `docs/handoff/LATEST.md` (+70 / -13)
- Session 10 → Session 11 に更新
- TL;DR を「ブランディング審査待ち」→「先方返信待ち（ブランディング審査は非ブロッキング放置）」に差し替え
- 「次セッション必読手順」先頭を「🔴 最優先: sayori-maeda さん返信確認」に変更
- Session 11 成果物セクション追加（Session 10 の内容は履歴として保持）

### `docs/runbook/oauth-external-publish.md` (+25 / -0)
- §審査の有無 に「⚠️ GCP Console UI の警告に騙されない」節追加、2026-04-23 実例を記録（PR #324, #325 の不要作業への言及）
- §2.5 新設: Publish 直後の §5 連絡テンプレ送信を明示的チェックボックス化（Issue 宙浮き防止）

## 再発防止効果

| 同種の状況で | 発動するガード |
|-------------|--------------|
| OAuth で UI 警告が出た | §審査の有無「UI 警告に騙されない」節 → scopes を確認して必要性判定 |
| OAuth Publish 完了直後 | §2.5 チェックボックスで §5 連絡テンプレ送信を強制 |
| 次セッション開始時 | LATEST.md 先頭 = 「先方返信確認」、迷わない |

加えて、個人 memory（`~/.claude/memory/`）に以下 3 件の教訓を追加済（本 PR には含まれない、別リポジトリ）:
- `feedback_runbook_first_then_ui.md`: 既存 runbook がある作業は UI 誘導より runbook 記述を優先
- `feedback_goal_vs_setup_gap.md`: 技術設定完了 ≠ 業務目的達成
- `feedback_oauth_basic_scopes_no_review.md`: OAuth basic scopes は審査・ブランディング検証不要

## Test plan

- [x] 変更ファイル 2件のみ（ドキュメント/MD のみ、コード変更ゼロ）
- [x] markdown 構文チェック: Read で再読して確認済
- [x] リンク整合性: runbook §5 既存実在、LATEST.md から参照する Session 10 成果物セクションも履歴として保持
- [x] CLAUDE.md「main 直接 push 禁止」遵守: feature branch (`docs/handoff-session-11-2026-04-23`) 経由
- [x] CLAUDE.md Quality Gate: Quality Gate 発動条件（3 ファイル+ / 5 ファイル+ / 新機能）非該当

## 関連

- Issue #272 診断コメント: https://github.com/system-279/lms-279/issues/272#issuecomment-4304190864
- Session 10 ハンドオフ: #326
- 前提 PR: #323 (runbook WBS 整備) / #324 (/privacy /terms 公開) / #325 (Search Console 所有権確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)