### PR TITLE
fix(api): unify POST /tenants transaction error classification via classifyFirestoreError

### DIFF
--- a/services/api/src/routes/__tests__/super-admin-tenants-gcip.test.ts
+++ b/services/api/src/routes/__tests__/super-admin-tenants-gcip.test.ts
@@ -423,3 +423,88 @@ describe("POST /api/v2/super/tenants — GCIP 初期値 (Issue #312)", () => {
     expect(tenantMetadata.useGcip).toBe(false);
   });
 });
+
+describe("POST /api/v2/super/tenants — transaction transient/permanent 分離 (Issue #310 follow-up)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("AUTH_MODE", "dev");
+    vi.stubEnv("SUPER_ADMIN_EMAILS", "super@example.com");
+    mockTransactionCreate.mockReset();
+    mockTransactionSet.mockReset();
+    mockRunTransaction.mockReset();
+    mockSuperAdminsCollectionGet.mockResolvedValue({ docs: [] });
+    mockTenantDocGet.mockResolvedValue({ exists: false });
+    mockGetUserByEmail.mockRejectedValue(new Error("not found"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("transient エラー (code: 14 UNAVAILABLE) は 503 transaction_failed を返す", async () => {
+    mockRunTransaction.mockRejectedValueOnce(Object.assign(new Error("Firestore unavailable"), { code: 14 }));
+
+    const app = await buildApp();
+    const res = await supertest(app)
+      .post("/api/v2/super/tenants")
+      .set("X-User-Email", "super@example.com")
+      .send({ name: "New Tenant", ownerEmail: "owner@example.com" });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("transaction_failed");
+    expect(res.body.message).toContain("一時的");
+  });
+
+  it('transient エラー (code: "aborted") は 503 transaction_failed を返す (Issue #310 拡張)', async () => {
+    mockRunTransaction.mockRejectedValueOnce(Object.assign(new Error("Aborted"), { code: "aborted" }));
+
+    const app = await buildApp();
+    const res = await supertest(app)
+      .post("/api/v2/super/tenants")
+      .set("X-User-Email", "super@example.com")
+      .send({ name: "New Tenant", ownerEmail: "owner@example.com" });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("transaction_failed");
+  });
+
+  it('transient エラー (code: "internal") は 503 transaction_failed を返す (Issue #310 拡張)', async () => {
+    mockRunTransaction.mockRejectedValueOnce(Object.assign(new Error("Internal"), { code: "internal" }));
+
+    const app = await buildApp();
+    const res = await supertest(app)
+      .post("/api/v2/super/tenants")
+      .set("X-User-Email", "super@example.com")
+      .send({ name: "New Tenant", ownerEmail: "owner@example.com" });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("transaction_failed");
+  });
+
+  it('permanent エラー (code: "permission-denied") は 500 transaction_failed を返す', async () => {
+    mockRunTransaction.mockRejectedValueOnce(Object.assign(new Error("Permission denied"), { code: "permission-denied" }));
+
+    const app = await buildApp();
+    const res = await supertest(app)
+      .post("/api/v2/super/tenants")
+      .set("X-User-Email", "super@example.com")
+      .send({ name: "New Tenant", ownerEmail: "owner@example.com" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("transaction_failed");
+    expect(res.body.message).toContain("エラーが発生");
+  });
+
+  it("code 属性なしのエラーは 500 transaction_failed を返す (permanent fallback)", async () => {
+    mockRunTransaction.mockRejectedValueOnce(new Error("Unknown failure"));
+
+    const app = await buildApp();
+    const res = await supertest(app)
+      .post("/api/v2/super/tenants")
+      .set("X-User-Email", "super@example.com")
+      .send({ name: "New Tenant", ownerEmail: "owner@example.com" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("transaction_failed");
+  });
+});

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -314,22 +314,21 @@ router.post("/tenants", async (req: Request, res: Response) => {
       }
     });
   } catch (txError) {
-    const grpcCode = (txError as { code?: number })?.code;
-    const isTransient = grpcCode === 14 || grpcCode === 4;
+    const { grpcCode, isTransient } = classifyFirestoreError(txError);
 
     logger.error("Tenant creation transaction failed", {
       error: txError instanceof Error ? txError : new Error(String(txError)),
       tenantId,
       ownerEmail: normalizedOwnerEmail,
       operatorEmail: req.superAdmin?.email,
-      grpcCode,
+      grpcCode: grpcCode ?? null,
       isTransient,
     });
 
     res.status(isTransient ? 503 : 500).json({
       error: "transaction_failed",
       message: isTransient
-        ? "サーバーが一時的に利用できません。数秒後に再度お試しください。"
+        ? TRANSIENT_RETRY_MESSAGE_JA
         : "テナントの作成中にエラーが発生しました。",
     });
     return;


### PR DESCRIPTION
## Summary

PR #352 (Issue #310) の silent-failure-hunter Important #1 + code-reviewer 確認による follow-up。

L317 旧 inline パターン \`grpcCode === 14 || grpcCode === 4\` を \`classifyFirestoreError\` に置換し、他 6 callsite と分類ロジックを統一する。これで全 7 callsite で transient/permanent 分類が同形になる。

## 変更ファイル (2)

| ファイル | 変更内容 |
|---|---|
| \`services/api/src/routes/super-admin.ts\` | POST /tenants transaction catch (L316-) を \`classifyFirestoreError\` で置換、message を \`TRANSIENT_RETRY_MESSAGE_JA\` 定数に統一 |
| \`services/api/src/routes/__tests__/super-admin-tenants-gcip.test.ts\` | 新規 describe で transient (code: 14, "aborted", "internal") / permanent (code: "permission-denied", code なし) の統合テスト 5 件追加 |

## 影響

- **ABORTED (10) / INTERNAL (13) で 500 → 503 に挙動変化** (PR #352 で util を 4 種 transient に拡張済のため自動波及)
  - ABORTED = transaction 競合、retry 可能
  - INTERNAL = gRPC 内部一時障害、Firestore SDK 内部 retry config でも retryable と定義
- **UX 一貫性**: 全 7 callsite で transient → 503 / permanent → 500 が完全に統一
  - \`auth-errors\` (PR #352), \`super-admin.ts\` L1568/L1651/L1705, \`tenants.ts\` L450, \`progress-pdf.ts\` L179 と同形に
- 既存挙動 (UNAVAILABLE=14 / DEADLINE_EXCEEDED=4) は変化なし

## Test plan

- [x] \`npm run lint\` PASS
- [x] \`npm run type-check -w @lms-279/api\` PASS
- [x] \`vitest run\` 1385 tests PASS (新規 5 件含む、回帰なし)
- [x] super-admin-tenants-gcip.test.ts 16 tests PASS

## レビュー指摘との対応

- silent-failure-hunter Important #1 (PR #352): "L317 旧パターンが \`classifyFirestoreError\` と乖離、UI 側 retry 判定が endpoint ごとに不揃い" → **本 PR で解消**
- code-reviewer (PR #352): "全 6 callsite は安全に同形、L317 のみ outlier" → **本 PR で 7 callsite 全統一**

🤖 Generated with [Claude Code](https://claude.com/claude-code)