### PR TITLE
refactor(audit): extract pure functions and strengthen types (Issue #281)

### DIFF
--- a/scripts/audit-users-vs-allowed-emails.ts
+++ b/scripts/audit-users-vs-allowed-emails.ts
@@ -36,99 +36,40 @@
  *   SUPER_ADMIN_EMAILS              スーパー管理者メール（カンマ区切り）
  */
 
-import {
-  initializeApp,
-  cert,
-  getApps,
-  type ServiceAccount,
-} from "firebase-admin/app";
+import { initializeApp, cert, getApps } from "firebase-admin/app";
 import { getAuth } from "firebase-admin/auth";
-import { getFirestore, type WriteBatch } from "firebase-admin/firestore";
+import { getFirestore } from "firebase-admin/firestore";
 import {
   planAudit,
   buildAuditFixNote,
+  planApplyFix,
+  mergeSuperAdmins,
+  parseAuditArgs,
+  detectDuplicateUsers,
+  toNormalizedEmail,
+  HelpRequestedError,
   type AuditUserInput,
   type AuditAllowedEmailInput,
   type AuditReport,
+  type CliOptions,
+  type NormalizedEmail,
 } from "../services/api/src/services/allowed-email-audit.js";
 import { toISOOptional } from "../services/api/src/datasource/firestore.js";
-
-type CliOptions = {
-  fix: boolean;
-  execute: boolean;
-  skipAuthMetadata: boolean;
-  tenantFilter: string | null;
-  extraSuperAdmins: string[];
-};
-
-function parseArgs(argv: string[]): CliOptions {
-  const options: CliOptions = {
-    fix: false,
-    execute: false,
-    skipAuthMetadata: false,
-    tenantFilter: null,
-    extraSuperAdmins: [],
-  };
-
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    switch (arg) {
-      case "--fix":
-        options.fix = true;
-        break;
-      case "--execute":
-        options.execute = true;
-        break;
-      case "--skip-auth-metadata":
-        options.skipAuthMetadata = true;
-        break;
-      case "--tenant": {
-        const val = argv[++i];
-        if (!val) throw new Error("--tenant の値が指定されていません");
-        options.tenantFilter = val;
-        break;
-      }
-      case "--super-admins": {
-        const val = argv[++i];
-        if (!val) throw new Error("--super-admins の値が指定されていません");
-        options.extraSuperAdmins = val
-          .split(",")
-          .map((s) => s.trim())
-          .filter((s) => s.length > 0);
-        break;
-      }
-      case "--help":
-      case "-h":
-        console.log(
-          "使い方は scripts/audit-users-vs-allowed-emails.ts 冒頭のコメントを参照してください。"
-        );
-        process.exit(0);
-      // eslint-disable-next-line no-fallthrough
-      default:
-        // `--tenant` を忘れて位置引数だけ渡すと全テナント走査に巻き込まれる事故を防ぐため、
-        // 未知の引数（オプション形式でないものも含む）は明示的にエラーにする。
-        throw new Error(`未知の引数: ${arg}`);
-    }
-  }
-
-  return options;
-}
 
 function initializeFirebase(): void {
   if (getApps().length > 0) return;
 
   const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
   if (credPath) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const serviceAccount = require(credPath) as ServiceAccount;
-    initializeApp({ credential: cert(serviceAccount) });
+    // Issue #281: require(credPath) 撤廃。firebase-admin の cert は string パスも受け取れる。
+    initializeApp({ credential: cert(credPath) });
   } else {
     initializeApp();
   }
 }
 
 type SuperAdminsResult = {
-  emails: string[];
+  emails: NormalizedEmail[];
   firestoreFetchFailed: boolean;
 };
 
@@ -142,26 +83,22 @@ type SuperAdminsResult = {
  *
  * strict=false（dry-run 時）の場合は続行するが、firestoreFetchFailed フラグを立てて
  * 呼び出し側がレポート冒頭・Summary 両方に警告を出せるようにする。
+ *
+ * Issue #281: union 計算は純粋関数 mergeSuperAdmins に分離済。本関数は Firestore 取得の
+ * 副作用と strict mode の判定のみを担う。
  */
 async function collectSuperAdmins(
   extra: string[],
   strict: boolean
 ): Promise<SuperAdminsResult> {
-  const result = new Set<string>();
-  let firestoreFetchFailed = false;
-
   const envCsv = process.env.SUPER_ADMIN_EMAILS ?? "";
-  for (const email of envCsv.split(",")) {
-    const n = email.trim().toLowerCase();
-    if (n) result.add(n);
-  }
+  let firestoreEmails: string[] = [];
+  let firestoreFetchFailed = false;
 
   try {
     const db = getFirestore();
     const snapshot = await db.collection("superAdmins").get();
-    for (const doc of snapshot.docs) {
-      result.add(doc.id.toLowerCase());
-    }
+    firestoreEmails = snapshot.docs.map((doc) => doc.id);
   } catch (error) {
     if (strict) {
       throw new Error(
@@ -174,12 +111,10 @@ async function collectSuperAdmins(
     );
   }
 
-  for (const email of extra) {
-    const n = email.trim().toLowerCase();
-    if (n) result.add(n);
-  }
-
-  return { emails: Array.from(result).sort(), firestoreFetchFailed };
+  return {
+    emails: mergeSuperAdmins(envCsv, firestoreEmails, extra),
+    firestoreFetchFailed,
+  };
 }
 
 type AuthMetadataEnrichment = {
@@ -303,12 +238,6 @@ function printTenantReport(tenantId: string, report: AuditReport): void {
   }
 }
 
-/**
- * Firestore WriteBatch の上限は 500 件/commit。
- * 未定義動作を避けるため安全マージンを取って 450 件で切り替える。
- */
-const WRITE_BATCH_LIMIT = 450;
-
 type ApplyFixResult = {
   applied: number;
   skippedExisting: number;
@@ -324,6 +253,10 @@ type ApplyFixResult = {
  * アトミシティ:
  *   WriteBatch で束ねてコミットすることで、ネットワーク往復の削減と
  *   同一バッチ内の原子性を確保する（Firestore は 500 件/commit 上限）。
+ *
+ * Issue #281: 重複ガード + バッチ分割計画は純粋関数 planApplyFix に分離済。
+ * 本関数は Firestore IO (既存 allowed_emails 取得 + WriteBatch コミット) と
+ * 進捗ログ出力のみを担う。
  */
 async function applyFix(
   tenantId: string,
@@ -340,124 +273,79 @@ async function applyFix(
   const currentSnap = await db
     .collection(`tenants/${tenantId}/allowed_emails`)
     .get();
-  const existingEmails = new Set<string>();
+  const existingEmails: NormalizedEmail[] = [];
   for (const doc of currentSnap.docs) {
-    const email = doc.data().email;
-    if (typeof email === "string") {
-      const n = email.trim().toLowerCase();
-      if (n) existingEmails.add(n);
-    }
+    const n = toNormalizedEmail(doc.data().email);
+    if (n !== null) existingEmails.push(n);
   }
 
-  const pendingBatches: WriteBatch[] = [];
-  const pendingBatchEmails: string[][] = [];
-  let currentBatch = db.batch();
-  let currentBatchEmails: string[] = [];
-  let opCount = 0;
-  let applied = 0;
-  let skippedExisting = 0;
+  const plan = planApplyFix(report, existingEmails);
 
-  // entry.email は planAudit が normalizeEmail で正規化した値。
-  // existingEmails 側も同じ規則で正規化済みのため、直接比較してよい。
-  for (const entry of report.usersWithoutAllowedEmail) {
-    if (existingEmails.has(entry.email)) {
-      console.log(
-        `[SKIP EXISTING] tenant=${tenantId} email=${entry.email} (既に allowed_emails に存在)`
-      );
-      skippedExisting++;
-      continue;
-    }
-
+  for (const email of plan.toSkip) {
     console.log(
-      `[FIX] tenant=${tenantId} add allowed_email email=${entry.email} userId=${entry.userId}`
+      `[SKIP EXISTING] tenant=${tenantId} email=${email} (既に allowed_emails に存在)`
     );
+  }
+  for (const email of plan.toAdd) {
+    console.log(`[FIX] tenant=${tenantId} add allowed_email email=${email}`);
+  }
 
-    if (execute) {
+  if (!execute) {
+    return { applied: 0, skippedExisting: plan.toSkip.length };
+  }
+
+  for (let i = 0; i < plan.batches.length; i++) {
+    const batchEmails = plan.batches[i];
+    const writeBatch = db.batch();
+    for (const email of batchEmails) {
       const ref = db.collection(`tenants/${tenantId}/allowed_emails`).doc();
-      currentBatch.set(ref, {
-        email: entry.email,
-        note,
-        createdAt: new Date(),
-      });
-      currentBatchEmails.push(entry.email);
-      opCount++;
-      applied++;
-      existingEmails.add(entry.email); // 同一 run 内での重複防止
-
-      if (opCount >= WRITE_BATCH_LIMIT) {
-        pendingBatches.push(currentBatch);
-        pendingBatchEmails.push(currentBatchEmails);
-        currentBatch = db.batch();
-        currentBatchEmails = [];
-        opCount = 0;
-      }
+      writeBatch.set(ref, { email, note, createdAt: new Date() });
     }
-  }
-
-  if (execute && opCount > 0) {
-    pendingBatches.push(currentBatch);
-    pendingBatchEmails.push(currentBatchEmails);
-  }
-
-  for (let i = 0; i < pendingBatches.length; i++) {
     try {
-      await pendingBatches[i].commit();
+      await writeBatch.commit();
     } catch (error) {
-      const remaining = pendingBatches.length - i - 1;
-      const failedEmails = pendingBatchEmails[i].join(", ");
+      const remaining = plan.batches.length - i - 1;
       console.error(
-        `[BATCH FAILED] tenant=${tenantId} batch=${i + 1}/${pendingBatches.length}\n` +
-        `  committed so far: ${i} batch(es)\n` +
-        `  failed batch emails (${pendingBatchEmails[i].length} 件): ${failedEmails}\n` +
-        `  remaining batches: ${remaining} (not attempted)\n` +
-        `  再実行時は skippedExisting で冪等。失敗原因を解消してから再実行してください。\n` +
-        `  error: ${String(error)}`
+        `[BATCH FAILED] tenant=${tenantId} batch=${i + 1}/${plan.batches.length}\n` +
+          `  committed so far: ${i} batch(es)\n` +
+          `  failed batch emails (${batchEmails.length} 件): ${batchEmails.join(", ")}\n` +
+          `  remaining batches: ${remaining} (not attempted)\n` +
+          `  再実行時は skippedExisting で冪等。失敗原因を解消してから再実行してください。\n` +
+          `  error: ${String(error)}`
       );
       throw error;
     }
   }
 
-  return { applied, skippedExisting };
+  return { applied: plan.toAdd.length, skippedExisting: plan.toSkip.length };
 }
 
 /**
  * 同一 email を持つ users レコードが複数ある場合に警告を出す。
  * planAudit は最初の 1 件のみ採用して後続を無視するため、実態の把握には
  * 事前にこの警告を出すことが重要（Evaluator エッジケース指摘）。
+ *
+ * Issue #281: 検出ロジックは純粋関数 detectDuplicateUsers に分離済。
+ * 本関数は console.warn の副作用のみを担う。
  */
 function warnDuplicateUsers(
   tenantId: string,
   rawUsers: AuditUserInput[]
 ): void {
-  const byEmail = new Map<string, string[]>();
-  for (const u of rawUsers) {
-    const n = (u.email ?? "").trim().toLowerCase();
-    if (!n) continue;
-    const ids = byEmail.get(n) ?? [];
-    ids.push(u.id);
-    byEmail.set(n, ids);
-  }
-  for (const [email, ids] of byEmail) {
-    if (ids.length > 1) {
-      console.warn(
-        `⚠️  [DUPLICATE USERS] tenant=${tenantId} email=${email} userIds=${ids.join(",")} (2件目以降は planAudit で無視されます)`
-      );
-    }
+  for (const dup of detectDuplicateUsers(rawUsers)) {
+    console.warn(
+      `⚠️  [DUPLICATE USERS] tenant=${tenantId} email=${dup.email} userIds=${dup.userIds.join(",")} (2件目以降は planAudit で無視されます)`
+    );
   }
 }
 
 async function main(options: CliOptions): Promise<void> {
-  if (options.execute && !options.fix) {
-    throw new Error(
-      "--execute は --fix と併用する必要があります。補正なしの dry-run なら --execute を外してください。"
-    );
-  }
-
   initializeFirebase();
   const db = getFirestore();
 
-  const writeMode = options.fix && options.execute;
-  const header = `=== audit-users-vs-allowed-emails (${writeMode ? "EXECUTE" : "DRY-RUN"}${options.fix ? " + FIX" : ""}) ===`;
+  const writeMode = options.mode.kind === "fix-execute";
+  const fixMode = options.mode.kind !== "dry-run";
+  const header = `=== audit-users-vs-allowed-emails (${writeMode ? "EXECUTE" : "DRY-RUN"}${fixMode ? " + FIX" : ""}) ===`;
   console.log(header);
   console.log(`Issue: #279`);
   console.log(`Date : ${new Date().toISOString()}`);
@@ -520,6 +408,7 @@ async function main(options: CliOptions): Promise<void> {
           firebaseUid: (data.firebaseUid as string | undefined) ?? undefined,
           role: (data.role as string | undefined) ?? "student",
           createdAt: toISOOptional(data.createdAt) ?? "unknown",
+          lastSignInTime: null,
         };
       });
 
@@ -559,12 +448,12 @@ async function main(options: CliOptions): Promise<void> {
         tenantsWithDiff.push(tenantId);
       }
 
-      if (options.fix) {
+      if (fixMode) {
         const { applied, skippedExisting } = await applyFix(
           tenantId,
           report,
           note,
-          options.execute
+          writeMode
         );
         totalApplied += applied;
         totalSkippedExisting += skippedExisting;
@@ -621,8 +510,8 @@ async function main(options: CliOptions): Promise<void> {
     }
   }
 
-  if (options.fix) {
-    if (options.execute) {
+  if (fixMode) {
+    if (writeMode) {
       console.log(`allowed_emails added (executed): ${totalApplied}`);
       console.log(`skipped (already existed)      : ${totalSkippedExisting}`);
     } else {
@@ -647,12 +536,18 @@ const isMain =
 
 if (isMain) {
   try {
-    const options = parseArgs(process.argv.slice(2));
+    const options = parseAuditArgs(process.argv.slice(2));
     main(options).catch((err) => {
       console.error("audit-users-vs-allowed-emails failed:", err);
       process.exit(1);
     });
   } catch (err) {
+    if (err instanceof HelpRequestedError) {
+      console.log(
+        "使い方は scripts/audit-users-vs-allowed-emails.ts 冒頭のコメントを参照してください。"
+      );
+      process.exit(0);
+    }
     console.error((err as Error).message);
     process.exit(2);
   }

--- a/scripts/audit-users-vs-allowed-emails.ts
+++ b/scripts/audit-users-vs-allowed-emails.ts
@@ -61,7 +61,7 @@ function initializeFirebase(): void {
 
   const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
   if (credPath) {
-    // Issue #281: require(credPath) 撤廃。firebase-admin の cert は string パスも受け取れる。
+    // firebase-admin の cert() は string パスも受け取れる (ESM で require を避けるため)
     initializeApp({ credential: cert(credPath) });
   } else {
     initializeApp();
@@ -84,8 +84,8 @@ type SuperAdminsResult = {
  * strict=false（dry-run 時）の場合は続行するが、firestoreFetchFailed フラグを立てて
  * 呼び出し側がレポート冒頭・Summary 両方に警告を出せるようにする。
  *
- * Issue #281: union 計算は純粋関数 mergeSuperAdmins に分離済。本関数は Firestore 取得の
- * 副作用と strict mode の判定のみを担う。
+ * union 計算は純粋関数 `mergeSuperAdmins` に委譲。本関数は Firestore 取得の副作用と
+ * strict mode 判定のみ担う。
  */
 async function collectSuperAdmins(
   extra: string[],
@@ -254,9 +254,8 @@ type ApplyFixResult = {
  *   WriteBatch で束ねてコミットすることで、ネットワーク往復の削減と
  *   同一バッチ内の原子性を確保する（Firestore は 500 件/commit 上限）。
  *
- * Issue #281: 重複ガード + バッチ分割計画は純粋関数 planApplyFix に分離済。
- * 本関数は Firestore IO (既存 allowed_emails 取得 + WriteBatch コミット) と
- * 進捗ログ出力のみを担う。
+ * 重複ガード + バッチ分割計画は純粋関数 `planApplyFix` に委譲。本関数は Firestore IO
+ * (既存 allowed_emails 取得 + WriteBatch コミット) と進捗ログ出力のみ担う。
  */
 async function applyFix(
   tenantId: string,
@@ -325,8 +324,8 @@ async function applyFix(
  * planAudit は最初の 1 件のみ採用して後続を無視するため、実態の把握には
  * 事前にこの警告を出すことが重要（Evaluator エッジケース指摘）。
  *
- * Issue #281: 検出ロジックは純粋関数 detectDuplicateUsers に分離済。
- * 本関数は console.warn の副作用のみを担う。
+ * 検出ロジックは純粋関数 `detectDuplicateUsers` に委譲。本関数は console.warn の
+ * 副作用のみを担う。
  */
 function warnDuplicateUsers(
   tenantId: string,

--- a/services/api/src/services/__tests__/allowed-email-audit.test.ts
+++ b/services/api/src/services/__tests__/allowed-email-audit.test.ts
@@ -2,9 +2,25 @@ import { describe, it, expect } from "vitest";
 import {
   planAudit,
   buildAuditFixNote,
+  planApplyFix,
+  mergeSuperAdmins,
+  parseAuditArgs,
+  detectDuplicateUsers,
+  toNormalizedEmail,
+  HelpRequestedError,
+  WRITE_BATCH_LIMIT,
   type AuditUserInput,
   type AuditAllowedEmailInput,
+  type NormalizedEmail,
+  type AuditReport,
 } from "../allowed-email-audit.js";
+
+/** テスト用ヘルパ: 文字列を NormalizedEmail として cast する (正規化済みである前提) */
+function ne(s: string): NormalizedEmail {
+  const n = toNormalizedEmail(s);
+  if (n === null) throw new Error(`Invalid email for test fixture: ${s}`);
+  return n;
+}
 
 function u(
   id: string,
@@ -16,6 +32,7 @@ function u(
     email,
     role: "student",
     createdAt: "2026-01-01T00:00:00.000Z",
+    lastSignInTime: null,
     ...opts,
   };
 }
@@ -224,6 +241,7 @@ describe("planAudit", () => {
       allowedEmailsWithoutUser: [],
       invalid: [],
       excludedSuperAdmins: [],
+      duplicateUsers: [],
     });
   });
 
@@ -265,5 +283,329 @@ describe("buildAuditFixNote", () => {
     expect(buildAuditFixNote(date)).toBe(
       "audit-fix (Issue #279) by scripts/audit-users-vs-allowed-emails on 2026-01-05"
     );
+  });
+});
+
+describe("planApplyFix (Issue #281)", () => {
+  function buildReport(
+    emails: string[]
+  ): Pick<AuditReport, "usersWithoutAllowedEmail"> {
+    return {
+      usersWithoutAllowedEmail: emails.map((email, i) => ({
+        userId: `u${i}`,
+        firebaseUid: undefined,
+        email: ne(email),
+        role: "student",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastSignInTime: null,
+      })),
+    };
+  }
+
+  it("空入力なら toAdd/toSkip/batches すべて空", () => {
+    const plan = planApplyFix(buildReport([]), []);
+    expect(plan).toEqual({ toAdd: [], toSkip: [], batches: [] });
+  });
+
+  it("既存に存在しない email は toAdd に分類される", () => {
+    const plan = planApplyFix(
+      buildReport(["a@x.com", "b@x.com"]),
+      [ne("c@x.com")]
+    );
+    expect(plan.toAdd).toEqual([ne("a@x.com"), ne("b@x.com")]);
+    expect(plan.toSkip).toEqual([]);
+  });
+
+  it("既存に存在する email は toSkip に分類される", () => {
+    const plan = planApplyFix(
+      buildReport(["a@x.com", "b@x.com"]),
+      [ne("a@x.com")]
+    );
+    expect(plan.toAdd).toEqual([ne("b@x.com")]);
+    expect(plan.toSkip).toEqual([ne("a@x.com")]);
+  });
+
+  it("usersWithoutAllowedEmail 内の同一 email 重複は toAdd に 1 回のみ", () => {
+    const plan = planApplyFix(
+      buildReport(["a@x.com", "a@x.com", "b@x.com"]),
+      []
+    );
+    expect(plan.toAdd).toEqual([ne("a@x.com"), ne("b@x.com")]);
+  });
+
+  it("WriteBatch 境界: 449 件 → 1 batch", () => {
+    const emails = Array.from({ length: 449 }, (_, i) => `u${i}@x.com`);
+    const plan = planApplyFix(buildReport(emails), []);
+    expect(plan.batches).toHaveLength(1);
+    expect(plan.batches[0]).toHaveLength(449);
+  });
+
+  it("WriteBatch 境界: 450 件 → 1 batch (上限ぴったり)", () => {
+    const emails = Array.from({ length: 450 }, (_, i) => `u${i}@x.com`);
+    const plan = planApplyFix(buildReport(emails), []);
+    expect(plan.batches).toHaveLength(1);
+    expect(plan.batches[0]).toHaveLength(450);
+  });
+
+  it("WriteBatch 境界: 900 件 → 2 batches (各 450 件)", () => {
+    const emails = Array.from({ length: 900 }, (_, i) => `u${i}@x.com`);
+    const plan = planApplyFix(buildReport(emails), []);
+    expect(plan.batches).toHaveLength(2);
+    expect(plan.batches[0]).toHaveLength(450);
+    expect(plan.batches[1]).toHaveLength(450);
+  });
+
+  it("WriteBatch 境界: 901 件 → 3 batches (450/450/1)", () => {
+    const emails = Array.from({ length: 901 }, (_, i) => `u${i}@x.com`);
+    const plan = planApplyFix(buildReport(emails), []);
+    expect(plan.batches).toHaveLength(3);
+    expect(plan.batches[0]).toHaveLength(450);
+    expect(plan.batches[1]).toHaveLength(450);
+    expect(plan.batches[2]).toHaveLength(1);
+  });
+
+  it("WRITE_BATCH_LIMIT は 450", () => {
+    expect(WRITE_BATCH_LIMIT).toBe(450);
+  });
+
+  it("batchLimit <= 0 はエラー", () => {
+    expect(() => planApplyFix(buildReport(["a@x.com"]), [], 0)).toThrow(
+      /must be positive/
+    );
+    expect(() => planApplyFix(buildReport(["a@x.com"]), [], -1)).toThrow(
+      /must be positive/
+    );
+  });
+});
+
+describe("mergeSuperAdmins (Issue #281)", () => {
+  it("env CSV + Firestore + extra の union を返す", () => {
+    const result = mergeSuperAdmins(
+      "a@x.com,b@x.com",
+      ["c@x.com"],
+      ["d@x.com"]
+    );
+    expect(result).toEqual([ne("a@x.com"), ne("b@x.com"), ne("c@x.com"), ne("d@x.com")]);
+  });
+
+  it("重複は除去される (env と Firestore の重複)", () => {
+    const result = mergeSuperAdmins("a@x.com,b@x.com", ["a@x.com"], []);
+    expect(result).toEqual([ne("a@x.com"), ne("b@x.com")]);
+  });
+
+  it("空白除去 + 小文字化される", () => {
+    const result = mergeSuperAdmins(" A@X.COM , b@x.com ", [" C@x.com "], []);
+    expect(result).toEqual([ne("a@x.com"), ne("b@x.com"), ne("c@x.com")]);
+  });
+
+  it("空文字は無視される", () => {
+    const result = mergeSuperAdmins(",,a@x.com,", ["", "  ", "b@x.com"], [""]);
+    expect(result).toEqual([ne("a@x.com"), ne("b@x.com")]);
+  });
+
+  it("全引数が空でも空配列を返す", () => {
+    const result = mergeSuperAdmins("", [], []);
+    expect(result).toEqual([]);
+  });
+
+  it("結果はソートされる", () => {
+    const result = mergeSuperAdmins("c@x.com", ["a@x.com"], ["b@x.com"]);
+    expect(result).toEqual([ne("a@x.com"), ne("b@x.com"), ne("c@x.com")]);
+  });
+});
+
+describe("parseAuditArgs (Issue #281)", () => {
+  it("引数なしは dry-run mode", () => {
+    expect(parseAuditArgs([])).toEqual({
+      mode: { kind: "dry-run" },
+      skipAuthMetadata: false,
+      tenantFilter: null,
+      extraSuperAdmins: [],
+    });
+  });
+
+  it("--fix のみは fix-dry-run mode", () => {
+    expect(parseAuditArgs(["--fix"]).mode).toEqual({ kind: "fix-dry-run" });
+  });
+
+  it("--fix --execute は fix-execute mode", () => {
+    expect(parseAuditArgs(["--fix", "--execute"]).mode).toEqual({
+      kind: "fix-execute",
+    });
+  });
+
+  it("--execute のみ (--fix 不在) は reject", () => {
+    expect(() => parseAuditArgs(["--execute"])).toThrow(
+      /--execute は --fix と併用/
+    );
+  });
+
+  it("位置引数は reject", () => {
+    expect(() => parseAuditArgs(["tenant1"])).toThrow(/未知の引数/);
+    expect(() => parseAuditArgs(["--fix", "tenant1"])).toThrow(/未知の引数/);
+  });
+
+  it("--tenant 値欠落は reject", () => {
+    expect(() => parseAuditArgs(["--tenant"])).toThrow(
+      /--tenant の値が指定されていません/
+    );
+  });
+
+  it("--super-admins 値欠落は reject", () => {
+    expect(() => parseAuditArgs(["--super-admins"])).toThrow(
+      /--super-admins の値が指定されていません/
+    );
+  });
+
+  it("--tenant に値を渡せる", () => {
+    expect(parseAuditArgs(["--tenant", "t1"]).tenantFilter).toBe("t1");
+  });
+
+  it("--super-admins は CSV を分解して空白除去", () => {
+    expect(
+      parseAuditArgs(["--super-admins", " a@x.com , b@x.com , "])
+        .extraSuperAdmins
+    ).toEqual(["a@x.com", "b@x.com"]);
+  });
+
+  it("--skip-auth-metadata を解釈する", () => {
+    expect(parseAuditArgs(["--skip-auth-metadata"]).skipAuthMetadata).toBe(true);
+  });
+
+  it("--help は HelpRequestedError を throw", () => {
+    expect(() => parseAuditArgs(["--help"])).toThrow(HelpRequestedError);
+    expect(() => parseAuditArgs(["-h"])).toThrow(HelpRequestedError);
+  });
+
+  it("未知のオプションは reject", () => {
+    expect(() => parseAuditArgs(["--unknown"])).toThrow(/未知の引数/);
+  });
+
+  it("複数オプションを組み合わせ可能", () => {
+    const opts = parseAuditArgs([
+      "--fix",
+      "--execute",
+      "--tenant",
+      "t1",
+      "--skip-auth-metadata",
+      "--super-admins",
+      "a@x.com",
+    ]);
+    expect(opts).toEqual({
+      mode: { kind: "fix-execute" },
+      skipAuthMetadata: true,
+      tenantFilter: "t1",
+      extraSuperAdmins: ["a@x.com"],
+    });
+  });
+});
+
+describe("detectDuplicateUsers (Issue #281)", () => {
+  it("重複なしなら空配列", () => {
+    const result = detectDuplicateUsers([
+      u("u1", "a@x.com"),
+      u("u2", "b@x.com"),
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("重複 email を含む全 userIds を返す", () => {
+    const result = detectDuplicateUsers([
+      u("u1", "a@x.com"),
+      u("u2", "a@x.com"),
+      u("u3", "a@x.com"),
+    ]);
+    expect(result).toEqual([
+      { email: ne("a@x.com"), userIds: ["u1", "u2", "u3"] },
+    ]);
+  });
+
+  it("正規化後に重複する email を検出する (大文字小文字)", () => {
+    const result = detectDuplicateUsers([
+      u("u1", "Alice@x.com"),
+      u("u2", "ALICE@x.com"),
+    ]);
+    expect(result).toEqual([
+      { email: ne("alice@x.com"), userIds: ["u1", "u2"] },
+    ]);
+  });
+
+  it("空 email / null は skip", () => {
+    const result = detectDuplicateUsers([
+      u("u1", ""),
+      u("u2", null),
+      u("u3", "a@x.com"),
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("Gmail dot trick negative: a.l.i.c.e@gmail.com と alice@gmail.com は別扱い", () => {
+    // toNormalizedEmail は trim+toLowerCase のみ。Gmail dot 正規化はしない。
+    const result = detectDuplicateUsers([
+      u("u1", "a.l.i.c.e@gmail.com"),
+      u("u2", "alice@gmail.com"),
+    ]);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("planAudit duplicateUsers 出力 (Issue #281)", () => {
+  it("重複 users があれば duplicateUsers に primary + 漏れた id をまとめて出力", () => {
+    const report = planAudit(
+      [
+        u("u1", "alice@x.com"),
+        u("u2", "alice@x.com"),
+        u("u3", "alice@x.com"),
+      ],
+      [],
+      []
+    );
+    expect(report.duplicateUsers).toEqual([
+      { email: ne("alice@x.com"), userIds: ["u1", "u2", "u3"] },
+    ]);
+  });
+
+  it("重複がなければ duplicateUsers は空配列", () => {
+    const report = planAudit([u("u1", "alice@x.com")], [], []);
+    expect(report.duplicateUsers).toEqual([]);
+  });
+
+  it("重複 users がいても matched は primary のみ", () => {
+    const report = planAudit(
+      [u("u1", "alice@x.com"), u("u2", "alice@x.com")],
+      [{ id: "ae1", email: "alice@x.com" }],
+      []
+    );
+    expect(report.matched).toEqual([
+      {
+        userId: "u1",
+        firebaseUid: undefined,
+        email: ne("alice@x.com"),
+        allowedEmailId: "ae1",
+      },
+    ]);
+    expect(report.duplicateUsers).toEqual([
+      { email: ne("alice@x.com"), userIds: ["u1", "u2"] },
+    ]);
+  });
+
+  it("invalid + valid 混在: invalid は invalid に、valid 重複は duplicateUsers に", () => {
+    const report = planAudit(
+      [
+        u("u1", "alice@x.com"),
+        u("u2", null),
+        u("u3", "alice@x.com"),
+        u("u4", ""),
+      ],
+      [],
+      []
+    );
+    expect(report.invalid).toEqual([
+      { kind: "user", id: "u2", reason: "email が空または null" },
+      { kind: "user", id: "u4", reason: "email が空または null" },
+    ]);
+    expect(report.duplicateUsers).toEqual([
+      { email: ne("alice@x.com"), userIds: ["u1", "u3"] },
+    ]);
   });
 });

--- a/services/api/src/services/__tests__/allowed-email-audit.test.ts
+++ b/services/api/src/services/__tests__/allowed-email-audit.test.ts
@@ -286,7 +286,7 @@ describe("buildAuditFixNote", () => {
   });
 });
 
-describe("planApplyFix (Issue #281)", () => {
+describe("planApplyFix", () => {
   function buildReport(
     emails: string[]
   ): Pick<AuditReport, "usersWithoutAllowedEmail"> {
@@ -378,7 +378,7 @@ describe("planApplyFix (Issue #281)", () => {
   });
 });
 
-describe("mergeSuperAdmins (Issue #281)", () => {
+describe("mergeSuperAdmins", () => {
   it("env CSV + Firestore + extra の union を返す", () => {
     const result = mergeSuperAdmins(
       "a@x.com,b@x.com",
@@ -414,7 +414,7 @@ describe("mergeSuperAdmins (Issue #281)", () => {
   });
 });
 
-describe("parseAuditArgs (Issue #281)", () => {
+describe("parseAuditArgs", () => {
   it("引数なしは dry-run mode", () => {
     expect(parseAuditArgs([])).toEqual({
       mode: { kind: "dry-run" },
@@ -500,7 +500,7 @@ describe("parseAuditArgs (Issue #281)", () => {
   });
 });
 
-describe("detectDuplicateUsers (Issue #281)", () => {
+describe("detectDuplicateUsers", () => {
   it("重複なしなら空配列", () => {
     const result = detectDuplicateUsers([
       u("u1", "a@x.com"),
@@ -549,7 +549,7 @@ describe("detectDuplicateUsers (Issue #281)", () => {
   });
 });
 
-describe("planAudit duplicateUsers 出力 (Issue #281)", () => {
+describe("planAudit duplicateUsers 出力", () => {
   it("重複 users があれば duplicateUsers に primary + 漏れた id をまとめて出力", () => {
     const report = planAudit(
       [

--- a/services/api/src/services/allowed-email-audit.ts
+++ b/services/api/src/services/allowed-email-audit.ts
@@ -23,14 +23,64 @@
 
 import { normalizeEmail as normalizeEmailUtil } from "../utils/tenant-id.js";
 
+/**
+ * 正規化済みメールアドレスを表す brand 型 (Issue #281)。
+ *
+ * `toNormalizedEmail()` を通った文字列のみが NormalizedEmail として扱える。
+ * MatchedEntry.email 等が `email.toLowerCase().trim()` 済みであることを型レベルで保証し、
+ * 未正規化文字列が直接代入されることをコンパイル時に防ぐ。
+ *
+ * 実体は string だが、unique symbol を持つ phantom field で区別する。
+ */
+declare const __NormalizedEmailBrand: unique symbol;
+export type NormalizedEmail = string & {
+  readonly [__NormalizedEmailBrand]: void;
+};
+
+/**
+ * 任意文字列を NormalizedEmail に変換する。
+ * 空文字 / null / undefined / 正規化後が空文字なら null を返す。
+ */
+export function toNormalizedEmail(
+  raw: string | null | undefined
+): NormalizedEmail | null {
+  if (!raw) return null;
+  const n = normalizeEmailUtil(raw);
+  return n.length > 0 ? (n as NormalizedEmail) : null;
+}
+
+/**
+ * CLI 実行モード (Issue #281)。
+ *
+ * 旧 `{ fix: boolean; execute: boolean }` の組み合わせ 4 通りのうち、
+ * `{ fix: false, execute: true }`（補正なしで書き込みのみ）は意味的に不正な状態だったが、
+ * 旧型ではコンパイル時に防げず runtime チェックに依存していた。
+ *
+ * 3 状態の discriminated union 化で `--execute` 単体を型レベルで排除する。
+ */
+export type AuditMode =
+  | { kind: "dry-run" }
+  | { kind: "fix-dry-run" }
+  | { kind: "fix-execute" };
+
+export type CliOptions = {
+  mode: AuditMode;
+  skipAuthMetadata: boolean;
+  tenantFilter: string | null;
+  extraSuperAdmins: string[];
+};
+
 export type AuditUserInput = {
   id: string;
   email: string | null | undefined;
   firebaseUid?: string;
   role: string;
   createdAt: string;
-  /** Firebase Auth から取得した最終サインイン時刻。取得不可なら null */
-  lastSignInTime?: string | null;
+  /**
+   * Firebase Auth から取得した最終サインイン時刻。取得不可なら null。
+   * Issue #281: optional を撤廃し必須化 (silent failure 防止)。
+   */
+  lastSignInTime: string | null;
 };
 
 export type AuditAllowedEmailInput = {
@@ -41,14 +91,14 @@ export type AuditAllowedEmailInput = {
 export type MatchedEntry = {
   userId: string;
   firebaseUid?: string;
-  email: string;
+  email: NormalizedEmail;
   allowedEmailId: string;
 };
 
 export type UserWithoutAllowedEmailEntry = {
   userId: string;
   firebaseUid?: string;
-  email: string;
+  email: NormalizedEmail;
   role: string;
   createdAt: string;
   lastSignInTime: string | null;
@@ -56,7 +106,7 @@ export type UserWithoutAllowedEmailEntry = {
 
 export type AllowedEmailWithoutUserEntry = {
   allowedEmailId: string;
-  email: string;
+  email: NormalizedEmail;
 };
 
 export type InvalidEntry = {
@@ -67,7 +117,16 @@ export type InvalidEntry = {
 
 export type ExcludedSuperAdminEntry = {
   userId: string;
-  email: string;
+  email: NormalizedEmail;
+};
+
+/**
+ * Issue #281: 同一 email を持つ users レコードが複数ある場合の可視化エントリ。
+ * planAudit は最初の 1 件のみ採用するため、ここで漏れを可視化する。
+ */
+export type DuplicateUserEntry = {
+  email: NormalizedEmail;
+  userIds: string[];
 };
 
 export type AuditReport = {
@@ -76,12 +135,9 @@ export type AuditReport = {
   allowedEmailsWithoutUser: AllowedEmailWithoutUserEntry[];
   invalid: InvalidEntry[];
   excludedSuperAdmins: ExcludedSuperAdminEntry[];
+  /** Issue #281: 同一 email が複数 users にある場合、最初の 1 件以外はここに可視化 */
+  duplicateUsers: DuplicateUserEntry[];
 };
-
-function normalizeEmail(raw: string | null | undefined): string {
-  if (!raw) return "";
-  return normalizeEmailUtil(raw);
-}
 
 /**
  * users / allowed_emails / スーパー管理者リストを突き合わせて監査レポートを生成。
@@ -95,18 +151,18 @@ export function planAudit(
   allowedEmails: AuditAllowedEmailInput[],
   superAdminEmails: Iterable<string>
 ): AuditReport {
-  const superAdminSet = new Set<string>();
+  const superAdminSet = new Set<NormalizedEmail>();
   for (const email of superAdminEmails) {
-    const n = normalizeEmail(email);
-    if (n) superAdminSet.add(n);
+    const n = toNormalizedEmail(email);
+    if (n !== null) superAdminSet.add(n);
   }
 
-  const allowedByNormalized = new Map<string, AuditAllowedEmailInput>();
+  const allowedByNormalized = new Map<NormalizedEmail, AuditAllowedEmailInput>();
   const invalid: InvalidEntry[] = [];
 
   for (const ae of allowedEmails) {
-    const n = normalizeEmail(ae.email);
-    if (!n) {
+    const n = toNormalizedEmail(ae.email);
+    if (n === null) {
       invalid.push({
         kind: "allowed_email",
         id: ae.id,
@@ -119,10 +175,12 @@ export function planAudit(
     }
   }
 
-  const usersByNormalized = new Map<string, AuditUserInput>();
+  // Issue #281: 重複 users を可視化するため、最初の 1 件を採用 + 後続を duplicateUserIds に記録
+  const usersByNormalized = new Map<NormalizedEmail, AuditUserInput>();
+  const duplicateUserIds = new Map<NormalizedEmail, string[]>();
   for (const u of users) {
-    const n = normalizeEmail(u.email);
-    if (!n) {
+    const n = toNormalizedEmail(u.email);
+    if (n === null) {
       invalid.push({
         kind: "user",
         id: u.id,
@@ -132,6 +190,10 @@ export function planAudit(
     }
     if (!usersByNormalized.has(n)) {
       usersByNormalized.set(n, u);
+    } else {
+      const list = duplicateUserIds.get(n) ?? [];
+      list.push(u.id);
+      duplicateUserIds.set(n, list);
     }
   }
 
@@ -162,7 +224,7 @@ export function planAudit(
       email: n,
       role: u.role,
       createdAt: u.createdAt,
-      lastSignInTime: u.lastSignInTime ?? null,
+      lastSignInTime: u.lastSignInTime,
     });
   }
 
@@ -176,12 +238,21 @@ export function planAudit(
     }
   }
 
+  // primary (採用) + 漏れた N 件 を 1 entry に集約して全体像を保つ。
+  // duplicateUserIds に entry がある email は usersByNormalized にも primary がいる前提。
+  const duplicateUsers: DuplicateUserEntry[] = [];
+  for (const [n, droppedIds] of duplicateUserIds) {
+    const primary = usersByNormalized.get(n)!;
+    duplicateUsers.push({ email: n, userIds: [primary.id, ...droppedIds] });
+  }
+
   return {
     matched,
     usersWithoutAllowedEmail,
     allowedEmailsWithoutUser,
     invalid,
     excludedSuperAdmins,
+    duplicateUsers,
   };
 }
 
@@ -196,4 +267,193 @@ export function buildAuditFixNote(date: Date = new Date()): string {
   const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
   const dd = String(date.getUTCDate()).padStart(2, "0");
   return `audit-fix (Issue #279) by scripts/audit-users-vs-allowed-emails on ${yyyy}-${mm}-${dd}`;
+}
+
+/** Firestore WriteBatch の commit 上限（公式: 500 op / batch、本スクリプトは set のみで安全側 450）。 */
+export const WRITE_BATCH_LIMIT = 450;
+
+/**
+ * Issue #281: `--fix` 実行計画の純粋ロジック。
+ *
+ * `report.usersWithoutAllowedEmail` から `existingEmails` を引いた差分を「追加対象」とし、
+ * 既存に同じ email がある entry は `toSkip` として分離。さらに WriteBatch の op 上限
+ * ({@link WRITE_BATCH_LIMIT}) でバッチ分割し、`batches` に email 配列の配列を返す。
+ *
+ * Firestore IO は scripts 側で `db.batch().set(...)` を実行する。本関数は純粋。
+ *
+ * 同一 batch 内の重複 (同じ entry を 2 回 push) は planAudit 側で発生しないため、ここでは
+ * 防御しない（早期発見のため duplicate を引数で受けたら throw する選択肢もあるが、現状
+ * 不要）。
+ */
+export type ApplyFixPlan = {
+  toAdd: NormalizedEmail[];
+  toSkip: NormalizedEmail[];
+  batches: NormalizedEmail[][];
+};
+
+export function planApplyFix(
+  report: Pick<AuditReport, "usersWithoutAllowedEmail">,
+  existingEmails: Iterable<NormalizedEmail>,
+  batchLimit: number = WRITE_BATCH_LIMIT
+): ApplyFixPlan {
+  if (batchLimit <= 0) {
+    throw new Error(`batchLimit must be positive (got ${batchLimit})`);
+  }
+
+  const existingSet = new Set<NormalizedEmail>(existingEmails);
+  const toAdd: NormalizedEmail[] = [];
+  const toSkip: NormalizedEmail[] = [];
+  // O(1) lookup でループ内重複を排除（901+ 件のテストで O(n²) を回避）
+  const toAddSet = new Set<NormalizedEmail>();
+
+  for (const entry of report.usersWithoutAllowedEmail) {
+    if (existingSet.has(entry.email)) {
+      toSkip.push(entry.email);
+      continue;
+    }
+    if (toAddSet.has(entry.email)) continue;
+    toAddSet.add(entry.email);
+    toAdd.push(entry.email);
+  }
+
+  const batches: NormalizedEmail[][] = [];
+  for (let i = 0; i < toAdd.length; i += batchLimit) {
+    batches.push(toAdd.slice(i, i + batchLimit));
+  }
+
+  return { toAdd, toSkip, batches };
+}
+
+/**
+ * Issue #281: env CSV + Firestore emails + 手動追加分の union 計算 (純粋関数)。
+ *
+ * Firestore 取得は scripts 側で行う。本関数は文字列入力のみで純粋。
+ * 各入力は trim().toLowerCase() で正規化され、空文字は除去される。結果はソート済み。
+ */
+export function mergeSuperAdmins(
+  envCsv: string,
+  firestoreEmails: Iterable<string>,
+  extra: Iterable<string>
+): NormalizedEmail[] {
+  const result = new Set<NormalizedEmail>();
+
+  const pushAll = (source: Iterable<string>): void => {
+    for (const raw of source) {
+      const n = toNormalizedEmail(raw);
+      if (n !== null) result.add(n);
+    }
+  };
+
+  pushAll(envCsv.split(","));
+  pushAll(firestoreEmails);
+  pushAll(extra);
+
+  return Array.from(result).sort();
+}
+
+/**
+ * Issue #281: CLI 引数パース (純粋関数)。
+ *
+ * - 位置引数 (`--` 接頭辞なし) は明示的に reject。
+ * - `--execute` 単体（`--fix` 未指定）は reject。
+ * - `--tenant` / `--super-admins` の値欠落も reject。
+ * - 戻り値の {@link CliOptions.mode} は discriminated union 化済 (旧 `fix/execute` boolean ペア廃止)。
+ *
+ * `--help` / `-h` は scripts 側で I/O 込みでハンドリングするため、本関数では `kind: "help"`
+ * を返さず、`HelpRequestedError` でフロー制御する。
+ */
+export class HelpRequestedError extends Error {
+  constructor() {
+    super("HELP_REQUESTED");
+    this.name = "HelpRequestedError";
+  }
+}
+
+export function parseAuditArgs(argv: readonly string[]): CliOptions {
+  let fix = false;
+  let execute = false;
+  let skipAuthMetadata = false;
+  let tenantFilter: string | null = null;
+  let extraSuperAdmins: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--fix":
+        fix = true;
+        break;
+      case "--execute":
+        execute = true;
+        break;
+      case "--skip-auth-metadata":
+        skipAuthMetadata = true;
+        break;
+      case "--tenant": {
+        const val = argv[++i];
+        if (!val) throw new Error("--tenant の値が指定されていません");
+        tenantFilter = val;
+        break;
+      }
+      case "--super-admins": {
+        const val = argv[++i];
+        if (!val) throw new Error("--super-admins の値が指定されていません");
+        extraSuperAdmins = val
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0);
+        break;
+      }
+      case "--help":
+      case "-h":
+        throw new HelpRequestedError();
+      default:
+        // `--tenant` を忘れて位置引数だけ渡すと全テナント走査に巻き込まれる事故を防ぐため、
+        // 未知の引数（オプション形式でないものも含む）は明示的にエラーにする。
+        throw new Error(`未知の引数: ${arg}`);
+    }
+  }
+
+  if (execute && !fix) {
+    throw new Error(
+      "--execute は --fix と併用する必要があります。補正なしの dry-run なら --execute を外してください。"
+    );
+  }
+
+  // execute && !fix は上で reject 済み。残るのは 3 状態のみ。
+  let mode: AuditMode;
+  if (execute) {
+    mode = { kind: "fix-execute" };
+  } else if (fix) {
+    mode = { kind: "fix-dry-run" };
+  } else {
+    mode = { kind: "dry-run" };
+  }
+
+  return { mode, skipAuthMetadata, tenantFilter, extraSuperAdmins };
+}
+
+/**
+ * Issue #281: 同一 email を持つ users レコードを検出する純粋関数。
+ *
+ * planAudit も内部で重複検出するが、`AuditUserInput` の段階で early-warn したい
+ * （scripts は planAudit 呼び出し前に console.warn を出すフロー）ために独立した関数を提供。
+ */
+export function detectDuplicateUsers(
+  rawUsers: readonly AuditUserInput[]
+): DuplicateUserEntry[] {
+  const byEmail = new Map<NormalizedEmail, string[]>();
+  for (const u of rawUsers) {
+    const n = toNormalizedEmail(u.email);
+    if (n === null) continue;
+    const ids = byEmail.get(n) ?? [];
+    ids.push(u.id);
+    byEmail.set(n, ids);
+  }
+  const result: DuplicateUserEntry[] = [];
+  for (const [email, userIds] of byEmail) {
+    if (userIds.length > 1) {
+      result.push({ email, userIds });
+    }
+  }
+  return result;
 }

--- a/services/api/src/services/allowed-email-audit.ts
+++ b/services/api/src/services/allowed-email-audit.ts
@@ -24,7 +24,7 @@
 import { normalizeEmail as normalizeEmailUtil } from "../utils/tenant-id.js";
 
 /**
- * 正規化済みメールアドレスを表す brand 型 (Issue #281)。
+ * 正規化済みメールアドレスを表す brand 型。
  *
  * `toNormalizedEmail()` を通った文字列のみが NormalizedEmail として扱える。
  * MatchedEntry.email 等が `email.toLowerCase().trim()` 済みであることを型レベルで保証し、
@@ -50,7 +50,7 @@ export function toNormalizedEmail(
 }
 
 /**
- * CLI 実行モード (Issue #281)。
+ * CLI 実行モード。
  *
  * 旧 `{ fix: boolean; execute: boolean }` の組み合わせ 4 通りのうち、
  * `{ fix: false, execute: true }`（補正なしで書き込みのみ）は意味的に不正な状態だったが、
@@ -78,7 +78,7 @@ export type AuditUserInput = {
   createdAt: string;
   /**
    * Firebase Auth から取得した最終サインイン時刻。取得不可なら null。
-   * Issue #281: optional を撤廃し必須化 (silent failure 防止)。
+   * 必須化することで silent failure (退職者判定の誤誘導) を防ぐ。
    */
   lastSignInTime: string | null;
 };
@@ -121,7 +121,7 @@ export type ExcludedSuperAdminEntry = {
 };
 
 /**
- * Issue #281: 同一 email を持つ users レコードが複数ある場合の可視化エントリ。
+ * 同一 email を持つ users レコードが複数ある場合の可視化エントリ。
  * planAudit は最初の 1 件のみ採用するため、ここで漏れを可視化する。
  */
 export type DuplicateUserEntry = {
@@ -135,7 +135,7 @@ export type AuditReport = {
   allowedEmailsWithoutUser: AllowedEmailWithoutUserEntry[];
   invalid: InvalidEntry[];
   excludedSuperAdmins: ExcludedSuperAdminEntry[];
-  /** Issue #281: 同一 email が複数 users にある場合、最初の 1 件以外はここに可視化 */
+  /** 同一 email が複数 users にある場合、最初の 1 件以外はここに可視化 */
   duplicateUsers: DuplicateUserEntry[];
 };
 
@@ -175,7 +175,7 @@ export function planAudit(
     }
   }
 
-  // Issue #281: 重複 users を可視化するため、最初の 1 件を採用 + 後続を duplicateUserIds に記録
+  // 重複 users を可視化するため、最初の 1 件を採用 + 後続を duplicateUserIds に記録
   const usersByNormalized = new Map<NormalizedEmail, AuditUserInput>();
   const duplicateUserIds = new Map<NormalizedEmail, string[]>();
   for (const u of users) {
@@ -273,7 +273,7 @@ export function buildAuditFixNote(date: Date = new Date()): string {
 export const WRITE_BATCH_LIMIT = 450;
 
 /**
- * Issue #281: `--fix` 実行計画の純粋ロジック。
+ * `--fix` 実行計画の純粋ロジック。
  *
  * `report.usersWithoutAllowedEmail` から `existingEmails` を引いた差分を「追加対象」とし、
  * 既存に同じ email がある entry は `toSkip` として分離。さらに WriteBatch の op 上限
@@ -325,7 +325,7 @@ export function planApplyFix(
 }
 
 /**
- * Issue #281: env CSV + Firestore emails + 手動追加分の union 計算 (純粋関数)。
+ * env CSV + Firestore emails + 手動追加分の union 計算 (純粋関数)。
  *
  * Firestore 取得は scripts 側で行う。本関数は文字列入力のみで純粋。
  * 各入力は trim().toLowerCase() で正規化され、空文字は除去される。結果はソート済み。
@@ -352,7 +352,7 @@ export function mergeSuperAdmins(
 }
 
 /**
- * Issue #281: CLI 引数パース (純粋関数)。
+ * CLI 引数パース (純粋関数)。
  *
  * - 位置引数 (`--` 接頭辞なし) は明示的に reject。
  * - `--execute` 単体（`--fix` 未指定）は reject。
@@ -433,10 +433,13 @@ export function parseAuditArgs(argv: readonly string[]): CliOptions {
 }
 
 /**
- * Issue #281: 同一 email を持つ users レコードを検出する純粋関数。
+ * 同一 email を持つ users レコードを検出する純粋関数。
  *
  * planAudit も内部で重複検出するが、`AuditUserInput` の段階で early-warn したい
  * （scripts は planAudit 呼び出し前に console.warn を出すフロー）ために独立した関数を提供。
+ *
+ * null/empty な email は invalid として skip する (重複検出の対象外、`planAudit` 側で
+ * `AuditReport.invalid[]` に記録される)。
  */
 export function detectDuplicateUsers(
   rawUsers: readonly AuditUserInput[]


### PR DESCRIPTION
## Summary

PR #280 のレビュー指摘 (Firestore IO と純粋ロジックの分離不十分) を完遂する構造リファクタ。本番影響なし、CLI スクリプト + 純粋関数追加に閉じる。

## Changes

### `services/api/src/services/allowed-email-audit.ts` (+302)

**新規型**:
- \`NormalizedEmail\` brand 型 + \`toNormalizedEmail()\` ヘルパ
  → \`MatchedEntry.email\` 等が正規化済みであることを型レベルで保証
- \`AuditMode\` discriminated union (\`{ kind: \"dry-run\" | \"fix-dry-run\" | \"fix-execute\" }\`)
  → 旧 \`fix\`/\`execute\` boolean ペアの不正状態 (\`--execute && !--fix\`) を型レベルで排除
- \`DuplicateUserEntry\` + \`AuditReport.duplicateUsers\`
  → \`planAudit\` が silently drop していた重複 users を可視化 (primary + 漏れた N 件)
- \`AuditUserInput.lastSignInTime\` を optional → \`string | null\` 必須化
  → silent failure 防止

**新規純粋関数**:
- \`planApplyFix\`: \`applyFix\` の重複ガード + WriteBatch 分割計画 (Set ベース O(n) dedup)
- \`mergeSuperAdmins\`: env CSV + Firestore + extra の union 計算
- \`parseAuditArgs\`: 引数パース + Mode 構築 (\`HelpRequestedError\` throw)
- \`detectDuplicateUsers\`: 重複検出ロジック

### \`services/api/src/services/__tests__/allowed-email-audit.test.ts\` (+342)

- 既存 17 件 PASS 維持 + 新規 **38 件追加** (合計 55)
- **WriteBatch 境界**: 449/450/900/901 件で batch 数を検証
- **引数検証**: \`--execute && !--fix\` reject / 位置引数 reject / \`--tenant\`/\`--super-admins\` 値欠落
- **mergeSuperAdmins**: 空白除去・重複除去・小文字化・ソート
- **Gmail dot trick negative**: \`a.l.i.c.e@gmail.com\` ≠ \`alice@gmail.com\` (本スクリプトは email 文字列で比較する設計)
- **planAudit duplicateUsers**: invalid + valid 混在、primary + 漏れた N 件の集約

### \`scripts/audit-users-vs-allowed-emails.ts\` (-202/+257)

副作用 (Firestore IO + ログ + プロセス制御) のみを残し、純粋ロジックを services 側に委譲:
- \`parseArgs\` → \`parseAuditArgs\` (Mode discriminated union) に置換
- \`collectSuperAdmins\` の union 計算ロジックを \`mergeSuperAdmins\` に委譲
- \`applyFix\` の重複ガード + バッチ分割を \`planApplyFix\` に委譲
- \`warnDuplicateUsers\` の検出ロジックを \`detectDuplicateUsers\` に委譲
- \`require(credPath)\` 撤廃 → \`cert(credPath)\` 直接 (string path 対応、ESM 化)
- \`main()\` の \`options.fix\`/\`execute\` を \`options.mode.kind\` ベースに変更
- ローカル \`WRITE_BATCH_LIMIT\`/\`ApplyFixResult\` 重複定義削除

## Acceptance Criteria (Issue #281)

- [x] 4 純粋関数が \`services/api/src/services/\` 配下に存在し、npm test でカバー
- [x] \`planApplyFix\` の WriteBatch 境界 4 ケース PASS
- [x] \`CliOptions\` discriminated union 化で \`--execute\` 単体が型レベル不可
- [x] 既存 17 tests 継続 PASS (55/55 PASS)
- [x] Gmail dot trick negative test 追加
- [x] \`require(credPath)\` 撤廃

## Quality Gate

| Gate | Result |
|------|--------|
| \`npm run lint\` | ✅ PASS |
| \`npm run type-check\` | ✅ PASS (4 workspaces) |
| \`npm run test -w @lms-279/api\` | ✅ 742 PASS (704 → 742, +38) |
| \`/simplify\` 3 並列レビュー (reuse/quality/efficiency) | ✅ CRITICAL/IMPORTANT 5 件吸収 |
| \`/safe-refactor\` | ✅ 未使用 import 1 件削除 |

## /simplify レビューで対応した指摘

| Agent | Finding | 対応 |
|---|---|---|
| Efficiency | \`planApplyFix\` の \`toAdd.includes\` が O(n²) | Set ベース O(n) dedup に変更 |
| Quality | \`planAudit\` の \`primary ? ... : droppedIds\` fallback が unreachable | \`primary!\` で non-null assertion 化 |
| Quality | \`parseAuditArgs\` のネステッド ternary | if/else if/else 構造に変更 |
| Quality / Reuse | テストヘルパ重複 (\`mkUser\` / 内側 \`u()\`) | file-scope \`u()\` 1 つに統一 |
| Reuse | super-admin.ts の normalization drift / \`BATCH_LIMIT\` 共有化 | 別 PR で follow-up (本 PR scope 外) |

## Test plan

- [x] lint / type-check / API test 全 PASS
- [x] allowed-email-audit.test.ts 55 件 (既存 17 + 新規 38) PASS
- [ ] **マージ後**: 既存 \`audit-users-vs-allowed-emails.ts\` を dry-run で実行し、レポート出力が従来と等価であることを確認

## Related

- Issue #281 (allowed_emails 監査 CLI の純粋関数分割と型強化)
- Parent: Issue #279 (本番棚卸し)
- Original PR: #280 (本 PR の前段、マージブロッカー対応のみ)
- レビュー指摘元: pr-test-analyzer / type-design-analyzer / code-reviewer

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)