### PR TITLE
feat(tenants/mine): PR #329 フォローアップ (silent-failure observability + test 追加)

### DIFF
--- a/packages/shared-types/src/tenant.ts
+++ b/packages/shared-types/src/tenant.ts
@@ -106,6 +106,13 @@ export interface MyTenantInfo {
   createdAt: string | null;
 }
 
+/**
+ * `GET /api/v2/tenants/mine` のレスポンス本体。
+ *
+ * `tenants` は `createdAt` 降順、`createdAt: null` は末尾に配置される。
+ * クライアントは追加 sort せずにそのまま表示してよい（API 契約として保証）。
+ * 同一 `createdAt` の相対順序は保証しない（unstable; 現状は Map insertion 順 = owner 優先）。
+ */
 export interface MineTenantsResponse {
   tenants: MyTenantInfo[];
 }

--- a/packages/shared-types/src/tenant.ts
+++ b/packages/shared-types/src/tenant.ts
@@ -81,7 +81,7 @@ export interface PublicTenantInfoResponse {
  * 「ログインユーザーがアクセス可能なテナント」の最小情報を返す。
  * - owner として作成したテナント
  * - allowed_emails に email が登録されたテナント（招待）
- * の和集合（重複排除済み）。
+ * の和集合（重複排除済み、`createdAt` 降順、`createdAt: null` は末尾）。
  *
  * `ownerEmail` は意図的に含めない。招待ユーザーに対しても等しく返却される
  * エンドポイントのため、招待された全テナントの所有者 email が漏れる。

--- a/services/api/src/routes/__tests__/tenants.test.ts
+++ b/services/api/src/routes/__tests__/tenants.test.ts
@@ -771,7 +771,8 @@ describe("GET /api/v2/tenants/mine — owner + invited 統合", () => {
   // -------------------------------------------------------------------
   it("[AC-15] ?status=invalid → 400 invalid_status (Firestore 呼び出し前に拒否)", async () => {
     mockVerifyIdToken.mockResolvedValue(decoded("uid-1", "u@example.com"));
-    setMine({ tenants: [], allowedEmails: [] });
+    // Firestore に到達したら throw させ、guard 前拒否を assertion でも明示する。
+    mockGetFirestore.mockImplementation(throwFirestoreImpl);
     const app = await buildApp();
 
     const res = await supertest(app)
@@ -780,6 +781,7 @@ describe("GET /api/v2/tenants/mine — owner + invited 統合", () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("invalid_status");
+    expect(mockGetFirestore).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------

--- a/services/api/src/routes/__tests__/tenants.test.ts
+++ b/services/api/src/routes/__tests__/tenants.test.ts
@@ -764,4 +764,70 @@ describe("GET /api/v2/tenants/mine — owner + invited 統合", () => {
     expect(res.status).toBe(200);
     expect(res.body.tenants).toHaveLength(N);
   });
+
+  // -------------------------------------------------------------------
+  // AC-15: ?status=invalid → 400 invalid_status
+  //        Firestore に到達する前に hard fail する（"active"/"suspended" 以外）。
+  // -------------------------------------------------------------------
+  it("[AC-15] ?status=invalid → 400 invalid_status (Firestore 呼び出し前に拒否)", async () => {
+    mockVerifyIdToken.mockResolvedValue(decoded("uid-1", "u@example.com"));
+    setMine({ tenants: [], allowedEmails: [] });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine?status=pending")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_status");
+  });
+
+  // -------------------------------------------------------------------
+  // AC-16: createdAt: null を含むテナント群の sort 末尾配置
+  //        ISO 文字列は降順、null は最後尾に寄せる。
+  // -------------------------------------------------------------------
+  it("[AC-16] createdAt:null は sort 末尾に寄る (降順 + null last)", async () => {
+    mockVerifyIdToken.mockResolvedValue(decoded("uid-owner", "o@example.com"));
+    setMine({
+      tenants: [
+        {
+          id: "t-old",
+          name: "Old",
+          ownerEmail: "o@example.com",
+          ownerId: "uid-owner",
+          status: "active",
+          createdAt: "2026-04-18T00:00:00.000Z",
+        },
+        {
+          id: "t-null",
+          name: "Null Created",
+          ownerEmail: "o@example.com",
+          ownerId: "uid-owner",
+          status: "active",
+          createdAt: null,
+        },
+        {
+          id: "t-new",
+          name: "New",
+          ownerEmail: "o@example.com",
+          ownerId: "uid-owner",
+          status: "active",
+          createdAt: "2026-04-20T00:00:00.000Z",
+        },
+      ],
+      allowedEmails: [],
+    });
+    const app = await buildApp();
+
+    const res = await supertest(app)
+      .get("/api/v2/tenants/mine")
+      .set("authorization", "Bearer t");
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenants.map((t: { id: string }) => t.id)).toEqual([
+      "t-new",
+      "t-old",
+      "t-null",
+    ]);
+  });
 });

--- a/services/api/src/routes/tenants.ts
+++ b/services/api/src/routes/tenants.ts
@@ -375,6 +375,7 @@ router.get("/mine", async (req: Request, res: Response) => {
               logger.warn("allowed_emails doc has null grandparent ref", {
                 errorType: "allowed_emails_schema_violation",
                 path: allowedDoc.ref.path,
+                uid,
                 endpoint: "/tenants/mine",
               });
             }
@@ -412,6 +413,7 @@ router.get("/mine", async (req: Request, res: Response) => {
         logger.warn("invited tenant doc not found (allowed_emails orphan?)", {
           errorType: "invited_tenant_orphan",
           tenantId: doc.id,
+          uid,
           endpoint: "/tenants/mine",
         });
       }

--- a/services/api/src/routes/tenants.ts
+++ b/services/api/src/routes/tenants.ts
@@ -366,7 +366,18 @@ router.get("/mine", async (req: Request, res: Response) => {
           const refs: DocumentReference[] = [];
           for (const allowedDoc of snap.docs) {
             const tenantRef = allowedDoc.ref.parent.parent;
-            if (tenantRef) refs.push(tenantRef);
+            if (tenantRef) {
+              refs.push(tenantRef);
+            } else {
+              // ref.parent.parent が null になるのは allowed_emails が
+              // tenants/{id}/allowed_emails/{id} 以外のパスに置かれた場合のみ。
+              // スキーマ違反のため検知できるよう warn ログを残す。
+              logger.warn("allowed_emails doc has null grandparent ref", {
+                errorType: "allowed_emails_schema_violation",
+                path: allowedDoc.ref.path,
+                endpoint: "/tenants/mine",
+              });
+            }
           }
           return refs;
         })
@@ -393,9 +404,16 @@ router.get("/mine", async (req: Request, res: Response) => {
   if (invitedRefsToFetch.length > 0) {
     const invitedDocs = await db.getAll(...invitedRefsToFetch);
     for (const doc of invitedDocs) {
-      // tenant doc が削除済み等で存在しない場合はスキップ（fail-closed）
+      // tenant doc が削除済み等で存在しない場合はスキップ（fail-closed）。
+      // allowed_emails が先行削除されずに孤児化している兆候なので warn ログ。
       if (doc.exists) {
         tenantDocsById.set(doc.id, doc);
+      } else {
+        logger.warn("invited tenant doc not found (allowed_emails orphan?)", {
+          errorType: "invited_tenant_orphan",
+          tenantId: doc.id,
+          endpoint: "/tenants/mine",
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary

- PR #329 レビュー指摘 (rating 5-7、Issue 化対象外) の後追い対応
- silent-failure 2 箇所を構造化 `logger.warn` で検知可能化 (observability)
- `MyTenantInfo` JSDoc に「createdAt 降順 / null 末尾 sort」仕様を明記
- `/tenants/mine` に AC-15 (`?status=invalid` → 400) / AC-16 (`createdAt:null` 末尾 sort) のテスト追加

## 背景

PR #329 の `/review-pr` 6 観点並列レビューで以下が指摘されていた:

| 観点 | 指摘 | rating | 本 PR の対応 |
|------|------|--------|-----------|
| pr-test-analyzer | `?status=invalid` の 400 テスト欠落 | 7 | AC-15 追加 |
| pr-test-analyzer | `createdAt:null` sort 末尾のテスト欠落 | 6 | AC-16 追加 |
| silent-failure-hunter | `allowed_emails.ref.parent.parent=null` 時 silent skip | 5 | `logger.warn` 追加 |
| silent-failure-hunter | `invitedDoc.exists=false` 時 silent skip | 5 | `logger.warn` 追加 |
| comment-analyzer | `MyTenantInfo` JSDoc に sort 仕様記載なし | 5 | JSDoc 1 行追記 |

いずれも triage 基準 (rating ≥ 7 & confidence ≥ 80) を Issue 化するほどではないが、次 PR でまとめ対応することで合意 (Session 12 ハンドオフ `docs/handoff/LATEST.md` の「フォローアップ候補」)。

## 実装

### 1. `packages/shared-types/src/tenant.ts`
`MyTenantInfo` の JSDoc 「和集合（重複排除済み）」→「和集合（重複排除済み、`createdAt` 降順、`createdAt: null` は末尾）」。

### 2. `services/api/src/routes/tenants.ts`
2 箇所の silent-failure に `logger.warn` を追加:
- `errorType: allowed_emails_schema_violation` — `ref.parent.parent=null` (`tenants/{id}/allowed_emails/{id}` 以外の場所に置かれた場合)
- `errorType: invited_tenant_orphan` — `invitedDoc.exists=false` (tenant 削除済みで allowed_emails が孤児化)

既存の `logger.warn` 形式 (`public.ts` 等) に合わせ `errorType` field を付与し、Cloud Logging でのアラート設定を容易にした。

### 3. `services/api/src/routes/__tests__/tenants.test.ts`
- AC-15: `?status=pending` (validStatuses に無い値) → 400 `invalid_status`、Firestore 呼び出し前に hard fail
- AC-16: 3 テナント (createdAt 新/旧/null) を返却 → sort 結果が `[新, 旧, null]` であることを assert

## 動作確認

- [x] type-check: PASS
- [x] lint: PASS (eslint clean)
- [x] test: API 645 tests (前回 643 + AC-15/16 の 2) / web 33 tests PASS
- [x] 影響範囲: `/tenants/mine` のレスポンス契約・ステータスコード変更なし (behavior preserving)

## Test plan

- [x] `npm run type-check` 全ワークスペース PASS
- [x] `npm run lint` eslint clean
- [x] `npm run test -w @lms-279/api` 645 PASS
- [x] `npm run test -w @lms-279/web` 33 PASS
- [ ] Cloud Run デプロイ後 smoke test (200/401/400 確認、500 なし)
- [ ] Cloud Logging で `errorType=allowed_emails_schema_violation` / `errorType=invited_tenant_orphan` が検索可能であることを確認 (実発生時に有用性確認)

## 関連

- 親 PR: #329 (feat(tenants/mine): 招待ユーザーを含む所属テナント一覧返却 恒久対応)
- ハンドオフ: `docs/handoff/LATEST.md` (コミット `fb2e316`) の「本 PR #329 のフォローアップ候補」セクション
- Issue #272 (close 済, 2026-04-24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)