### PR TITLE
fix(api): add react and @types/react to api workspace deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14412,13 +14412,15 @@
         "express-rate-limit": "^8.3.1",
         "firebase-admin": "^13.6.0",
         "googleapis": "^171.4.0",
-        "helmet": "^8.1.0"
+        "helmet": "^8.1.0",
+        "react": "19.2.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "5.0.6",
         "@types/node": "25.0.7",
         "@types/pdf-parse": "^1.1.5",
+        "@types/react": "19.2.8",
         "@types/supertest": "^6.0.3",
         "@vitest/coverage-v8": "^4.0.18",
         "pdf-parse": "^2.4.5",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -25,13 +25,15 @@
     "express-rate-limit": "^8.3.1",
     "firebase-admin": "^13.6.0",
     "googleapis": "^171.4.0",
-    "helmet": "^8.1.0"
+    "helmet": "^8.1.0",
+    "react": "19.2.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "5.0.6",
     "@types/node": "25.0.7",
     "@types/pdf-parse": "^1.1.5",
+    "@types/react": "19.2.8",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^4.0.18",
     "pdf-parse": "^2.4.5",


### PR DESCRIPTION
## Summary

- PR #345 (ADR-032 Phase 1) で `@react-pdf/renderer` を導入したが、API workspace に `react` / `@types/react` が無く Cloud Run deploy が連続失敗中
- API workspace の `dependencies` に `react` 19.2.3、`devDependencies` に `@types/react` 19.2.8 を追加し Docker workspace 限定インストールでも `react/jsx-runtime` を解決できる状態にする

## 背景

直近 main push (PR #345 / PR #347) の `Deploy to Cloud Run` が連続 failure：

\`\`\`
src/services/progress-pdf-document.tsx(125,5): error TS7016: Could not find a declaration file for module 'react/jsx-runtime'. '/app/node_modules/react/jsx-runtime.js' implicitly has an 'any' type.
\`\`\`

ローカル / CI は npm workspaces hoisting で `web/` の `react` を root に hoist して通過していたが、`services/api/Dockerfile` は workspace 限定インストールを行うため Docker 単体ビルドで初発覚。

\`\`\`dockerfile
RUN npm ci -w @lms-279/shared-types -w @lms-279/api
\`\`\`

## 修正方針

- `services/api/package.json` の `dependencies` に `react: "19.2.3"` を追加（`@react-pdf/renderer` の peerDep + 実行時 `_jsx`/`_jsxs` 呼び出しに必須）
- `services/api/package.json` の `devDependencies` に `@types/react: "19.2.8"` を追加（`tsc --build` 時の `jsx: "react-jsx"` 型解決に必須、`npm ci --omit=dev` で実行時イメージからは除外）
- バージョンは `web/package.json` と合わせて hoisting 互換性を維持

## Test plan

- [x] `npm run type-check -w @lms-279/api` PASS
- [x] `npm run lint` PASS
- [x] `npm run test -w @lms-279/api` PASS (684/684)
- [ ] CI `Deploy to Cloud Run` が success に戻ること（マージ後のフルリハーサル）
- [ ] 本番 `POST /api/v2/super/tenants/:tenantId/users/:userId/progress-pdf` が PDF を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)