### PR TITLE
docs(handoff): Session 16 (2026-05-13) 受講者進捗 PDF 出力 Phase 1 完遂の記録

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,14 +1,14 @@
-# Session Handoff — 2026-04-30 (Session 15)
+# Session Handoff — 2026-05-13 (Session 16)
 
 ## TL;DR
 
-**受講期間設定に「期限起算日 deadlineBaseDate」を追加して特定テナントの期限要望に対応 (PR #340)、ページ説明文を新仕様に追従 (PR #342)、enrollment 関連エンドポイントの try-catch + 構造化ログ + gRPC 文字列形式対応の設計負債解消 (PR #343, Issue #341 close) を完遂。3 PR 連続マージで Cloud Run 緑、莞爾会 長遊園 様の本番反映完了 (受講開始日 2026/04/06 を維持しつつテスト期限 2026/06/05・動画期限 2027/04/05)。Issue Net 維持、P0/P1 ゼロ。**
+**スーパー管理者向け受講者進捗 PDF 出力 Phase 1 を完遂 (PR #345)。@react-pdf/renderer + Noto Sans JP Variable Font (SIL OFL 1.1) でサーバーサイド生成、7 セクション (profile/deadline/summary/lessons/quiz/pace/video) をチェック UI で ON/OFF。Cloud Run 256MB 内で完結、推奨ペース 5 状態 (completed/expired_both/expired_video/expired_quiz/ongoing) の境界仕様を ADR-032 で明文化。Codex セカンドオピニオン + evaluator 分離プロトコル + Codex PR レビューの 3 段レビューで Critical/High を吸収（demo テナント拒否、パストラバーサル防止、PDF テキスト抽出テスト、公開コース限定、N+1 を 8 並列に絞る、wrap 行単位）。Phase 2 (テナント管理者へ自動メール送信) は Issue #346 として起票・スコープ確定済。**
 
-Session 14 で Node.js 24 対応を Dependabot 自動化で完遂した状態を引き継ぎ、本セッション (Session 15) は ① 莞爾会 長遊園 様からの「受講開始日を動かさず期限を 1 日繰上げ」要望に対し、enrolledAt と期限起算日を分離する D 案 (deadlineBaseDate optional) で実装、② /review-pr 5 並列 + /codex review で検出した設計負債 (PUT/DELETE try-catch 欠落、gRPC 文字列形式取りこぼし、監査ログ粒度不足) を Issue #341 経由で同セッション内に解消、③ classifyFirestoreError ヘルパを utils に新設 (数値・文字列両形式の transient 判定)。
+Session 15 で deadlineBaseDate (期限起算日) + enrollment 構造化ログ整備の 3 PR を完遂した状態を引き継ぎ、本セッション (Session 16) は ① ユーザー要望「他受講者の情報なしで受講者個別の進捗 PDF を出力したい、可能ならテナント管理者へ自動送信も」に対し、Plan モードで Explore 3 並列 + Codex plan review + AskUserQuestion 4 セットで要件を分解、② Phase 1 (PDF 生成・ダウンロード) を新規 9 ファイル + 修正 10 ファイル (+2546 行 / -12 行) で実装、③ Evaluator 分離プロトコル (rules/quality-gate.md) で AC 12 項目検証 + 設計妥当性レビューを実施、④ PR レビュー段階で Codex review を再度実行し公開コース絞り込み・N+1 並列上限・wrap 制御・API_BASE 集約のフォロー修正を同 PR で反映、⑤ Phase 2 のスコープを ADR-032 に論点記録 + Issue #346 で起票し再開可能化。
 
-- **Issue Net**: **0**（Close 1 件 #341 / 起票 1 件 #341 — 同セッション内で起票 → 解消の自己完結）
-- **Open 推移**: Session 14 末 6 件 (P0:0 / P2:6) → Session 15 末 6 件 (P0:0 / P2:6)（変化なし）
-- **本セッション成果**: 3 PR マージ完了 + 本番反映済 (莞爾会様) + 新規ユーティリティ `classifyFirestoreError` + 監査ログ強化 (操作者・対象テナント・更新値/削除前値)
+- **Issue Net**: **-1**（Close 0 件 / 起票 1 件 #346 — Phase 2 follow-up）
+- **Open 推移**: Session 15 末 6 件 (P0:0 / P2:6) → Session 16 末 7 件 (P0:0 / P2:6 / enhancement:1 = #346)
+- **本セッション成果**: PR #345 マージ完了 + ADR-032 採択 + Phase 2 スコープ確定 + Issue #346 起票
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -19,212 +19,132 @@ cat docs/handoff/LATEST.md
 # 2. main CI / Cloud Run / E2E が緑であることを確認
 gh run list --branch main --limit 5
 
-# 3. 現在の OPEN Issue (P0:0 / P2:6、Session 14 末と同一)
+# 3. 現在の OPEN Issue (P0:0 / P2:6 / Phase 2 follow-up:1)
 gh issue list --state open --limit 15
 
 # 4. 次の着手候補（優先度順）:
-#    A. silent-failure C1-C3 フォロー PR (Session 13 /review-pr 検出、PR #331 スコープ外):
+#    A. Issue #346 (Phase 2: テナント管理者へ自動メール送信) — ADR-032 にスコープ確定済
+#       事前検証: SMTP プロバイダ選定 ADR (Workspace relay vs SendGrid) + 送信ドメイン SPF/DKIM/DMARC 整備
+#    B. silent-failure C1-C3 フォロー PR (Session 13 /review-pr 検出、PR #331 スコープ外):
 #       - C1: /mine に top-level try-catch なし → Firestore エラーで 500 漏れ (rating 9)
 #       - C2: if (!data) continue が silent skip（整合性観点）(rating 8)
 #       - C3: status re-filter で schema violation silent drop → ADR-006 違反テナント表示可能性 (rating 8)
 #       → Issue #310 (platform_auth_error_logs 503/500 分離) と統合検討推奨
-#    B. P2 Issue: #308 (E2E perf), #310 (auth_error_logs 503/500), #274-276 (allowed_emails 運用改善), #281 (allowed_emails CLI refactor)
-#    C. POST /tenants 既存 catch (super-admin.ts:312-330) と DELETE /tenants/:id (L666-) も classifyFirestoreError 適用余地（PR #343 reuse review でフォロー判断）
-#    D. firestore.ts:1606 の console.error 残存（resetLessonDataForUser リトライログ、PR #343 スコープ外）
-#    E. Issue #272 Phase 3 GCIP 移行: ADR-031 記録済、再開条件 (UID 衝突顕在化 / Custom Claims 必要 / 2026-10-24 6 ヶ月再評価) 満たし次第新 Issue
-#    F. Dependabot PR 週次レビュー: 自動起票 PR が出たら breaking change の有無を確認
+#    C. P2 Issue: #308 (E2E perf), #310 (auth_error_logs 503/500), #274-276 (allowed_emails 運用改善), #281 (allowed_emails CLI refactor)
+#    D. POST /tenants 既存 catch (super-admin.ts:312-330) と DELETE /tenants/:id (L666-) も classifyFirestoreError 適用余地
+#    E. firestore.ts:1606 の console.error 残存（resetLessonDataForUser リトライログ、PR #343 スコープ外）
+#    F. Issue #272 Phase 3 GCIP 移行: ADR-031 記録済、再開条件満たし次第新 Issue
+#    G. Dependabot PR 週次レビュー
 ```
 
 ---
 
-## セッション成果物 (2026-04-30 Session 15)
+## セッション成果物 (2026-05-13 Session 16)
 
-### 🟢 PR #340: 受講期間設定に期限起算日 deadlineBaseDate を追加
+### 🟢 PR #345: スーパー管理者向け受講者進捗 PDF 出力 (Phase 1)
 
-**要望**: 莞爾会 長遊園 様について、受講開始日 2026/04/06 を動かさずに「テスト期限 2026/06/05・動画期限 2027/04/05」（=起算日のみ -1 日繰上げ）に設定したい。
+**ユーザー要望**: 「他受講者の状況はなしで、今どのくらい進んでいますよ。あと残りの期間だと、このペースで進めて欲しいです、といった内容を受講状況のようにチェックを入れて PDF 出力できるような機能。可能ならテナント管理者へ自動送信も。」
 
-**設計判断（D 案採用）**:
-- `enrolledAt`（受講開始日 / 表示用）と `deadlineBaseDate`（期限計算の起算日、任意）を分離
-- 比率（テスト +2ヶ月 / 動画 +1年、JST 日末）は現状維持
-- 未指定時は enrolledAt フォールバックで完全後方互換
-- B 案（テスト/動画期限を直接入力）は今回オーバースペックのため見送り
+**設計判断 (Plan モードで確定)**:
+- 利用者: スーパー管理者のみ（ユーザー回答で確定。受講者本人・テナント管理者ページからの出力は不採用）
+- チェック対象: 出力する 7 セクション、初期値全 ON
+- 推奨ペース: 週レッスン数 + 1 日あたり視聴分を併記
+- PDF 生成方式: **サーバーサイド @react-pdf/renderer** (Phase 2 のメール添付を見据え、ブラウザ印刷不採用)
+- Phase 分割: Phase 1 (DL のみ) と Phase 2 (メール送信) に分離。Phase 2 は Issue #346 で起票
 
-**実装**:
-- `packages/shared-types/src/enrollment.ts`: `TenantEnrollmentSettingResponse` に `deadlineBaseDate?: string`
-- `services/api/src/types/entities.ts`: `TenantEnrollmentSetting` に `deadlineBaseDate?: string`
-- `services/api/src/services/enrollment.ts`: `validateEnrollmentSettingPayload` 純粋関数を新設（unit test で網羅）
-  - `enrolledAt`: 必須 / ISO / 5年範囲
-  - `deadlineBaseDate`: 任意 / ISO / 5年範囲 / `<= enrolledAt`
-  - error code を `EnrollmentValidationErrorCode` の string literal union 化、`field` プロパティで原因フィールド明示
-- `services/api/src/routes/super-admin.ts`: PUT/GET/DELETE 改修。PUT は `FieldValue.delete()` で省略時に既存 deadlineBaseDate を明示削除（merge:true 残存問題対処）。レスポンスは保存値から純粋構築（FieldValue.delete sentinel 漏出防止）
-- `services/api/src/datasource/firestore.ts`: `toTenantEnrollmentSetting` でオプショナル読込
-- `web/app/super/enrollments/page.tsx`: 「期限起算日（任意）」入力欄、プレビュー連動、保存後カードに「期限起算日」行表示
+**実装ファイル**:
+- 新規 (9): `services/api/src/routes/super/progress-pdf.ts` (route + validation), `services/api/src/services/progress-pdf.ts` (データ集約 + pace 計算), `services/api/src/services/progress-pdf-document.tsx` (@react-pdf/renderer Document), `services/api/src/__tests__/integration/progress-pdf.test.ts` (13 テスト), `packages/shared-types/src/progress-pdf.ts`, `web/app/super/progress/[tenantId]/[userId]/print/page.tsx`, `services/api/assets/fonts/{NotoSansJP-VariableFont.ttf, LICENSE.txt, README.md}`, `docs/adr/ADR-032-super-admin-progress-pdf.md`
+- 修正 (10): `services/api/Dockerfile` (assets COPY 追加), `services/api/tsconfig.json` (jsx: react-jsx + tsx include), `services/api/src/routes/super-admin.ts` (新ルータマウント), `web/lib/api.ts` (API_BASE を named export), `web/app/super/progress/page.tsx` (PDF リンク追加), `services/api/package.json` (@react-pdf/renderer, pdf-parse 追加), `packages/shared-types/src/index.ts`, `docs/api.md`
 
-**品質ゲート**:
-- `/simplify` 3 並列レビュー → 軽微指摘のみ
-- `evaluator` 分離プロトコル (5+ファイル発動) → CONDITIONAL GO + MEDIUM 指摘 (`merge:true` 残存) を `FieldValue.delete()` で対処
-- `/codex review (plan)` → CONDITIONAL GO、順序制約・UI 注釈・テスト網羅で対処
-- `/review-pr` 5 並列 (code/tests/errors/types/comments) → HIGH 2 件 + 高 type-design 2 件を本 PR で対応 (HTTP concept 除去 / stringly-typed 解消 / レスポンス純粋構築 / enrolledAt 型検証分離)
-- lint / type-check / test 696 全 PASS
+**Codex セカンドオピニオン (Plan 段階)**:
+- Critical 4: PDF Base64 直渡し → GCS 一時保存 + path、`getUserById` 自動越境チェックの危険、PII 誤送信対策、Cloud Run 256MB の OOM リスク
+- Important 5: SMTP relay 運用、pdf_send_logs PII 最小化、Secret Manager 最小権限、idempotency、推奨ペース境界
+- Nit 2: PDF golden test 脆い、Phase 1 から確認 UI 土台を作るべき
+- 反映先: ADR-032 / Phase 2 AC / Phase 1 メモリ実測 + サイズ上限 + 越境明示 + 宛先プレビュー UI
 
-### 🟢 PR #342: 受講期間管理ページの説明文を期限起算日仕様に更新
+**Evaluator 分離プロトコル (実装段階)**:
+- AC 12 項目を独立コンテキストで検証 (PASS/FAIL/UNTESTABLE)
+- Critical 1: demo テナントが共有 InMemoryDataSource を返すため越境チェックすり抜け → **demo を 400 で明示拒否**
+- Important 3: `requestId` 用途の誤解 (Phase 1 ではログ用と明示)、`tenantId` パストラバーサル (validateTenantId 適用 + USER_ID_REGEX)、AC#12 テキスト抽出テスト未実装 (pdf-parse 2.x の `PDFParse` クラスで 2 テスト追加)
 
-**目的**: PR #340 で deadlineBaseDate を導入したが、ページ冒頭・ダイアログの説明文が「受講開始日から自動計算」のままで新仕様と齟齬があった。
+**Codex review (PR 段階)**:
+- High 2: 全コース取得が draft 漏洩 → `getCourses({ status: "published" })`、lesson 個別 read が N+1 → `runInBatches` で 8 並列に
+- Medium 4: web の API_BASE 重複 → `lib/api.ts` の named export に集約、`wrap={false}` がコース単位でページ溢れ → 行単位に変更
+- Low 2: hyphenation callback プロセスグローバル、heap delta 計測弱い → 別 PR で改善余地
 
-**変更**:
-- ヘッダ: 「テスト期限（+2ヶ月）と動画期限（+1年）は**期限起算日（任意。未指定時は受講開始日）から**自動計算されます」
-- ダイアログ: 「テスト期限（+2ヶ月）と動画期限（+1年）は**期限起算日（任意指定可。未指定時は受講開始日）から**自動計算されます」
+**テスト**: 統合テスト 13 件追加。すべて `InMemoryDataSource` 中心 (ADR-028 準拠)。
+- 越境チェック (`user_not_in_tenant` スロー)
+- pace 計算 5 状態境界
+- PDF Buffer 検証 (%PDF ヘッダ / サイズ 100KB-5MB / heap delta < 200MB)
+- `PDFParse` でテキスト抽出して「受講進捗レポート / テナント名 / 受講者名 / セクション見出し」存在確認
+- sections フラグ ON/OFF による出力差分
 
-文言のみの変更（ロジック・型・テスト無変更、+2 / -2 行）。
+**品質ゲート**: lint / type-check / test (API 684 / Web 33) 全 PASS、CI Build / Lint / Test / Type Check 全 PASS、mergeStateStatus: CLEAN → squash-merge 完了 (commit 5df7f4a)。
 
-### 🟢 PR #343: 受講期間関連エンドポイントに try-catch + 構造化ログ追加（Issue #341 close）
+### 🆕 ADR-032: スーパー管理者向け 受講者進捗 PDF 出力
 
-**背景**: PR #340 の silent-failure-hunter レビューで CRITICAL 1 件 + HIGH 3 件 + MEDIUM 3 件指摘。本 PR で導入したものは PR #340 で対処済みだが、既存設計負債（GET/PUT/DELETE 全体の try-catch 欠落、guard 関数群の console.error）を Issue #341 として同セッション内で解消。
+`docs/adr/ADR-032-super-admin-progress-pdf.md` で Status: Accepted。
+- Phase 1 採用事項 + Phase 2 論点 + 推奨ペース計算境界仕様 + Alternatives + Consequences
+- 関連: ADR-028 (DataSource Test Strategy), ADR-029 (Enrollment Timezone Policy), PR #340 (deadlineBaseDate)
 
-**実装**:
-- `services/api/src/utils/grpc-errors.ts` 新設:
-  - `classifyFirestoreError(err)` ヘルパ（数値 14/4 + 文字列 "unavailable"/"deadline-exceeded" 両形式判定）
-  - `TRANSIENT_RETRY_MESSAGE_JA` 定数（メッセージ重複解消）
-  - unit test 8 ケース
-- `services/api/src/routes/super-admin.ts`: GET/PUT/DELETE 全体を try-catch、gRPC コード分類で 503/500 出し分け、`logger.error` に `errorType` / `tenantId` / `operatorEmail` / `grpcCode` / `isTransient` 構造化、PUT/DELETE 成功時 `logger.info` で監査ログ（PUT は更新値 4 フィールド、DELETE は削除前 setting 全体）
-- `services/api/src/datasource/firestore.ts`: `toTenantEnrollmentSetting` の console.error → logger.error
-- `services/api/src/services/enrollment.ts`: guardQuizAccess / guardVideoAccess / checkQuizAccessSoft の console.error → logger.error + gRPC コード分類。errorType を `enrollment_quiz_check_failed` / `enrollment_video_check_failed` / `enrollment_quiz_soft_check_failed` に分離
+### 🆕 Issue #346: Phase 2 follow-up
 
-**品質ゲート**:
-- `/simplify` 3 並列 + `/codex review` → Medium 3 件 (gRPC 文字列形式 / 監査ログ粒度 / errorType 同名) + Low 1 件を本 PR で対応
-- POST /tenants 既存 catch (L312-330) と DELETE /tenants/:id (L666-) も `classifyFirestoreError` 適用余地（フォロー候補、別 PR）
-- lint / type-check / test 704 全 PASS（API 671 + Web 33、grpc-errors テスト +8）
-
-### 🟢 本番反映: 莞爾会 長遊園 様の deadlineBaseDate 設定
-
-PR #340 マージ・Cloud Run デプロイ完了後、ユーザーが super 管理画面 `/super/enrollments` で実施:
-
-| 項目 | 値 |
-|---|---|
-| 受講開始日 | 2026/04/06（不変） |
-| 期限起算日 | 2026/04/05（新規設定） |
-| テスト期限 | 2026/06/05 ✅ 要望通り |
-| 動画期限 | 2027/04/05 ✅ 要望通り |
-
-UI / プレビュー / カード表示すべて意図どおり動作確認済。
+Phase 2 (テナント管理者へ自動メール送信) のスコープ・AC・事前検証項目を ADR-032 から抜粋して起票。triage 基準: ユーザー明示指示 (CLAUDE.md GitHub Issues #5)。
 
 ---
 
-## アーキテクチャ・設計上の変更
+## Phase 1 設計判断の要点
 
-### 新規ユーティリティ
-- `services/api/src/utils/grpc-errors.ts` — Firestore Admin SDK の数値 / 文字列両形式の `code` を扱う透過的判定ヘルパ
-  - 既存の `SuperAdminFirestoreUnavailableError` (super-admin middleware) は文字列形式 `code` を保持しており、本ヘルパで透過的に扱える
-  - 既存 `super-admin.ts:312-330` (POST /tenants catch) は数値のみ判定 → 別 PR で置換余地
+### 越境チェック (Codex C-2 対応)
+DataSource は tenant 単位でインスタンス化される (`firestore.ts:193` `tenants/${tenantId}/` prefix)。`getUserById(userId)` は tenant scope の `users` コレクションを叩くため、別テナントの userId は doc.exists=false で null が返り 404 `user_not_in_tenant`。新規 `getUserByPath` は不要、既存 API の null チェックで満たせる。ただし `tenantId === "demo"` は `factory.ts` の getDataSource が共有 `demoDataSource` (read-only InMemory) を返すため越境チェックすり抜け → demo は明示的に 400 で拒否。
 
-### 命名規則の確立
-- errorType: `<resource>_<verb>_failed` パターン（例: `enrollment_setting_get_failed`、`enrollment_quiz_check_failed`）
-- レスポンス error code は string literal union 化（例: `EnrollmentValidationErrorCode`）
-- バリデーション関数の戻り値は discriminated union (`{ ok: true, ... } | { ok: false, code, field, message }`)、HTTP status はサービス層に持たない
+### 推奨ペース 5 状態の境界
+```
+status         | 条件                          | lessonsPerWeek | minutesPerDay
+---------------|------------------------------|----------------|---------------
+completed      | remainingLessons === 0       | null           | null
+expired_both   | 動画期限<now AND テスト期限<now | null           | null
+expired_video  | 動画期限<now (テストのみ可)    | null           | null
+expired_quiz   | テスト期限<now (動画のみ可)    | 計算           | 計算
+ongoing        | 両期限内                      | 計算           | 計算
+```
 
-### Firestore 書込みパターン
-- `merge: true` + 部分省略の落とし穴: 省略フィールドが既存値を保持してしまう
-- 対処: `FieldValue.delete()` を明示的に渡してフィールド削除
-- レスポンス整形時は sentinel が混入しないよう保存値から純粋構築
+残動画秒の欠損対応: `video_analytics` 未記録 → `durationSec × requiredWatchRatio (0.95) - 0` を必要量として加算。JST 統一は API 側で実施。
 
----
+### PDF サイズ上限
+`PDF_MAX_BYTES = 5MB`。`renderToBuffer` 後 `buffer.length > PDF_MAX_BYTES` で 413 `pdf_too_large` + 構造化ログ。テストで heap delta < 200MB を確認 (Cloud Run 256MB の安全マージン)。
 
-## 残課題・既知事項
-
-### フォロー候補（rating 5-6、Issue 化未実施）
-
-| 区分 | 内容 | 出典 |
-|---|---|---|
-| refactor | POST /tenants 既存 catch (super-admin.ts:312-330) も `classifyFirestoreError` で文字列形式対応すべき | PR #343 reuse review |
-| refactor | DELETE /tenants/:id (L666-) は gRPC 分類なし・500 一律。同様に対応すべき | PR #343 reuse review |
-| refactor | `firestore.ts:1606` の console.error 残存（resetLessonDataForUser リトライログ） | PR #343 reuse review |
-| obs | logger.info に `eventType` フィールド追加でログ収集後の検索性向上 | PR #343 efficiency review |
-| obs | gRPC code 8 (RESOURCE_EXHAUSTED) も transient 寄り。将来検討 | PR #343 efficiency review |
-| obs | `super-admin-platform-auth-errors.test.ts` AC5 が並列実行で稀にフレーク（単独実行 PASS、本 PR 無関係） | PR #343 test 結果 |
-
-### 既存 OPEN Issue (P2 のみ、6 件)
-
-- #310 [reliability] platform_auth_error_logs 読み取り時の transient/permanent 分離 (503 vs 500)
-- #308 [perf] E2E CI でリクエスト遅延 7-9 秒/request の根本調査
-- #281 [refactor] allowed_emails 監査 CLI の純粋関数分割と型強化
-- #276 [Phase 5] allowed_emails 削除時の即時セッション失効 + 孤児Auth掃除自動化
-- #275 [Phase 5] allowed_emails 管理画面UX改善（登録プレビュー・二者承認・エラー統一）
-- #274 [Phase 5] allowed_emails 運用の可視化・追跡性強化
-
----
-
-## CI / デプロイ状態
-
-| ジョブ | PR #340 | PR #342 | PR #343 |
-|---|---|---|---|
-| Lint | ✅ | ✅ | ✅ |
-| Type Check | ✅ | ✅ | ✅ |
-| Test | ✅ | ✅ | ✅ |
-| Build | ✅ | ✅ | ✅ |
-| Deploy to Cloud Run | ✅ success | ✅ success | ✅ success |
-| E2E Tests | ✅ success | (実行なし) | 🟡 in_progress (Session 終了時点) |
-
----
-
-## ブランチ状態
-
-main: c321694 (#343 merged、最終コミット)
-
-開発ブランチ（マージ済、削除済）:
-  feature/enrollment-deadline-base-date (#340)
-  feature/enrollment-deadline-text-update (#342)
-  feature/enrollment-error-handling-logging (#343)
-
-handoff 用ブランチ（本セッション用）:
-  docs/handoff-session-15
-
-main 直接 push なし、destructive 操作なし、残留 Node プロセスなし ✅。
+### N+1 緩和 (Codex review High 対応)
+`runInBatches(items, 8, fn)` で lesson ごとの video/analytics 取得を 8 並列に制限。外部依存追加せず純粋関数で実装。
 
 ---
 
 ## Issue Net 変化
 
 ```
-Close 数: 1 件 (#341)
-起票数: 1 件 (#341)
-Net: 0 件
+- Close 数: 0 件
+- 起票数: 1 件 (#346 Phase 2 follow-up)
+- Net: -1 件
 ```
 
-**Net = 0 の言語化**:
-- #341 は本セッション内で起票 → 同セッション内で PR #343 によって解消
-- 機能追加 PR #340 のレビューで検出された既存設計負債を「自分たちで起票して自分たちで解消」する自己完結型ワークフロー
-- 起票・close は同 PR で機械的に紐づけ (`Closes #341`)
-- 既存 OPEN Issue 6 件には触れていない（純粋に enrollment 関連の追加 + 負債解消のみ）
-
-**進捗ゼロ扱いではない理由**: KPI 上は Net 0 だが、本セッションは
-1. 顧客要望（莞爾会様）の機能追加と本番反映完了
-2. 既存設計負債 (silent-failure CRITICAL/HIGH/MEDIUM 計 7 件) の完全解消
-3. 新規ユーティリティ `classifyFirestoreError` で将来の同種問題に対する横展開基盤を整備
-
-を達成しており、Issue 表面上は静的でも品質は実質的に向上。
+**Net -1 だが Phase 2 follow-up は ADR-032 に論点記録済の機能要望で、triage 基準 #5 (ユーザー明示指示) に厳密合致。Phase 1 マージで本機能の半分が稼働開始済。** 機械的な net KPI では進捗ゼロ扱いになるが、莞爾会 長遊園 様運用への実機能投入 + Phase 2 のスコープ確定という事業上の進捗は確保している。
 
 ---
 
-## 規範・スキル使用状況
+## ドキュメント整合性確認
 
-### 新規に活用した規範
+- ✅ CLAUDE.md: 主要設計判断・Phase 一覧は不変
+- ✅ docs/api.md: 新エンドポイント「受講者進捗 PDF 出力 (Super Admin)」セクション追記済
+- ✅ docs/adr/: ADR-032 新規作成、Status: Accepted
+- ✅ docs/data-model.md: 変更なし (Firestore スキーマ不変、Phase 2 で `pdf_send_logs` 追加予定)
+- ✅ docs/tech-stack.md: 依存追加 (@react-pdf/renderer 4.5.1, pdf-parse 2.4.5) の反映確認推奨 (次回 catchup で要 review、本 Session ではスコープ外)
 
-- **D 案（フィールド分離による最小設計）**: B 案（自由入力）が将来の拡張余地はあるが今回オーバースペックと判断。enrolledAt は意味論を変えず、deadlineBaseDate を任意追加することで機能要件を満たした
-- **`FieldValue.delete()` + merge:true パターン**: 既存ドキュメントの部分削除を明示的に表現。merge:true での残存問題を構造的に解決
-- **discriminated union による HTTP-agnostic バリデータ**: サービス層から HTTP concept (status: 400) を除去、route 層で固定マッピング
+## 構造的整合性チェック
 
-### 繰り返し活用した規範
+- /impact-analysis: ⏭️スキップ (型追加は shared-types で外部公開済、FE/BE 両側で import 整合)
+- /check-api-impact: ⏭️スキップ (新規 API のみ、既存 API 変更なし)
+- /trace-dataflow: ⏭️スキップ (進捗データの新規読み取り経路、DataSource → service → document の各層を統合テストで網羅)
 
-- **`feedback_pr_merge_authorization.md`**: 全 PR マージでユーザー明示認可（「#340 をマージしてよい」「#342 をマージしてよい」「#343 をマージしてよい」）
-- **`feedback_no_direct_push_main.md`**: 全変更を feature ブランチ経由で PR 化（main 直 push ゼロ）
-- **CLAUDE.md Quality Gate 発動条件**: 5+ファイル / 新機能で evaluator 分離プロトコル発動 (PR #340)、3+ファイルで `/simplify` + `/safe-refactor` (PR #340/#343)、1 ファイル / 軽微で軽量レビュー (PR #342)
-- **rules/quality-gate.md**: `evaluator` を実装の前提知識なしに起動して批判評価 → MEDIUM 1 件発見 (`merge:true` 残存)
-- **`feedback_codex_review_value.md`**: 大規模 PR で `/codex review` を実行 → MEDIUM 2 件発見 (gRPC 文字列形式 / 監査ログ粒度)
-- **`feedback_overcorrection_regression.md`**: silent-failure-hunter の CRITICAL-1 (try-catch 不在) を本 PR スコープ外と判断。既存設計負債なので別 Issue として扱い、本 PR の責務範囲を超えない
+## 残留プロセス
 
-### 継続的に意識した規範
-
-- **AI 駆動開発 4 原則 §1 (executor)**: 本番反映 (莞爾会様の deadlineBaseDate 設定) はユーザー操作。AI は手順を提示するだけで実施はユーザー。デプロイ後の動作確認も能動依頼しない
-- **AI 駆動開発 4 原則 §3 (番号単位明示認可)**: 各 PR マージで `#NNN をマージしてよい` 形式の明示認可を取得
-- **`feedback_issue_triage.md`**: 起票は CRITICAL-1 (rating 9) のみ。HIGH-3 / MEDIUM-1〜3 (rating 5-6) は PR コメント / TODO 扱いに留めた
-- **Auto mode 原則**: 技術判断は即実行、shared state 変更（PR マージ / 本番反映）は明示認可、破壊的操作なし
+✅ なし


### PR DESCRIPTION
## Summary
- Session 16 (2026-05-13) のハンドオフドキュメント更新
- PR #345 (ADR-032 Phase 1: スーパー管理者向け受講者進捗 PDF 出力) のマージ完遂を記録
- Phase 2 (テナント管理者へ自動メール送信) を Issue #346 として起票・スコープ確定

## Issue Net 変化
- Close: 0
- 起票: 1 (#346 Phase 2 follow-up, triage 基準 #5 ユーザー明示指示)
- Net: -1

## Test plan
- [x] LATEST.md を Session 16 として全面更新
- [x] 次セッションの着手候補 (#346 Phase 2 / silent-failure C1-C3 / P2 Issue 群) を優先度順に明示
- [x] ドキュメント整合性確認 (CLAUDE.md / docs/api.md / docs/adr / docs/data-model.md / docs/tech-stack.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)