### PR TITLE
feat(super): 受講期間設定に期限起算日 deadlineBaseDate を追加

### DIFF
--- a/packages/shared-types/src/enrollment.ts
+++ b/packages/shared-types/src/enrollment.ts
@@ -1,5 +1,6 @@
 export interface TenantEnrollmentSettingResponse {
   enrolledAt: string;
+  deadlineBaseDate?: string;
   quizAccessUntil: string;
   videoAccessUntil: string;
   createdBy: string;

--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -1644,7 +1644,7 @@ export class FirestoreDataSource implements DataSource {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private toTenantEnrollmentSetting(id: string, data: any): TenantEnrollmentSetting {
     try {
-      return {
+      const result: TenantEnrollmentSetting = {
         id,
         enrolledAt: toDateStrict(data.enrolledAt, "enrolledAt").toISOString(),
         quizAccessUntil: toDateStrict(data.quizAccessUntil, "quizAccessUntil").toISOString(),
@@ -1652,6 +1652,10 @@ export class FirestoreDataSource implements DataSource {
         createdBy: data.createdBy,
         updatedAt: toDateStrict(data.updatedAt, "updatedAt").toISOString(),
       };
+      if (data.deadlineBaseDate != null) {
+        result.deadlineBaseDate = toDateStrict(data.deadlineBaseDate, "deadlineBaseDate").toISOString();
+      }
+      return result;
     } catch (e) {
       const error = e instanceof Error ? e.message : String(e);
       console.error(`Failed to parse TenantEnrollmentSetting:`, error);

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -1569,7 +1569,7 @@ router.put("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
 
   const validated = validateEnrollmentSettingPayload(req.body);
   if (!validated.ok) {
-    res.status(validated.status).json({ error: validated.error, message: validated.message });
+    res.status(400).json({ error: validated.code, field: validated.field, message: validated.message });
     return;
   }
 
@@ -1577,28 +1577,35 @@ router.put("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
   const deadlines = calculateDefaultDeadlines(normalizedDeadlineBaseDate ?? normalizedEnrolledAt);
   const basePath = `tenants/${tenantId}`;
   const docRef = db.collection(`${basePath}/enrollment_setting`).doc("_config");
+  const updatedAt = new Date().toISOString();
+  const operatorEmail = req.superAdmin!.email;
 
   // PUT は明示的な完全更新セマンティクス。
-  // - 指定あり: 値を保存
-  // - 省略: FieldValue.delete() で既存フィールドを除去（merge:true でも残らないようにする）
-  // 他フィールド（enrolledAt 等）は必須なので undefined 除去対象外。
-  const settingData: Record<string, unknown> = {
+  // 省略時は FieldValue.delete() で既存 deadlineBaseDate を除去（merge:true でも残さない）。
+  // 他フィールドは必須なので undefined 除去対象外。
+  const writeData: Record<string, unknown> = {
     enrolledAt: normalizedEnrolledAt,
     deadlineBaseDate: normalizedDeadlineBaseDate ?? FieldValue.delete(),
     quizAccessUntil: deadlines.quizAccessUntil,
     videoAccessUntil: deadlines.videoAccessUntil,
-    createdBy: req.superAdmin!.email,
-    updatedAt: new Date().toISOString(),
+    createdBy: operatorEmail,
+    updatedAt,
   };
 
-  await docRef.set(settingData, { merge: true });
+  await docRef.set(writeData, { merge: true });
 
-  // レスポンスは FieldValue.delete sentinel を含めず、保存時の論理状態を返す
-  const responseData = { ...settingData };
-  if (!normalizedDeadlineBaseDate) {
-    delete responseData.deadlineBaseDate;
+  // レスポンスは保存値から純粋に構築（FieldValue.delete sentinel が混入しない設計）。
+  const response: TenantEnrollmentSettingResponse = {
+    enrolledAt: normalizedEnrolledAt,
+    quizAccessUntil: deadlines.quizAccessUntil,
+    videoAccessUntil: deadlines.videoAccessUntil,
+    createdBy: operatorEmail,
+    updatedAt,
+  };
+  if (normalizedDeadlineBaseDate) {
+    response.deadlineBaseDate = normalizedDeadlineBaseDate;
   }
-  res.json({ setting: toEnrollmentSettingResponse(responseData) });
+  res.json({ setting: response });
 });
 
 /**

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -11,7 +11,7 @@
  */
 
 import { Router, Request, Response } from "express";
-import { getFirestore } from "firebase-admin/firestore";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { getAuth } from "firebase-admin/auth";
 import type { SuperAttendanceResponse, SuperStudentProgressResponse, TenantEnrollmentSettingResponse } from "@lms-279/shared-types";
 import {
@@ -25,7 +25,7 @@ import {
 } from "../middleware/super-admin.js";
 import type { TenantMetadata, TenantStatus } from "../types/tenant.js";
 import { masterRouter } from "./super-admin-master.js";
-import { calculateDefaultDeadlines } from "../services/enrollment.js";
+import { calculateDefaultDeadlines, validateEnrollmentSettingPayload } from "../services/enrollment.js";
 import { generateTenantId, normalizeEmail, parseTenantGcipFields } from "../utils/tenant-id.js";
 import { logger } from "../utils/logger.js";
 import { getPlatformDataSource } from "../middleware/platform-datasource.js";
@@ -1511,28 +1511,20 @@ router.post("/tenants/:tenantId/student-progress/export-sheets", async (req: Req
 // 受講期間管理（テナント×コース単位）
 // ============================================================
 
-const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z?)?$/;
-
-function isValidISODate(value: string): boolean {
-  return ISO_DATE_RE.test(value) && !isNaN(new Date(value).getTime());
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function toEnrollmentSettingResponse(data: any): TenantEnrollmentSettingResponse {
-  return {
+  const deadlineBaseDateRaw = data.deadlineBaseDate?.toDate?.()?.toISOString?.() ?? data.deadlineBaseDate;
+  const response: TenantEnrollmentSettingResponse = {
     enrolledAt: data.enrolledAt?.toDate?.()?.toISOString?.() ?? data.enrolledAt ?? "",
     quizAccessUntil: data.quizAccessUntil?.toDate?.()?.toISOString?.() ?? data.quizAccessUntil ?? "",
     videoAccessUntil: data.videoAccessUntil?.toDate?.()?.toISOString?.() ?? data.videoAccessUntil ?? "",
     createdBy: data.createdBy ?? "",
     updatedAt: data.updatedAt?.toDate?.()?.toISOString?.() ?? data.updatedAt ?? "",
   };
-}
-
-const ENROLLEDAT_RANGE_YEARS = 5;
-
-function isEnrolledAtInRange(dateStr: string): boolean {
-  const diff = Math.abs(new Date(dateStr).getTime() - Date.now());
-  return diff <= ENROLLEDAT_RANGE_YEARS * 365.25 * 24 * 60 * 60 * 1000;
+  if (deadlineBaseDateRaw) {
+    response.deadlineBaseDate = deadlineBaseDateRaw;
+  }
+  return response;
 }
 
 /**
@@ -1568,7 +1560,6 @@ router.get("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
 router.put("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Response) => {
   const db = getFirestore();
   const tenantId = req.params.tenantId as string;
-  const { enrolledAt } = req.body;
 
   const tenantDoc = await db.collection("tenants").doc(tenantId).get();
   if (!tenantDoc.exists) {
@@ -1576,28 +1567,24 @@ router.put("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
     return;
   }
 
-  if (!enrolledAt) {
-    res.status(400).json({ error: "bad_request", message: "enrolledAt is required" });
+  const validated = validateEnrollmentSettingPayload(req.body);
+  if (!validated.ok) {
+    res.status(validated.status).json({ error: validated.error, message: validated.message });
     return;
   }
 
-  if (!isValidISODate(enrolledAt)) {
-    res.status(400).json({ error: "invalid_date", message: "enrolledAt must be a valid date string" });
-    return;
-  }
-
-  if (!isEnrolledAtInRange(enrolledAt)) {
-    res.status(400).json({ error: "date_out_of_range", message: `enrolledAt must be within ${ENROLLEDAT_RANGE_YEARS} years from now` });
-    return;
-  }
-
-  const normalizedEnrolledAt = new Date(enrolledAt).toISOString();
-  const deadlines = calculateDefaultDeadlines(normalizedEnrolledAt);
+  const { enrolledAt: normalizedEnrolledAt, deadlineBaseDate: normalizedDeadlineBaseDate } = validated;
+  const deadlines = calculateDefaultDeadlines(normalizedDeadlineBaseDate ?? normalizedEnrolledAt);
   const basePath = `tenants/${tenantId}`;
   const docRef = db.collection(`${basePath}/enrollment_setting`).doc("_config");
 
-  const settingData = {
+  // PUT は明示的な完全更新セマンティクス。
+  // - 指定あり: 値を保存
+  // - 省略: FieldValue.delete() で既存フィールドを除去（merge:true でも残らないようにする）
+  // 他フィールド（enrolledAt 等）は必須なので undefined 除去対象外。
+  const settingData: Record<string, unknown> = {
     enrolledAt: normalizedEnrolledAt,
+    deadlineBaseDate: normalizedDeadlineBaseDate ?? FieldValue.delete(),
     quizAccessUntil: deadlines.quizAccessUntil,
     videoAccessUntil: deadlines.videoAccessUntil,
     createdBy: req.superAdmin!.email,
@@ -1605,7 +1592,13 @@ router.put("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
   };
 
   await docRef.set(settingData, { merge: true });
-  res.json({ setting: toEnrollmentSettingResponse(settingData) });
+
+  // レスポンスは FieldValue.delete sentinel を含めず、保存時の論理状態を返す
+  const responseData = { ...settingData };
+  if (!normalizedDeadlineBaseDate) {
+    delete responseData.deadlineBaseDate;
+  }
+  res.json({ setting: toEnrollmentSettingResponse(responseData) });
 });
 
 /**

--- a/services/api/src/services/__tests__/enrollment.test.ts
+++ b/services/api/src/services/__tests__/enrollment.test.ts
@@ -196,43 +196,83 @@ describe("validateEnrollmentSettingPayload", () => {
     if (result.ok) expect(result.deadlineBaseDate).toBeUndefined();
   });
 
-  it("enrolledAt 未指定 → 400 bad_request", () => {
+  it("enrolledAt 未指定 → missing_enrolled_at", () => {
     const result = validateEnrollmentSettingPayload({});
-    expect(result).toMatchObject({ ok: false, status: 400, error: "bad_request" });
+    expect(result).toMatchObject({ ok: false, code: "missing_enrolled_at", field: "enrolledAt" });
   });
 
-  it("enrolledAt が非 ISO → 400 invalid_date", () => {
+  it("body 自体が undefined → missing_enrolled_at", () => {
+    const result = validateEnrollmentSettingPayload(undefined);
+    expect(result).toMatchObject({ ok: false, code: "missing_enrolled_at" });
+  });
+
+  it.each([
+    ["数値", { enrolledAt: 1717000000000 }, "invalid_type"],
+    ["配列", { enrolledAt: ["2026-04-06"] }, "invalid_type"],
+    ["boolean", { enrolledAt: true }, "invalid_type"],
+  ])("enrolledAt が %s → invalid_type", (_label, body, expectedCode) => {
+    const result = validateEnrollmentSettingPayload(body);
+    expect(result).toMatchObject({ ok: false, code: expectedCode, field: "enrolledAt" });
+  });
+
+  it("enrolledAt が非 ISO → invalid_date", () => {
     const result = validateEnrollmentSettingPayload({ enrolledAt: "not-a-date" });
-    expect(result).toMatchObject({ ok: false, status: 400, error: "invalid_date" });
+    expect(result).toMatchObject({ ok: false, code: "invalid_date", field: "enrolledAt" });
   });
 
-  it("enrolledAt が 5 年以上先 → 400 date_out_of_range", () => {
+  it("enrolledAt が 5 年以上先 → date_out_of_range", () => {
     const result = validateEnrollmentSettingPayload({ enrolledAt: "2032-04-02" });
-    expect(result).toMatchObject({ ok: false, status: 400, error: "date_out_of_range" });
+    expect(result).toMatchObject({ ok: false, code: "date_out_of_range", field: "enrolledAt" });
   });
 
-  it("deadlineBaseDate が非 ISO → 400 invalid_date", () => {
+  it("deadlineBaseDate が undefined（明示渡し）→ 未指定扱い", () => {
+    const result = validateEnrollmentSettingPayload({
+      enrolledAt: "2026-04-06",
+      deadlineBaseDate: undefined,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.deadlineBaseDate).toBeUndefined();
+  });
+
+  it("deadlineBaseDate が null → 未指定扱い", () => {
+    const result = validateEnrollmentSettingPayload({
+      enrolledAt: "2026-04-06",
+      deadlineBaseDate: null,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.deadlineBaseDate).toBeUndefined();
+  });
+
+  it("deadlineBaseDate が非 ISO → invalid_date", () => {
     const result = validateEnrollmentSettingPayload({
       enrolledAt: "2026-04-06",
       deadlineBaseDate: "garbage",
     });
-    expect(result).toMatchObject({ ok: false, status: 400, error: "invalid_date" });
+    expect(result).toMatchObject({ ok: false, code: "invalid_date", field: "deadlineBaseDate" });
   });
 
-  it("deadlineBaseDate が 5 年以上前 → 400 date_out_of_range", () => {
+  it("deadlineBaseDate が 5 年以上前 → date_out_of_range", () => {
     const result = validateEnrollmentSettingPayload({
       enrolledAt: "2026-04-06",
       deadlineBaseDate: "2020-04-02",
     });
-    expect(result).toMatchObject({ ok: false, status: 400, error: "date_out_of_range" });
+    expect(result).toMatchObject({ ok: false, code: "date_out_of_range", field: "deadlineBaseDate" });
   });
 
-  it("deadlineBaseDate > enrolledAt（順序違反）→ 400 invalid_deadline_base_date", () => {
+  it("deadlineBaseDate が 5 年以上先 → date_out_of_range（範囲チェックが順序チェックに先行）", () => {
+    const result = validateEnrollmentSettingPayload({
+      enrolledAt: "2026-04-06",
+      deadlineBaseDate: "2032-04-02",
+    });
+    expect(result).toMatchObject({ ok: false, code: "date_out_of_range", field: "deadlineBaseDate" });
+  });
+
+  it("deadlineBaseDate > enrolledAt（順序違反）→ invalid_deadline_base_date", () => {
     const result = validateEnrollmentSettingPayload({
       enrolledAt: "2026-04-06",
       deadlineBaseDate: "2026-04-07",
     });
-    expect(result).toMatchObject({ ok: false, status: 400, error: "invalid_deadline_base_date" });
+    expect(result).toMatchObject({ ok: false, code: "invalid_deadline_base_date", field: "deadlineBaseDate" });
   });
 });
 

--- a/services/api/src/services/__tests__/enrollment.test.ts
+++ b/services/api/src/services/__tests__/enrollment.test.ts
@@ -3,6 +3,7 @@ import {
   checkQuizAccess,
   checkVideoAccess,
   calculateDefaultDeadlines,
+  validateEnrollmentSettingPayload,
 } from "../enrollment.js";
 import { toDateStrict } from "../../datasource/firestore.js";
 import type { TenantEnrollmentSetting } from "../../types/entities.js";
@@ -132,14 +133,106 @@ describe("calculateDefaultDeadlines (JST日末基準)", () => {
   });
 
   it("無効な日付文字列は例外をスロー", () => {
-    expect(() => calculateDefaultDeadlines("not-a-date")).toThrow("invalid enrolledAt");
-    expect(() => calculateDefaultDeadlines("")).toThrow("invalid enrolledAt");
+    expect(() => calculateDefaultDeadlines("not-a-date")).toThrow("invalid baseDate");
+    expect(() => calculateDefaultDeadlines("")).toThrow("invalid baseDate");
   });
 
   it("年末の日付でも正しく計算", () => {
     const result = calculateDefaultDeadlines("2026-12-15T00:00:00Z");
     expect(result.quizAccessUntil).toBe("2027-02-15T14:59:59.999Z");
     expect(result.videoAccessUntil).toBe("2027-12-15T14:59:59.999Z");
+  });
+
+  it("deadlineBaseDate 起算（要望ケース: 2026-04-05 起算）でテスト=2026-06-05 / 動画=2027-04-05 の JST 日末", () => {
+    const result = calculateDefaultDeadlines("2026-04-05T00:00:00Z");
+    expect(result.quizAccessUntil).toBe("2026-06-05T14:59:59.999Z");
+    expect(result.videoAccessUntil).toBe("2027-04-05T14:59:59.999Z");
+  });
+});
+
+describe("validateEnrollmentSettingPayload", () => {
+  beforeEach(() => {
+    vi.setSystemTime(new Date("2026-04-02T10:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("enrolledAt のみ指定 → 正規化された ISO を返し deadlineBaseDate は欠落（後方互換）", () => {
+    const result = validateEnrollmentSettingPayload({ enrolledAt: "2026-04-06" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.enrolledAt).toBe("2026-04-06T00:00:00.000Z");
+      expect(result.deadlineBaseDate).toBeUndefined();
+    }
+  });
+
+  it("enrolledAt + deadlineBaseDate 指定 → 両方正規化", () => {
+    const result = validateEnrollmentSettingPayload({
+      enrolledAt: "2026-04-06",
+      deadlineBaseDate: "2026-04-05",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.enrolledAt).toBe("2026-04-06T00:00:00.000Z");
+      expect(result.deadlineBaseDate).toBe("2026-04-05T00:00:00.000Z");
+    }
+  });
+
+  it("deadlineBaseDate = enrolledAt は許可（同日)", () => {
+    const result = validateEnrollmentSettingPayload({
+      enrolledAt: "2026-04-06",
+      deadlineBaseDate: "2026-04-06",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("deadlineBaseDate が空文字は未指定扱い", () => {
+    const result = validateEnrollmentSettingPayload({
+      enrolledAt: "2026-04-06",
+      deadlineBaseDate: "",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.deadlineBaseDate).toBeUndefined();
+  });
+
+  it("enrolledAt 未指定 → 400 bad_request", () => {
+    const result = validateEnrollmentSettingPayload({});
+    expect(result).toMatchObject({ ok: false, status: 400, error: "bad_request" });
+  });
+
+  it("enrolledAt が非 ISO → 400 invalid_date", () => {
+    const result = validateEnrollmentSettingPayload({ enrolledAt: "not-a-date" });
+    expect(result).toMatchObject({ ok: false, status: 400, error: "invalid_date" });
+  });
+
+  it("enrolledAt が 5 年以上先 → 400 date_out_of_range", () => {
+    const result = validateEnrollmentSettingPayload({ enrolledAt: "2032-04-02" });
+    expect(result).toMatchObject({ ok: false, status: 400, error: "date_out_of_range" });
+  });
+
+  it("deadlineBaseDate が非 ISO → 400 invalid_date", () => {
+    const result = validateEnrollmentSettingPayload({
+      enrolledAt: "2026-04-06",
+      deadlineBaseDate: "garbage",
+    });
+    expect(result).toMatchObject({ ok: false, status: 400, error: "invalid_date" });
+  });
+
+  it("deadlineBaseDate が 5 年以上前 → 400 date_out_of_range", () => {
+    const result = validateEnrollmentSettingPayload({
+      enrolledAt: "2026-04-06",
+      deadlineBaseDate: "2020-04-02",
+    });
+    expect(result).toMatchObject({ ok: false, status: 400, error: "date_out_of_range" });
+  });
+
+  it("deadlineBaseDate > enrolledAt（順序違反）→ 400 invalid_deadline_base_date", () => {
+    const result = validateEnrollmentSettingPayload({
+      enrolledAt: "2026-04-06",
+      deadlineBaseDate: "2026-04-07",
+    });
+    expect(result).toMatchObject({ ok: false, status: 400, error: "invalid_deadline_base_date" });
   });
 });
 

--- a/services/api/src/services/enrollment.ts
+++ b/services/api/src/services/enrollment.ts
@@ -184,6 +184,15 @@ function isWithinRange(dateStr: string): boolean {
   return diff <= ENROLLEDAT_RANGE_YEARS * 365.25 * 24 * 60 * 60 * 1000;
 }
 
+export const ENROLLMENT_VALIDATION_ERROR_CODES = [
+  "missing_enrolled_at",
+  "invalid_type",
+  "invalid_date",
+  "date_out_of_range",
+  "invalid_deadline_base_date",
+] as const;
+export type EnrollmentValidationErrorCode = typeof ENROLLMENT_VALIDATION_ERROR_CODES[number];
+
 export type ValidatedEnrollmentPayload = {
   ok: true;
   enrolledAt: string;
@@ -192,8 +201,8 @@ export type ValidatedEnrollmentPayload = {
 
 export type ValidationError = {
   ok: false;
-  status: 400;
-  error: string;
+  code: EnrollmentValidationErrorCode;
+  field: "enrolledAt" | "deadlineBaseDate";
   message: string;
 };
 
@@ -206,39 +215,43 @@ export function validateEnrollmentSettingPayload(body: unknown): ValidatedEnroll
   const payload = (body ?? {}) as { enrolledAt?: unknown; deadlineBaseDate?: unknown };
   const { enrolledAt, deadlineBaseDate } = payload;
 
-  if (!enrolledAt || typeof enrolledAt !== "string") {
-    return { ok: false, status: 400, error: "bad_request", message: "enrolledAt is required" };
+  // 未指定（undefined/null/空文字）と型違反を明確に区別
+  if (enrolledAt === undefined || enrolledAt === null || enrolledAt === "") {
+    return { ok: false, code: "missing_enrolled_at", field: "enrolledAt", message: "enrolledAt is required" };
+  }
+  if (typeof enrolledAt !== "string") {
+    return { ok: false, code: "invalid_type", field: "enrolledAt", message: `enrolledAt must be a string, got ${typeof enrolledAt}` };
   }
   if (!isValidISODate(enrolledAt)) {
-    return { ok: false, status: 400, error: "invalid_date", message: "enrolledAt must be a valid date string" };
+    return { ok: false, code: "invalid_date", field: "enrolledAt", message: "enrolledAt must be a valid date string" };
   }
   if (!isWithinRange(enrolledAt)) {
     return {
-      ok: false, status: 400, error: "date_out_of_range",
-      message: `enrolledAt must be within ${ENROLLEDAT_RANGE_YEARS} years from now`,
+      ok: false, code: "date_out_of_range", field: "enrolledAt",
+      message: `enrolledAt must be within ±${ENROLLEDAT_RANGE_YEARS} years from now`,
     };
   }
 
   const normalizedEnrolledAt = new Date(enrolledAt).toISOString();
 
-  // 空文字・undefined は未指定扱い
+  // JSON null / undefined / "" は全て未指定扱い（FieldValue.delete sentinel と整合）
   const hasDeadlineBaseDate = typeof deadlineBaseDate === "string" && deadlineBaseDate.length > 0;
   if (!hasDeadlineBaseDate) {
     return { ok: true, enrolledAt: normalizedEnrolledAt };
   }
 
   if (!isValidISODate(deadlineBaseDate)) {
-    return { ok: false, status: 400, error: "invalid_date", message: "deadlineBaseDate must be a valid date string" };
+    return { ok: false, code: "invalid_date", field: "deadlineBaseDate", message: "deadlineBaseDate must be a valid date string" };
   }
   if (!isWithinRange(deadlineBaseDate)) {
     return {
-      ok: false, status: 400, error: "date_out_of_range",
-      message: `deadlineBaseDate must be within ${ENROLLEDAT_RANGE_YEARS} years from now`,
+      ok: false, code: "date_out_of_range", field: "deadlineBaseDate",
+      message: `deadlineBaseDate must be within ±${ENROLLEDAT_RANGE_YEARS} years from now`,
     };
   }
   if (new Date(deadlineBaseDate).getTime() > new Date(enrolledAt).getTime()) {
     return {
-      ok: false, status: 400, error: "invalid_deadline_base_date",
+      ok: false, code: "invalid_deadline_base_date", field: "deadlineBaseDate",
       message: "deadlineBaseDate must be on or before enrolledAt",
     };
   }

--- a/services/api/src/services/enrollment.ts
+++ b/services/api/src/services/enrollment.ts
@@ -147,25 +147,105 @@ export async function checkQuizAccessSoft(
 }
 
 /**
- * enrolledAtからデフォルトの期限を計算（JST日末基準）
+ * 起算日（enrolledAt または deadlineBaseDate）からデフォルトの期限を計算（JST日末基準）
  */
-export function calculateDefaultDeadlines(enrolledAt: string): {
+export function calculateDefaultDeadlines(baseDate: string): {
   quizAccessUntil: string;
   videoAccessUntil: string;
 } {
-  const base = new Date(enrolledAt);
+  const base = new Date(baseDate);
   if (isNaN(base.getTime())) {
-    throw new Error(`calculateDefaultDeadlines: invalid enrolledAt "${enrolledAt}"`);
+    throw new Error(`calculateDefaultDeadlines: invalid baseDate "${baseDate}"`);
   }
 
-  // テスト: enrolledAt + 2ヶ月（JST日末まで有効）
+  // テスト: 起算日 + 2ヶ月（JST日末まで有効）
   const quizDeadline = endOfDayJST(addMonths(base, 2));
 
-  // 動画: enrolledAt + 1年（JST日末まで有効）
+  // 動画: 起算日 + 1年（JST日末まで有効）
   const videoDeadline = endOfDayJST(addYears(base, 1));
 
   return {
     quizAccessUntil: quizDeadline.toISOString(),
     videoAccessUntil: videoDeadline.toISOString(),
+  };
+}
+
+// `<input type="date">` 由来の `YYYY-MM-DD` と ISO datetime（末尾 Z 任意）を許容。
+// super-admin.ts の `ISO_DATE_REGEX` は attendance 用で UTC `Z` 必須の別仕様。統合しない。
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z?)?$/;
+const ENROLLEDAT_RANGE_YEARS = 5;
+
+function isValidISODate(value: unknown): value is string {
+  return typeof value === "string" && ISO_DATE_RE.test(value) && !isNaN(new Date(value).getTime());
+}
+
+function isWithinRange(dateStr: string): boolean {
+  const diff = Math.abs(new Date(dateStr).getTime() - Date.now());
+  return diff <= ENROLLEDAT_RANGE_YEARS * 365.25 * 24 * 60 * 60 * 1000;
+}
+
+export type ValidatedEnrollmentPayload = {
+  ok: true;
+  enrolledAt: string;
+  deadlineBaseDate?: string;
+};
+
+export type ValidationError = {
+  ok: false;
+  status: 400;
+  error: string;
+  message: string;
+};
+
+/**
+ * PUT /super/tenants/:tenantId/enrollment-setting の body を検証して正規化する。
+ * - enrolledAt: 必須、ISO、5年範囲内
+ * - deadlineBaseDate: 任意、空文字は未指定扱い、ISO、5年範囲内、enrolledAt 以前であること
+ */
+export function validateEnrollmentSettingPayload(body: unknown): ValidatedEnrollmentPayload | ValidationError {
+  const payload = (body ?? {}) as { enrolledAt?: unknown; deadlineBaseDate?: unknown };
+  const { enrolledAt, deadlineBaseDate } = payload;
+
+  if (!enrolledAt || typeof enrolledAt !== "string") {
+    return { ok: false, status: 400, error: "bad_request", message: "enrolledAt is required" };
+  }
+  if (!isValidISODate(enrolledAt)) {
+    return { ok: false, status: 400, error: "invalid_date", message: "enrolledAt must be a valid date string" };
+  }
+  if (!isWithinRange(enrolledAt)) {
+    return {
+      ok: false, status: 400, error: "date_out_of_range",
+      message: `enrolledAt must be within ${ENROLLEDAT_RANGE_YEARS} years from now`,
+    };
+  }
+
+  const normalizedEnrolledAt = new Date(enrolledAt).toISOString();
+
+  // 空文字・undefined は未指定扱い
+  const hasDeadlineBaseDate = typeof deadlineBaseDate === "string" && deadlineBaseDate.length > 0;
+  if (!hasDeadlineBaseDate) {
+    return { ok: true, enrolledAt: normalizedEnrolledAt };
+  }
+
+  if (!isValidISODate(deadlineBaseDate)) {
+    return { ok: false, status: 400, error: "invalid_date", message: "deadlineBaseDate must be a valid date string" };
+  }
+  if (!isWithinRange(deadlineBaseDate)) {
+    return {
+      ok: false, status: 400, error: "date_out_of_range",
+      message: `deadlineBaseDate must be within ${ENROLLEDAT_RANGE_YEARS} years from now`,
+    };
+  }
+  if (new Date(deadlineBaseDate).getTime() > new Date(enrolledAt).getTime()) {
+    return {
+      ok: false, status: 400, error: "invalid_deadline_base_date",
+      message: "deadlineBaseDate must be on or before enrolledAt",
+    };
+  }
+
+  return {
+    ok: true,
+    enrolledAt: normalizedEnrolledAt,
+    deadlineBaseDate: new Date(deadlineBaseDate).toISOString(),
   };
 }

--- a/services/api/src/types/entities.ts
+++ b/services/api/src/types/entities.ts
@@ -329,9 +329,10 @@ export interface LessonSessionFilter {
 
 export interface TenantEnrollmentSetting {
   id: string;              // = "_config"
-  enrolledAt: string;      // ISO — スーパー管理者が設定する受講開始日
-  quizAccessUntil: string; // ISO — enrolledAt + 2ヶ月（JST日末、自動計算）
-  videoAccessUntil: string;// ISO — enrolledAt + 1年（JST日末、自動計算）
+  enrolledAt: string;      // ISO — スーパー管理者が設定する受講開始日（表示用）
+  deadlineBaseDate?: string; // ISO — 期限計算の起算日（任意。未指定時は enrolledAt を起算日とする）
+  quizAccessUntil: string; // ISO — (deadlineBaseDate ?? enrolledAt) + 2ヶ月（JST日末、自動計算）
+  videoAccessUntil: string;// ISO — (deadlineBaseDate ?? enrolledAt) + 1年（JST日末、自動計算）
   createdBy: string;       // スーパー管理者email
   updatedAt: string;
 }

--- a/web/app/super/enrollments/page.tsx
+++ b/web/app/super/enrollments/page.tsx
@@ -49,6 +49,7 @@ export default function EnrollmentsPage() {
   // 設定ダイアログ
   const [settingOpen, setSettingOpen] = useState(false);
   const [settingEnrolledAt, setSettingEnrolledAt] = useState("");
+  const [settingDeadlineBaseDate, setSettingDeadlineBaseDate] = useState("");
   const [settingLoading, setSettingLoading] = useState(false);
 
   // テナント一覧取得
@@ -86,16 +87,29 @@ export default function EnrollmentsPage() {
   // 設定保存
   const handleSave = async () => {
     if (!selectedTenant || !settingEnrolledAt) return;
+    // 起算日が受講開始日より後の場合はクライアント側で早期ガード
+    if (
+      settingDeadlineBaseDate &&
+      !isNaN(new Date(settingDeadlineBaseDate).getTime()) &&
+      new Date(settingDeadlineBaseDate) > new Date(settingEnrolledAt)
+    ) {
+      setError("期限起算日は受講開始日以前の日付を指定してください");
+      return;
+    }
     setSettingLoading(true);
     try {
+      const body: { enrolledAt: string; deadlineBaseDate?: string } = {
+        enrolledAt: new Date(settingEnrolledAt).toISOString(),
+      };
+      if (settingDeadlineBaseDate) {
+        body.deadlineBaseDate = new Date(settingDeadlineBaseDate).toISOString();
+      }
       await superFetch(
         `/api/v2/super/tenants/${selectedTenant}/enrollment-setting`,
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            enrolledAt: new Date(settingEnrolledAt).toISOString(),
-          }),
+          body: JSON.stringify(body),
         }
       );
       setSettingOpen(false);
@@ -124,6 +138,7 @@ export default function EnrollmentsPage() {
   // 設定ダイアログを開く
   const openSettingDialog = () => {
     setSettingEnrolledAt(setting?.enrolledAt?.split("T")[0] ?? "");
+    setSettingDeadlineBaseDate(setting?.deadlineBaseDate?.split("T")[0] ?? "");
     setSettingOpen(true);
   };
 
@@ -158,6 +173,12 @@ export default function EnrollmentsPage() {
           <div className="grid grid-cols-2 gap-y-2 text-sm">
             <span className="text-muted-foreground">受講開始日</span>
             <span>{formatDate(setting.enrolledAt)}</span>
+            {setting.deadlineBaseDate && (
+              <>
+                <span className="text-muted-foreground">期限起算日</span>
+                <span>{formatDate(setting.deadlineBaseDate)}</span>
+              </>
+            )}
             <span className="text-muted-foreground">テスト期限</span>
             <span className={isExpired(setting.quizAccessUntil) ? "text-destructive font-medium" : ""}>
               {formatDate(setting.quizAccessUntil)}
@@ -201,12 +222,31 @@ export default function EnrollmentsPage() {
                 onChange={(e) => setSettingEnrolledAt(e.target.value)}
               />
             </div>
-            {settingEnrolledAt && !isNaN(new Date(settingEnrolledAt).getTime()) && (
-              <div className="text-sm text-muted-foreground space-y-1">
-                <p>テスト期限: {formatDate(addMonths(new Date(settingEnrolledAt), 2).toISOString())}（この日のJST 23:59まで有効）</p>
-                <p>動画期限: {formatDate(addYears(new Date(settingEnrolledAt), 1).toISOString())}（この日のJST 23:59まで有効）</p>
-              </div>
-            )}
+            <div>
+              <label className="text-sm">期限起算日（任意）</label>
+              <Input
+                type="date"
+                value={settingDeadlineBaseDate}
+                max={settingEnrolledAt || undefined}
+                onChange={(e) => setSettingDeadlineBaseDate(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                未入力時は受講開始日から起算します。受講開始日は変更されません。受講開始日以前の日付のみ指定可能です。
+              </p>
+            </div>
+            {settingEnrolledAt && !isNaN(new Date(settingEnrolledAt).getTime()) && (() => {
+              const baseDateStr = settingDeadlineBaseDate && !isNaN(new Date(settingDeadlineBaseDate).getTime())
+                ? settingDeadlineBaseDate
+                : settingEnrolledAt;
+              const baseDate = new Date(baseDateStr);
+              const baseLabel = settingDeadlineBaseDate ? "期限起算日" : "受講開始日";
+              return (
+                <div className="text-sm text-muted-foreground space-y-1">
+                  <p>テスト期限: {formatDate(addMonths(baseDate, 2).toISOString())}（{baseLabel} +2ヶ月、JST 23:59まで有効）</p>
+                  <p>動画期限: {formatDate(addYears(baseDate, 1).toISOString())}（{baseLabel} +1年、JST 23:59まで有効）</p>
+                </div>
+              );
+            })()}
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setSettingOpen(false)}>キャンセル</Button>


### PR DESCRIPTION
## Summary
- 受講開始日（enrolledAt）を変更せずに期限計算の起算日のみ別指定可能にする
- 未指定時は enrolledAt フォールバックで既存挙動と完全互換
- 比率（+2ヶ月 / +1年、JST 日末）は現状維持

## 背景
特定テナント（莞爾会 長遊園 様）について、受講開始日 2026/04/06 を動かさずに **テスト期限 2026/06/05 / 動画期限 2027/04/05**（=起算日のみ -1日）に設定したいという要望。期限を直接編集する UI（B 案）はオーバースペックなため、起算日のみ任意指定可能とする最小設計（D 案）を採用。

## 主な変更
- **共有型**: `TenantEnrollmentSetting` / `TenantEnrollmentSettingResponse` に `deadlineBaseDate?: string` を追加
- **API**:
  - `validateEnrollmentSettingPayload` を `services/enrollment.ts` に新設（純粋関数、unit test で網羅）
    - `enrolledAt`: 必須 / ISO / 5年範囲
    - `deadlineBaseDate`: 任意 / ISO / 5年範囲 / `<= enrolledAt`
  - `PUT /super/tenants/:tenantId/enrollment-setting`: deadlineBaseDate を任意受領、`calculateDefaultDeadlines(deadlineBaseDate ?? enrolledAt)` で計算
  - 省略時は **`FieldValue.delete()`** で既存フィールドを明示削除（`merge:true` 下での残存防止）
- **Web UI**: super 受講期間管理ページに「期限起算日（任意）」入力欄 + プレビュー連動 + 保存後カードに「期限起算日」行を追加
- **Datasource**: Firestore datasource で `deadlineBaseDate` をオプショナル読込

## 不変条件 / 後方互換
- `checkQuizAccess` / `checkVideoAccess` は最終 ISO（`quizAccessUntil` / `videoAccessUntil`）のみ参照 → **変更なし**
- 学生 UI / banner も最終 ISO のみ参照 → **変更なし**
- 既存 Firestore ドキュメント（deadlineBaseDate 欠落）は読込時 undefined → enrolledAt フォールバック → **完全後方互換**

## 品質ゲート結果
- **lint**: ✅ 0 issues
- **type-check**: ✅ 4 workspaces 全 PASS
- **test**: ✅ 689 / 689 PASS（API: 656, Web: 33。enrollment.test.ts に 10 ケース追加）
- **/simplify** 3並列レビュー: 軽微指摘のみ（false-positive 多）
- **evaluator 分離プロトコル**: CONDITIONAL GO → MEDIUM 指摘（`merge:true` 下での deadlineBaseDate 残存）を `FieldValue.delete()` で対処
- **/codex review (plan)**: CONDITIONAL GO → 順序制約・UI 注釈・テスト網羅で対処

## Test plan
- [ ] dev サーバ起動: `npm run dev -w @lms-279/web` & `npm run start -w @lms-279/api`
- [ ] super 管理画面 `/super/enrollments` でテナント選択
- [ ] 「変更」ダイアログを開き、受講開始日 `2026/04/06`、期限起算日 `2026/04/05` を入力
  - プレビュー: テスト期限 `2026/06/05` / 動画期限 `2027/04/05` が表示される
- [ ] 保存後、カードに「期限起算日: 2026/04/05」「テスト期限: 2026/06/05」「動画期限: 2027/04/05」が表示される
- [ ] 期限起算日に受講開始日より後の日付を入力 → クライアントエラー「期限起算日は受講開始日以前の日付を指定してください」
- [ ] 期限起算日を空欄にして保存 → カードから「期限起算日」行が消え、テスト期限/動画期限が enrolledAt 起算で再計算される（`FieldValue.delete()` 動作確認）
- [ ] 既存テナント（deadlineBaseDate 未設定）の表示が崩れない

## 本番反映手順（マージ後・別途認可）
1. main マージ → Cloud Run 自動デプロイ
2. `/super/enrollments` で「莞爾会 長遊園 様」テナントを選択
3. 「変更」ダイアログから受講開始日 `2026/04/06` のまま、期限起算日 `2026/04/05` を設定
4. テスト期限 `2026/06/05` / 動画期限 `2027/04/05` の表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)