### PR TITLE
docs(super): 受講期間管理ページの説明文を期限起算日仕様に更新

### DIFF
--- a/web/app/super/enrollments/page.tsx
+++ b/web/app/super/enrollments/page.tsx
@@ -146,7 +146,7 @@ export default function EnrollmentsPage() {
     <div className="space-y-4">
       <h2 className="text-xl font-bold">受講期間管理</h2>
       <p className="text-sm text-muted-foreground">
-        テナント単位で受講期間を設定します。テスト期限（+2ヶ月）と動画期限（+1年）は受講開始日から自動計算されます。期限は日本時間の日末（23:59）まで有効です。
+        テナント単位で受講期間を設定します。テスト期限（+2ヶ月）と動画期限（+1年）は期限起算日（任意。未指定時は受講開始日）から自動計算されます。期限は日本時間の日末（23:59）まで有効です。
       </p>
 
       {/* テナント選択 */}
@@ -210,7 +210,7 @@ export default function EnrollmentsPage() {
           <DialogHeader>
             <DialogTitle>受講期間を設定</DialogTitle>
             <DialogDescription>
-              テナントの受講開始日を設定します。テスト期限（+2ヶ月）と動画期限（+1年）は自動計算されます。
+              テナントの受講開始日を設定します。テスト期限（+2ヶ月）と動画期限（+1年）は期限起算日（任意指定可。未指定時は受講開始日）から自動計算されます。
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3">


### PR DESCRIPTION
## Summary
- PR #340 で `deadlineBaseDate`（期限起算日）を導入したが、受講期間管理ページ・ダイアログの説明文が「受講開始日から自動計算」のままで、新仕様と齟齬があった
- 文言のみの変更（ロジック・型・テスト無変更）

## 変更
| 箇所 | Before | After |
|---|---|---|
| ヘッダ説明文 | 「テスト期限（+2ヶ月）と動画期限（+1年）は**受講開始日から**自動計算されます」 | 「テスト期限（+2ヶ月）と動画期限（+1年）は**期限起算日（任意。未指定時は受講開始日）から**自動計算されます」 |
| ダイアログ説明文 | 「テスト期限（+2ヶ月）と動画期限（+1年）は自動計算されます」 | 「テスト期限（+2ヶ月）と動画期限（+1年）は**期限起算日（任意指定可。未指定時は受講開始日）から**自動計算されます」 |

## 品質ゲート
- lint: ✅ 0 issues
- type-check: ✅ PASS
- test: 文言のみのため不要（テスト変更なし）

## Test plan
- [ ] dev サーバ or 本番 `/super/enrollments` で説明文の更新を目視確認
- [ ] ダイアログを開いて DialogDescription の更新を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)