### PR TITLE
fix(api): separate transient/permanent errors in GET /platform/auth-errors (503 vs 500)

### DIFF
--- a/docs/adr/ADR-031-gcip-multi-tenancy.md
+++ b/docs/adr/ADR-031-gcip-multi-tenancy.md
@@ -122,7 +122,8 @@ Firebase Authentication を Google Cloud Identity Platform（GCIP）のマルチ
 - ~~`platform_auth_error_logs` を **admin UI から参照する経路は未実装**。Phase 1 では Cloud Logging（`logger.warn/error` の構造化出力）経由で確認する前提~~
 - ~~`getPlatformAuthErrorLogs()` / super-admin 画面 UI は別 Issue で追加（PR #298 code-reviewer H1 指摘）~~
 - **Issue #299 で解消（2026-04-22）**: `DataSource.getPlatformAuthErrorLogs()` を I/F / Firestore / InMemory の 3 実装に追加し、`GET /api/v2/super/platform/auth-errors` (super-admin のみ) で admin API 経由の読み取りが可能になった。FE 管理画面 UI は引き続き別 Issue。Firestore 複合 index `(email ASC, occurredAt DESC)` を宣言し、`email` equality + `occurredAt` range/orderBy の組み合わせクエリに対応
-- `SuperAdminFirestoreUnavailableError` の transient (`unavailable`/`deadline-exceeded`) と permanent (`permission-denied` 等) の区別は現状未実装。すべて 503 を返すが、permanent は 500 相当（**Issue #310 で対応予定**。`/platform/auth-errors` も同じ事情で一律 500 `fetch_failed` を返す）
+- `SuperAdminFirestoreUnavailableError` の transient (`unavailable`/`deadline-exceeded`) と permanent (`permission-denied` 等) の区別は現状未実装。すべて 503 を返すが、permanent は 500 相当（middleware 側は別 Issue 残課題）
+- **Issue #310 で部分解消 (2026-05-14)**: `GET /api/v2/super/platform/auth-errors` catch 節で `classifyFirestoreError` を適用し、transient (UNAVAILABLE/DEADLINE_EXCEEDED/ABORTED/INTERNAL) → 503 `service_unavailable`、permanent → 500 `fetch_failed` に分離。`classifyFirestoreError` util も 2 種 → 4 種 transient code に拡張
 - `tenant-auth.ts:checkSuperAdmin` が `SuperAdminFirestoreUnavailableError` も false fallback に潰している点（Issue #293 の silent 権限剥奪を tenant 経路では部分的に残す）も別 Issue で対応
 
 ### UID保持戦略

--- a/services/api/src/routes/__tests__/super-admin-platform-auth-errors.test.ts
+++ b/services/api/src/routes/__tests__/super-admin-platform-auth-errors.test.ts
@@ -264,12 +264,94 @@ describe("GET /api/v2/super/platform/auth-errors (Issue #299)", () => {
     expect(logs[0].firebaseErrorCode).toBe("auth/id-token-revoked");
   });
 
-  it("DataSource 障害時は 500 fetch_failed を返す（evaluator 指摘）", async () => {
+  it("DataSource 障害 (code 属性なし) は 500 fetch_failed を返す", async () => {
     // super@example.com は env fast path で super-admin 判定される
-    // getPlatformAuthErrorLogs を reject させる
+    // code 属性なしの Error は permanent 扱い (classifyFirestoreError)
     const brokenDs = {
       ...ds,
       getPlatformAuthErrorLogs: vi.fn().mockRejectedValue(new Error("Firestore unavailable")),
+      createPlatformAuthErrorLog: ds.createPlatformAuthErrorLog.bind(ds),
+    } as unknown as InMemoryDataSource;
+
+    const app = await buildApp(brokenDs);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("fetch_failed");
+  });
+
+  // Issue #310: transient/permanent 分離
+  it("Issue #310: transient エラー (code: 14 UNAVAILABLE) は 503 service_unavailable を返す", async () => {
+    const brokenDs = {
+      ...ds,
+      getPlatformAuthErrorLogs: vi.fn().mockRejectedValue(Object.assign(new Error("Firestore unavailable"), { code: 14 })),
+      createPlatformAuthErrorLog: ds.createPlatformAuthErrorLog.bind(ds),
+    } as unknown as InMemoryDataSource;
+
+    const app = await buildApp(brokenDs);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("service_unavailable");
+    expect(res.body.message).toContain("一時的");
+  });
+
+  it('Issue #310: transient エラー (code: "deadline-exceeded") は 503 service_unavailable を返す', async () => {
+    const brokenDs = {
+      ...ds,
+      getPlatformAuthErrorLogs: vi.fn().mockRejectedValue(Object.assign(new Error("Deadline exceeded"), { code: "deadline-exceeded" })),
+      createPlatformAuthErrorLog: ds.createPlatformAuthErrorLog.bind(ds),
+    } as unknown as InMemoryDataSource;
+
+    const app = await buildApp(brokenDs);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("service_unavailable");
+  });
+
+  it('Issue #310: transient エラー (code: "aborted") は 503 service_unavailable を返す', async () => {
+    const brokenDs = {
+      ...ds,
+      getPlatformAuthErrorLogs: vi.fn().mockRejectedValue(Object.assign(new Error("Aborted"), { code: "aborted" })),
+      createPlatformAuthErrorLog: ds.createPlatformAuthErrorLog.bind(ds),
+    } as unknown as InMemoryDataSource;
+
+    const app = await buildApp(brokenDs);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("service_unavailable");
+  });
+
+  it('Issue #310: transient エラー (code: "internal") は 503 service_unavailable を返す', async () => {
+    const brokenDs = {
+      ...ds,
+      getPlatformAuthErrorLogs: vi.fn().mockRejectedValue(Object.assign(new Error("Internal"), { code: "internal" })),
+      createPlatformAuthErrorLog: ds.createPlatformAuthErrorLog.bind(ds),
+    } as unknown as InMemoryDataSource;
+
+    const app = await buildApp(brokenDs);
+    const res = await supertest(app)
+      .get("/api/v2/super/platform/auth-errors")
+      .set("X-User-Email", "super@example.com");
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("service_unavailable");
+  });
+
+  it('Issue #310: permanent エラー (code: "permission-denied") は 500 fetch_failed を返す', async () => {
+    const brokenDs = {
+      ...ds,
+      getPlatformAuthErrorLogs: vi.fn().mockRejectedValue(Object.assign(new Error("Permission denied"), { code: "permission-denied" })),
       createPlatformAuthErrorLog: ds.createPlatformAuthErrorLog.bind(ds),
     } as unknown as InMemoryDataSource;
 

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -920,22 +920,29 @@ router.get("/platform/auth-errors", async (req: Request, res: Response) => {
       })),
     });
   } catch (e) {
-    // Firestore 障害時のレスポンス形式を保証する（AC: 500 fetch_failed）。
-    // transient (UNAVAILABLE/DEADLINE_EXCEEDED) と permanent の分離は
-    // ADR-031 Phase 1 制約で別 Issue 対応予定。現状は一律 500 を返す。
-    // ログは errorType + firebaseErrorCode + 入力パラメータで再現性を確保する
-    // （`/admins/:email` DELETE と同等の構造化レベル）。
-    const err = e as { code?: string } | undefined;
+    // Issue #310: transient (UNAVAILABLE/DEADLINE_EXCEEDED/ABORTED/INTERNAL) は 503、
+    // permanent は 500 fetch_failed に分離する（rules/error-handling.md §3）。
+    const { grpcCode, isTransient } = classifyFirestoreError(e);
     logger.error("Failed to fetch platform auth error logs", {
-      errorType: "platform_auth_errors_fetch_failed",
+      errorType: isTransient
+        ? "platform_auth_errors_unavailable"
+        : "platform_auth_errors_fetch_failed",
       error: e instanceof Error ? e : new Error(String(e)),
-      firebaseErrorCode: typeof err?.code === "string" ? err.code : null,
+      grpcCode: grpcCode ?? null,
+      isTransient,
       operatorEmail: req.superAdmin?.email,
       filterEmail: email ?? null,
       filterStartDate: startDateStr ?? null,
       filterEndDate: endDateStr ?? null,
       filterLimit: limit,
     });
+    if (isTransient) {
+      res.status(503).json({
+        error: "service_unavailable",
+        message: TRANSIENT_RETRY_MESSAGE_JA,
+      });
+      return;
+    }
     res.status(500).json({
       error: "fetch_failed",
       message: "認証エラーログの取得に失敗しました。再度お試しください。",

--- a/services/api/src/utils/__tests__/grpc-errors.test.ts
+++ b/services/api/src/utils/__tests__/grpc-errors.test.ts
@@ -24,6 +24,28 @@ describe("classifyFirestoreError", () => {
     });
   });
 
+  it("数値形式 10 (ABORTED) → transient", () => {
+    expect(classifyFirestoreError({ code: 10 })).toEqual({ grpcCode: 10, isTransient: true });
+  });
+
+  it('文字列形式 "aborted" → transient', () => {
+    expect(classifyFirestoreError({ code: "aborted" })).toEqual({
+      grpcCode: "aborted",
+      isTransient: true,
+    });
+  });
+
+  it("数値形式 13 (INTERNAL) → transient", () => {
+    expect(classifyFirestoreError({ code: 13 })).toEqual({ grpcCode: 13, isTransient: true });
+  });
+
+  it('文字列形式 "internal" → transient', () => {
+    expect(classifyFirestoreError({ code: "internal" })).toEqual({
+      grpcCode: "internal",
+      isTransient: true,
+    });
+  });
+
   it("数値形式 7 (PERMISSION_DENIED) → permanent", () => {
     expect(classifyFirestoreError({ code: 7 })).toEqual({ grpcCode: 7, isTransient: false });
   });

--- a/services/api/src/utils/grpc-errors.ts
+++ b/services/api/src/utils/grpc-errors.ts
@@ -9,8 +9,15 @@
  * `code` を保持する。両形式の取りこぼしを防ぐため、両方を判定する。
  */
 
-const TRANSIENT_GRPC_CODES_NUMERIC = new Set<number>([14, 4]);
-const TRANSIENT_GRPC_CODES_STRING = new Set<string>(["unavailable", "deadline-exceeded"]);
+// transient (retry 可能): UNAVAILABLE(14), DEADLINE_EXCEEDED(4), ABORTED(10), INTERNAL(13)
+// ABORTED はトランザクション競合、INTERNAL は gRPC 内部一時障害で retry 可能（Issue #310）
+const TRANSIENT_GRPC_CODES_NUMERIC = new Set<number>([14, 4, 10, 13]);
+const TRANSIENT_GRPC_CODES_STRING = new Set<string>([
+  "unavailable",
+  "deadline-exceeded",
+  "aborted",
+  "internal",
+]);
 
 export function classifyFirestoreError(err: unknown): {
   grpcCode: number | string | undefined;


### PR DESCRIPTION
## Summary

`GET /api/v2/super/platform/auth-errors` の Firestore 障害時のレスポンスを transient/permanent で分離する (Issue #310)。

- transient (UNAVAILABLE/DEADLINE_EXCEEDED/ABORTED/INTERNAL) → **503** \`service_unavailable\`
- permanent (PERMISSION_DENIED 等) → **500** \`fetch_failed\` (既存)

これにより \`rules/error-handling.md §3\` の transient/permanent 分類原則を満たし、UI が「retry すべきか permanent failure か」判断可能になる。

## Acceptance Criteria (Issue #310)

- [x] \`isTransientFirestoreError\` util (実装名 \`classifyFirestoreError\`) が 4 つの transient code をカバー (UNAVAILABLE/DEADLINE_EXCEEDED/ABORTED/INTERNAL)
- [x] \`/platform/auth-errors\` transient → 503、permanent → 500
- [x] 503 レスポンス body は既存 \`/admins/:email\` DELETE と schema 一致 (\`error: "service_unavailable"\`, \`message: TRANSIENT_RETRY_MESSAGE_JA\`)
- [x] 統合テスト追加 (transient: 14 / "deadline-exceeded" / "aborted" / "internal" 各 1 件、permanent: "permission-denied" 1 件)
- [x] ADR-031 Phase 1 制約の該当項目を close マーク

## 変更ファイル (5)

| ファイル | 変更内容 |
|---|---|
| \`services/api/src/utils/grpc-errors.ts\` | transient code を 2 種 → 4 種に拡張 |
| \`services/api/src/routes/super-admin.ts\` | \`/platform/auth-errors\` catch 節を \`classifyFirestoreError\` で分岐 |
| \`services/api/src/utils/__tests__/grpc-errors.test.ts\` | ABORTED/INTERNAL のテスト 4 件追加 |
| \`services/api/src/routes/__tests__/super-admin-platform-auth-errors.test.ts\` | transient (4 件) / permanent (1 件) のテスト 5 件追加 |
| \`docs/adr/ADR-031-gcip-multi-tenancy.md\` | Phase 1 制約「Issue #310 で対応予定」を「部分解消 (2026-05-14)」に更新 |

## 影響範囲

\`classifyFirestoreError\` を利用する他箇所 (\`super-admin.ts\` L1561/L1644/L1698, \`tenants.ts\` L450, \`progress-pdf.ts\`) でも ABORTED/INTERNAL が transient 扱いに変化する。これらの箇所は元々 transient → 503 / permanent → 500 の分離を実装済みのため、ABORTED (transaction 競合) / INTERNAL (gRPC 内部一時障害) で 500 → 503 に挙動変化する。retry 可能な状況で 503 を返すのは適切な挙動改善 (UX 向上)。

回帰テスト: vitest 全 1380 件 PASS。

## スコープ外 (本 PR では扱わない)

- L317 \`super-admin.ts\` POST /tenants の旧 inline パターン \`grpcCode === 14 || 4\` を \`classifyFirestoreError\` に置換 (別 Issue で検討)
- \`SuperAdminFirestoreUnavailableError\` middleware 側の transient/permanent 分離 (ADR-031 別残課題)

## Test plan

- [x] \`npm run lint\` PASS
- [x] \`npm run type-check -w @lms-279/api\` PASS
- [x] \`vitest run\` 1380 tests PASS (回帰なし)
- [x] grpc-errors.test.ts 12 tests (新 4 件含む) PASS
- [x] super-admin-platform-auth-errors.test.ts 17 tests (新 5 件含む) PASS

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)