### PR TITLE
refactor(api): resetLessonDataForUser のリトライ失敗ログを構造化

### DIFF
--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -1603,10 +1603,15 @@ export class FirestoreDataSource implements DataSource {
           break;
         } catch (err) {
           lastError = err;
-          console.error(
-            `resetLessonDataForUser batch ${Math.floor(i / BATCH_LIMIT) + 1} ` +
-            `attempt ${attempt + 1}/${MAX_RETRIES} failed:`, err
-          );
+          logger.error("resetLessonDataForUser batch deletion failed", {
+            userId,
+            lessonId,
+            batchNumber: Math.floor(i / BATCH_LIMIT) + 1,
+            totalBatches: Math.ceil(docsToDelete.length / BATCH_LIMIT),
+            attempt: attempt + 1,
+            maxRetries: MAX_RETRIES,
+            error: err,
+          });
           if (attempt < MAX_RETRIES - 1) {
             await new Promise(r => setTimeout(r, 100 * Math.pow(2, attempt)));
           }


### PR DESCRIPTION
## Summary

- `services/api/src/datasource/firestore.ts` の `resetLessonDataForUser` リトライ失敗時のログを `console.error` から `logger.error` に置換
- Cloud Logging で検索・集計できる構造化フィールド (`userId` / `lessonId` / `batchNumber` / `totalBatches` / `attempt` / `maxRetries` / `error`) を付与
- 同ファイル冒頭で `logger` は既に import 済み

## Background

Session 19 ハンドオフで「軽量・AI 独立可」として記録されていた候補 F。`resetLessonDataForUser` は出席管理 (lesson-session abandon 等) で呼ばれる batch 削除関数で、Firestore 障害時のリトライ失敗ログが残るコードパス。同ファイル内の他の error ログ ([L155](https://github.com/system-279/lms-279/blob/main/services/api/src/datasource/firestore.ts#L155), [L429](https://github.com/system-279/lms-279/blob/main/services/api/src/datasource/firestore.ts#L429), [L1660](https://github.com/system-279/lms-279/blob/main/services/api/src/datasource/firestore.ts#L1660) 等) は既に `logger.error` を使っており、本箇所のみ `console.error` が残っていた。

## Changes

| Before | After |
|---|---|
| `console.error("resetLessonDataForUser batch X attempt Y/Z failed:", err)` | `logger.error("resetLessonDataForUser batch deletion failed", { userId, lessonId, batchNumber, totalBatches, attempt, maxRetries, error: err })` |

`logger.error` は内部で `serializeError` を通すため、Error オブジェクトを渡すと `{ name, message, stack }` に展開される。

## Test plan

- [x] `npm test -w @lms-279/api` → 831 件全 PASS
- [x] `npm run type-check` → PASS
- [x] `npx eslint services/api/src/datasource/firestore.ts` → PASS (no output)

## Related

- Session 19 / Session 20 ハンドオフ候補 F (firestore.ts:1606 構造化ログ化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)