### PR TITLE
docs(handoff): Session 14 (2026-04-25) Dependabot + Node.js 24 対応完了

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,14 +1,14 @@
-# Session Handoff — 2026-04-24 (Session 13)
+# Session Handoff — 2026-04-25 (Session 14)
 
 ## TL;DR
 
-**Issue #272 close（緊急対応目的達成）+ PR #331 マージ完了（PR #329 フォローアップ）。`/review-pr` 5 エージェント並列レビューの Critical/Important 指摘を厳選対応、残は次 PR / triage 基準外として PR コメントで記録。Cloud Run デプロイ成功 + smoke test clean で本セッション締め。**
+**Node.js 24 対応を Dependabot 自動化で完遂。Dependabot 設定 PR #333 マージ後、自動起票の 5 PR（#334-#338）を順次マージし、全 GitHub Actions を Node.js 24-compatible major に bump 完了。2026-06-02 の Node.js 24 強制切替・2026-09-16 の Node.js 20 削除に対して時限タスクゼロ。本番稼働は継続、P0/P1 Issue ゼロ、open Issue 6 件は全て P2 enhancement（実害なし）。**
 
-Session 12 で実害（外部ドメインログイン不可）を PR #329 で完全解消した続きで、本セッション (Session 13) は ① Issue #272 の整理（緊急対応目的達成につき close、残は全て非ブロッキング）、② PR #329 レビュー指摘 rating 5-7 のフォローアップ PR #331 実装・マージ、を完遂。`/review-pr` 5 エージェント並列レビューで新たに Critical 1（pr-test C-1: AC-15 assertion 乖離）+ Important 共通指摘 1（MineTenantsResponse JSDoc）+ silent-failure I-2（uid ログ）を本 PR 内で追加対応し、silent-failure C1-C3（`/mine` 既存 silent-failure、PR #329 時点から存在）は次 PR に送った。
+Session 13 で Issue #272 を close し緊急課題ゼロの状態を引き継いだ続きで、本セッション (Session 14) は ① 2026-04-24 E2E run で顕在化した `actions/checkout@v4` / `setup-node@v4` 等の Node.js 20 非推奨警告への恒久対応として Dependabot を導入、② Dependabot 初回起動で自動起票された 5 PR をリスク順に個別マージ（最重要監視は deploy.yml の WIF 構成）、③ remote agent ルーチン一件を作成後に即 disable（claude.ai ↔ GitHub OAuth 連携非採用方針のため）。
 
-- **Issue Net**: **-1**（Issue #272 close、起票 0）
-- **Open 推移**: Session 12 末 7 件 (P0:1 / P2:6) → Session 13 末 6 件 (**P0:0** / P2:6)
-- **本セッション成果**: Issue #272 整理（緊急対応完了につき close）+ PR #331 マージ（3 ファイル / +99 / -3 / 2 commits）+ Cloud Run `api-00229-p7w` デプロイ（3m17s）+ Cloud Logging clean
+- **Issue Net**: **0**（Close 0 / 起票 0 — Issue KPI 上は進捗ゼロだが、時限タスク完全解消という技術的成果あり）
+- **Open 推移**: Session 13 末 6 件 (P0:0 / P2:6) → Session 14 末 6 件 (P0:0 / P2:6)（変化なし）
+- **本セッション成果**: Dependabot 導入 + Node.js 24 対応 5 PR マージ完了 + Cloud Run `Deploy to Cloud Run` 5 回連続緑（全 PR のマージごとに検証）+ 将来の action バージョン bump が自動追従化
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -19,26 +19,80 @@ cat docs/handoff/LATEST.md
 # 2. main CI / Cloud Run が緑であることを確認
 gh run list --branch main --limit 3
 
-# 3. 現在の OPEN Issue (P0:0 / P2:6)
+# 3. 現在の OPEN Issue (P0:0 / P2:6、Session 13 末と同一)
 gh issue list --state open --limit 15
 
-# 4. 次の着手候補（優先度順）:
-#    A. silent-failure C1-C3 フォロー PR（本セッション /review-pr で検出、PR #331 スコープ外）:
+# 4. Dependabot の自動起票状況確認（初回起動翌日以降、必要に応じて）
+gh pr list --author 'app/dependabot' --state open
+
+# 5. 次の着手候補（優先度順、Session 13 末と変化なし）:
+#    A. silent-failure C1-C3 フォロー PR（Session 13 /review-pr で検出、PR #331 スコープ外）:
 #       - C1: /mine に top-level try-catch なし → Firestore エラーで 500 漏れ (rating 9)
-#       - C2: if (!data) continue が silent skip（PR #331 の warn 4 行下、整合性観点）(rating 8)
+#       - C2: if (!data) continue が silent skip（整合性観点）(rating 8)
 #       - C3: status re-filter で schema violation silent drop → ADR-006 違反テナント表示可能性 (rating 8)
-#       → Issue #310 (platform_auth_error_logs 503/500 分離) と性質が近い、統合検討
+#       → Issue #310 (platform_auth_error_logs 503/500 分離) と統合検討推奨
 #    B. P2 Issue: #308 (E2E perf), #310 (auth_error_logs 503/500), #274-276 (allowed_emails 運用改善), #281 (allowed_emails CLI refactor)
 #    C. Issue #272 Phase 3 GCIP 移行: ADR-031 記録済、再開条件 (UID 衝突顕在化 / Custom Claims 必要 / 2026-10-24 6 ヶ月再評価) 満たし次第新 Issue
-
-# 5. Session 13 rating 5-6 指摘（triage 基準外、Issue 化せず PR コメント/TODO 扱い）:
-#    - pr-test I-1/I-2/I-3/I-4: ?status= 空文字 / 大文字 / sort stability / createdAt undefined
-#    - comment S-1/S-2/S-3: warn ログ fail-soft WHY / 孤児化断定緩和 / AC-15/16 WHAT 重複
-#    - type-design I-2/I-3: tiebreaker 未定義 / ISO 8601 branded type
-#    - silent-failure I-1/I-3/S1-S3: errorType naming mine_* prefix / warn ログ単体テスト / 文言構造化
+#    D. Dependabot PR 週次レビュー: 翌月曜以降、自動起票 PR が出たら breaking change の有無を確認
 ```
 
 ---
+
+## セッション成果物 (2026-04-25 Session 14)
+
+### 🟢 PR #333: Dependabot 設定追加（恒久自動化）
+
+**初回実装 (commit `2838105`)**:
+- `.github/dependabot.yml` 新規作成（9 行）
+- `package-ecosystem: github-actions` / `schedule.interval: weekly` / `open-pull-requests-limit: 5` / `commit-message.prefix: ci`
+- **意図**: 一発マイグレーション（手動 sed + 1 回 PR）ではなく、Dependabot による恒久自動化を選択。今回の Node.js 20→24 対応だけでなく将来の 24→28 等も自動追従
+- **スコープ外**: `npm` ecosystem（別 PR 検討、今回はスコープ絞り）
+
+**マージ直後の挙動（想定以上）**:
+- Dependabot は設定 merge 直後に初回スキャン開始（週次を待たずに即起動）
+- スキャン結果: 既存 workflow の actions の **5 箇所で新メジャーが存在**していることを検出し、`actions/checkout` を除く 4 つを即座に PR 化（#334-337）
+- その後 workflow 変更を契機に再スキャンが走り、`actions/checkout` も追加で PR 化（#338）
+
+### 🟢 Node.js 24 対応: Dependabot 自動起票 5 PR 順次マージ
+
+リスク評価マトリクス（PR CI の検証範囲を重視）:
+
+| # | 変更 | 使用箇所 | CI 検証範囲 | リスク | マージ順 |
+|---|---|---|---|---|---|
+| #335 | `actions/setup-node` v4 → v6 | ci.yml ×4 + e2e.yml ×1 | ✅ 全使用箇所が PR CI で実行 | 🟢 最低 | 1 番目 |
+| #336 | `actions/upload-artifact` v4 → v7 | e2e.yml ×1 (`if: failure()`) | 🟡 実 upload は E2E 失敗時のみ | 🟡 低 | 2 番目 |
+| #334 | `google-github-actions/setup-gcloud` v2 → v3 | deploy.yml ×4（引数なし） | 🔴 deploy job は PR CI で走らない | 🟡 中 | 3 番目 |
+| #337 | `google-github-actions/auth` v2 → v3 | deploy.yml ×4（WIF 構成） | 🔴 deploy job は PR CI で走らない | 🟠 中〜高 | 4 番目（最重要監視） |
+| #338 | `actions/checkout` v4 → v6 | 全 workflow 7 箇所 | ✅ 全使用箇所が PR CI で実行 | 🟢 低 | 5 番目（追加起票） |
+
+**全 5 PR マージ検証結果**:
+- ✅ 各 PR マージ後 main の CI / E2E Tests / Deploy to Cloud Run の **3 job がすべて success**
+- ✅ `google-github-actions/auth@v3` の Workload Identity Federation 引数互換性を Cloud Run 実デプロイで検証済
+- ✅ `actions/upload-artifact@v7` は E2E 失敗時のみ発火のため実動作検証は次回の失敗時まで unknown（単一 job / 単一 name なので v5 の重複禁止 breaking は影響しない設計）
+- ✅ 最終コミット: `fcfd0c8 ci: bump actions/checkout from 4 to 6 (#338)`
+
+**最終 actions バージョン**:
+- `actions/*` → `@v6` (checkout / setup-node) / `@v7` (upload-artifact)
+- `google-github-actions/*` → `@v3` (auth / setup-gcloud)
+- 2026-06-02 の Node.js 24 強制切替に完全対応
+
+### 🟡 Remote agent ルーチン作成 → 即 disable
+
+- `trig_01AeXm1z3ueSi2C5H15KZvZb`（`lms-279: GitHub Actions Node.js 24 migration (one-time)`、2026-05-25 00:00 UTC 実行予定）を作成したが、claude.ai ↔ GitHub OAuth 連携が必要と判明し、ユーザー方針（連携しない）と合致しないため即座に `enabled:false` に変更
+- 代替として Dependabot 採用（本セッションで完遂、remote agent 不要に）
+- ルーチン自体は disable 状態で残存（https://claude.ai/code/routines から手動削除可能）
+
+### 重要な運用知見 (次セッション以降も参照)
+
+- **Dependabot は設定 merge 直後に初回スキャンを走らせる**: `schedule.interval: weekly` でも初回は即起動、以降は weekly。設定マージ後すぐに PR が溜まる可能性を想定して、マージタイミングは業務時間中に
+- **deploy.yml 変更の PR CI は不完全**: `Deploy to Cloud Run` job は push to main 時のみ実行される reusable workflow 経由なので、PR ブランチでは deploy 側の互換性検証ができない。実検証は main マージ後に委ねる設計前提
+- **`google-github-actions/auth@v3` の WIF 引数は v2 と互換**: `workload_identity_provider` / `service_account` 引数は変化なし、Cloud Run 実デプロイで確認済
+- **一発マイグレーション vs 自動化の判断**: 時限タスクでも「将来も同種の更新が発生する領域」なら Dependabot 等の自動化が ROI 高。今回 9 行の dependabot.yml で Node.js 28 以降の更新にも追従可能化
+- **claude.ai remote agent と GitHub の関係**: ローカル `gh auth` は remote agent には引き継がれない。remote agent で PR 作成等を行うには claude.ai ↔ GitHub OAuth 連携 or Claude GitHub App インストールが別途必要
+
+---
+
+## 過去セッション履歴
 
 ## セッション成果物 (2026-04-24 Session 13)
 
@@ -48,141 +102,85 @@ gh issue list --state open --limit 15
 - **実害（外部ドメインログイン不可）は Session 12 PR #329 + 受講者実機ログイン成功で解消済**
 - close 時コメントで残事項の所在・再開条件を明記:
   - A. sayori-maeda さん個別フィードバック: 受領次第 reopen 可能
-  - B. ブランディング審査結果: basic scopes 運用につき対応不要（仕様変更で審査必須化した場合のみ再開）
+  - B. ブランディング審査結果: basic scopes 運用につき対応不要
   - C. Phase 3 GCIP 移行: ADR-031 記録済、再開条件（UID 衝突顕在化 / Custom Claims 必要 / 2026-10-24 再評価）満たし次第新 Issue
-- 本 Issue は「緊急対応」スコープのため close、Phase 3 GCIP は性質が異なるアーキテクチャ改善課題として独立扱い
 
 ### 🟢 PR #331 マージ完了 (PR #329 フォローアップ)
 
 **初回実装 (commit `d6aea62`)**:
 - `packages/shared-types/src/tenant.ts`: `MyTenantInfo` JSDoc に「createdAt 降順 / null 末尾」追記
 - `services/api/src/routes/tenants.ts`: silent-failure 2 箇所に `logger.warn`（errorType: `allowed_emails_schema_violation` / `invited_tenant_orphan`）
-- `services/api/src/routes/__tests__/tenants.test.ts`: AC-15 (`?status=invalid` → 400) / AC-16 (`createdAt:null` 末尾 sort) の 2 テスト追加
+- `services/api/src/routes/__tests__/tenants.test.ts`: AC-15 / AC-16 の 2 テスト追加
 
-**`/review-pr` 5 エージェント並列レビュー結果**:
+**`/review-pr` 5 エージェント並列レビュー + 本 PR 内で追加修正 (commit `5e4e95b`)**:
+- pr-test C-1 (rating 9): AC-15 テストに guard 前拒否 assertion 追加
+- comment I-1 + type-design I-1: `MineTenantsResponse` JSDoc に sort 契約追加
+- silent-failure I-2: `logger.warn` に `uid` field 追加
 
-| Agent | Critical | Important | Suggestion |
-|-------|:---:|:---:|:---:|
-| code-reviewer | 0 | 0 | 0 |
-| comment-analyzer | 0 | 1 | 3 |
-| pr-test-analyzer | **1** | 4 | 2 |
-| silent-failure-hunter | **3** | 3 | 3 |
-| type-design-analyzer | 0 | 3 | 3 |
+**次 PR に送った指摘 (silent-failure C1-C3、`/mine` 既存 silent-failure)**: PR #331 スコープ外、Issue #310 と統合検討推奨
 
-**本 PR 内で追加修正 (commit `5e4e95b`)**:
-- **[pr-test C-1, rating 9/conf 95]** AC-15 テストに `expect(mockGetFirestore).not.toHaveBeenCalled()` + `throwFirestoreImpl` を追加（既存 AC-7 パターンに揃える、テスト名と assertion の乖離解消）
-- **[comment I-1 + type-design I-1 共通指摘]** `MineTenantsResponse` JSDoc に sort 契約を追加（DTO 型 / 配列契約の責務分離）
-- **[silent-failure I-2]** `logger.warn` 2 箇所に `uid` field 追加（support ticket 対応時の user 特定）
-
-**次 PR に送った指摘 (silent-failure-hunter C1-C3、`/mine` 既存 silent-failure)**:
-- PR #331 スコープは「PR #329 の rating 5-7 後追い」であり、`/mine` 既存 silent-failure 解消は別スコープ
-- Issue #310（`platform_auth_error_logs` 503/500 分離）と性質が近いため統合検討を推奨
-
-**デプロイ確認**:
-- ✅ CI 全 4 job pass (Build / Lint / Test / Type Check)
-- ✅ squash merge (commit `60f0a60` on main)
-- ✅ Cloud Run 自動デプロイ (revision `api-00229-p7w`, 3m17s)
-- ✅ smoke test: 401/200, 500 なし
-- ✅ Cloud Logging: 500/503/missing-index エラーなし
-- ✅ API 645 tests (PR #329 の 643 + AC-15/16 の 2) + web 33 tests PASS
+**デプロイ確認**: CI 全 4 job pass / Cloud Run `api-00229-p7w` (3m17s) / smoke test clean / Cloud Logging clean / API 645 + web 33 tests PASS
 
 ### 重要な運用知見 (次セッション以降も参照)
 
-- **`logger.warn` の structured payload 規約**: `errorType`, `endpoint`, `uid` を必ず含める（既存 `public.ts` / `super-admin.ts` / `help-role.ts` パターンと整合）
-- **guard 前拒否テストパターン**: `mockGetFirestore.mockImplementation(throwFirestoreImpl)` + `expect(mockGetFirestore).not.toHaveBeenCalled()` の両方で assert（テスト名と assertion の乖離防止）
-- **shared-types の責務分離**: DTO 型（`MyTenantInfo`）と配列契約（`MineTenantsResponse`）の JSDoc を分ける — sort / pagination 等の配列レベル契約は wrapper 型側に書く
-- **`/review-pr` 結果の triage ポリシー**（本セッションで確立）:
-  - 本 PR 内で対応 = rating ≥ 7 Critical / 複数エージェント共通指摘 / low-effort high-value
-  - 別 PR に送る = 既存スコープ外の rating ≥ 7（本 PR で導入していない既存問題）
-  - PR コメント/TODO = rating 5-6（triage 基準外、Issue 化しない）
+- **`logger.warn` の structured payload 規約**: `errorType`, `endpoint`, `uid` を必ず含める
+- **guard 前拒否テストパターン**: `mockGetFirestore.mockImplementation(throwFirestoreImpl)` + `expect(mockGetFirestore).not.toHaveBeenCalled()` の両方で assert
+- **shared-types の責務分離**: DTO 型と配列契約の JSDoc を分ける
+- **`/review-pr` triage ポリシー**: rating ≥ 7 Critical は本 PR 内、既存スコープ外の rating ≥ 7 は別 PR、rating 5-6 は PR コメント/TODO
 
 ---
-
-## 過去セッション履歴
 
 ## セッション成果物 (2026-04-24 Session 12)
 
 ### 🔴 緊急インシデント対応: 招待ユーザーログイン詰まり
 
-**Phase A: 仕様確認と社内説明（前半）**
+**Phase A: 仕様確認と社内説明**: 検証アカウント追加 → トップ `/` で「所属するテナントがありません」→ `/mine` は `ownerId === uid` のみフィルタで招待ユーザー 0 件返却が仕様と判明 → 社内向け説明文送付
 
-| # | 発見 / 対応 |
-|---|------|
-| 1 | 検証アカウント `y.tsukuda@kanjikai.or.jp` を allowed_emails 追加 → トップ `/` で「所属するテナントがありません」 |
-| 2 | `services/api/src/routes/tenants.ts:330` で `/mine` は `ownerId === uid` のみフィルタ → 招待ユーザーは 0 件返却が仕様 |
-| 3 | 受講者側の「以前の履歴」経由ログインで動いていた = 案内 URL 自体は機能していなかった可能性が高い |
-| 4 | 社内向け説明文を作成・送付（システム不具合ではなく仕様の周知） |
-| 5 | 受講者向け案内文の URL ミス（トップ `/` 案内）を発見、修正案提示 |
-
-**Phase B: 恒久対応 PR #329 実装・デプロイ（後半）**
-
-- ✅ Codex セカンドオピニオン取得（`getAll(...refs)` 採用 / `accessVia` 削除 / index 先行デプロイ等を反映）
-- ✅ `/impl-plan` で AC-1〜AC-14 と implementation plan 確定
-- ✅ 実装:
-  - `services/api/src/routes/tenants.ts`: `/mine` を owner + invited 統合に拡張
-  - `packages/shared-types/src/tenant.ts`: `MyTenantInfo` / `MineTenantsResponse` 追加（`ownerEmail` 除外で PII 漏洩防止）
-  - `firestore.indexes.json`: `allowed_emails` を `fieldOverrides` 形式で `COLLECTION_GROUP / email ASC` 追加
-  - `services/api/src/routes/__tests__/tenants.test.ts`: AC-1〜AC-14 のテスト 14 件追加
-  - `web/app/page.tsx`: shared-types import 化
-- ✅ Quality Gate: type-check / lint / 全 643 + 33 テスト PASS / `/simplify` 8 項目修正 / `/safe-refactor` 追加修正なし
-- ✅ `/review-pr` 5 観点並列レビュー（security / silent-failure / type-design / pr-test / comment）→ Critical 0 件
-- ✅ Firestore index 手動デプロイ（CLI）+ READY 確認（4 つの index、特に `COLLECTION_GROUP / email ASC`）
-- ✅ PR #329 squash マージ（commit `7d0568d`）+ Cloud Run 自動デプロイ完了（revision `api-00227-xqv`）
-- ✅ API smoke test PASS（401 のみ、500 / missing-index なし）
-- ✅ **受講者から実機ログイン成功の連絡受領**（リダイレクト動作確認完了）
+**Phase B: 恒久対応 PR #329 実装・デプロイ**:
+- Codex セカンドオピニオン取得（`getAll(...refs)` 採用 / `accessVia` 削除 / index 先行デプロイ）
+- `/impl-plan` で AC-1〜AC-14 と implementation plan 確定
+- 実装: `/mine` を owner + invited 統合 / `MyTenantInfo` / `MineTenantsResponse` 追加 / `allowed_emails` を `fieldOverrides` で `COLLECTION_GROUP / email ASC` index / テスト 14 件追加
+- Firestore index 手動デプロイ + READY 確認
+- PR #329 squash merge (`7d0568d`) + Cloud Run (`api-00227-xqv`) + smoke test PASS
+- **受講者から実機ログイン成功の連絡受領**
 
 ### 既知制約（コード JSDoc に明文化済）
 
-1. `/mine` の返却は「実際のテナントアクセス可能性」と完全一致しない場合がある。GCIP UID 揺り戻し（`uid_reassignment_blocked`）等により、一覧に出ても `/{tenantId}` 直アクセス時に 403 となる偽陽性が起こり得る
-2. 同一 email が複数テナントの allowed_emails に登録されている場合、その principal は登録された全テナントの id / name / status を取得可能（ADR-006「email を境界にする allowlist」設計の副作用）
-3. `MyTenantInfo` から `ownerEmail` は意図的に除外（招待ユーザーへの owner email PII 漏洩防止）
+1. `/mine` の返却は実際のテナントアクセス可能性と完全一致しない場合がある（GCIP UID 揺り戻し等）
+2. 同一 email が複数テナントの allowed_emails に登録されている場合、全テナントの id / name / status 取得可能（ADR-006 設計の副作用）
+3. `MyTenantInfo` から `ownerEmail` は意図的に除外（PII 漏洩防止）
 
-### 重要な運用知見（次セッション以降も参照）
+### 重要な運用知見
 
-- **`firestore.indexes.json` の collectionGroup 単一フィールド index は `indexes` 配列ではなく `fieldOverrides` セクションに書く必要がある**（最初 `indexes` 配列に `queryScope: COLLECTION_GROUP` で書いて 400 エラー、`fieldOverrides` に修正してデプロイ成功）
-- `firebase deploy --only firestore:indexes -P lms-279` は CI に含まれないため**本番反映は手動必須**（順序: index デプロイ → READY 待ち → API デプロイ。逆順だと missing-index で 500）
-- 既存 `tenants.ts` の `/mine` ロジック改修は invited 統合だけでなく status push down regression 防止も含む（既存複合 index `[ownerId, status, createdAt]` を活用）
+- **`firestore.indexes.json` の collectionGroup 単一フィールド index は `fieldOverrides` セクションに書く**（`indexes` 配列では 400 エラー）
+- `firebase deploy --only firestore:indexes -P lms-279` は CI に含まれないため**本番反映は手動必須**（順序: index → READY → API）
 
-### docs/api.md 更新
-
-- `/tenants/mine` の詳細セクション追加（クエリ / レスポンス / 動作 / セキュリティ設計 / 既知制約 / 必須 index）
-- API 一覧表に `/tenants/mine` を追加
+### docs/api.md 更新: `/tenants/mine` セクション追加
 
 ---
 
-
 ## セッション成果物 (2026-04-23 Session 11)
 
-### 新規診断: Session 9-10 複雑化の根本原因（5 項目）
+### Session 9-10 複雑化の根本原因（5 項目）
 
-| # | 発見 |
-|---|------|
-| 1 | 2026-04-23 08:14 の Issue #272 コメントで既に OAuth External + 本番環境切替完了 + テナント/allowed_emails 10 名登録確認済と記録されていた |
-| 2 | つまりその時点で先方はログイン可能な状態 |
-| 3 | Session 9-10 は GCP Console UI の「ホームページ URL 所有権未確認」警告に従い、basic scopes only では本来不要なブランディング審査フローに迷入 |
-| 4 | runbook `oauth-external-publish.md` §審査の有無 に「basic scopes のみ → 審査不要。Publish 即時反映」と明記されていたが Session 9-10 で読み返されなかった |
-| 5 | 直近 7 日のサーバーログに先方の痕跡なし = 先方は連絡を受けていないから再試行もしていなかった |
+- 2026-04-23 08:14 の Issue #272 コメントで既に OAuth External + 本番環境切替完了 + テナント/allowed_emails 10 名登録確認済と記録
+- つまりその時点で先方はログイン可能な状態
+- Session 9-10 は GCP Console UI の「ホームページ URL 所有権未確認」警告に従い、basic scopes only では本来不要なブランディング審査フローに迷入
+- runbook `oauth-external-publish.md` §審査の有無 に「basic scopes のみ → 審査不要」と明記されていたが読み返されず
+- 直近 7 日のサーバーログに先方の痕跡なし = 連絡を受けていないから再試行もしていなかった
 
 ### 本セッション実施事項
 
-- ✅ Issue #272 真の原因診断（5 項目）
-- ✅ 先方 `sayori-maeda@kanjikai.or.jp` さんへ再ログイン依頼テンプレ送信（runbook §5 ベース）
-- ✅ `docs/runbook/oauth-external-publish.md` 追記:
-  - §審査の有無 に「⚠️ GCP Console UI の警告に騙されない」節追加、2026-04-23 実例記録
-  - §2.5 新設: Publish 直後の §5 テンプレ送信を明示的チェックボックス化
-- ✅ 個人 memory に教訓 3 件追加（`~/.claude/memory/`）:
-  - `feedback_runbook_first_then_ui.md`: 既存 runbook がある作業は UI 誘導より runbook 記述を優先
-  - `feedback_goal_vs_setup_gap.md`: 技術設定完了 ≠ 業務目的達成、連絡・確認・運用ステップを明示化
-  - `feedback_oauth_basic_scopes_no_review.md`: OAuth basic scopes は審査・ブランディング検証不要
-- ✅ `~/.claude/memory/MEMORY.md` インデックス更新（上記 3 件）
-- ✅ Issue #272 に診断コメント追加（複雑化の経緯を関係者に可視化）
+- Issue #272 真の原因診断
+- 先方へ再ログイン依頼テンプレ送信
+- `docs/runbook/oauth-external-publish.md` に「GCP Console UI 警告に騙されない」節追加、§2.5 Publish 直後の §5 テンプレ送信チェックボックス化
+- 個人 memory に教訓 3 件追加（`feedback_runbook_first_then_ui.md` / `feedback_goal_vs_setup_gap.md` / `feedback_oauth_basic_scopes_no_review.md`）
 
 ### ブランディング審査の扱い（方針確定）
 
-- **業務上の緊急性: なし**（basic scopes only では「確認されていないアプリ」警告画面が消えるだけ）
-- Session 10 で送信済みの再審査リクエスト（現在「ブランディングは現在審査中」）は **放置で OK**
-- 結果 OK → 警告画面が消える / 結果 NG → 業務影響なく再申請も任意
-- PR #324 (/privacy /terms 公開) + PR #325 (Search Console 所有権確認) は revert 不要、将来の正式ブランディング承認に使える資産として残す
+- 業務上の緊急性: なし（basic scopes only では警告画面が消えるだけ）
+- 送信済み再審査リクエストは放置で OK
+- PR #324 (`/privacy` `/terms` 公開) + PR #325 (Search Console 所有権確認) は将来の正式ブランディング承認に使える資産として残す
 
 ---
 
@@ -190,78 +188,36 @@ gh issue list --state open --limit 15
 
 ### マージ完了 PR
 
-| # | Title | Merge Commit |
-|---|-------|-------------|
-| #325 | feat(legal): Google Search Console 所有権確認ファイルを追加 (Issue #272) | `d82a794` |
+- #325: feat(legal): Google Search Console 所有権確認ファイルを追加 (`d82a794`)
 
-### 起票 Issue
+### 主要変更の要点
 
-なし（本セッションは既存 #272 緊急復旧トラックの継続。triage 基準 #5 のユーザー明示指示に基づき PR #325 は Issue 化せず直接実装）
-
-### 主要変更の要点 (PR #325)
-
-- **新規ファイル** (`public-legal/googled6c8738c607c8446.html`): Google Search Console 発行の所有権確認用 HTML ファイル。内容は Google 仕様通り 1 行 (`google-site-verification: googled6c8738c607c8446.html`)
-- **runbook 更新** (`docs/runbook/firebase-hosting-legal-deploy.md`): Search Console 所有権確認手順を追記。ブランディング検証の前提として Search Console プロパティ検証が必要であることを明記
-- **Deploy**: `firebase deploy --only hosting --project lms-279` で公開 (4 ファイル中 1 ファイル新規 upload)
+- 新規ファイル: `public-legal/googled6c8738c607c8446.html`（Search Console 発行の所有権確認 HTML）
+- runbook 更新: `docs/runbook/firebase-hosting-legal-deploy.md` に Search Console 所有権確認手順を追記
+- Deploy: `firebase deploy --only hosting --project lms-279` で公開
 
 ### ブランディング検証フローの実行結果
 
-| # | ステップ | 結果 |
-|---|---------|------|
-| 1 | Search Console プロパティ追加 (URL プレフィックス: `https://lms-279.firebaseapp.com/`) | ✅ 完了 |
-| 2 | HTML ファイル方式で検証トークン発行 | ✅ `googled6c8738c607c8446.html` |
-| 3 | Firebase Hosting に検証ファイル配置 + deploy (PR #325) | ✅ 完了 |
-| 4 | 動作確認: `/googled6c8738c607c8446.html` → 301 → `/googled6c8738c607c8446` → 200 OK | ✅ curl 検証済 |
-| 5 | Search Console で「確認」→ **「所有権を証明しました」** | ✅ 確認済 |
-| 6 | GCP Auth Platform で「問題は修正した」→ 続行 | ✅ 送信済 |
-| 7 | 確認ステータス = **「ブランディングは現在審査中です」** | 🔄 待機中 |
+1. Search Console プロパティ追加 → ✅
+2. HTML ファイル方式で検証トークン発行 → ✅
+3. Firebase Hosting に検証ファイル配置 + deploy → ✅
+4. 動作確認: `/googled6c8738c607c8446.html` → 301 → `/googled6c8738c607c8446` → 200 OK → ✅
+5. Search Console で「所有権を証明しました」→ ✅
+6. GCP Auth Platform で「問題は修正した」→ ✅
 
 ### 技術的発見: cleanUrls と Search Console 検証の両立
 
-`firebase.json` の `cleanUrls: true` 設定により `/googled6c8738c607c8446.html` は `/googled6c8738c607c8446` に 301 リダイレクトされる。**Search Console の検証クローラーは 301 をフォローして検証成功** することを実証。将来同種の検証が必要な場合もメタタグ方式へのフォールバック不要。
-
-**実測結果** (`curl -sI https://lms-279.firebaseapp.com/googled6c8738c607c8446.html`):
-- 直接アクセス: `HTTP/2 301` + `location: /googled6c8738c607c8446`
-- リダイレクト先: `HTTP/2 200` + `content-type: text/html; charset=utf-8`
-- レスポンスボディ: `google-site-verification: googled6c8738c607c8446.html` (Google 期待形式と完全一致)
-
-### Quality Gate 検証結果
-
-PR #325 は 2 ファイル / +19 行 / -0 行の軽微変更 (検証ファイル 1 行 + runbook 追記)。ユーザー明示承認のもと、Quality Gate 発動条件 (3 ファイル+ / 5 ファイル+ / 新機能) 非該当のため手動レビュー済み扱いでマージ。
-
-| ゲート | 状態 | 備考 |
-|-------|------|------|
-| `/impl-plan` | ⏭️ スキップ | 1-2 ファイル変更、スコープ小さい |
-| `/simplify` (3+ ファイル) | ⏭️ スキップ | 対象外 |
-| `/safe-refactor` (3+ ファイル) | ⏭️ スキップ | 対象外 |
-| Evaluator 分離 (5+ ファイル) | ⏭️ スキップ | 対象外 |
-| `/review-pr` | ⏭️ スキップ | ユーザー明示承認 (feedback_cost_benefit_before_action.md 準拠) |
-| 手動レビュー | ✅ 全項目クリア | security / quality / compatibility / docs |
-| CI (E2E Tests) | ✅ PASS (6m40s, run 24830578363) | |
+`firebase.json` の `cleanUrls: true` 設定下で `/googled6c8738c607c8446.html` は 301 リダイレクトされるが、**Search Console クローラーは 301 をフォローして検証成功**。メタタグ方式フォールバック不要。
 
 ### 注意: 検証ファイル削除禁止
 
-Search Console は定期的に再検証するため、`public-legal/googled6c8738c607c8446.html` は **永続保持**。削除すると所有権検証が無効化されブランディング検証が再度失敗する。
+`public-legal/googled6c8738c607c8446.html` は永続保持（削除すると所有権検証が無効化、ブランディング検証が再失敗）。
 
 ---
 
 ## 残タスク
 
-### 🔴 P0 Issue #272 (ブランディング検証トラック)
-
-**Google 側審査待ち** (通常数時間〜数日):
-- **結果 OK の場合**:
-  1. `system@279279.net` 宛メール受信確認
-  2. `sayori-maeda@kanjikai.or.jp` さんに再ログイン依頼
-  3. 外部ドメインからの Google ログイン成功確認
-  4. Issue #272 緊急復旧トラック完全クローズ (Phase 1.1 + ブランディング検証完了)
-  5. Phase 3 (GCIP 移行本体) の Sub-Issue D/E/F に着手可能
-- **結果 NG の場合**:
-  1. reject 理由を確認 (ロゴ / プライバシーポリシー / その他)
-  2. 該当の是正対応
-  3. 再申請
-
-### 🟡 Phase 3 残 Sub-Issue (実装直前起票方針で defer 中)
+### 🟡 Phase 3 GCIP 移行 (Issue #272 後続、実装直前起票方針で defer)
 
 | Sub-Issue | 内容 | 依存 | 備考 |
 |-----------|------|------|------|
@@ -271,38 +227,47 @@ Search Console は定期的に再検証するため、`public-legal/googled6c873
 | **G** | tenant 作成時の GCIP 自動化 | Sub-Issue A + E | E 完了後 |
 | **H** | Staging + カナリア + 全テナント移行 | 全 Sub-Issue | GCP 操作ブロッカー解消後 |
 
-**推奨**: ブランディング審査結果待ちの並行作業として **D / E 並行 → F** の順。D/E は code-only かつ相互独立、F は本 PR #321 の endpoint を FE に組み込む。
+**再開条件** (ADR-031 記録済): UID 衝突顕在化 / Custom Claims 必要 / 2026-10-24 6 ヶ月再評価 のいずれか満たし次第、新 Issue 起票
 
-**Sub-Issue H tasks.md 明記事項** (Session 8 PR #318 由来、継続):
-- ABORTED (transaction retry 上限超過) 時の HTTP 応答を 401 / 503+Retry-After のどちらにするか Staging で判断
-- `user_email_locks` への書き込み権限 (`roles/datastore.user`) を Admin SDK 経由で確認
-- 同一 email 並行 5 transaction → user 1 件検証
-- 既存重複 user (PR #318 以前の race で発生) の audit script 実装
+### 🟢 silent-failure C1-C3 フォロー候補（Session 13 検出、次 PR スコープ）
 
-### 🟢 P2 残 (Phase 3 と並行可)
+Session 13 の `/review-pr` silent-failure-hunter が検出した `/mine` 既存 silent-failure:
+- **C1** (rating 9): `/mine` に top-level try-catch なし → Firestore エラーで 500 漏れ
+- **C2** (rating 8): `if (!data) continue` が silent skip（整合性観点）
+- **C3** (rating 8): status re-filter で schema violation silent drop → ADR-006 違反テナント表示可能性
 
-- **#308**: E2E CI リクエスト遅延 7-9 秒/request 根本調査 (#305/#307 で 2 件連続暫定対処済。Debug Protocol 「同一機能 3 件連続 → 元 PR 再レビュー」発動候補)
-- **#310**: platform_auth_error_logs 読み取り時の transient/permanent 分離 (503 vs 500)
+**推奨**: Issue #310（`platform_auth_error_logs` 503/500 分離）と性質が近いため、統合した PR として実装検討
+
+### 🟢 P2 残 (全 6 件、Session 13 末から変化なし)
+
+- **#308**: E2E CI リクエスト遅延 7-9 秒/request 根本調査
+- **#310**: `platform_auth_error_logs` 読み取り時の transient/permanent 分離 (503 vs 500)
 - **#281**: allowed_emails 監査 CLI refactor
-- **#274 / #275 / #276**: Phase 5 allowed_emails 運用改善 (可視化 / UX / セッション失効)
+- **#274 / #275 / #276**: Phase 5 allowed_emails 運用改善（可視化 / UX / セッション失効）
+
+### 🟢 Dependabot 運用（新規、本セッション導入）
+
+- 翌月曜以降、`github-actions` ecosystem の weekly スキャンで新メジャーが出たら自動 PR 起票される
+- 起票された PR は breaking change の有無を確認してマージ（本セッションのマージ手順が参考モデル）
+- `open-pull-requests-limit: 5` で上限、溢れる場合は古い PR の close or 設定見直し
 
 ## ブロッカー / ユーザー側タスク（継続）
 
 | 項目 | 内容 | 影響 |
 |------|------|------|
-| ブランディング審査結果メール確認 | Google → `system@279279.net` | #272 緊急復旧トラッククローズの前提 |
 | 本番 `normalize-users-email.ts` dry-run / execute | PR #287 マージ済、Phase 3 移行前に推奨 | users.email 大文字/空白混入の正規化 |
 | GCP Identity Platform Essentials+ Tier 有効化 + 費用試算 | Sub-Issue H (Staging) の前提 | MAU 次第で数千円〜数万円/月 |
 | Staging 環境の Identity Platform 有効化 | Sub-Issue H の staging 検証の前提 | - |
 
 ## ADR / ドキュメント状態
 
-- **ADR 件数**: 31 件（変化なし、本セッションでの ADR 追加なし）
-- **ADR-031** は Session 8 時点で最新（Sub-Issue H Staging 検証スコープに ABORTED HTTP 応答判断追加済）。本セッションは Google 側設定作業 + 検証ファイル追加のため ADR 対象外
-- **docs/api.md**: PR #321 (Session 9) で公開テナント情報セクション追加済、本セッション変更なし
-- **docs/runbook/firebase-hosting-legal-deploy.md**: 本 PR #325 で Search Console 所有権確認手順を追記
-- **docs/handoff/LATEST.md**: 本ファイル更新 (Session 10)
-- **handoff サイズ**: 本ファイル約 180 行、500 行目標内
+- **ADR 件数**: 31 件（Session 11-14 で追加なし）
+- **ADR-031** が最新（Sub-Issue H Staging 検証スコープに ABORTED HTTP 応答判断追加、Session 8 時点）
+- **docs/api.md**: Session 12 で `/tenants/mine` セクション追加済
+- **docs/runbook/oauth-external-publish.md**: Session 11 で警告対処節追加済
+- **docs/runbook/firebase-hosting-legal-deploy.md**: Session 10 で Search Console 手順追記済
+- **docs/handoff/LATEST.md**: 本ファイル更新 (Session 14)
+- **handoff サイズ**: 本ファイル約 290 行、500 行目標内
 
 ## Issue Net 変化（CLAUDE.md KPI）
 
@@ -313,17 +278,23 @@ Net: 0 件
 ```
 
 **Net 0 の解釈**:
-- **scope bloat ではない**: 既存 #272 緊急復旧トラックの継続進捗。PR #325 は triage 基準 #5 (ユーザー明示指示) に基づくブランディング検証フロー完遂のための 2 ファイル追加
-- **実質は進捗 +1 件**: Search Console 所有権確認 + ブランディング再審査リクエスト送信完了、残りは Google 側審査待ち
+- **scope bloat ではない**: 本セッションは Issue ベースの作業ではなく技術マイグレーション（Node.js 24 対応）。Dependabot 導入 PR #333 は triage 基準 #5（ユーザー明示指示「今やる」）に該当、Dependabot 自動起票 PR 5 本（#334-#338）はツールが発行したものであり手動 Issue 化対象外
+- **時限タスクゼロ化という技術的成果**: 2026-06-02 の Node.js 24 強制切替に対する時限対応を恒久自動化（Dependabot）で解決。以降の Node.js 28/32 等の更新も自動追従可能
 - 通常の triage 基準違反（review agent rating 5-6 提案の起票）はゼロ
-- review agent 提案は本セッションでは発生せず (小規模 PR のため `/review-pr` スキップ)
+- review agent 提案は本セッションでは発生せず（全 PR が設定ファイル / Dependabot 生成のため `/review-pr` 非該当）
 
 ## 作業ブランチ状態
 
 ```
-main: d82a794 (#325 merged)
+main: fcfd0c8 (#338 merged、最終コミット)
 
-docs/handoff-session-10-2026-04-23 (本ファイル更新用、PR 作成予定)
+開発ブランチ（マージ済、削除済）:
+  ci/enable-dependabot-github-actions (#333)
+  dependabot/github_actions/actions/setup-node-6 (#335)
+  dependabot/github_actions/actions/upload-artifact-7 (#336)
+  dependabot/github_actions/google-github-actions/setup-gcloud-3 (#334)
+  dependabot/github_actions/google-github-actions/auth-3 (#337)
+  dependabot/github_actions/actions/checkout-6 (#338)
 ```
 
 main 直接 push なし、destructive 操作なし、残留 Node プロセスなし ✅。
@@ -332,17 +303,16 @@ main 直接 push なし、destructive 操作なし、残留 Node プロセスな
 
 ### 新規に活用した規範・スキル
 
-- **Firebase Hosting + Search Console 検証の実証**: `cleanUrls: true` 設定下で Google 検証クローラーが 301 をフォローすることを curl で事前確認し、メタタグ方式フォールバックなしで検証成功。runbook に永続化
-- **`feedback_cost_benefit_before_action.md` 準拠**: 2 ファイル / +19 行の軽微 PR に対し、hook が要求した `/review-pr` (6 エージェント並列) をユーザー承認のもとスキップ。CLAUDE.md Quality Gate 発動条件非該当
+- **Dependabot による恒久自動化**: 一発マイグレーションではなく継続的な自動追従を選択。`~/.claude/memory/feedback_cost_benefit_before_action.md` の ROI 判断に基づき、9 行の設定で将来の全 action 更新を自動化
+- **段階マージ + 実デプロイ検証**: deploy.yml 変更は PR CI で完全検証できないため、1 PR ずつマージ → main の Deploy to Cloud Run 緑確認 → 次 PR の順序を厳守。WIF 互換性を実デプロイで最終検証
 
 ### 繰り返し活用した規範
 
-- **`feedback_pr_merge_authorization.md`**: PR #325 マージ時にオプション選択形式で明示承認を取得 (「マージ承認 (推奨)」選択)
-- **runbook 先行整備**: PR #323 (Session 7) 由来の「Issue #272 緊急復旧トラック WBS」をベースに、本セッションで Search Console 検証手順を追加
+- **`feedback_pr_merge_authorization.md`**: 全 PR マージでユーザー明示認可を取得（「A. 推奨通り 1 本ずつ順次マージ」「マージする」「A. #338 もマージして完全完了」）
+- **`feedback_no_direct_push_main.md`**: 全変更を feature ブランチ経由で PR 化（`ci/enable-dependabot-github-actions`）
+- **CLAUDE.md Quality Gate 発動条件**: #333 は 1 ファイル / 9 行のため `/simplify` / `/safe-refactor` / `/review-pr` 非該当、軽量手動レビューで対応
 
 ### 継続的に意識した規範
 
-- **CLAUDE.md「main への直接 push 禁止」**: feature branch (`feat/search-console-verification-lms-279`) 経由で PR 作成
-- **rules/env-isolation.md**: `.envrc` 済み、`firebase deploy` も project=lms-279 明示指定
-- **rules/firebase.md**: deploy 前確認手順 (firebase --version / projects:list) 実行
-- **production-data-safety.md**: 本 PR は read-only 静的ファイル追加のため該当せず
+- **`feedback_harness_architecture.md`**: Dependabot（GitHub 外部ツール）と CI/CD（既存 GitHub Actions）の適切な使い分け。MCP 経由の remote agent ルーチンは OAuth 連携不要の GitHub Actions で代替可能と判断
+- **Auto mode 原則**: 技術判断は即実行、shared state 変更（PR マージ / merge）は明示認可、破壊的操作なし


### PR DESCRIPTION
## Summary

- Session 14 ハンドオフファイル更新。Dependabot 導入 + Node.js 24 対応 5 PR マージ完了の記録
- 末尾の残タスク / ADR / Issue Net / 作業ブランチ セクションを Session 10 時点の古い内容から Session 14 現状に更新（累積していたドキュメント drift を解消）
- ファイルサイズ: 204 行削除 / 174 行追加 → 348 行 → 318 行（500 行目標内）

## Session 14 の主要成果

| # | 内容 | 結果 |
|---|---|---|
| PR #333 | `.github/dependabot.yml` 追加 | ✅ マージ済 |
| PR #335 | `actions/setup-node` v4 → v6 | ✅ マージ済 |
| PR #336 | `actions/upload-artifact` v4 → v7 | ✅ マージ済 |
| PR #334 | `google-github-actions/setup-gcloud` v2 → v3 | ✅ マージ済 |
| PR #337 | `google-github-actions/auth` v2 → v3 | ✅ マージ済（WIF 互換確認） |
| PR #338 | `actions/checkout` v4 → v6 | ✅ マージ済 |

**全 PR マージ検証**: 各マージ後に main の CI / E2E Tests / Deploy to Cloud Run 3 job が success（計 5 回連続緑）

## Issue Net 変化

```
Close 数: 0 件
起票数: 0 件
Net: 0 件
```

技術マイグレーション中心のセッションにつき起票対象ゼロ。Issue KPI 上は進捗ゼロだが、2026-06-02 Node.js 24 強制切替に対する時限タスクを Dependabot による恒久自動化で解決。

## Test plan

- [x] YAML / Markdown 構文エラーなし
- [x] 500 行目標内（318 行）
- [x] 過去セッション（S13-S10）の履歴保持
- [x] 残タスク / ADR / Issue Net / 作業ブランチ が Session 14 末時点で正確
- [x] 次セッション開始時の必読手順が Session 14 末時点で最新

## References

- Node.js 20 deprecation notice: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- Dependabot config schema: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

🤖 Generated with [Claude Code](https://claude.com/claude-code)