### PR TITLE
fix(e2e): playwright test timeout を 60s に戻す (Issue #308 解決後)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,11 +2,10 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
-  // CI の 1 リクエスト当たり 7-9 秒の遅延（Issue #308 で根本調査中）で 60秒は不足。
-  // 項目3/7 等のマルチリクエスト test が 60秒を超えて Request context disposed に
-  // なるのを回避するため 180秒に拡大。ローカルは fast path で影響なし。
+  // Issue #308 (PR #355) で CI 1 req 当たり 9 秒の Firestore lookup 遅延を解消。
+  // PR #307 で暫定 180 秒に拡大した test timeout を本来の 60 秒に戻す。
   // webServer.timeout (60000) は起動タイムアウトで据え置き — test timeout と意図的な差分。
-  timeout: 180000,
+  timeout: 60000,
   retries: 1,
   use: {
     baseURL: "http://localhost:3000",


### PR DESCRIPTION
## Summary

- PR #355 (Issue #308) で AUTH_MODE=dev の Firestore super-admin lookup 遅延（1 req 約 9 秒）が解消されたため、PR #307 で暫定的に拡大した E2E test timeout を本来の 60 秒へ戻す
- 関連コメントを Issue #308 (PR #355) 解決後の状態に更新
- `webServer.timeout` (60000) は起動タイムアウトで据え置き

## Background

Issue #308 (E2E CI でリクエスト遅延 7-9 秒/request の根本調査) は PR #355 でクローズ済み。同 PR の Test plan に「後続 PR で検討: PR #307 の playwright timeout 180000 を 60000 に戻せるか」と明記されており、本 PR がその後続にあたる。

## Test plan

- [ ] CI E2E ジョブが 60 秒 test timeout で全 PASS（マルチリクエスト test 含め）
- [ ] Issue #308 解決後の実測値で flake 再発がないこと

## Related

- Issue #308 (Closed): E2E CI でリクエスト遅延 7-9 秒/request の根本調査
- PR #307: playwright timeout 60s → 180s（本 PR で巻き戻し）
- PR #355: perf(auth): skip Firestore super-admin lookup in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)