### PR TITLE
fix(super): Gmail draft の transient 分類修正 + popup fallback UI

### DIFF
--- a/services/api/src/services/__tests__/gmail-draft.test.ts
+++ b/services/api/src/services/__tests__/gmail-draft.test.ts
@@ -282,6 +282,19 @@ describe("classifyGmailError: network error (string code) → transient", () => 
     expect(result.httpStatus).toBe(503);
   });
 
+  it("response.status=429 + e.code=ECONNRESET → HTTP status 優先で gmail_quota_exceeded (429)", () => {
+    // undici の retry レイヤーで rate-limit 検出後にコネクションが切れたケース。
+    // HTTP status (429) が確定しているので API レイヤ分類を優先し、
+    // transport code (ECONNRESET) で transient 503 に降格させない。
+    const err = {
+      response: { status: 429, data: { error: { message: "Quota exceeded" } } },
+      code: "ECONNRESET",
+    };
+    const result = classifyGmailError(err);
+    expect(result.errorCode).toBe("gmail_quota_exceeded");
+    expect(result.httpStatus).toBe(429);
+  });
+
   it("未知の string code (EUNKNOWN) → gmail_api_error (httpStatus 502)、過剰分類しない", () => {
     const err = { code: "EUNKNOWN", message: "unknown error" };
     const result = classifyGmailError(err);

--- a/services/api/src/services/__tests__/gmail-draft.test.ts
+++ b/services/api/src/services/__tests__/gmail-draft.test.ts
@@ -38,6 +38,7 @@ const {
   buildGmailDraftUrl,
   createGmailDraft,
   GmailDraftError,
+  TRANSIENT_NETWORK_CODES,
   __internal,
 } = await import("../gmail-draft.js");
 
@@ -248,6 +249,51 @@ describe("classifyGmailError", () => {
   it("status 不明の error も gmail_api_error にフォールバック", () => {
     const err = new Error("network failure");
     expect(classifyGmailError(err).errorCode).toBe("gmail_api_error");
+  });
+});
+
+describe("classifyGmailError: network error (string code) → transient", () => {
+  // Node.js / undici の transport error code を gmail_api_transient に分類する。
+  // 参考: rules/error-handling.md §3 — ECONNRESET / ETIMEDOUT 等は transient
+  // 実装側 (gmail-draft.ts) の TRANSIENT_NETWORK_CODES を参照し、定義二重化を避ける。
+  const TRANSIENT_CASES = Array.from(TRANSIENT_NETWORK_CODES);
+
+  it.each(TRANSIENT_CASES)("e.code === %s → gmail_api_transient (httpStatus 503)", (code) => {
+    const err = { code, message: `${code}: connection issue` };
+    const result = classifyGmailError(err);
+    expect(result.errorCode).toBe("gmail_api_transient");
+    expect(result.httpStatus).toBe(503);
+  });
+
+  it("e.cause.code === ECONNRESET のみ (e.code なし) → gmail_api_transient", () => {
+    const err = { cause: { code: "ECONNRESET" }, message: "fetch failed" };
+    const result = classifyGmailError(err);
+    expect(result.errorCode).toBe("gmail_api_transient");
+    expect(result.httpStatus).toBe(503);
+  });
+
+  it("response.status=503 + e.code=ECONNRESET 両存在 → HTTP status 優先で gmail_api_transient", () => {
+    const err = {
+      response: { status: 503, data: { error: { message: "Service unavailable" } } },
+      code: "ECONNRESET",
+    };
+    const result = classifyGmailError(err);
+    expect(result.errorCode).toBe("gmail_api_transient");
+    expect(result.httpStatus).toBe(503);
+  });
+
+  it("未知の string code (EUNKNOWN) → gmail_api_error (httpStatus 502)、過剰分類しない", () => {
+    const err = { code: "EUNKNOWN", message: "unknown error" };
+    const result = classifyGmailError(err);
+    expect(result.errorCode).toBe("gmail_api_error");
+    expect(result.httpStatus).toBe(502);
+  });
+
+  it("e.code === '503' (string number) → 既存経路で gmail_api_transient (回帰なし)", () => {
+    const err = { code: "503", message: "Service unavailable" };
+    const result = classifyGmailError(err);
+    expect(result.errorCode).toBe("gmail_api_transient");
+    expect(result.httpStatus).toBe(503);
   });
 });
 

--- a/services/api/src/services/gmail-draft.ts
+++ b/services/api/src/services/gmail-draft.ts
@@ -155,12 +155,13 @@ export function buildRawMimeMessage(input: BuildRawMimeMessageInput): string {
 
 /**
  * Node.js / undici / gaxios の transport-level error code。
- * これらは一時的なネットワーク不安定で発生し、リトライで回復しうる。
+ * これらは一時的なネットワーク不安定で発生し、リトライで回復しうる
+ * (ECONNRESET / ETIMEDOUT 等は transient エラーとして扱う)。
  *
- * 参考: ~/.claude/rules/error-handling.md §3
- * (ECONNRESET / ETIMEDOUT / 429 / 503 等は transient → retry_pending 相当)
+ * 未収載の code は gmail_api_error (502) にフォールバックする。本番ログで
+ * transient 候補の漏れを発見したら本セットに追加する。
  *
- * Exported for test reuse — テスト側は本 Set を参照することで定義の二重化を避ける。
+ * export 理由: テスト側で本 Set を再利用し定義の二重化を避けるため。
  */
 export const TRANSIENT_NETWORK_CODES: ReadonlySet<string> = new Set([
   "ECONNRESET",
@@ -178,10 +179,12 @@ export const TRANSIENT_NETWORK_CODES: ReadonlySet<string> = new Set([
 /**
  * googleapis のエラーを ProgressPdfDraftErrorCode に分類する。
  *
- * 優先順位:
- *   1. HTTP status (response.status) — 401/403/429/503 等の API レイヤエラー
- *   2. transport-level network code (e.code / e.cause?.code) — ECONNRESET 等
- *   3. フォールバック (gmail_api_error)
+ * 評価順 (上位ほど優先):
+ *   1. response.status — Gmail API から返された HTTP status (401/403/429/503 等)
+ *   2. e.code が数値 / 数値文字列 — HTTP status として扱う (gaxios の歴史的挙動互換)
+ *   3. e.code / e.cause?.code が transport code 文字列 (ECONNRESET 等) — transient
+ *   4. e.status の存在 — HTTP status として扱う
+ *   5. フォールバック (gmail_api_error, httpStatus 502)
  *
  * GaxiosError の構造:
  * - .code: HTTP status (number) または transport code (string)
@@ -205,11 +208,13 @@ export function classifyGmailError(err: unknown): GmailDraftError {
     message?: string;
   };
 
-  const numericCodeFromString =
+  // e.code が "503" のような数値文字列のとき、それを HTTP status の候補として扱う。
+  // "ECONNRESET" 等の非数値文字列は undefined となり、後段の transport code 経路で評価される。
+  const httpStatusFromCode =
     typeof e.code === "string" && /^\d+$/.test(e.code) ? Number(e.code) : undefined;
   const status =
     e.response?.status ??
-    (typeof e.code === "number" ? e.code : numericCodeFromString) ??
+    (typeof e.code === "number" ? e.code : httpStatusFromCode) ??
     e.status ??
     0;
 
@@ -218,11 +223,13 @@ export function classifyGmailError(err: unknown): GmailDraftError {
   const message = e.response?.data?.error?.message ?? e.message ?? "Gmail API error";
 
   // transport-level network error は HTTP status 未確定のときのみ transient 扱い
-  // (HTTP status があれば API レイヤの分類を優先する)
+  // (HTTP status があれば API レイヤの分類を優先する)。
   if (!e.response?.status) {
-    const networkCode =
-      (typeof e.code === "string" && !numericCodeFromString ? e.code : undefined) ??
-      (typeof e.cause?.code === "string" ? e.cause.code : undefined);
+    const transportCodeFromError =
+      typeof e.code === "string" && httpStatusFromCode === undefined ? e.code : undefined;
+    const transportCodeFromCause =
+      typeof e.cause?.code === "string" ? e.cause.code : undefined;
+    const networkCode = transportCodeFromError ?? transportCodeFromCause;
     if (networkCode && TRANSIENT_NETWORK_CODES.has(networkCode)) {
       return new GmailDraftError(message, "gmail_api_transient", 503, err);
     }

--- a/services/api/src/services/gmail-draft.ts
+++ b/services/api/src/services/gmail-draft.ts
@@ -154,10 +154,38 @@ export function buildRawMimeMessage(input: BuildRawMimeMessageInput): string {
 }
 
 /**
+ * Node.js / undici / gaxios の transport-level error code。
+ * これらは一時的なネットワーク不安定で発生し、リトライで回復しうる。
+ *
+ * 参考: ~/.claude/rules/error-handling.md §3
+ * (ECONNRESET / ETIMEDOUT / 429 / 503 等は transient → retry_pending 相当)
+ *
+ * Exported for test reuse — テスト側は本 Set を参照することで定義の二重化を避ける。
+ */
+export const TRANSIENT_NETWORK_CODES: ReadonlySet<string> = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ESOCKETTIMEDOUT",
+  "ECONNABORTED",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/**
  * googleapis のエラーを ProgressPdfDraftErrorCode に分類する。
  *
+ * 優先順位:
+ *   1. HTTP status (response.status) — 401/403/429/503 等の API レイヤエラー
+ *   2. transport-level network code (e.code / e.cause?.code) — ECONNRESET 等
+ *   3. フォールバック (gmail_api_error)
+ *
  * GaxiosError の構造:
- * - .code: HTTP status (string or number)
+ * - .code: HTTP status (number) または transport code (string)
+ * - .cause?.code: undici が wrapping した下層 transport code
  * - .response?.status: HTTP status
  * - .response?.data?.error?.errors?: [{ reason: string, message: string }]
  * - .errors?: [{ reason: string, message: string }]
@@ -168,6 +196,7 @@ export function classifyGmailError(err: unknown): GmailDraftError {
   const e = err as {
     code?: number | string;
     status?: number;
+    cause?: { code?: unknown };
     response?: {
       status?: number;
       data?: { error?: { code?: number; message?: string; errors?: Array<{ reason?: string; message?: string }> } };
@@ -176,15 +205,28 @@ export function classifyGmailError(err: unknown): GmailDraftError {
     message?: string;
   };
 
+  const numericCodeFromString =
+    typeof e.code === "string" && /^\d+$/.test(e.code) ? Number(e.code) : undefined;
   const status =
     e.response?.status ??
-    (typeof e.code === "number" ? e.code : typeof e.code === "string" ? Number(e.code) : NaN) ??
+    (typeof e.code === "number" ? e.code : numericCodeFromString) ??
     e.status ??
     0;
 
   const errors = e.response?.data?.error?.errors ?? e.errors ?? [];
   const reason = errors[0]?.reason ?? "";
   const message = e.response?.data?.error?.message ?? e.message ?? "Gmail API error";
+
+  // transport-level network error は HTTP status 未確定のときのみ transient 扱い
+  // (HTTP status があれば API レイヤの分類を優先する)
+  if (!e.response?.status) {
+    const networkCode =
+      (typeof e.code === "string" && !numericCodeFromString ? e.code : undefined) ??
+      (typeof e.cause?.code === "string" ? e.cause.code : undefined);
+    if (networkCode && TRANSIENT_NETWORK_CODES.has(networkCode)) {
+      return new GmailDraftError(message, "gmail_api_transient", 503, err);
+    }
+  }
 
   // 401: invalid_access_token
   if (status === 401) {

--- a/web/app/super/progress/[tenantId]/[userId]/print/__tests__/page.test.tsx
+++ b/web/app/super/progress/[tenantId]/[userId]/print/__tests__/page.test.tsx
@@ -101,7 +101,9 @@ describe("AC-9: 成功時 window.open で Gmail タブを開く", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const windowOpenSpy = vi.fn();
+    // window.open は成功時に Window-like オブジェクト ({ closed: false }) を返す前提。
+    // popup ブロック検出 (null / closed=true) と区別するため明示的に non-null を返す。
+    const windowOpenSpy = vi.fn().mockReturnValue({ closed: false } as Window);
     vi.stubGlobal("open", windowOpenSpy);
 
     render(<PrintPage />);
@@ -130,6 +132,9 @@ describe("AC-9: 成功時 window.open で Gmail タブを開く", () => {
         "noopener,noreferrer",
       );
     });
+
+    // 成功時は fallback UI (Gmail を開くリンク) が出ないこと
+    expect(screen.queryByRole("link", { name: /Gmail を開いてください/ })).toBeNull();
   });
 });
 
@@ -151,7 +156,7 @@ describe("AC-5: scope 不足エラーで再同意リトライ", () => {
       });
     vi.stubGlobal("fetch", fetchMock);
 
-    const windowOpenSpy = vi.fn();
+    const windowOpenSpy = vi.fn().mockReturnValue({ closed: false } as Window);
     vi.stubGlobal("open", windowOpenSpy);
 
     render(<PrintPage />);
@@ -173,6 +178,103 @@ describe("AC-5: scope 不足エラーで再同意リトライ", () => {
         "_blank",
         "noopener,noreferrer",
       );
+    });
+  });
+});
+
+describe("I5: popup ブロック時の fallback UI", () => {
+  it("window.open が null を返す → 「下書きは作成済み」+ Gmail を開くリンクが描画される", async () => {
+    const draftUrl = "https://mail.google.com/mail/u/0/?ogbl#drafts/r-popup-null";
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ draftId: "r-popup-null", draftUrl }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // popup ブロック相当: window.open が null を返す
+    const windowOpenSpy = vi.fn().mockReturnValue(null);
+    vi.stubGlobal("open", windowOpenSpy);
+
+    render(<PrintPage />);
+
+    const draftButton = await screen.findByRole("button", { name: /Gmail 下書き作成/ });
+    fireEvent.click(draftButton);
+
+    // 「下書きは作成済み」を含む文言と Gmail を開くリンクが出る
+    const fallbackLink = await screen.findByRole("link", { name: /Gmail を開いてください/ });
+    expect(fallbackLink.getAttribute("href")).toBe(draftUrl);
+    expect(fallbackLink.getAttribute("target")).toBe("_blank");
+    // rel: target=_blank なら noopener / noreferrer 必須
+    const rel = fallbackLink.getAttribute("rel") ?? "";
+    expect(rel).toMatch(/noopener/);
+    expect(rel).toMatch(/noreferrer/);
+
+    // 「ブロック」と断定する文言は使わない: noopener/noreferrer + COOP で参照切れになり、
+    // 成功時でも null/closed=true が返るケースがあり「blocked」誤検知し得るため。
+    expect(screen.queryByText(/ブロックされました/)).toBeNull();
+    expect(screen.queryByText(/下書きは作成済み/)).not.toBeNull();
+  });
+
+  it("window.open が closed=true の Window を返す → fallback UI が描画される", async () => {
+    const draftUrl = "https://mail.google.com/mail/u/0/?ogbl#drafts/r-closed-true";
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ draftId: "r-closed-true", draftUrl }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const windowOpenSpy = vi.fn().mockReturnValue({ closed: true } as Window);
+    vi.stubGlobal("open", windowOpenSpy);
+
+    render(<PrintPage />);
+
+    const draftButton = await screen.findByRole("button", { name: /Gmail 下書き作成/ });
+    fireEvent.click(draftButton);
+
+    const fallbackLink = await screen.findByRole("link", { name: /Gmail を開いてください/ });
+    expect(fallbackLink.getAttribute("href")).toBe(draftUrl);
+  });
+
+  it("2 回目の handleCreateDraft 開始時、前回の fallback URL がクリアされる", async () => {
+    const firstUrl = "https://mail.google.com/mail/u/0/?ogbl#drafts/r-first";
+    const secondUrl = "https://mail.google.com/mail/u/0/?ogbl#drafts/r-second";
+
+    // 1 回目: null 返却 → fallback 表示。2 回目: 成功 ({ closed: false }) → fallback 消える
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ draftId: "r-first", draftUrl: firstUrl }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ draftId: "r-second", draftUrl: secondUrl }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const windowOpenSpy = vi
+      .fn()
+      .mockReturnValueOnce(null) // 1 回目: ブロック相当
+      .mockReturnValue({ closed: false } as Window); // 2 回目以降: 成功
+    vi.stubGlobal("open", windowOpenSpy);
+
+    render(<PrintPage />);
+
+    const draftButton = await screen.findByRole("button", { name: /Gmail 下書き作成/ });
+
+    // 1 回目: fallback 表示
+    fireEvent.click(draftButton);
+    const firstLink = await screen.findByRole("link", { name: /Gmail を開いてください/ });
+    expect(firstLink.getAttribute("href")).toBe(firstUrl);
+
+    // 2 回目: ボタンが enabled に戻るのを待ってから再押下
+    await waitFor(() => expect(draftButton).not.toBeDisabled());
+    fireEvent.click(draftButton);
+
+    // 古い fallback link が消えて新規 API が呼ばれる
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      expect(screen.queryByRole("link", { name: /Gmail を開いてください/ })).toBeNull();
     });
   });
 });

--- a/web/app/super/progress/[tenantId]/[userId]/print/page.tsx
+++ b/web/app/super/progress/[tenantId]/[userId]/print/page.tsx
@@ -84,6 +84,9 @@ export default function ProgressPdfPrintPage() {
   const [draftCreating, setDraftCreating] = useState(false);
   const [draftError, setDraftError] = useState<string | null>(null);
   const [draftRequestId, setDraftRequestId] = useState<string>(() => crypto.randomUUID());
+  // window.open が popup ブロック (null) または COOP で参照切れ (closed=true) となった場合の
+  // フォールバック URL。ユーザーが手動で Gmail 下書きを開くためのリンクを描画する。
+  const [draftFallbackUrl, setDraftFallbackUrl] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -197,6 +200,7 @@ export default function ProgressPdfPrintPage() {
     if (!meta || !ownerEmail) return;
     setDraftCreating(true);
     setDraftError(null);
+    setDraftFallbackUrl(null);
 
     const callDraftApi = async (accessToken: string): Promise<ProgressPdfDraftResponse> => {
       const idToken = AUTH_MODE === "firebase" ? await getIdToken() : null;
@@ -245,8 +249,14 @@ export default function ProgressPdfPrintPage() {
         }
       }
 
-      // 3. 下書き URL を新規タブで開く
-      window.open(result.draftUrl, "_blank", "noopener,noreferrer");
+      // 3. 下書き URL を新規タブで開く。
+      //    win === null は popup ブロック、closed=true は COOP/ブラウザ実装で参照切れ。
+      //    どちらも「開けたか」を断定できないため、フォールバックリンクを描画して
+      //    ユーザーが確実に Gmail 下書きにたどり着けるようにする。
+      const win = window.open(result.draftUrl, "_blank", "noopener,noreferrer");
+      if (!win || win.closed) {
+        setDraftFallbackUrl(result.draftUrl);
+      }
 
       // 次回用に requestId 再発行
       setDraftRequestId(crypto.randomUUID());
@@ -266,6 +276,7 @@ export default function ProgressPdfPrintPage() {
         const messages: Partial<Record<ProgressPdfDraftErrorCode, string>> = {
           gmail_quota_exceeded: "Gmail API の送信制限に達しました。しばらくしてから再試行してください。",
           gmail_scope_required: "Gmail 送信権限の同意が必要です。再度お試しください。",
+          gmail_api_transient: "Gmail サーバーへの接続が一時的に不安定です。しばらく後に再試行してください。",
           pdf_too_large_for_gmail: "PDF サイズが上限 (5MB) を超えました。出力項目を絞ってください。",
           owner_email_not_set: "テナント管理者メールが未設定です。テナント詳細画面で設定してください。",
           no_sections_selected: "出力項目を少なくとも 1 つ選択してください。",
@@ -359,6 +370,20 @@ export default function ProgressPdfPrintPage() {
             {generateError && <span className="text-sm text-red-600">{generateError}</span>}
             {draftError && <span className="text-sm text-red-600">{draftError}</span>}
           </div>
+          {draftFallbackUrl && (
+            <p className="text-sm text-amber-700">
+              下書きは作成済みです。新しいタブが開かない場合は
+              <a
+                href={draftFallbackUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline ml-1 mr-1"
+              >
+                こちらから Gmail を開いてください
+              </a>
+              。
+            </p>
+          )}
           <p className="text-xs text-muted-foreground">
             「Gmail 下書き作成」はスーパー管理者本人の Gmail 下書きフォルダに、宛先 ({ownerEmail ?? "未設定"}) と PDF 添付付きで下書きを作成します。Gmail が新しいタブで開きますので内容を確認・編集してから送信してください。
           </p>


### PR DESCRIPTION
## Summary

PR #358 follow-up Important 級 2 件を 1 PR で対応。Codex セカンドオピニオン + `/simplify` + `/safe-refactor` 通過済み。

- **I1**: `classifyGmailError` が `ECONNRESET` / `ETIMEDOUT` 等の transport-level error code を `gmail_api_error` (permanent) に誤分類していた問題を修正。グローバルルール `~/.claude/rules/error-handling.md §3` (transient/permanent 分類) への準拠。
- **I5**: `window.open` が popup ブロック (`null`) または COOP で参照切れ (`closed=true`) のときの silent failure を解消。「下書きは作成済み」+ Gmail を手動で開く fallback リンクを表示。

## 修正内容

### I1 - services/api/src/services/gmail-draft.ts

| 変更 | 内容 |
|---|---|
| `TRANSIENT_NETWORK_CODES` set | `ECONNRESET` / `ETIMEDOUT` / `ENOTFOUND` / `EAI_AGAIN` / `ECONNREFUSED` / `ESOCKETTIMEDOUT` / `ECONNABORTED` / `UND_ERR_CONNECT_TIMEOUT` / `UND_ERR_HEADERS_TIMEOUT` / `UND_ERR_SOCKET` (10 種) を transient として `gmail_api_transient` (HTTP 503) に分類 |
| 優先順位明文化 | 1. `response.status`、2. transport network code (`e.code` / `e.cause?.code`)、3. フォールバック |
| `e.cause?.code` 検出 | undici 経由でラップされた transport error にも対応 |
| `numericCodeFromString` 抽出 | `code === "503"` のような数値文字列は既存 HTTP status 経路を維持 |
| `TRANSIENT_NETWORK_CODES` export | テストから参照して定義の二重化を解消 |

### I5 - web/app/super/progress/[tenantId]/[userId]/print/page.tsx

| 変更 | 内容 |
|---|---|
| `draftFallbackUrl` state 追加 | popup 開けない場合の手動リンク用 URL |
| `handleCreateDraft` 冒頭 clear | 前回の fallback URL 残留を防止 |
| `window.open` 戻り値チェック | `!win || win.closed` のとき `setDraftFallbackUrl` |
| FE エラーメッセージマップに `gmail_api_transient` 追加 | `"Gmail サーバーへの接続が一時的に不安定です。しばらく後に再試行してください。"` |
| JSX に `<a>` fallback リンク | `target="_blank"` + `rel="noopener noreferrer"` で安全 |

「ブロックされました」と断定せず、`noopener,noreferrer` + COOP で参照切れになり成功時でも `null/closed=true` が返るケースに耐える文言で吸収（Codex 指摘）。

### スコープ外 (本 PR で対応しない)

- **I2** (`GmailDraftError.originalError` が GaxiosError raw を保持): 現状 route 層で `originalError` を logger に渡さない方針が HIGH-1 (Session 20) で対応済。本 PR では規約として継続のみ、コード変更なし。

## 影響

- 本番デプロイ後、Gmail API 呼び出し中のネットワーク瞬断時に FE が「一時的な通信エラー、しばらく後に再試行」を表示するようになる (従来は `gmail_api_error` 扱いで何度試行しても同メッセージ)。
- Safari / Firefox で popup ブロック時に「下書きは作成済み + Gmail を開くリンク」が表示される (従来は silent failure)。
- shared-types 変更なし、route 層変更なし、API 契約変更なし。

## Test plan

- [x] `npm test -w @lms-279/api` → 845 PASS (Phase 2 末 831 → +14: transient 10 + cause.code + status 優先 + EUNKNOWN + "503" string)
- [x] `npm test -w @lms-279/web` → 40 PASS (Phase 2 末 37 → +3: I5 popup null / closed=true / fallback URL clear)
- [x] `npm run lint` → PASS
- [x] `npm run type-check` → PASS (4 workspaces)
- [x] `/simplify` 3 並列 (reuse / quality / efficiency) → MEDIUM 2 件修正済 (TRANSIENT_NETWORK_CODES export + task-reference コメント技術背景化)、LOW 4 件は別 PR / 本 PR スコープ外
- [x] `/safe-refactor` → HIGH/MEDIUM 0 件、LOW 4 件は本 PR スコープ外で修正不要
- [x] Codex `mcp__codex__codex` plan モード → 5 観点 (致命的欠陥 / AC 抜け漏れ / I2 同梱判断 / 追加リスク / PR 分割 ROI) で評価、High 1 件を計画段階で吸収 (I5 「ブロック」断定を避ける文言設計)
- [ ] CI (GitHub Actions) PASS 確認 (push 後)
- [ ] E2E (e2e.yml) PASS 確認 (push 後)

## Acceptance Criteria

### I1 - classifyGmailError (15 件)

| AC | 内容 | 検証 |
|---|---|---|
| AC-I1-1〜10 | 10 種の transient code → `gmail_api_transient` (503) | `it.each` 10 件 |
| AC-I1-11 | `e.cause.code === "ECONNRESET"` のみ → `gmail_api_transient` | vitest |
| AC-I1-12 | `response.status=503 + e.code=ECONNRESET` → HTTP status 優先 | vitest |
| AC-I1-13 | 未知 string code (`EUNKNOWN`) → `gmail_api_error` (502)、過剰分類しない | vitest |
| AC-I1-14 | `e.code === "503"` (string number) → 既存 transient 経路維持 | vitest |
| AC-I1-15 (既存) | 401/403/429/503/500 の HTTP status 分類は回帰なし | 既存 9 件 |

### I5 - popup ブロック fallback (3 件)

| AC | 内容 | 検証 |
|---|---|---|
| AC-I5-1 | `window.open === null` → 「下書きは作成済み」+ `<a>` リンク描画、`target="_blank"` + `rel` 含む | vitest |
| AC-I5-2 | `window.open` が `{ closed: true }` を返す → fallback UI 描画 | vitest |
| AC-I5-3 | 2 回目開始時、前回の `draftFallbackUrl` がクリアされる | vitest |
| AC-I5-4 (既存) | `window.open` が non-null Window を返す → fallback UI 出ない (回帰なし) | 既存 AC-9 拡張 |

## Risk と回復策

| Risk | 影響 | 対策 |
|---|---|---|
| `noopener,noreferrer` で成功時にも `null` 返却するブラウザ実装 | UX 低下（実害なし、リンクで Gmail 開ける） | 「ブロック」断定文言を避け安全文言で吸収 |
| 未知 string code を transient に過剰分類 | 永久リトライループ | `TRANSIENT_NETWORK_CODES` set で明示列挙のみ、未知 code は `gmail_api_error` (permanent) |
| 既存 AC-9 / AC-5 テストの `window.open` mock が undefined 返却で fallback UI 誤発火 | テスト破壊 | mock を `vi.fn().mockReturnValue({ closed: false } as Window)` に更新 |

## Refs

- PR #358 (Phase 2 Gmail draft 採用)
- ADR-034 §8 (`ProgressPdfDraftErrorCode` Union 既存 17 値の re-use)
- `~/.claude/rules/error-handling.md §3` (transient/permanent 分類)
- `~/.claude/rules/testing.md §5` (外部API エラー分類のテスト必須)

🤖 Generated with [Claude Code](https://claude.com/claude-code)