### PR TITLE
feat(super): 受講期間関連エンドポイントに try-catch + 構造化ログ追加

### DIFF
--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -1657,8 +1657,12 @@ export class FirestoreDataSource implements DataSource {
       }
       return result;
     } catch (e) {
-      const error = e instanceof Error ? e.message : String(e);
-      console.error(`Failed to parse TenantEnrollmentSetting:`, error);
+      logger.error("Failed to parse TenantEnrollmentSetting", {
+        errorType: "enrollment_setting_parse_failed",
+        error: e instanceof Error ? e : new Error(String(e)),
+        tenantId: this.tenantId,
+        documentId: id,
+      });
       throw e;
     }
   }

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -28,6 +28,7 @@ import { masterRouter } from "./super-admin-master.js";
 import { calculateDefaultDeadlines, validateEnrollmentSettingPayload } from "../services/enrollment.js";
 import { generateTenantId, normalizeEmail, parseTenantGcipFields } from "../utils/tenant-id.js";
 import { logger } from "../utils/logger.js";
+import { classifyFirestoreError, TRANSIENT_RETRY_MESSAGE_JA } from "../utils/grpc-errors.js";
 import { getPlatformDataSource } from "../middleware/platform-datasource.js";
 
 const router = Router();
@@ -1534,6 +1535,7 @@ function toEnrollmentSettingResponse(data: any): TenantEnrollmentSettingResponse
 router.get("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Response) => {
   const db = getFirestore();
   const tenantId = req.params.tenantId as string;
+  const operatorEmail = req.superAdmin!.email;
 
   try {
     const tenantDoc = await db.collection("tenants").doc(tenantId).get();
@@ -1552,21 +1554,18 @@ router.get("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
 
     res.json({ setting: toEnrollmentSettingResponse(doc.data()) });
   } catch (e) {
-    const grpcCode = (e as { code?: number })?.code;
-    const isTransient = grpcCode === 14 || grpcCode === 4;
+    const { grpcCode, isTransient } = classifyFirestoreError(e);
     logger.error("Enrollment setting GET failed", {
       errorType: "enrollment_setting_get_failed",
       error: e instanceof Error ? e : new Error(String(e)),
       tenantId,
-      operatorEmail: req.superAdmin?.email,
+      operatorEmail,
       grpcCode,
       isTransient,
     });
     res.status(isTransient ? 503 : 500).json({
       error: "transaction_failed",
-      message: isTransient
-        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
-        : "受講期間設定の取得中にエラーが発生しました。",
+      message: isTransient ? TRANSIENT_RETRY_MESSAGE_JA : "受講期間設定の取得中にエラーが発生しました。",
     });
   }
 });
@@ -1615,10 +1614,14 @@ router.put("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
 
     await docRef.set(writeData, { merge: true });
 
+    // 監査ログ: 何の値に更新したか（後日インシデント時の復元用）
     logger.info("Enrollment setting upserted by super admin", {
       tenantId,
       operatorEmail,
-      hasDeadlineBaseDate: Boolean(normalizedDeadlineBaseDate),
+      enrolledAt: normalizedEnrolledAt,
+      deadlineBaseDate: normalizedDeadlineBaseDate ?? null,
+      quizAccessUntil: deadlines.quizAccessUntil,
+      videoAccessUntil: deadlines.videoAccessUntil,
     });
 
     // レスポンスは保存値から純粋に構築（FieldValue.delete sentinel が混入しない設計）。
@@ -1634,8 +1637,7 @@ router.put("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
     }
     res.json({ setting: response });
   } catch (e) {
-    const grpcCode = (e as { code?: number })?.code;
-    const isTransient = grpcCode === 14 || grpcCode === 4;
+    const { grpcCode, isTransient } = classifyFirestoreError(e);
     logger.error("Enrollment setting PUT failed", {
       errorType: "enrollment_setting_put_failed",
       error: e instanceof Error ? e : new Error(String(e)),
@@ -1646,9 +1648,7 @@ router.put("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
     });
     res.status(isTransient ? 503 : 500).json({
       error: "transaction_failed",
-      message: isTransient
-        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
-        : "受講期間設定の更新中にエラーが発生しました。",
+      message: isTransient ? TRANSIENT_RETRY_MESSAGE_JA : "受講期間設定の更新中にエラーが発生しました。",
     });
   }
 });
@@ -1678,17 +1678,20 @@ router.delete("/tenants/:tenantId/enrollment-setting", async (req: Request, res:
       return;
     }
 
+    // 削除前の値を監査ログに残す（後日インシデント時の復元用）
+    const deletedSetting = toEnrollmentSettingResponse(doc.data());
+
     await docRef.delete();
 
     logger.info("Enrollment setting deleted by super admin", {
       tenantId,
       operatorEmail,
+      deletedSetting,
     });
 
     res.status(204).send();
   } catch (e) {
-    const grpcCode = (e as { code?: number })?.code;
-    const isTransient = grpcCode === 14 || grpcCode === 4;
+    const { grpcCode, isTransient } = classifyFirestoreError(e);
     logger.error("Enrollment setting DELETE failed", {
       errorType: "enrollment_setting_delete_failed",
       error: e instanceof Error ? e : new Error(String(e)),
@@ -1699,9 +1702,7 @@ router.delete("/tenants/:tenantId/enrollment-setting", async (req: Request, res:
     });
     res.status(isTransient ? 503 : 500).json({
       error: "transaction_failed",
-      message: isTransient
-        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
-        : "受講期間設定の削除中にエラーが発生しました。",
+      message: isTransient ? TRANSIENT_RETRY_MESSAGE_JA : "受講期間設定の削除中にエラーが発生しました。",
     });
   }
 });

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -1535,21 +1535,40 @@ router.get("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
   const db = getFirestore();
   const tenantId = req.params.tenantId as string;
 
-  const tenantDoc = await db.collection("tenants").doc(tenantId).get();
-  if (!tenantDoc.exists) {
-    res.status(404).json({ error: "not_found", message: "Tenant not found" });
-    return;
+  try {
+    const tenantDoc = await db.collection("tenants").doc(tenantId).get();
+    if (!tenantDoc.exists) {
+      res.status(404).json({ error: "not_found", message: "Tenant not found" });
+      return;
+    }
+
+    const basePath = `tenants/${tenantId}`;
+    const doc = await db.collection(`${basePath}/enrollment_setting`).doc("_config").get();
+
+    if (!doc.exists) {
+      res.json({ setting: null });
+      return;
+    }
+
+    res.json({ setting: toEnrollmentSettingResponse(doc.data()) });
+  } catch (e) {
+    const grpcCode = (e as { code?: number })?.code;
+    const isTransient = grpcCode === 14 || grpcCode === 4;
+    logger.error("Enrollment setting GET failed", {
+      errorType: "enrollment_setting_get_failed",
+      error: e instanceof Error ? e : new Error(String(e)),
+      tenantId,
+      operatorEmail: req.superAdmin?.email,
+      grpcCode,
+      isTransient,
+    });
+    res.status(isTransient ? 503 : 500).json({
+      error: "transaction_failed",
+      message: isTransient
+        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
+        : "受講期間設定の取得中にエラーが発生しました。",
+    });
   }
-
-  const basePath = `tenants/${tenantId}`;
-  const doc = await db.collection(`${basePath}/enrollment_setting`).doc("_config").get();
-
-  if (!doc.exists) {
-    res.json({ setting: null });
-    return;
-  }
-
-  res.json({ setting: toEnrollmentSettingResponse(doc.data()) });
 });
 
 /**
@@ -1560,52 +1579,78 @@ router.get("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
 router.put("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Response) => {
   const db = getFirestore();
   const tenantId = req.params.tenantId as string;
+  const operatorEmail = req.superAdmin!.email;
 
-  const tenantDoc = await db.collection("tenants").doc(tenantId).get();
-  if (!tenantDoc.exists) {
-    res.status(404).json({ error: "not_found", message: "Tenant not found" });
-    return;
-  }
-
+  // バリデーションは例外ではなく値で返るため try の前で実行（純粋関数）。
   const validated = validateEnrollmentSettingPayload(req.body);
   if (!validated.ok) {
     res.status(400).json({ error: validated.code, field: validated.field, message: validated.message });
     return;
   }
 
-  const { enrolledAt: normalizedEnrolledAt, deadlineBaseDate: normalizedDeadlineBaseDate } = validated;
-  const deadlines = calculateDefaultDeadlines(normalizedDeadlineBaseDate ?? normalizedEnrolledAt);
-  const basePath = `tenants/${tenantId}`;
-  const docRef = db.collection(`${basePath}/enrollment_setting`).doc("_config");
-  const updatedAt = new Date().toISOString();
-  const operatorEmail = req.superAdmin!.email;
+  try {
+    const tenantDoc = await db.collection("tenants").doc(tenantId).get();
+    if (!tenantDoc.exists) {
+      res.status(404).json({ error: "not_found", message: "Tenant not found" });
+      return;
+    }
 
-  // PUT は明示的な完全更新セマンティクス。
-  // 省略時は FieldValue.delete() で既存 deadlineBaseDate を除去（merge:true でも残さない）。
-  // 他フィールドは必須なので undefined 除去対象外。
-  const writeData: Record<string, unknown> = {
-    enrolledAt: normalizedEnrolledAt,
-    deadlineBaseDate: normalizedDeadlineBaseDate ?? FieldValue.delete(),
-    quizAccessUntil: deadlines.quizAccessUntil,
-    videoAccessUntil: deadlines.videoAccessUntil,
-    createdBy: operatorEmail,
-    updatedAt,
-  };
+    const { enrolledAt: normalizedEnrolledAt, deadlineBaseDate: normalizedDeadlineBaseDate } = validated;
+    const deadlines = calculateDefaultDeadlines(normalizedDeadlineBaseDate ?? normalizedEnrolledAt);
+    const basePath = `tenants/${tenantId}`;
+    const docRef = db.collection(`${basePath}/enrollment_setting`).doc("_config");
+    const updatedAt = new Date().toISOString();
 
-  await docRef.set(writeData, { merge: true });
+    // PUT は明示的な完全更新セマンティクス。
+    // 省略時は FieldValue.delete() で既存 deadlineBaseDate を除去（merge:true でも残さない）。
+    // 他フィールドは必須なので undefined 除去対象外。
+    const writeData: Record<string, unknown> = {
+      enrolledAt: normalizedEnrolledAt,
+      deadlineBaseDate: normalizedDeadlineBaseDate ?? FieldValue.delete(),
+      quizAccessUntil: deadlines.quizAccessUntil,
+      videoAccessUntil: deadlines.videoAccessUntil,
+      createdBy: operatorEmail,
+      updatedAt,
+    };
 
-  // レスポンスは保存値から純粋に構築（FieldValue.delete sentinel が混入しない設計）。
-  const response: TenantEnrollmentSettingResponse = {
-    enrolledAt: normalizedEnrolledAt,
-    quizAccessUntil: deadlines.quizAccessUntil,
-    videoAccessUntil: deadlines.videoAccessUntil,
-    createdBy: operatorEmail,
-    updatedAt,
-  };
-  if (normalizedDeadlineBaseDate) {
-    response.deadlineBaseDate = normalizedDeadlineBaseDate;
+    await docRef.set(writeData, { merge: true });
+
+    logger.info("Enrollment setting upserted by super admin", {
+      tenantId,
+      operatorEmail,
+      hasDeadlineBaseDate: Boolean(normalizedDeadlineBaseDate),
+    });
+
+    // レスポンスは保存値から純粋に構築（FieldValue.delete sentinel が混入しない設計）。
+    const response: TenantEnrollmentSettingResponse = {
+      enrolledAt: normalizedEnrolledAt,
+      quizAccessUntil: deadlines.quizAccessUntil,
+      videoAccessUntil: deadlines.videoAccessUntil,
+      createdBy: operatorEmail,
+      updatedAt,
+    };
+    if (normalizedDeadlineBaseDate) {
+      response.deadlineBaseDate = normalizedDeadlineBaseDate;
+    }
+    res.json({ setting: response });
+  } catch (e) {
+    const grpcCode = (e as { code?: number })?.code;
+    const isTransient = grpcCode === 14 || grpcCode === 4;
+    logger.error("Enrollment setting PUT failed", {
+      errorType: "enrollment_setting_put_failed",
+      error: e instanceof Error ? e : new Error(String(e)),
+      tenantId,
+      operatorEmail,
+      grpcCode,
+      isTransient,
+    });
+    res.status(isTransient ? 503 : 500).json({
+      error: "transaction_failed",
+      message: isTransient
+        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
+        : "受講期間設定の更新中にエラーが発生しました。",
+    });
   }
-  res.json({ setting: response });
 });
 
 /**
@@ -1615,24 +1660,50 @@ router.put("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Re
 router.delete("/tenants/:tenantId/enrollment-setting", async (req: Request, res: Response) => {
   const db = getFirestore();
   const tenantId = req.params.tenantId as string;
+  const operatorEmail = req.superAdmin!.email;
 
-  const tenantDoc = await db.collection("tenants").doc(tenantId).get();
-  if (!tenantDoc.exists) {
-    res.status(404).json({ error: "not_found", message: "Tenant not found" });
-    return;
+  try {
+    const tenantDoc = await db.collection("tenants").doc(tenantId).get();
+    if (!tenantDoc.exists) {
+      res.status(404).json({ error: "not_found", message: "Tenant not found" });
+      return;
+    }
+
+    const basePath = `tenants/${tenantId}`;
+    const docRef = db.collection(`${basePath}/enrollment_setting`).doc("_config");
+    const doc = await docRef.get();
+
+    if (!doc.exists) {
+      res.status(404).json({ error: "not_found", message: "Enrollment setting not found" });
+      return;
+    }
+
+    await docRef.delete();
+
+    logger.info("Enrollment setting deleted by super admin", {
+      tenantId,
+      operatorEmail,
+    });
+
+    res.status(204).send();
+  } catch (e) {
+    const grpcCode = (e as { code?: number })?.code;
+    const isTransient = grpcCode === 14 || grpcCode === 4;
+    logger.error("Enrollment setting DELETE failed", {
+      errorType: "enrollment_setting_delete_failed",
+      error: e instanceof Error ? e : new Error(String(e)),
+      tenantId,
+      operatorEmail,
+      grpcCode,
+      isTransient,
+    });
+    res.status(isTransient ? 503 : 500).json({
+      error: "transaction_failed",
+      message: isTransient
+        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
+        : "受講期間設定の削除中にエラーが発生しました。",
+    });
   }
-
-  const basePath = `tenants/${tenantId}`;
-  const docRef = db.collection(`${basePath}/enrollment_setting`).doc("_config");
-  const doc = await docRef.get();
-
-  if (!doc.exists) {
-    res.status(404).json({ error: "not_found", message: "Enrollment setting not found" });
-    return;
-  }
-
-  await docRef.delete();
-  res.status(204).send();
 });
 
 export const superAdminRouter = router;

--- a/services/api/src/services/enrollment.ts
+++ b/services/api/src/services/enrollment.ts
@@ -7,6 +7,7 @@ import { addMonths, addYears } from "date-fns";
 import type { Request, Response } from "express";
 import type { TenantEnrollmentSetting } from "../types/entities.js";
 import { logger } from "../utils/logger.js";
+import { classifyFirestoreError, TRANSIENT_RETRY_MESSAGE_JA } from "../utils/grpc-errors.js";
 
 /** JST日末 (23:59:59.999 JST = 14:59:59.999 UTC)。入力はUTC基準のDateであること。 */
 function endOfDayJST(date: Date): Date {
@@ -84,10 +85,9 @@ export async function guardQuizAccess(
     }
     return false;
   } catch (err) {
-    const grpcCode = (err as { code?: number })?.code;
-    const isTransient = grpcCode === 14 || grpcCode === 4;
+    const { grpcCode, isTransient } = classifyFirestoreError(err);
     logger.error("Failed to check quiz access", {
-      errorType: "enrollment_check_failed",
+      errorType: "enrollment_quiz_check_failed",
       error: err instanceof Error ? err : new Error(String(err)),
       tenantId: req.tenantContext?.tenantId,
       grpcCode,
@@ -95,9 +95,7 @@ export async function guardQuizAccess(
     });
     res.status(isTransient ? 503 : 500).json({
       error: "enrollment_check_failed",
-      message: isTransient
-        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
-        : "受講期限チェックが失敗しました",
+      message: isTransient ? TRANSIENT_RETRY_MESSAGE_JA : "受講期限チェックが失敗しました",
     });
     return true;
   }
@@ -123,10 +121,9 @@ export async function guardVideoAccess(
     }
     return false;
   } catch (err) {
-    const grpcCode = (err as { code?: number })?.code;
-    const isTransient = grpcCode === 14 || grpcCode === 4;
+    const { grpcCode, isTransient } = classifyFirestoreError(err);
     logger.error("Failed to check video access", {
-      errorType: "enrollment_check_failed",
+      errorType: "enrollment_video_check_failed",
       error: err instanceof Error ? err : new Error(String(err)),
       tenantId: req.tenantContext?.tenantId,
       grpcCode,
@@ -134,9 +131,7 @@ export async function guardVideoAccess(
     });
     res.status(isTransient ? 503 : 500).json({
       error: "enrollment_check_failed",
-      message: isTransient
-        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
-        : "受講期限チェックが失敗しました",
+      message: isTransient ? TRANSIENT_RETRY_MESSAGE_JA : "受講期限チェックが失敗しました",
     });
     return true;
   }
@@ -158,10 +153,9 @@ export async function checkQuizAccessSoft(
     }
     return { accessExpired: false };
   } catch (err) {
-    const grpcCode = (err as { code?: number })?.code;
-    const isTransient = grpcCode === 14 || grpcCode === 4;
+    const { grpcCode, isTransient } = classifyFirestoreError(err);
     logger.error("Failed to check quiz access (soft)", {
-      errorType: "enrollment_check_failed",
+      errorType: "enrollment_quiz_soft_check_failed",
       error: err instanceof Error ? err : new Error(String(err)),
       tenantId: req.tenantContext?.tenantId,
       grpcCode,
@@ -169,9 +163,7 @@ export async function checkQuizAccessSoft(
     });
     res.status(isTransient ? 503 : 500).json({
       error: "enrollment_check_failed",
-      message: isTransient
-        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
-        : "受講期限チェックが失敗しました",
+      message: isTransient ? TRANSIENT_RETRY_MESSAGE_JA : "受講期限チェックが失敗しました",
     });
     return null;
   }

--- a/services/api/src/services/enrollment.ts
+++ b/services/api/src/services/enrollment.ts
@@ -6,6 +6,7 @@
 import { addMonths, addYears } from "date-fns";
 import type { Request, Response } from "express";
 import type { TenantEnrollmentSetting } from "../types/entities.js";
+import { logger } from "../utils/logger.js";
 
 /** JST日末 (23:59:59.999 JST = 14:59:59.999 UTC)。入力はUTC基準のDateであること。 */
 function endOfDayJST(date: Date): Date {
@@ -83,10 +84,20 @@ export async function guardQuizAccess(
     }
     return false;
   } catch (err) {
-    console.error("Failed to check quiz access:", err);
-    res.status(500).json({
+    const grpcCode = (err as { code?: number })?.code;
+    const isTransient = grpcCode === 14 || grpcCode === 4;
+    logger.error("Failed to check quiz access", {
+      errorType: "enrollment_check_failed",
+      error: err instanceof Error ? err : new Error(String(err)),
+      tenantId: req.tenantContext?.tenantId,
+      grpcCode,
+      isTransient,
+    });
+    res.status(isTransient ? 503 : 500).json({
       error: "enrollment_check_failed",
-      message: "受講期限チェックが失敗しました",
+      message: isTransient
+        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
+        : "受講期限チェックが失敗しました",
     });
     return true;
   }
@@ -112,10 +123,20 @@ export async function guardVideoAccess(
     }
     return false;
   } catch (err) {
-    console.error("Failed to check video access:", err);
-    res.status(500).json({
+    const grpcCode = (err as { code?: number })?.code;
+    const isTransient = grpcCode === 14 || grpcCode === 4;
+    logger.error("Failed to check video access", {
+      errorType: "enrollment_check_failed",
+      error: err instanceof Error ? err : new Error(String(err)),
+      tenantId: req.tenantContext?.tenantId,
+      grpcCode,
+      isTransient,
+    });
+    res.status(isTransient ? 503 : 500).json({
       error: "enrollment_check_failed",
-      message: "受講期限チェックが失敗しました",
+      message: isTransient
+        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
+        : "受講期限チェックが失敗しました",
     });
     return true;
   }
@@ -137,10 +158,20 @@ export async function checkQuizAccessSoft(
     }
     return { accessExpired: false };
   } catch (err) {
-    console.error("Failed to check quiz access:", err);
-    res.status(500).json({
+    const grpcCode = (err as { code?: number })?.code;
+    const isTransient = grpcCode === 14 || grpcCode === 4;
+    logger.error("Failed to check quiz access (soft)", {
+      errorType: "enrollment_check_failed",
+      error: err instanceof Error ? err : new Error(String(err)),
+      tenantId: req.tenantContext?.tenantId,
+      grpcCode,
+      isTransient,
+    });
+    res.status(isTransient ? 503 : 500).json({
       error: "enrollment_check_failed",
-      message: "受講期限チェックが失敗しました",
+      message: isTransient
+        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
+        : "受講期限チェックが失敗しました",
     });
     return null;
   }

--- a/services/api/src/utils/__tests__/grpc-errors.test.ts
+++ b/services/api/src/utils/__tests__/grpc-errors.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { classifyFirestoreError } from "../grpc-errors.js";
+
+describe("classifyFirestoreError", () => {
+  it("数値形式 14 (UNAVAILABLE) → transient", () => {
+    expect(classifyFirestoreError({ code: 14 })).toEqual({ grpcCode: 14, isTransient: true });
+  });
+
+  it("数値形式 4 (DEADLINE_EXCEEDED) → transient", () => {
+    expect(classifyFirestoreError({ code: 4 })).toEqual({ grpcCode: 4, isTransient: true });
+  });
+
+  it('文字列形式 "unavailable" → transient', () => {
+    expect(classifyFirestoreError({ code: "unavailable" })).toEqual({
+      grpcCode: "unavailable",
+      isTransient: true,
+    });
+  });
+
+  it('文字列形式 "deadline-exceeded" → transient', () => {
+    expect(classifyFirestoreError({ code: "deadline-exceeded" })).toEqual({
+      grpcCode: "deadline-exceeded",
+      isTransient: true,
+    });
+  });
+
+  it("数値形式 7 (PERMISSION_DENIED) → permanent", () => {
+    expect(classifyFirestoreError({ code: 7 })).toEqual({ grpcCode: 7, isTransient: false });
+  });
+
+  it('文字列形式 "permission-denied" → permanent', () => {
+    expect(classifyFirestoreError({ code: "permission-denied" })).toEqual({
+      grpcCode: "permission-denied",
+      isTransient: false,
+    });
+  });
+
+  it("code 無しのエラー → permanent (undefined)", () => {
+    expect(classifyFirestoreError(new Error("plain"))).toEqual({
+      grpcCode: undefined,
+      isTransient: false,
+    });
+  });
+
+  it("null / undefined / 文字列入力 → permanent (undefined)", () => {
+    expect(classifyFirestoreError(null)).toEqual({ grpcCode: undefined, isTransient: false });
+    expect(classifyFirestoreError(undefined)).toEqual({ grpcCode: undefined, isTransient: false });
+    expect(classifyFirestoreError("not an error")).toEqual({ grpcCode: undefined, isTransient: false });
+  });
+});

--- a/services/api/src/utils/grpc-errors.ts
+++ b/services/api/src/utils/grpc-errors.ts
@@ -1,0 +1,27 @@
+/**
+ * Firestore / Firebase Admin SDK の例外を transient / permanent に分類するヘルパ。
+ *
+ * Firestore Admin SDK は `code` プロパティを以下 2 形式のいずれかで返す:
+ * - 数値形式: gRPC 標準コード (例: 14 = UNAVAILABLE, 4 = DEADLINE_EXCEEDED)
+ * - 文字列形式: kebab-case (例: "unavailable", "deadline-exceeded")
+ *
+ * 例えば super-admin middleware の `SuperAdminFirestoreUnavailableError` は文字列形式の
+ * `code` を保持する。両形式の取りこぼしを防ぐため、両方を判定する。
+ */
+
+const TRANSIENT_GRPC_CODES_NUMERIC = new Set<number>([14, 4]);
+const TRANSIENT_GRPC_CODES_STRING = new Set<string>(["unavailable", "deadline-exceeded"]);
+
+export function classifyFirestoreError(err: unknown): {
+  grpcCode: number | string | undefined;
+  isTransient: boolean;
+} {
+  const code = (err as { code?: number | string })?.code;
+  const isTransient =
+    (typeof code === "number" && TRANSIENT_GRPC_CODES_NUMERIC.has(code)) ||
+    (typeof code === "string" && TRANSIENT_GRPC_CODES_STRING.has(code));
+  return { grpcCode: code, isTransient };
+}
+
+export const TRANSIENT_RETRY_MESSAGE_JA =
+  "サーバーが一時的に利用できません。数秒後に再度お試しください。";

--- a/services/api/src/utils/index.ts
+++ b/services/api/src/utils/index.ts
@@ -3,4 +3,5 @@
  */
 
 export * from "./errors.js";
+export * from "./grpc-errors.js";
 export * from "./logger.js";


### PR DESCRIPTION
Closes #341

## Summary
- PR #340 silent-failure-hunter レビュー指摘の **CRITICAL-1 / MEDIUM-2 / MEDIUM-3**（既存設計負債）を解消
- 受講期間関連エンドポイントの全 catch パスを構造化ログ + gRPC コード分類に統一
- 振る舞い変更: transient (UNAVAILABLE/DEADLINE_EXCEEDED) を 503 で返却（従来は Express デフォルトハンドラ任せで 500）

## 主な変更
### super-admin.ts (GET/PUT/DELETE /tenants/:tenantId/enrollment-setting)
- 全体を try-catch でラップ（POST /tenants 既存パターンに準拠）
- gRPC code 14 (`UNAVAILABLE`) / 4 (`DEADLINE_EXCEEDED`) → **503** / その他 → **500**
- `logger.error` に `errorType` / `tenantId` / `operatorEmail` / `grpcCode` / `isTransient` を構造化
- PUT / DELETE 成功時は `logger.info` で監査ログ（操作者・対象テナント・有無）

### firestore.ts (toTenantEnrollmentSetting)
- `console.error` → `logger.error`
- `errorType: "enrollment_setting_parse_failed"` / `tenantId` / `documentId` を構造化

### enrollment.ts (guardQuizAccess / guardVideoAccess / checkQuizAccessSoft)
- `console.error` → `logger.error`
- gRPC コード分類で 503 / 500 出し分け
- `tenantId` は `req.tenantContext?.tenantId` から取得（DataSource interface に依存しない）

## 後方互換
- レスポンス契約は維持（403 / 404 / 400 のステータスコードは変更なし）
- 500 → 503 への変更は transient エラー時のみ。クライアントは新たに retry 判定可能になるが、
  既存の 500 ハンドリングも引き続き動作（503 はサブセット）
- 認証・認可・データ書込ロジックは無変更

## 品質ゲート
- lint: ✅ 0 issues
- type-check: ✅ 4 workspaces 全 PASS
- test: ✅ 696 PASS (API: 663, Web: 33)。`super-admin-platform-auth-errors.test.ts` の AC5 が
  並列実行で時々フレークするが、単独実行 / 再実行で安定 PASS。本 PR 無関係（既存テスト・ファイル無変更）

## Test plan
- [ ] dev サーバで GET/PUT/DELETE /super/tenants/:tenantId/enrollment-setting を叩き、
      200 / 404 / 400 のレスポンスが従来通りであることを確認
- [ ] Cloud Logging で `errorType: enrollment_setting_*_failed` のフィルタが効くことを確認
      （本番障害時のため、デプロイ後に強制的に Firestore へアクセスできない状況を作るのは難しいため、
       ローカルでテンプレート検証で代替）
- [ ] 既存の guardQuizAccess / guardVideoAccess / checkQuizAccessSoft が動作することを
      期限切れシナリオで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)