### PR TITLE
perf(auth): skip Firestore super-admin lookup in dev mode (Issue #308)

### DIFF
--- a/services/api/src/middleware/__tests__/super-admin-firestore-failure.test.ts
+++ b/services/api/src/middleware/__tests__/super-admin-firestore-failure.test.ts
@@ -172,7 +172,10 @@ describe("superAdminAuthMiddleware (dev mode) — Issue #293: Firestore fail-clo
     expect(res.body.superAdmin.email).toBe("env-admin@example.com");
   });
 
-  it("env 未登録 + Firestore 障害は 503 (dev mode でも silent 403 を防ぐ)", async () => {
+  it("env 未登録は 403 (Issue #308: dev mode は env-only、Firestore lookup スキップ)", async () => {
+    // Issue #308: AUTH_MODE=dev では Firestore credentials を持たない CI 環境で
+    // SDK の deadline 待ちが ~7-9 秒積み上がるため、env 未登録時は Firestore を
+    // 引かず即 false 判定する。本番運用は AUTH_MODE=firebase 必須 (Issue #290)。
     const { app } = await buildApp();
     mockFirestoreGet.mockRejectedValue(new Error("UNAVAILABLE: Firestore down"));
 
@@ -180,9 +183,10 @@ describe("superAdminAuthMiddleware (dev mode) — Issue #293: Firestore fail-clo
       .get("/me")
       .set("x-user-email", "firestore-admin@example.com");
 
-    expect(res.status).toBe(503);
-    expect(res.body.error).toBe("service_unavailable");
-    expect(res.body.message).toContain("一時的に利用できません");
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain("スーパー管理者権限が必要です");
+    // Firestore lookup は呼ばれない (dev mode は env-only)
+    expect(mockFirestoreGet).not.toHaveBeenCalled();
   });
 
   it("Firestore 正常 + 非 super-admin は 403（既存挙動の回帰防止）", async () => {
@@ -199,6 +203,9 @@ describe("superAdminAuthMiddleware (dev mode) — Issue #293: Firestore fail-clo
 describe("isSuperAdmin (unit) — Issue #293: Firestore throw contract", () => {
   beforeEach(() => {
     vi.resetModules();
+    // Issue #293 の throw contract は AUTH_MODE=firebase で発火する
+    // (Issue #308 で dev mode は env-only に確定、Firestore lookup スキップ)
+    vi.stubEnv("AUTH_MODE", "firebase");
     vi.stubEnv("SUPER_ADMIN_EMAILS", "env-admin@example.com");
     mockFirestoreGet.mockReset();
   });
@@ -249,5 +256,46 @@ describe("isSuperAdmin (unit) — Issue #293: Firestore throw contract", () => {
       expect(e.cause).toBe(firestoreErr);
       expect(e.message).toContain("SUPER_ADMIN_FIRESTORE_UNAVAILABLE");
     }
+  });
+});
+
+describe("isSuperAdmin (unit) — Issue #308: dev mode skips Firestore lookup", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("AUTH_MODE", "dev");
+    vi.stubEnv("SUPER_ADMIN_EMAILS", "env-admin@example.com");
+    mockFirestoreGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("env 登録済みなら true を返し、Firestore は引かない（高速パス）", async () => {
+    const { isSuperAdmin } = await import("../super-admin.js");
+    mockFirestoreGet.mockRejectedValue(new Error("UNAVAILABLE: Firestore down"));
+
+    await expect(isSuperAdmin("env-admin@example.com")).resolves.toBe(true);
+    expect(mockFirestoreGet).not.toHaveBeenCalled();
+  });
+
+  it("env 未登録なら false を返し、Firestore は引かない（CI E2E perf: 9秒タイムアウト解消）", async () => {
+    const { isSuperAdmin } = await import("../super-admin.js");
+    // Firestore が UNAVAILABLE で reject するように設定しても、lookup 自体されないので影響なし
+    mockFirestoreGet.mockRejectedValue(new Error("UNAVAILABLE: Firestore down"));
+
+    await expect(isSuperAdmin("unknown@example.com")).resolves.toBe(false);
+    expect(mockFirestoreGet).not.toHaveBeenCalled();
+  });
+
+  it("env 未登録なら Firestore 正常応答でも false を返す（dev mode は env-only）", async () => {
+    const { isSuperAdmin } = await import("../super-admin.js");
+    // Firestore に登録があっても無視される (env-only 設計)
+    mockFirestoreGet.mockResolvedValue({
+      docs: [{ id: "firestore-only-admin@example.com" }],
+    });
+
+    await expect(isSuperAdmin("firestore-only-admin@example.com")).resolves.toBe(false);
+    expect(mockFirestoreGet).not.toHaveBeenCalled();
   });
 });

--- a/services/api/src/middleware/super-admin.ts
+++ b/services/api/src/middleware/super-admin.ts
@@ -194,6 +194,13 @@ export async function getSuperAdminsFromFirestore(): Promise<string[]> {
  * env フォールバックに載っている場合は Firestore アクセスなしで true を返す（高速パス）。
  * Firestore 障害時は SuperAdminFirestoreUnavailableError を throw するため、
  * 呼び出し側で catch して 503 として返却する必要がある。
+ *
+ * AUTH_MODE=dev では Firestore lookup をスキップ (Issue #308 / ADR-031 延長):
+ *   本番運用は AUTH_MODE=firebase が必須 (Issue #290 で起動時 assert 済) で、
+ *   dev mode は env-only のフォールバック構成。dev mode で Firestore credentials が
+ *   存在しないと SDK の deadline 待ち (~7-9 秒) でリクエスト遅延が積み上がる。
+ *   CI E2E では毎 request この遅延が出ていたため、dev mode では env チェック後
+ *   即 false return して Firestore lookup を回避する。
  */
 export async function isSuperAdmin(email: string | undefined): Promise<boolean> {
   if (!email) return false;
@@ -202,6 +209,11 @@ export async function isSuperAdmin(email: string | undefined): Promise<boolean> 
   // 環境変数でチェック（高速パス。Firestore 障害でも通過する）
   if (envSuperAdminEmails.includes(normalizedEmail)) {
     return true;
+  }
+
+  // AUTH_MODE=dev では Firestore lookup をスキップ (env-only フォールバック構成)
+  if (authMode !== "firebase") {
+    return false;
   }
 
   // Firestore でチェック（障害時は throw → 呼び出し側で 503）


### PR DESCRIPTION
## Summary

E2E CI で 1 request 7-9 秒の遅延を根本解消する。

**根本原因**: `isSuperAdmin()` が AUTH_MODE=dev でも env 非登録 user に対し Firestore lookup を実行し、CI 環境では credentials 不在のため SDK の deadline 待ちで毎 request ~9 秒タイムアウト → `SuperAdminFirestoreUnavailableError` → `tenant-auth.ts:checkSuperAdmin` catch → tenant role 続行という流れ。機能影響はなかったが、`attendance-api.spec.ts` は ~5.6 分要していた。

E2E ログ (CI run 25829580319):
\`\`\`
[WebServer] {"level":"error","message":"Super admin check failed, proceeding with tenant role","email":"student1@demo.example.com","error":"SUPER_ADMIN_FIRESTORE_UNAVAILABLE: unknown"}
\`\`\`
が 7-9 秒間隔で 40 件以上連続出力。

## Changes

### `services/api/src/middleware/super-admin.ts`
- \`isSuperAdmin\` に AUTH_MODE 分岐追加: \`authMode !== "firebase"\` の場合、env チェック後即 \`false\` を返し Firestore lookup を回避。
- JSDoc に Issue #308 / ADR-031 延長として「dev mode は env-only フォールバック構成」を明文化。
- 本番運用は AUTH_MODE=firebase 必須化済 (Issue #290 で起動時 assert)、本番挙動は不変。

### `services/api/src/middleware/__tests__/super-admin-firestore-failure.test.ts`
- L175-186 dev mode テスト更新: \`503 (Firestore 障害)\` → \`403 (Firestore lookup スキップ)\` + \`mockFirestoreGet.not.toHaveBeenCalled()\` 追加。
- Issue #293 unit test ブロック (\`isSuperAdmin throw contract\`) に \`AUTH_MODE=firebase\` stub を明示追加。これまでは AUTH_MODE 未設定で実装 default の dev で動いていた潜在不整合を解消。
- Issue #308 unit test ブロックを新規追加 (3 件): env 登録 / env 未登録 + Firestore 障害 / env 未登録 + Firestore 正常 すべて Firestore lookup スキップを検証。

## 挙動変更

| シナリオ | Before | After |
|---|---|---|
| AUTH_MODE=dev + env 登録 super-admin | 200 (高速パス) | 200 (高速パス) ✓ 不変 |
| AUTH_MODE=dev + env 未登録 + Firestore 正常 + Firestore 登録あり | 200 | **403** ⚠️ |
| AUTH_MODE=dev + env 未登録 + Firestore 障害 | 503 (Issue #293) | **403** ⚠️ |
| AUTH_MODE=firebase + env 登録 super-admin | 200 (高速パス) | 200 (高速パス) ✓ 不変 |
| AUTH_MODE=firebase + env 未登録 + Firestore 正常 + Firestore 登録あり | 200 | 200 ✓ 不変 |
| AUTH_MODE=firebase + env 未登録 + Firestore 障害 | 503 | 503 ✓ 不変 (Issue #293) |

⚠️ dev mode の Firestore lookup 経路は本番運用では使われない (Issue #290 で AUTH_MODE=firebase 必須化済)。dev mode で Firestore に super-admin を登録する運用は標準的でなく、env-only が本来の設計。

## Quality Gate

| Gate | Result |
|---|---|
| \`npm run lint\` | ✅ PASS |
| \`npm run type-check\` | ✅ PASS (4 workspaces) |
| \`npm run test -w @lms-279/api\` | ✅ 704 PASS (新規 +3) |
| 影響範囲 | 2 ファイル (\`/simplify\` 不要) |

## Test plan

- [x] lint / type-check / API test 全 PASS
- [x] super-admin-firestore-failure.test.ts 13 件 PASS (Issue #293 + #308)
- [ ] **マージ後**: CI E2E 実測で \`attendance-api.spec.ts\` 実行時間が \`5.6m → ~30s\` 程度に短縮されることを確認
- [ ] **後続 PR で検討**: PR #307 の \`playwright timeout 180000\` を \`60000\` に戻せるか

## AC 達成状況 (Issue #308)

- [x] 1 request あたり Firestore タイムアウト分 (~9秒) を解消、ms 単位に短縮見込み
- [ ] PR #307 timeout 180000 → 60000: 後続 PR で実測後に対応
- [-] allowlist lookup O(1) 化: 本 PR の修正で 9 秒遅延の主因は除去された。allowlist O(n) 自体は demo データ件数 ≪ 100 件で実害なし。残作業として後続化、優先度 low。

## Related

- Issue #308 (E2E perf 根本調査)
- Issue #290 (AUTH_MODE=firebase 本番必須化、起動時 assert)
- Issue #293 (Firestore fail-closed 503)
- ADR-031 (GCIP マルチテナンシー)
- PR #307 (playwright timeout 暫定拡大、本 PR で巻き戻し検討)
- PR #284 (allowed_emails 継続的認可境界)

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)