### PR TITLE
docs(adr): add ADR-033 draft - Phase 2 SMTP selection and DNS auth setup

### DIFF
--- a/docs/adr/ADR-033-phase2-smtp-selection.md
+++ b/docs/adr/ADR-033-phase2-smtp-selection.md
@@ -1,0 +1,130 @@
+# ADR-033: Phase 2 受講者進捗 PDF メール送信 - SMTP プロバイダ選定とドメイン認証整備
+
+- Status: **Proposed** (ユーザー判断待ち)
+- Date: 2026-05-14
+- Deciders: system-279, sanwaminamihonda@gmail.com
+- 関連: ADR-032 (Phase 1 採択), Issue #346 (Phase 2 起票)
+
+## Context
+
+ADR-032 Phase 2 は「スーパー管理者が `tenants/{id}.ownerEmail` 宛に受講者進捗 PDF を自動メール送信する」機能。Phase 1 (PDF 生成・ダウンロード) は PR #345 で完了済、Phase 2 着手前に下記 2 つの判断が必要:
+
+1. **SMTP プロバイダ**: Workspace SMTP relay vs SendGrid
+2. **送信ドメイン認証**: 現在 `279279.net` は SPF / DKIM / DMARC が全て未整備
+
+## 送信ドメイン現状 (2026-05-14 dig 確認)
+
+| レコード | 設定状況 |
+|---------|---------|
+| MX | `1 smtp.google.com.` ✅ (Workspace 受信稼働中) |
+| SPF (`TXT 279279.net`) | ❌ `google-site-verification` のみ、`v=spf1 ...` なし |
+| DKIM (`TXT google._domainkey`) | ❌ レコードなし |
+| DKIM (`TXT selector1._domainkey`) | ❌ レコードなし |
+| DMARC (`TXT _dmarc.279279.net`) | ❌ レコードなし |
+
+このまま Phase 2 を展開すると以下のリスクが顕在化する:
+- Gmail / Outlook の受信側で SPF/DKIM 失敗 → spam フォルダ直行
+- Yahoo Mail / Gmail の 2024-02 以降の送信ガイドライン違反 (大量送信時)
+- DMARC reject ポリシーを持つ受信ドメインで全 reject
+
+**Phase 2 着手前にドメインオーナー (sanwaminamihonda@gmail.com) による DNS レコード追加が必須**。
+
+## Decision (推奨案)
+
+### 1. SMTP プロバイダ: **Google Workspace SMTP relay** を推奨
+
+理由:
+- 既に Workspace 契約済 (`279279.net` で `smtp.google.com` 利用中)
+- 追加コスト 0 円 (Workspace ライセンス内)
+- Phase 2 想定送信 volume が小さい (莞爾会 1 テナント・月 10-30 通想定)
+- Nodemailer による SMTP 抽象化で、将来 SendGrid 等への切替容易
+
+### 2. 送信元アドレス: `lms-noreply@279279.net` (Workspace で新規発行)
+
+理由:
+- 受信者の返信を blackhole にして誤運用を防ぐ
+- Phase 1 で出力される PDF と紐付くため、ドメインと用途が明確
+- `lms@279279.net` を採用すると、人が応答する印象を与え運用負荷増
+
+### 3. DNS 整備順序 (Phase 2 実装前のブロッカー)
+
+| Step | レコード | 値 | 担当 |
+|------|----------|----|----|
+| 1 | TXT `279279.net` | `v=spf1 include:_spf.google.com ~all` | ドメインオーナー |
+| 2 | Workspace 管理コンソール | DKIM 鍵生成 → 表示された TXT 値を控える | ドメインオーナー |
+| 3 | TXT `google._domainkey.279279.net` | (Step 2 で取得した値) | ドメインオーナー |
+| 4 | Workspace 管理コンソール | DKIM 認証 ON 切替 | ドメインオーナー |
+| 5 | TXT `_dmarc.279279.net` | `v=DMARC1; p=quarantine; rua=mailto:sanwaminamihonda@gmail.com; pct=100; adkim=s; aspf=s` | ドメインオーナー |
+| 6 | dig 検証 + Gmail への送信テスト | SPF=pass / DKIM=pass / DMARC=pass | system-279 |
+
+注: Step 5 の `p=quarantine` は Phase 2 リリース直後の初期値。1 週間以上 rua レポートを監視して問題なければ `p=reject` に強化する。
+
+### 4. Phase 2 アーキテクチャ (確定事項を ADR-032 から引き継ぎ)
+
+- `services/api` → PDF 生成 + GCS `gs://lms-279-pdf-tmp/{tenantId}/{userId}/{requestId}.pdf` に保存 (TTL 7 日)
+- `services/api` → Firestore `tenants/{id}/pdf_send_logs/{requestId}` に PII 最小化ログ
+- `services/api` → `services/notification` に `object path` を渡す (Base64 ではなく)
+- `services/notification` → GCS から PDF 読み出し、Nodemailer で SMTP relay 経由送信
+- レート制限: スーパー管理者 60 通/時、テナント 30 通/日
+- idempotency key (`requestId`) で二重送信防止
+- 失敗時はエラーコード表示 + PDF ダウンロードへフォールバック
+
+## Alternatives Considered
+
+### A. SendGrid
+
+| 項目 | Workspace SMTP relay | SendGrid |
+|------|---------------------|----------|
+| 月額コスト | **0 円** (既存) | Free 100 通/日, Essentials $19.95/月 |
+| 送信元制約 | Workspace ドメイン内のみ | 任意 (要 SPF/DKIM 認証) |
+| レート制限 | 10,000 通/日/アカウント | プランによる |
+| bounce 監視 | Postmaster Tools (集計)、個別 bounce は SMTP 応答のみ | Webhook + ダッシュボード (個別追跡) |
+| 設定の手間 | Workspace 管理画面で 5-10 分 | アカウント作成 + ドメイン認証 + API key 管理 |
+| 切替容易性 | Nodemailer SMTP transport → SendGrid SMTP transport に変更可 | (同左) |
+
+**SendGrid 不採用理由**: Phase 2 の volume (月数十通) では Free でも十分だが、追加サービス契約 + API key 管理 + Secret Manager 設定の運用負荷が増える。bounce 監視の優位性は Phase 2 では best-effort で許容できる範囲。
+
+### B. Amazon SES
+
+不採用理由:
+- AWS アカウントを別途運用する必要 (現在 GCP 一本)
+- ismap 観点で GCP 内完結方針 (memory `feedback_ismap_gcp_only.md`) に反する
+- Workspace で十分な機能を有償別サービスに置換する合理性なし
+
+### C. Cloud Run + Postfix 自前運用
+
+不採用理由:
+- Cloud Run はアウトバウンド SMTP の port 25 が closed
+- 587 (submission) で外部 relay を利用する必要があり、結局 Workspace か SendGrid 等に依存
+- 自前運用するメリットなし
+
+## Consequences
+
+### 良い影響
+
+- 追加コスト 0 円で Phase 2 リリース可能
+- SPF/DKIM/DMARC 整備により Phase 2 以外の Workspace メール (Calendar 招待等) の到達性も向上
+- Nodemailer の抽象化で将来の SendGrid 切替に向けた逃げ道を維持
+
+### 注意点・残存リスク
+
+- DNS 整備はドメインオーナー手作業のため、Phase 2 実装着手前のリードタイムが発生する (見積 30-60 分)
+- Workspace SMTP relay のレート制限 (10,000 通/日/アカウント) は Phase 2 想定 volume なら十分だが、将来複数テナント拡大で月数千通を超えたら SendGrid 切替を再評価
+- bounce 監視は Postmaster Tools の集計レベル。個別メールの bounce 追跡は `services/notification` 側で SMTP 応答コードを `pdf_send_logs.errorCode` に記録する best-effort で対応
+- `pdf-misfire.md` runbook は本 ADR 採択後、Phase 2 実装と並行して整備
+
+### Phase 2 実装着手のブロッカー
+
+以下を満たすまで Phase 2 のコード実装には着手しない:
+
+- [ ] 本 ADR-033 が Accepted
+- [ ] DNS Step 1-5 完了
+- [ ] DNS Step 6 検証 PASS (Gmail への送信テストで SPF=pass / DKIM=pass / DMARC=pass)
+- [ ] Workspace で `lms-noreply@279279.net` 発行
+
+## 関連
+
+- ADR-032: Phase 1 採択 (PR #345 マージ済)
+- Issue #346: Phase 2 起票
+- ADR-010: フラットエラーレスポンス形式 (Phase 2 メール送信失敗時のエラー形式と整合)
+- memory: `feedback_ismap_gcp_only.md` (個人情報を扱うプロジェクトの GCP 内完結方針)


### PR DESCRIPTION
## Summary

- Issue #346 (Phase 2 メール送信) 着手前の事前検証として ADR-033 を草案 (Status: **Proposed**) で起票
- 送信ドメイン `279279.net` の SPF/DKIM/DMARC が全て未整備であることを dig で確認、整備手順 6 ステップを ADR に記録
- SMTP プロバイダ比較 (Workspace SMTP relay vs SendGrid vs SES) で **Workspace SMTP relay + `lms-noreply@279279.net`** を推奨

## ユーザー判断が必要な項目

このドキュメントは AI が一方的に決められない判断を含むため、Proposed のままユーザー判断を仰ぎたい:

1. **SMTP プロバイダ選定**: Workspace SMTP relay (推奨) で良いか、SendGrid 等を選びたいか
2. **送信元アドレス**: `lms-noreply@279279.net` で良いか
3. **DNS 整備のドメインオーナー側着手タイミング**: いつ DNS Step 1-5 (SPF/DKIM/DMARC 追加 + Workspace DKIM 認証 ON) を実施するか

## DNS 現状 (dig 2026-05-14 確認)

| レコード | 設定状況 |
|---------|---------|
| MX | ✅ \`smtp.google.com\` (Workspace 受信稼働中) |
| SPF | ❌ \`v=spf1 ...\` なし |
| DKIM | ❌ \`google._domainkey\` / \`selector1._domainkey\` なし |
| DMARC | ❌ \`_dmarc\` レコードなし |

このまま Phase 2 実装すると Gmail/Outlook で spam 行き、Yahoo/Gmail の 2024-02 送信ガイドライン違反のリスクあり。

## 推奨手順

1. **本 ADR をレビュー → SMTP 選定の判断**
2. ユーザー側で DNS Step 1-5 を完了 (見積 30-60 分)
3. Workspace で \`lms-noreply@279279.net\` 発行
4. dig + Gmail 送信テストで SPF=pass / DKIM=pass / DMARC=pass を検証
5. 検証 PASS したら ADR-033 を Accepted に変更 + Phase 2 実装着手

## Test plan

- [x] dig コマンドで現状 DNS レコード未整備を確認
- [x] ADR 文体・ファイル名規約が ADR-032 までと一貫していること
- [ ] ユーザーレビュー後に Status: Proposed → Accepted に更新

## 関連

- ADR-032: Phase 1 採択 (PR #345 マージ済)
- Issue #346: Phase 2 起票
- memory: \`feedback_ismap_gcp_only.md\` (GCP 内完結方針)

🤖 Generated with [Claude Code](https://claude.com/claude-code)