### PR TITLE
feat(tenants/mine): 招待ユーザーを含む所属テナント一覧返却 (恒久対応)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -195,6 +195,13 @@
         { "fieldPath": "courseId", "order": "ASCENDING" },
         { "fieldPath": "entryAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "allowed_emails",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "email", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -195,14 +195,18 @@
         { "fieldPath": "courseId", "order": "ASCENDING" },
         { "fieldPath": "entryAt", "order": "DESCENDING" }
       ]
-    },
-    {
-      "collectionGroup": "allowed_emails",
-      "queryScope": "COLLECTION_GROUP",
-      "fields": [
-        { "fieldPath": "email", "order": "ASCENDING" }
-      ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "allowed_emails",
+      "fieldPath": "email",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION" },
+        { "arrayConfig": "CONTAINS", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    }
+  ]
 }

--- a/packages/shared-types/src/tenant.ts
+++ b/packages/shared-types/src/tenant.ts
@@ -74,3 +74,38 @@ export interface PublicTenantInfo {
 export interface PublicTenantInfoResponse {
   tenant: PublicTenantInfo;
 }
+
+/**
+ * `GET /api/v2/tenants/mine` のレスポンス要素
+ *
+ * 「ログインユーザーがアクセス可能なテナント」の最小情報を返す。
+ * - owner として作成したテナント
+ * - allowed_emails に email が登録されたテナント（招待）
+ * の和集合（重複排除済み）。
+ *
+ * `ownerEmail` は意図的に含めない。招待ユーザーに対しても等しく返却される
+ * エンドポイントのため、招待された全テナントの所有者 email が漏れる。
+ * owner 自身が必要な場合は別エンドポイント（super-admin 系）から取得する。
+ *
+ * 既知制約:
+ *   - 本一覧は「実際のテナントアクセス可能性」と完全一致しない場合がある。
+ *     GCIP UID 揺り戻し（uid_reassignment_blocked）により、一覧に出ても
+ *     `/{tenantId}` 直アクセス時に 403 となる偽陽性が起こり得る。
+ *   - 同一 email が複数テナントの allowed_emails に登録されている場合、
+ *     その principal は登録された全テナントの id / name / status を取得可能。
+ *     これは ADR-006「email を境界にする allowlist」の設計上の副作用。
+ *
+ * `accessVia` 等の入手経路情報は含めない（緊急修正のため契約変更を最小化）。
+ * 将来 UI で owner/invited を区別したくなった場合は、別フィールドとして
+ * 後方互換を保ったまま追加すること（owner 優先 1 値潰しは情報を失うので不可）。
+ */
+export interface MyTenantInfo {
+  id: string;
+  name: string;
+  status: TenantStatus;
+  createdAt: string | null;
+}
+
+export interface MineTenantsResponse {
+  tenants: MyTenantInfo[];
+}

--- a/services/api/src/routes/__tests__/tenants.test.ts
+++ b/services/api/src/routes/__tests__/tenants.test.ts
@@ -21,11 +21,12 @@ import express from "express";
 import supertest from "supertest";
 
 const mockVerifyIdToken = vi.fn();
-const mockGetFirestore = vi.fn(() => {
+const throwFirestoreImpl = () => {
   throw new Error(
     "getFirestore should not be called in guard-rejection tests (reached Firestore after guard was supposed to 403)"
   );
-});
+};
+const mockGetFirestore = vi.fn(throwFirestoreImpl);
 
 vi.mock("firebase-admin/auth", () => ({
   getAuth: () => ({
@@ -60,6 +61,9 @@ describe("POST /api/v2/tenants — auth guards (Issue #294)", () => {
   beforeEach(() => {
     vi.resetModules();
     mockVerifyIdToken.mockReset();
+    // Firestore は guard で到達しないことを期待（throw に固定）
+    mockGetFirestore.mockReset();
+    mockGetFirestore.mockImplementation(throwFirestoreImpl);
   });
 
   afterEach(() => {
@@ -173,5 +177,591 @@ describe("POST /api/v2/tenants — auth guards (Issue #294)", () => {
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBe("unauthorized");
+  });
+});
+
+// =====================================================================
+// GET /api/v2/tenants/mine — owner + invited 統合 (allowed_emails 横断)
+// =====================================================================
+//
+// 設計上の確認 (services/api/src/routes/tenants.ts の /mine JSDoc 参照):
+//   - owner ownerId クエリ + allowed_emails collectionGroup query を並列実行
+//   - 重複排除キー = tenantId（owner と invited 両方該当時は 1 件のみ返却）
+//   - tenant doc は getAll(...refs) で取得（chunk 不要）
+//   - status filter は in-memory で適用
+//   - decodedToken.email 欠落時は invited 検索を行わず owner のみ返す（fail-closed）
+//
+// 既知制約のテスト (AC-13): /mine は GCIP UID 揺り戻しによる偽陽性を含み得る。
+// 一覧返却ロジック自体は CAS と独立のため、ここでは「invited として allowed_emails
+// に登録されていれば、users コレクションに既存 user / firebaseUid 紐付けがあろうと
+// なかろうと一覧に出る」ことを回帰テストとして固定する。
+
+type AllowedEmailDocSpec = { tenantId: string; email: string };
+type TenantDocSpec = {
+  id: string;
+  name: string;
+  ownerEmail: string;
+  ownerId: string;
+  status: "active" | "suspended";
+  /** ISO string。null は欠落扱い */
+  createdAt: string | null;
+};
+
+/**
+ * /mine 用 Firestore モックを構築する。
+ *
+ * - `db.collection("tenants").where("ownerId","==",uid).get()` →
+ *   `tenants` のうち `ownerId === uid` を返す。
+ * - `db.collectionGroup("allowed_emails").where("email","==",email).get()` →
+ *   `allowedEmails` のうち `email === email` を返す。各 doc の
+ *   `ref.parent.parent` は `tenants/{tenantId}` の DocumentReference を指す。
+ * - `db.getAll(...refs)` → 渡された ref id に対応する tenant doc を返す
+ *   （存在しない id は `{ exists: false }` の DocumentSnapshot を返す）。
+ */
+function makeMineFirestoreMock(opts: {
+  tenants: TenantDocSpec[];
+  allowedEmails: AllowedEmailDocSpec[];
+}) {
+  const tenantById = new Map<string, TenantDocSpec>();
+  for (const t of opts.tenants) tenantById.set(t.id, t);
+
+  const toTenantSnapshot = (id: string) => {
+    const t = tenantById.get(id);
+    if (!t) {
+      return { id, exists: false, data: () => undefined };
+    }
+    const data = {
+      ...t,
+      // tenants.ts は createdAt?.toDate?.()?.toISOString() を呼ぶ。
+      // null なら toDate を呼ばないので undefined のままで良い。
+      createdAt:
+        t.createdAt === null
+          ? null
+          : { toDate: () => new Date(t.createdAt as string) },
+    };
+    return { id, exists: true, data: () => data };
+  };
+
+  const makeTenantRef = (tenantId: string) => ({
+    id: tenantId,
+    // allowedDoc.ref.parent.parent.id でも参照される
+  });
+
+  const makeAllowedDoc = (spec: AllowedEmailDocSpec, idx: number) => ({
+    id: `allowed-${idx}`,
+    ref: {
+      parent: {
+        parent: makeTenantRef(spec.tenantId),
+      },
+    },
+    data: () => ({ email: spec.email }),
+  });
+
+  type OwnerFilters = { ownerId?: unknown; status?: unknown };
+  // owner query は `where("ownerId").where("status")` のように chain される。
+  // 各 where 呼び出しごとに新しい builder を返し、累積した filter で get() する。
+  const makeOwnerQuery = (filters: OwnerFilters) => ({
+    where(field: string, op: string, value: unknown) {
+      if (op !== "==") {
+        throw new Error(`Unexpected where op: ${op}`);
+      }
+      if (field === "ownerId") {
+        return makeOwnerQuery({ ...filters, ownerId: value });
+      }
+      if (field === "status") {
+        return makeOwnerQuery({ ...filters, status: value });
+      }
+      throw new Error(`Unexpected where field: ${field}`);
+    },
+    async get() {
+      let matched = opts.tenants;
+      if (filters.ownerId !== undefined) {
+        matched = matched.filter((t) => t.ownerId === filters.ownerId);
+      }
+      if (filters.status !== undefined) {
+        matched = matched.filter((t) => t.status === filters.status);
+      }
+      return {
+        docs: matched.map((t) => toTenantSnapshot(t.id)),
+      };
+    },
+  });
+
+  return {
+    collection(name: string) {
+      if (name !== "tenants") {
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+      return makeOwnerQuery({});
+    },
+    collectionGroup(name: string) {
+      if (name !== "allowed_emails") {
+        throw new Error(`Unexpected collectionGroup: ${name}`);
+      }
+      return {
+        where(field: string, op: string, value: unknown) {
+          if (field !== "email" || op !== "==") {
+            throw new Error(`Unexpected where: ${field} ${op}`);
+          }
+          return {
+            async get() {
+              const matched = opts.allowedEmails.filter(
+                (a) => a.email === value
+              );
+              return {
+                docs: matched.map((a, i) => makeAllowedDoc(a, i)),
+              };
+            },
+          };
+        },
+      };
+    },
+    async getAll(...refs: { id: string }[]) {
+      return refs.map((r) => toTenantSnapshot(r.id));
+    },
+  };
+}
+
+describe("GET /api/v2/tenants/mine — owner + invited 統合", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockVerifyIdToken.mockReset();
+    mockGetFirestore.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function setMine(opts: {
+    tenants: TenantDocSpec[];
+    allowedEmails: AllowedEmailDocSpec[];
+  }) {
+    mockGetFirestore.mockReturnValue(makeMineFirestoreMock(opts) as never);
+  }
+
+  function decoded(uid: string, email: string | undefined) {
+    return makeDecodedToken({ uid, email });
+  }
+
+  // -------------------------------------------------------------------
+  // AC-1: owner=user, invited 0 件 → 当該 1 件返却
+  // -------------------------------------------------------------------
+  it("[AC-1] owner のみ: ownerId 一致テナント 1 件を返す", async () => {
+    mockVerifyIdToken.mockResolvedValue(decoded("uid-1", "owner@example.com"));
+    setMine({
+      tenants: [
+        {
+          id: "t-own",
+          name: "Owner Tenant",
+          ownerEmail: "owner@example.com",
+          ownerId: "uid-1",
+          status: "active",
+          createdAt: "2026-04-20T00:00:00.000Z",
+        },
+      ],
+      allowedEmails: [],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toHaveLength(1);
+    expect(res.body.tenants[0].id).toBe("t-own");
+  });
+
+  // -------------------------------------------------------------------
+  // AC-2: owner 0 件 + allowed_emails に email 登録のテナント 1 件
+  //       → 招待テナントが 1 件返る
+  // -------------------------------------------------------------------
+  it("[AC-2] invited のみ: allowed_emails 経由で 1 件返る", async () => {
+    mockVerifyIdToken.mockResolvedValue(
+      decoded("uid-invited", "guest@example.com")
+    );
+    setMine({
+      tenants: [
+        {
+          id: "t-inv",
+          name: "Invited Tenant",
+          ownerEmail: "owner@example.com",
+          ownerId: "uid-other",
+          status: "active",
+          createdAt: "2026-04-19T00:00:00.000Z",
+        },
+      ],
+      allowedEmails: [{ tenantId: "t-inv", email: "guest@example.com" }],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toHaveLength(1);
+    expect(res.body.tenants[0].id).toBe("t-inv");
+  });
+
+  // -------------------------------------------------------------------
+  // AC-3: owner 1 + 別テナントに invited 1 → 2 件、重複なし
+  // -------------------------------------------------------------------
+  it("[AC-3] owner + 別テナントの invited → 2 件返る (重複なし)", async () => {
+    mockVerifyIdToken.mockResolvedValue(
+      decoded("uid-mixed", "user@example.com")
+    );
+    setMine({
+      tenants: [
+        {
+          id: "t-own",
+          name: "Owner Tenant",
+          ownerEmail: "user@example.com",
+          ownerId: "uid-mixed",
+          status: "active",
+          createdAt: "2026-04-20T00:00:00.000Z",
+        },
+        {
+          id: "t-inv",
+          name: "Invited Tenant",
+          ownerEmail: "another@example.com",
+          ownerId: "uid-other",
+          status: "active",
+          createdAt: "2026-04-18T00:00:00.000Z",
+        },
+      ],
+      allowedEmails: [{ tenantId: "t-inv", email: "user@example.com" }],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    const ids = res.body.tenants.map((t: { id: string }) => t.id).sort();
+    expect(ids).toEqual(["t-inv", "t-own"]);
+  });
+
+  // -------------------------------------------------------------------
+  // AC-4: 同一テナントで owner かつ invited → 1 件のみ (重複排除)
+  // -------------------------------------------------------------------
+  it("[AC-4] 同一テナントで owner かつ invited → 1 件のみ (重複排除)", async () => {
+    mockVerifyIdToken.mockResolvedValue(decoded("uid-dup", "dup@example.com"));
+    setMine({
+      tenants: [
+        {
+          id: "t-dup",
+          name: "Dup Tenant",
+          ownerEmail: "dup@example.com",
+          ownerId: "uid-dup",
+          status: "active",
+          createdAt: "2026-04-20T00:00:00.000Z",
+        },
+      ],
+      // owner 自身も allowed_emails に登録されている (テナント作成時に自動追加される)
+      allowedEmails: [{ tenantId: "t-dup", email: "dup@example.com" }],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toHaveLength(1);
+    expect(res.body.tenants[0].id).toBe("t-dup");
+  });
+
+  // -------------------------------------------------------------------
+  // AC-5: ?status=active で suspended owner tenant を除外
+  // -------------------------------------------------------------------
+  it("[AC-5] status=active で suspended owner tenant を除外", async () => {
+    mockVerifyIdToken.mockResolvedValue(decoded("uid-1", "owner@example.com"));
+    setMine({
+      tenants: [
+        {
+          id: "t-active",
+          name: "A",
+          ownerEmail: "owner@example.com",
+          ownerId: "uid-1",
+          status: "active",
+          createdAt: "2026-04-20T00:00:00.000Z",
+        },
+        {
+          id: "t-susp",
+          name: "S",
+          ownerEmail: "owner@example.com",
+          ownerId: "uid-1",
+          status: "suspended",
+          createdAt: "2026-04-19T00:00:00.000Z",
+        },
+      ],
+      allowedEmails: [],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine?status=active")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toHaveLength(1);
+    expect(res.body.tenants[0].id).toBe("t-active");
+  });
+
+  // -------------------------------------------------------------------
+  // AC-6: ?status=active で suspended invited tenant も除外
+  // -------------------------------------------------------------------
+  it("[AC-6] status=active で suspended invited tenant も除外", async () => {
+    mockVerifyIdToken.mockResolvedValue(
+      decoded("uid-g", "guest@example.com")
+    );
+    setMine({
+      tenants: [
+        {
+          id: "t-inv-susp",
+          name: "Invited Suspended",
+          ownerEmail: "o@example.com",
+          ownerId: "uid-other",
+          status: "suspended",
+          createdAt: "2026-04-19T00:00:00.000Z",
+        },
+      ],
+      allowedEmails: [{ tenantId: "t-inv-susp", email: "guest@example.com" }],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine?status=active")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------
+  // AC-7: email_verified=false → 403 (verifyAuthToken の guard 維持)
+  // -------------------------------------------------------------------
+  it("[AC-7] email_verified=false → 403", async () => {
+    mockVerifyIdToken.mockResolvedValue(
+      makeDecodedToken({ email_verified: false })
+    );
+    // Firestore に到達しないことを期待
+    mockGetFirestore.mockImplementation(throwFirestoreImpl);
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(403);
+  });
+
+  // -------------------------------------------------------------------
+  // AC-8: tenants 1 件 → FE は自動 redirect (FE 既存ロジックの責務として
+  //       本テストでは API が 1 件返すことを保証)
+  // -------------------------------------------------------------------
+  it("[AC-8] 単一テナント返却で FE 自動 redirect 条件を満たす", async () => {
+    mockVerifyIdToken.mockResolvedValue(decoded("uid-1", "u@example.com"));
+    setMine({
+      tenants: [
+        {
+          id: "t-only",
+          name: "Only",
+          ownerEmail: "u@example.com",
+          ownerId: "uid-1",
+          status: "active",
+          createdAt: "2026-04-20T00:00:00.000Z",
+        },
+      ],
+      allowedEmails: [],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine?status=active")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------
+  // AC-9: tenants 0 件 → 「所属なし」表示の根拠として空配列を返す
+  // -------------------------------------------------------------------
+  it("[AC-9] owner も invited もなければ空配列", async () => {
+    mockVerifyIdToken.mockResolvedValue(decoded("uid-no", "no@example.com"));
+    setMine({ tenants: [], allowedEmails: [] });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------
+  // AC-10: invited tenant に users 未作成でも一覧に出る
+  //        (allowed_emails が discovery の正本である設計の確認)
+  // -------------------------------------------------------------------
+  it("[AC-10] invited tenant に users 未作成でも返る", async () => {
+    mockVerifyIdToken.mockResolvedValue(decoded("uid-new", "new@example.com"));
+    setMine({
+      tenants: [
+        {
+          id: "t-no-user",
+          name: "No User Yet",
+          ownerEmail: "o@example.com",
+          ownerId: "uid-other",
+          status: "active",
+          createdAt: "2026-04-20T00:00:00.000Z",
+        },
+      ],
+      allowedEmails: [{ tenantId: "t-no-user", email: "new@example.com" }],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toHaveLength(1);
+    expect(res.body.tenants[0].id).toBe("t-no-user");
+  });
+
+  // -------------------------------------------------------------------
+  // AC-11: allowed_email はあるが tenant doc 削除済み → 無視 (fail-closed)
+  // -------------------------------------------------------------------
+  it("[AC-11] allowed_email はあるが tenant doc 不在 → 無視", async () => {
+    mockVerifyIdToken.mockResolvedValue(
+      decoded("uid-orphan", "orphan@example.com")
+    );
+    setMine({
+      tenants: [], // tenant doc は存在しない
+      allowedEmails: [
+        { tenantId: "t-deleted", email: "orphan@example.com" },
+      ],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------
+  // AC-12: decodedToken.email 欠落時は invited 検索をスキップし
+  //        owner のみ返す (fail-closed: 任意 email を allowlist 横断検索しない)
+  // -------------------------------------------------------------------
+  it("[AC-12] decodedToken.email 欠落 → invited 検索スキップ、owner のみ返す", async () => {
+    mockVerifyIdToken.mockResolvedValue(decoded("uid-no-email", undefined));
+    setMine({
+      tenants: [
+        {
+          id: "t-own",
+          name: "Owner",
+          ownerEmail: "o@example.com",
+          ownerId: "uid-no-email",
+          status: "active",
+          createdAt: "2026-04-20T00:00:00.000Z",
+        },
+        {
+          id: "t-invited-others",
+          name: "Should Not Appear",
+          ownerEmail: "x@example.com",
+          ownerId: "uid-other",
+          status: "active",
+          createdAt: "2026-04-19T00:00:00.000Z",
+        },
+      ],
+      // この allowed_emails は collectionGroup query 自体が走らないため無視される
+      allowedEmails: [
+        { tenantId: "t-invited-others", email: "leak@example.com" },
+      ],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toHaveLength(1);
+    expect(res.body.tenants[0].id).toBe("t-own");
+  });
+
+  // -------------------------------------------------------------------
+  // AC-13: GCIP UID conflict 等で users 既存・firebaseUid 不一致でも
+  //        /mine は allowed_emails ベースで invited 一覧に出す。
+  //        実アクセス時の 403 は別レイヤー (tenant-auth) の責務 (既知制約)。
+  // -------------------------------------------------------------------
+  it("[AC-13] users 既存・firebaseUid 不一致でも allowed_emails があれば返る (回帰、既知制約)", async () => {
+    mockVerifyIdToken.mockResolvedValue(
+      decoded("uid-new-after-gcip", "g@example.com")
+    );
+    // /mine は users コレクションに依存しない。allowed_emails のみで判定する。
+    setMine({
+      tenants: [
+        {
+          id: "t-gcip",
+          name: "GCIP Tenant",
+          ownerEmail: "o@example.com",
+          ownerId: "uid-other",
+          status: "active",
+          createdAt: "2026-04-20T00:00:00.000Z",
+        },
+      ],
+      allowedEmails: [{ tenantId: "t-gcip", email: "g@example.com" }],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toHaveLength(1);
+    expect(res.body.tenants[0].id).toBe("t-gcip");
+  });
+
+  // -------------------------------------------------------------------
+  // AC-14: 同一 email が 30 件超のテナントに招待 → getAll で chunk 不要
+  //        (in クエリの 30 値上限の影響なし)
+  // -------------------------------------------------------------------
+  it("[AC-14] 30 件超の invited tenant でも全件返る (getAll で chunk 不要)", async () => {
+    mockVerifyIdToken.mockResolvedValue(decoded("uid-many", "m@example.com"));
+    const N = 35;
+    const tenantSpecs: TenantDocSpec[] = [];
+    const allowedSpecs: AllowedEmailDocSpec[] = [];
+    for (let i = 0; i < N; i++) {
+      const id = `t-${String(i).padStart(2, "0")}`;
+      tenantSpecs.push({
+        id,
+        name: `Tenant ${i}`,
+        ownerEmail: "o@example.com",
+        ownerId: "uid-other",
+        status: "active",
+        // createdAt を異なる秒にして sort 安定化
+        createdAt: `2026-04-20T00:00:${String(i).padStart(2, "0")}.000Z`,
+      });
+      allowedSpecs.push({ tenantId: id, email: "m@example.com" });
+    }
+    setMine({ tenants: tenantSpecs, allowedEmails: allowedSpecs });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants).toHaveLength(N);
   });
 });

--- a/services/api/src/routes/tenants.ts
+++ b/services/api/src/routes/tenants.ts
@@ -5,10 +5,12 @@
  */
 
 import { Router, Request, Response } from "express";
-import { getFirestore } from "firebase-admin/firestore";
+import { getFirestore, type DocumentReference } from "firebase-admin/firestore";
 import { getAuth, type DecodedIdToken } from "firebase-admin/auth";
 import type { TenantMetadata, CreateTenantRequest } from "../types/tenant.js";
+import type { MyTenantInfo, TenantStatus } from "@lms-279/shared-types";
 import { RESERVED_TENANT_IDS, generateTenantId, validateOrganizationName, normalizeEmail } from "../utils/tenant-id.js";
+import { toISOOptional } from "../datasource/firestore.js";
 import { logger } from "../utils/logger.js";
 
 const router = Router();
@@ -295,14 +297,31 @@ router.post("/", async (req: Request, res: Response) => {
 });
 
 /**
- * 自分が所有するテナント一覧を取得
+ * 自分がアクセス可能なテナント一覧を取得
  * GET /api/v2/tenants/mine
  *
  * 認証必須: Firebase ID Token
  * クエリ: status (optional) - "active" | "suspended"
+ *
+ * 返却内容:
+ *   - owner として作成したテナント
+ *   - allowed_emails に email が登録されたテナント（招待）
+ *   の和集合（重複排除済み、createdAt 降順）。
+ *
+ * 既知制約 (shared-types `MyTenantInfo` JSDoc も参照):
+ *   1. 一覧は「実際のテナントアクセス可能性」と完全一致しない場合がある。
+ *      GCIP UID 揺り戻し（uid_reassignment_blocked）等により、一覧に出ても
+ *      `/{tenantId}` 直アクセス時に 403 となる偽陽性が起こり得る。
+ *   2. 同一 email が複数テナントの allowed_emails に登録されている場合、
+ *      その principal は登録された全テナントの id / name / status を取得可能。
+ *      ADR-006「email を境界にする allowlist」設計の副作用。
+ *
+ * 設計メモ:
+ *   - tenant doc 取得は `getAll(...refs)` を使用（chunk 不要、`in` 上限の影響なし）。
+ *   - status filter は in-memory で適用（owner / invited 両系統に同一適用）。
+ *   - super-admin に対して特別扱いはしない（owner / 招待のみで判定）。
  */
 router.get("/mine", async (req: Request, res: Response) => {
-  // 1. 認証チェック
   const authResult = await verifyAuthToken(req);
   if (!authResult.success) {
     res.status(authResult.status).json({
@@ -312,12 +331,12 @@ router.get("/mine", async (req: Request, res: Response) => {
     return;
   }
 
-  const { uid } = authResult.token;
+  const { uid, email } = authResult.token;
+  const normalizedEmail = email ? normalizeEmail(email) : undefined;
 
-  // 2. クエリパラメータ
+  const validStatuses: TenantStatus[] = ["active", "suspended"];
   const statusFilter = req.query.status as string | undefined;
-  const validStatuses = ["active", "suspended"];
-  if (statusFilter && !validStatuses.includes(statusFilter)) {
+  if (statusFilter && !validStatuses.includes(statusFilter as TenantStatus)) {
     res.status(400).json({
       error: "invalid_status",
       message: "statusは 'active' または 'suspended' を指定してください。",
@@ -325,25 +344,83 @@ router.get("/mine", async (req: Request, res: Response) => {
     return;
   }
 
-  // 3. テナント一覧を取得
   const db = getFirestore();
-  let query = db.collection("tenants").where("ownerId", "==", uid);
 
+  // owner クエリは status を Firestore 側に push down する（既存複合 index
+  // [ownerId, status, createdAt] を活用）。invited は allowed_emails に
+  // status を持たないため getAll 後に in-memory で同じ filter を再適用する。
+  let ownerQuery: FirebaseFirestore.Query = db
+    .collection("tenants")
+    .where("ownerId", "==", uid);
   if (statusFilter) {
-    query = query.where("status", "==", statusFilter);
+    ownerQuery = ownerQuery.where("status", "==", statusFilter);
   }
 
-  const snapshot = await query.orderBy("createdAt", "desc").get();
+  // invited 検索は email 必須（欠落時は owner のみ返す = fail-closed）。
+  const invitedTenantRefsPromise: Promise<DocumentReference[]> = normalizedEmail
+    ? db
+        .collectionGroup("allowed_emails")
+        .where("email", "==", normalizedEmail)
+        .get()
+        .then((snap) => {
+          const refs: DocumentReference[] = [];
+          for (const allowedDoc of snap.docs) {
+            const tenantRef = allowedDoc.ref.parent.parent;
+            if (tenantRef) refs.push(tenantRef);
+          }
+          return refs;
+        })
+    : Promise.resolve([]);
 
-  const tenants = snapshot.docs.map((doc) => {
+  const [ownerSnapshot, invitedTenantRefs] = await Promise.all([
+    ownerQuery.get(),
+    invitedTenantRefsPromise,
+  ]);
+
+  // 重複排除キーは tenantId。owner と invited に同じテナントがある場合は
+  // owner snapshot を採用する（状態は同一だが意味論的に owner を優先）。
+  const tenantDocsById = new Map<
+    string,
+    FirebaseFirestore.DocumentSnapshot
+  >();
+  for (const doc of ownerSnapshot.docs) {
+    tenantDocsById.set(doc.id, doc);
+  }
+
+  const invitedRefsToFetch = invitedTenantRefs.filter(
+    (ref) => !tenantDocsById.has(ref.id)
+  );
+  if (invitedRefsToFetch.length > 0) {
+    const invitedDocs = await db.getAll(...invitedRefsToFetch);
+    for (const doc of invitedDocs) {
+      // tenant doc が削除済み等で存在しない場合はスキップ（fail-closed）
+      if (doc.exists) {
+        tenantDocsById.set(doc.id, doc);
+      }
+    }
+  }
+
+  const tenants: MyTenantInfo[] = [];
+  for (const doc of tenantDocsById.values()) {
     const data = doc.data();
-    return {
+    if (!data) continue;
+    // owner query は status を push down 済だが、invited 経由は filter 未適用のためここで再判定。
+    if (statusFilter && data.status !== statusFilter) continue;
+    tenants.push({
       id: data.id,
       name: data.name,
-      ownerEmail: data.ownerEmail,
       status: data.status,
-      createdAt: data.createdAt?.toDate?.()?.toISOString() ?? null,
-    };
+      createdAt: toISOOptional(data.createdAt),
+    });
+  }
+
+  // createdAt desc。ISO 8601 は lexicographic 比較で時系列と一致するため
+  // localeCompare で desc を表現できる。null は末尾に寄せる。
+  tenants.sort((a, b) => {
+    if (a.createdAt === b.createdAt) return 0;
+    if (a.createdAt === null) return 1;
+    if (b.createdAt === null) return -1;
+    return b.createdAt.localeCompare(a.createdAt);
   });
 
   res.json({ tenants });

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -4,21 +4,16 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { CircleHelp } from "lucide-react";
+import type { MyTenantInfo, MineTenantsResponse } from "@lms-279/shared-types";
 import { useAuth } from "../lib/auth-context";
 import { apiFetch } from "../lib/api";
 
 const AUTH_MODE = process.env.NEXT_PUBLIC_AUTH_MODE ?? "dev";
 
-type TenantInfo = {
-  id: string;
-  name: string;
-  status: string;
-};
-
 export default function HomePage() {
   const router = useRouter();
   const { user, loading, error, signInWithGoogle, signOut, getIdToken } = useAuth();
-  const [tenants, setTenants] = useState<TenantInfo[]>([]);
+  const [tenants, setTenants] = useState<MyTenantInfo[]>([]);
   const [tenantsLoading, setTenantsLoading] = useState(false);
   const [tenantsError, setTenantsError] = useState<string | null>(null);
 
@@ -123,8 +118,8 @@ function LoggedInView({
   signOut: () => void;
   getIdToken: () => Promise<string | null>;
   router: ReturnType<typeof useRouter>;
-  tenants: TenantInfo[];
-  setTenants: (t: TenantInfo[]) => void;
+  tenants: MyTenantInfo[];
+  setTenants: (t: MyTenantInfo[]) => void;
   tenantsLoading: boolean;
   setTenantsLoading: (l: boolean) => void;
   tenantsError: string | null;
@@ -137,7 +132,7 @@ function LoggedInView({
       setTenantsError(null);
       try {
         const idToken = await getIdToken();
-        const data = await apiFetch<{ tenants: TenantInfo[] }>(
+        const data = await apiFetch<MineTenantsResponse>(
           "/api/v2/tenants/mine?status=active",
           { idToken: idToken ?? undefined }
         );


### PR DESCRIPTION
## Summary

- 招待された受講者がトップ画面 `/` を踏むと「所属するテナントがありません」と表示される本番障害の恒久対応
- `GET /api/v2/tenants/mine` を owner + 招待 (allowed_emails) 両方を返すように拡張
- FE は既存の自動 redirect / テナント選択 UI のままで動作。**共有済みのテナント案内 URL は変更不要**

## 背景

本日、長遊園テナント (`8vexhzpc`) の検証アカウント `y.tsukuda@kanjikai.or.jp` で、トップ URL アクセス時に「所属するテナントがありません」と表示されるインシデントを確認。調査の結果、`/api/v2/tenants/mine` が `ownerId === uid` のみを返す仕様となっており、allowed_emails に登録された招待ユーザーは 0 件返却されることが判明。
受講者側の URL 変更運用は持続不可能のため、システム側で自動リダイレクトされるよう恒久対応する。

## 実装

- owner クエリと `collectionGroup("allowed_emails")` クエリを並列実行
- invited 経路は `allowed_emails` の parent 経由で tenant `DocumentReference` を得て `getAll(...refs)` で一括取得 (chunk 不要、`in` 上限の影響なし)
- 重複排除キーは tenantId (owner と invited 両方該当時は owner snapshot を採用)
- owner クエリは `status` を Firestore 側に push down (既存複合 index `[ownerId, status, createdAt]` を活用)。invited 経由は in-memory 再 filter
- `decodedToken.email` 欠落時は invited 検索をスキップして owner のみ返す (fail-closed)
- tenant doc 不在 (削除済み等) は無視 (fail-closed)
- super-admin に対して特別扱いなし (owner / 招待のみで判定)

## 既知制約 (JSDoc に明文化)

1. `/mine` の返却は「実際のテナントアクセス可能性」と完全一致しない場合がある。GCIP UID 揺り戻し (`uid_reassignment_blocked`) 等により、一覧に出ても `/{tenantId}` 直アクセス時に 403 となる偽陽性が起こり得る。
2. 同一 email が複数テナントの allowed_emails に登録されている場合、その principal は登録された全テナントの id / name / status を取得可能。ADR-006「email を境界にする allowlist」設計の副作用。

`MyTenantInfo` から `ownerEmail` は意図的に除外 (招待ユーザーへの owner email PII 漏洩防止)。

## デプロイ手順 (rules/firebase.md 準拠)

`firestore.indexes.json` は **Cloud Run CI/CD に含まれない**。マージ前後で以下の順序を厳守:

```bash
# 1. CI green 確認
# 2. index を先にデプロイ (本 PR のマージより先)
firebase deploy --only firestore:indexes -P lms-279

# 3. GCP Console で `allowed_emails (CG: email ASC)` の状態が READY になるのを待つ (数分)

# 4. PR マージ (Cloud Run 自動デプロイ)
gh pr merge --squash <PR>

# 5. デプロイ完了確認 + 受講者ログイン E2E 確認
```

逆順 (API 先 → index 後) だと **missing-index エラーで本番 500** になるため厳守。

## 品質ゲート

- [x] type-check: 全 4 workspace PASS
- [x] lint: PASS
- [x] API test: 643/643 PASS (新規 14 件含む)
- [x] Web test: 33/33 PASS
- [x] Codex セカンドオピニオン取得済み (`getAll` 採用 / `accessVia` 削除 / index 先行デプロイ等を反映)
- [x] `/simplify`: 8 項目修正適用 (PII leak / status push down regression / `toISOOptional` / `TenantStatus[]` 型化 / 不要 alias 削除 / sort `localeCompare` 等)
- [x] `/safe-refactor`: 追加修正なし (HIGH 0 件、MEDIUM 1 件は既存パターン踏襲のため許容)

## Acceptance Criteria (AC-1〜AC-14)

| # | 条件 | 期待値 |
|---|------|-------|
| AC-1 | owner=user, invited 0 件 | 当該 1 件返却 |
| AC-2 | owner なし, invited 1 件 | 当該 1 件返却 |
| AC-3 | owner 1 + 別 tenant に invited 1 | 2 件、重複なし |
| AC-4 | 同一 tenant で owner かつ invited | 1 件のみ (重複排除) |
| AC-5 | `?status=active` で suspended owner tenant 除外 | suspended 除外 |
| AC-6 | `?status=active` で suspended invited tenant 除外 | suspended invited 除外 |
| AC-7 | email_verified=false | 403 維持 |
| AC-8 | tenants 1 件 → 自動 redirect | FE 既存 |
| AC-9 | tenants 0 件 | 「所属なし」表示 |
| AC-10 | invited tenant に users 未作成 | 当該 tenant 返却 |
| AC-11 | allowed_email あるが tenant doc 削除済み | 無視 |
| AC-12 | decodedToken.email 欠落 | invited 検索スキップ、owner のみ返却 |
| AC-13 | GCIP UID conflict 既存 user tenant | 一覧には返る (回帰、既知制約) |
| AC-14 | 30 件超の invited tenant | 全件返却 (`getAll` で chunk 不要) |

## Test plan

- [x] API 単体テスト 14 件 (上記 AC) 全 PASS
- [x] type-check / lint / 全テスト PASS
- [ ] **マージ前**: `firebase deploy --only firestore:indexes -P lms-279` 実行 + READY 確認
- [ ] **マージ後**: Cloud Run デプロイ完了確認
- [ ] **本番 E2E**: `y.tsukuda@kanjikai.or.jp` で `https://web-3zcica5euq-an.a.run.app/` にアクセス → `/8vexhzpc` まで自動到達確認
- [ ] **既存導線回帰**: 長遊園 owner アカウントで トップアクセス → 既存挙動 (owner tenant 自動 redirect) が壊れていないことを確認

## 変更ファイル

- `packages/shared-types/src/tenant.ts` (+33 行): `MyTenantInfo` / `MineTenantsResponse` 追加
- `services/api/src/routes/tenants.ts` (+99 行): `/mine` ロジック書き換え + JSDoc
- `services/api/src/routes/__tests__/tenants.test.ts` (+593 行): AC-1〜AC-14 の 14 テスト追加
- `firestore.indexes.json` (+7 行): `allowed_emails` collection group index (`email` ASC)
- `web/app/page.tsx` (+9 行 / -6 行): `MyTenantInfo` を shared-types から import

🤖 Generated with [Claude Code](https://claude.com/claude-code)