### PR TITLE
fix(super): Progress PDF ファイル名で日本語名を保持 (Issue #366)

### DIFF
--- a/packages/shared-types/src/filename.ts
+++ b/packages/shared-types/src/filename.ts
@@ -1,0 +1,59 @@
+/**
+ * 進捗 PDF 添付ファイル名を生成する共通ヘルパ。
+ *
+ * 背景: Issue #366
+ * 過去の sanitize ロジック `name.replace(/[^A-Za-z0-9._-]/g, "_")` は
+ * 日本語名を一律 `_` に置換し、`progress-___-2026-05-14.pdf` のような
+ * 識別不能なファイル名を生成していた。
+ *
+ * 設計:
+ * - Gmail draft 経路: services/api/src/services/gmail-draft.ts の
+ *   encodeMimeHeader が RFC 2047 (=?UTF-8?B?...?=) で Unicode を safe に
+ *   エンコードするため、filename に日本語を含めても表示は崩れない。
+ * - HTTP attachment 経路: services/api/src/routes/super/progress-pdf.ts は
+ *   Content-Disposition: filename*=UTF-8''<encoded> (RFC 6266) を発行
+ *   しており、モダンブラウザは Unicode filename を正しく扱える。
+ * - ブラウザダウンロード経路: <a download> 属性は modern browser で
+ *   Unicode をそのまま許容する。
+ *
+ * 本ヘルパは以下のみを除去する:
+ * - OS / HTTP unsafe な特殊文字: / \ : * ? " < > |
+ * - 制御文字 (U+0000 - U+001F, U+007F): CR/LF を含む
+ *
+ * name が空 / 全空白 / sanitize 結果が空 の場合は email にフォールバックする。
+ * email も同じ sanitize ロジックを通すが、@ が含まれるためまず置換されない。
+ */
+export interface BuildProgressPdfFilenameInput {
+  /** 受講者名 (null/undefined/空文字許容) */
+  name: string | null | undefined;
+  /** 受講者 email (name 空の場合の fallback) */
+  email: string;
+  /** 日付文字列 (YYYY-MM-DD 形式想定。本関数では検証しない) */
+  date: string;
+}
+
+// 制御文字 (U+0000 - U+001F, U+007F) + OS / HTTP unsafe 特殊文字を _ に置換する。
+// 文字クラス内のリテラル制御文字は editor / diff viewer で見えずレビュー事故の温床に
+// なるため、エスケープ表記で記述する。
+const UNSAFE_CHARS_RE = /[\x00-\x1f\x7f<>:"/\\|?*]/g;
+
+// 受講者名相当の長さ上限 (UTF-16 code unit 数)。
+// 日本語 50 文字 ≒ UTF-8 で約 150 bytes。全体 (`progress-` + name + `-YYYY-MM-DD.pdf`) で
+// ext4 / NTFS / HFS+ の 255 byte ファイル名制限内に収まる。
+const MAX_SANITIZED_LENGTH = 50;
+
+function sanitizeForFilename(value: string): string {
+  return value
+    .replace(UNSAFE_CHARS_RE, "_")
+    .replace(/_+/g, "_")
+    .replace(/^[._]+|[._]+$/g, "")
+    .trim()
+    .slice(0, MAX_SANITIZED_LENGTH);
+}
+
+export function buildProgressPdfFilename(input: BuildProgressPdfFilenameInput): string {
+  const rawName = (input.name ?? "").trim();
+  const sanitizedName = sanitizeForFilename(rawName);
+  const safeName = sanitizedName.length > 0 ? sanitizedName : sanitizeForFilename(input.email);
+  return `progress-${safeName}-${input.date}.pdf`;
+}

--- a/packages/shared-types/src/filename.ts
+++ b/packages/shared-types/src/filename.ts
@@ -37,18 +37,22 @@ export interface BuildProgressPdfFilenameInput {
 // なるため、エスケープ表記で記述する。
 const UNSAFE_CHARS_RE = /[\x00-\x1f\x7f<>:"/\\|?*]/g;
 
-// 受講者名相当の長さ上限 (UTF-16 code unit 数)。
+// 受講者名相当の長さ上限 (Unicode code point 数)。
 // 日本語 50 文字 ≒ UTF-8 で約 150 bytes。全体 (`progress-` + name + `-YYYY-MM-DD.pdf`) で
 // ext4 / NTFS / HFS+ の 255 byte ファイル名制限内に収まる。
+//
+// 注: `String.prototype.slice` は UTF-16 code unit 単位なのでサロゲートペア (絵文字等) を
+// 分断し lone surrogate を生成する。後段 progress-pdf.ts の encodeURIComponent が
+// URIError を投げて 500 になるため、Array.from() で code point 単位に分解してから slice する。
 const MAX_SANITIZED_LENGTH = 50;
 
 function sanitizeForFilename(value: string): string {
-  return value
+  const cleaned = value
     .replace(UNSAFE_CHARS_RE, "_")
     .replace(/_+/g, "_")
     .replace(/^[._]+|[._]+$/g, "")
-    .trim()
-    .slice(0, MAX_SANITIZED_LENGTH);
+    .trim();
+  return Array.from(cleaned).slice(0, MAX_SANITIZED_LENGTH).join("");
 }
 
 export function buildProgressPdfFilename(input: BuildProgressPdfFilenameInput): string {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -8,3 +8,4 @@ export type * from "./enrollment.js";
 export type * from "./quiz.js";
 export type * from "./tenant.js";
 export type * from "./progress-pdf.js";
+export * from "./filename.js";

--- a/services/api/src/__tests__/integration/progress-pdf-draft.test.ts
+++ b/services/api/src/__tests__/integration/progress-pdf-draft.test.ts
@@ -280,12 +280,30 @@ describe("POST /api/v2/super/tenants/:tenantId/users/:userId/progress-pdf-draft"
           subject: expect.stringContaining("莞爾会 長遊園"),
           body: expect.stringContaining("山田 太郎"),
           attachment: expect.objectContaining({
-            filename: expect.stringMatching(/^progress-.*\.pdf$/),
+            // Issue #366: 日本語名 (山田 太郎) がそのままファイル名に含まれる
+            // (連続 _ で受講者を識別不能にしない)
+            filename: expect.stringMatching(/^progress-山田 太郎-\d{4}-\d{2}-\d{2}\.pdf$/),
             contentType: "application/pdf",
             content: FAKE_PDF,
           }),
         }),
       );
+    });
+
+    // Issue #366 の再発防止リグレッションマーカー。AC-2 (上記) の正規表現でも完全に
+     // 検証済みだが、本テストは「日本語が ___ に潰れない」という Issue 本質を
+     // 直接的に表現するため、意図を明示するシグナルとして残す。
+    it("Issue #366: 日本語名は filename に保持され ___ に潰されない", async () => {
+      const { user } = await seedTenant(ds);
+
+      await request
+        .post(`/api/v2/super/tenants/tenant-1/users/${user.id}/progress-pdf-draft`)
+        .send({ requestId: "req-jp-name", sections: ALL_ON, accessToken: "t" });
+
+      const call = mocks.createGmailDraftMock.mock.calls[0]?.[0];
+      const filename: string = call?.attachment?.filename ?? "";
+      expect(filename).toContain("山田 太郎");
+      expect(filename).not.toMatch(/_{3,}/);
     });
 
     it("AC-8: 成功時 監査ログに status=success + PII 最小化", async () => {

--- a/services/api/src/__tests__/unit/filename.test.ts
+++ b/services/api/src/__tests__/unit/filename.test.ts
@@ -134,4 +134,30 @@ describe("buildProgressPdfFilename (Issue #366)", () => {
     });
     expect(filename).toBe(`progress-${"a".repeat(50)}-2026-05-14.pdf`);
   });
+
+  // Codex review 指摘: UTF-16 code unit slice はサロゲートペアを分断し、後段
+  // encodeURIComponent で URIError を投げて HTTP 500 になる。code point 単位で
+  // truncate することで境界が常に valid な UTF-16 / UTF-8 になることを保証する。
+  it("サロゲートペア (絵文字) を含む name で lone surrogate を生成しない", () => {
+    const filename = buildProgressPdfFilename({
+      name: "😀".repeat(100), // 100 code points = 200 UTF-16 code units
+      email: "x@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe(`progress-${"😀".repeat(50)}-2026-05-14.pdf`);
+    // encodeURIComponent で URIError が出ないこと (lone surrogate 不在の証明)
+    expect(() => encodeURIComponent(filename)).not.toThrow();
+  });
+
+  it("BMP 外文字を 50 code point 境界に持つ name も valid な UTF-16 を保つ", () => {
+    // 49 BMP 文字 + 1 絵文字 (UTF-16 で 2 code unit) → 全体 51 code unit だが 50 code point
+    const name = "a".repeat(49) + "😀" + "extra";
+    const filename = buildProgressPdfFilename({
+      name,
+      email: "x@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe(`progress-${"a".repeat(49)}😀-2026-05-14.pdf`);
+    expect(() => encodeURIComponent(filename)).not.toThrow();
+  });
 });

--- a/services/api/src/__tests__/unit/filename.test.ts
+++ b/services/api/src/__tests__/unit/filename.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { buildProgressPdfFilename } from "@lms-279/shared-types";
+
+describe("buildProgressPdfFilename (Issue #366)", () => {
+  it("AC-1: 日本語名はそのまま保持される", () => {
+    const filename = buildProgressPdfFilename({
+      name: "山田 太郎",
+      email: "y@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-山田 太郎-2026-05-14.pdf");
+    expect(filename).not.toMatch(/_{3,}/);
+  });
+
+  it("AC-1: 単純な日本語名 (テスト) で ___ にならない", () => {
+    const filename = buildProgressPdfFilename({
+      name: "テスト",
+      email: "test@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-テスト-2026-05-14.pdf");
+    expect(filename).not.toContain("___");
+  });
+
+  it("AC-2: name が null なら email にフォールバック", () => {
+    const filename = buildProgressPdfFilename({
+      name: null,
+      email: "user@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-user@example.com-2026-05-14.pdf");
+  });
+
+  it("AC-2: name が undefined なら email にフォールバック", () => {
+    const filename = buildProgressPdfFilename({
+      name: undefined,
+      email: "user@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-user@example.com-2026-05-14.pdf");
+  });
+
+  it("AC-2: name が空文字なら email にフォールバック", () => {
+    const filename = buildProgressPdfFilename({
+      name: "",
+      email: "user@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-user@example.com-2026-05-14.pdf");
+  });
+
+  it("AC-2: name が空白文字のみなら email にフォールバック", () => {
+    const filename = buildProgressPdfFilename({
+      name: "   ",
+      email: "user@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-user@example.com-2026-05-14.pdf");
+  });
+
+  it("AC-3: OS unsafe 文字 (/, \\, :, *, ?, \", <, >, |) は _ に置換", () => {
+    const filename = buildProgressPdfFilename({
+      name: 'a/b\\c:d*e?f"g<h>i|j',
+      email: "x@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-a_b_c_d_e_f_g_h_i_j-2026-05-14.pdf");
+  });
+
+  it("AC-3: 制御文字 (CR/LF) は _ に置換", () => {
+    const filename = buildProgressPdfFilename({
+      name: "line1\r\nline2",
+      email: "x@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-line1_line2-2026-05-14.pdf");
+  });
+
+  it("AC-3: 連続する _ は 1 つに圧縮", () => {
+    const filename = buildProgressPdfFilename({
+      name: "a///b",
+      email: "x@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-a_b-2026-05-14.pdf");
+  });
+
+  it("AC-4: name が全て危険文字なら email にフォールバック", () => {
+    const filename = buildProgressPdfFilename({
+      name: "///",
+      email: "user@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-user@example.com-2026-05-14.pdf");
+  });
+
+  it("英数字とドット・ハイフン・アンダースコアは保持される", () => {
+    const filename = buildProgressPdfFilename({
+      name: "John_Doe-2024.v1",
+      email: "x@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-John_Doe-2024.v1-2026-05-14.pdf");
+  });
+
+  it("名前先頭/末尾のドット・アンダースコアはトリム", () => {
+    const filename = buildProgressPdfFilename({
+      name: ".._Alice_..",
+      email: "x@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe("progress-Alice-2026-05-14.pdf");
+  });
+
+  it("極端に長い日本語名は 50 code unit で truncate される (ファイル名長制限対策)", () => {
+    const longName = "あ".repeat(200); // UTF-8 で約 600 bytes
+    const filename = buildProgressPdfFilename({
+      name: longName,
+      email: "x@example.com",
+      date: "2026-05-14",
+    });
+    // `progress-` (9) + あ × 50 (50 code units) + `-2026-05-14.pdf` (15) = 74 code units
+    expect(filename).toBe(`progress-${"あ".repeat(50)}-2026-05-14.pdf`);
+    // UTF-8 で日本語 50 文字 ≒ 150 bytes、全体で 174 bytes と 255 byte 上限内
+    expect(Buffer.byteLength(filename, "utf-8")).toBeLessThan(255);
+  });
+
+  it("極端に長い ASCII 名も 50 文字で truncate", () => {
+    const longName = "a".repeat(200);
+    const filename = buildProgressPdfFilename({
+      name: longName,
+      email: "x@example.com",
+      date: "2026-05-14",
+    });
+    expect(filename).toBe(`progress-${"a".repeat(50)}-2026-05-14.pdf`);
+  });
+});

--- a/services/api/src/routes/super/progress-pdf-draft.ts
+++ b/services/api/src/routes/super/progress-pdf-draft.ts
@@ -25,12 +25,13 @@
 import { Router, type Request, type Response } from "express";
 import { getFirestore } from "firebase-admin/firestore";
 import { renderToBuffer } from "@react-pdf/renderer";
-import type {
-  ProgressPdfDraftErrorCode,
-  ProgressPdfDraftRequest,
-  ProgressPdfDraftResponse,
-  ProgressPdfSectionKey,
-  ProgressPdfSections,
+import {
+  buildProgressPdfFilename,
+  type ProgressPdfDraftErrorCode,
+  type ProgressPdfDraftRequest,
+  type ProgressPdfDraftResponse,
+  type ProgressPdfSectionKey,
+  type ProgressPdfSections,
 } from "@lms-279/shared-types";
 import { getDataSource } from "../../datasource/factory.js";
 import { validateTenantId } from "../../middleware/tenant.js";
@@ -102,10 +103,6 @@ function parseBody(body: unknown): ParsedBody | ParseError {
     return { error: "invalid_access_token", message: "accessToken must be a non-empty string" };
   }
   return { requestId, sections: parsedSections, accessToken };
-}
-
-function sanitizeFilename(name: string): string {
-  return name.replace(/[^A-Za-z0-9._-]/g, "_");
 }
 
 router.post(
@@ -299,10 +296,13 @@ router.post(
       subject = template.subject;
       body = template.body;
 
-      const filenameSafeName = sanitizeFilename(pdfData.user.name ?? pdfData.user.email);
       const dateStr = pdfData.generatedAt.slice(0, 10);
       attachment = {
-        filename: `progress-${filenameSafeName}-${dateStr}.pdf`,
+        filename: buildProgressPdfFilename({
+          name: pdfData.user.name,
+          email: pdfData.user.email,
+          date: dateStr,
+        }),
         contentType: "application/pdf",
         content: pdfBuffer,
       };

--- a/services/api/src/routes/super/progress-pdf.ts
+++ b/services/api/src/routes/super/progress-pdf.ts
@@ -15,10 +15,11 @@
 import { Router, type Request, type Response } from "express";
 import { getFirestore } from "firebase-admin/firestore";
 import { renderToBuffer } from "@react-pdf/renderer";
-import type {
-  ProgressPdfRequest,
-  ProgressPdfSectionKey,
-  ProgressPdfSections,
+import {
+  buildProgressPdfFilename,
+  type ProgressPdfRequest,
+  type ProgressPdfSectionKey,
+  type ProgressPdfSections,
 } from "@lms-279/shared-types";
 import { getDataSource } from "../../datasource/factory.js";
 import { validateTenantId } from "../../middleware/tenant.js";
@@ -156,15 +157,26 @@ router.post(
         return;
       }
 
-      const filenameSafeName = (pdfData.user.name ?? pdfData.user.email).replace(/[^A-Za-z0-9._-]/g, "_");
       const dateStr = pdfData.generatedAt.slice(0, 10);
-      const filename = `progress-${filenameSafeName}-${dateStr}.pdf`;
+      const filename = buildProgressPdfFilename({
+        name: pdfData.user.name,
+        email: pdfData.user.email,
+        date: dateStr,
+      });
+      // RFC 6266: filename="..." は ASCII safe な fallback、filename*=UTF-8'' は Unicode。
+      // Node.js の setHeader は ISO-8859-1 を期待するため、非 ASCII を含む filename は
+      // email ベースの ASCII fallback に置き換える (モダンブラウザは filename* を優先)。
+      const asciiFallback = buildProgressPdfFilename({
+        name: null,
+        email: pdfData.user.email,
+        date: dateStr,
+      }).replace(/[^\x20-\x7e]/g, "_");
 
       res.setHeader("Content-Type", "application/pdf");
       res.setHeader("Content-Length", String(buffer.length));
       res.setHeader(
         "Content-Disposition",
-        `attachment; filename="${filename}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
+        `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
       );
       res.setHeader("Cache-Control", "no-store");
       res.status(200).send(buffer);

--- a/web/app/super/progress/[tenantId]/[userId]/print/page.tsx
+++ b/web/app/super/progress/[tenantId]/[userId]/print/page.tsx
@@ -23,13 +23,14 @@ import {
   requestGmailComposeAccessToken,
   GmailOAuthError,
 } from "@/lib/gmail-oauth";
-import type {
-  ProgressPdfDraftErrorCode,
-  ProgressPdfDraftResponse,
-  ProgressPdfSectionKey,
-  ProgressPdfSections,
-  SuperStudentProgressResponse,
-  SuperTenantDetailResponse,
+import {
+  buildProgressPdfFilename,
+  type ProgressPdfDraftErrorCode,
+  type ProgressPdfDraftResponse,
+  type ProgressPdfSectionKey,
+  type ProgressPdfSections,
+  type SuperStudentProgressResponse,
+  type SuperTenantDetailResponse,
 } from "@lms-279/shared-types";
 
 const AUTH_MODE = process.env.NEXT_PUBLIC_AUTH_MODE ?? "dev";
@@ -169,9 +170,12 @@ export default function ProgressPdfPrintPage() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      const filenameSafeName = (meta.userName ?? meta.userEmail).replace(/[^A-Za-z0-9._-]/g, "_");
       const dateStr = new Date().toISOString().slice(0, 10);
-      a.download = `progress-${filenameSafeName}-${dateStr}.pdf`;
+      a.download = buildProgressPdfFilename({
+        name: meta.userName,
+        email: meta.userEmail,
+        date: dateStr,
+      });
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);


### PR DESCRIPTION
## Summary

- Issue #366 修正: Phase 2 Gmail draft / Progress PDF の添付ファイル名で日本語名 → `___` に潰れる問題を解消
- 3 箇所に重複していた sanitize 正規表現 (`/[^A-Za-z0-9._-]/g`) を共通ヘルパ `buildProgressPdfFilename` に統合し、Unicode を保持
- OS/HTTP unsafe 文字 (`/ \ : * ? " < > |` + 制御文字) のみ除去、name が空/全危険文字なら email fallback、50 文字 truncate でファイル名長制限対策

## Root Cause

3 箇所のインライン正規表現 `(name ?? email).replace(/[^A-Za-z0-9._-]/g, "_")` が日本語を一律 `_` に変換していた。Gmail (RFC 2047) / HTTP (RFC 6266) / `<a download>` は既に Unicode safe な配信機構を持っているのに、入力側で潰されていたのが本質。

## Changes

- **packages/shared-types/src/filename.ts (新規)**: `buildProgressPdfFilename` ヘルパ。Unicode 保持 + 50 文字 truncate + email fallback
- **packages/shared-types/src/index.ts**: 初の runtime export 追加 (これまで `export type *` のみ)
- **services/api/src/routes/super/progress-pdf-draft.ts**: `sanitizeFilename` 撤去、共通ヘルパ参照
- **services/api/src/routes/super/progress-pdf.ts**: インライン正規表現撤去、RFC 6266 dual-filename の ASCII fallback を email-based で生成
- **web/app/super/progress/[tenantId]/[userId]/print/page.tsx**: インライン正規表現撤去、共通ヘルパ参照
- **services/api/src/__tests__/unit/filename.test.ts (新規)**: 14 件 (日本語保持 / null/undefined/空 → email fallback / 危険文字置換 / 連続_圧縮 / トリム / 50 文字 truncate)
- **services/api/src/__tests__/integration/progress-pdf-draft.test.ts**: AC-2 assertion 強化 (`/^progress-山田 太郎-\\d{4}-\\d{2}-\\d{2}\\.pdf$/`) + Issue #366 リグレッションマーカー 1 件追加

## Design Notes

3 経路の Unicode safe な配信機構を活用:
- **Gmail draft**: `services/api/src/services/gmail-draft.ts` の `encodeMimeHeader` が RFC 2047 (`=?UTF-8?B?...?=`) で attachment filename を base64 encode
- **HTTP attachment**: `Content-Disposition: filename="ASCII fallback"; filename*=UTF-8''<encoded>` (RFC 6266) — モダンブラウザは `filename*` を優先
- **ブラウザダウンロード**: `<a download>` 属性は Unicode をそのまま許容

shared-types は従来 `export type *` のみの型専用パッケージだったが、FE/BE で同一の filename 生成ロジックを担保するため初の runtime export を追加。代替案 (services/api と web/lib に同実装をコピー、または新規 utils パッケージ作成) より bundle 影響軽微・整合性高いと判断。

## Quality Gate

- ✅ Codex / Plan レビューに準ずる impl-plan 計画立案済
- ✅ `/simplify` 3 並列 (reuse / quality / efficiency): regex エスケープ表記化 + 50 文字 truncate + テストコメント補足を反映
- ✅ `/safe-refactor`: 型安全性 / null/undefined 安全性 / エラー処理いずれも問題なし
- ✅ API test 859 件 PASS (+13: ユニット 14 + integration 1)
- ✅ Web test 40 件 PASS
- ✅ lint / type-check 全 PASS

## Test plan

- [x] ユニット: `buildProgressPdfFilename` 14 件全 PASS
  - [x] 日本語名は `___` に潰れず保持される (山田 太郎 / テスト)
  - [x] name 空 (null / undefined / "" / "   ") → email fallback
  - [x] `/ \\ : * ? " < > |` + CR/LF → `_` 置換
  - [x] 全危険文字 → email fallback
  - [x] 連続 `_` 圧縮 / 先頭末尾トリム
  - [x] 50 文字 truncate (日本語 200 文字でも 255 byte 上限内)
- [x] integration: AC-2 assertion 強化 (regex で `progress-山田 太郎-YYYY-MM-DD.pdf` 厳密検証)
- [ ] **本番マージ後の実機検証** (Phase 2 ブロッカー解消):
  - [ ] 本番 (web-3zcica5euq-an.a.run.app) で日本語名受講者の Gmail draft 作成
  - [ ] ダウンロード添付ファイル名が `progress-{受講者名}-{日付}.pdf` (日本語そのまま) になることを確認
  - [ ] PDF 直接ダウンロード経路 (Phase 1) で Content-Disposition の `filename*=UTF-8''...` がブラウザで正しく解釈されることを確認

## Follow-up Candidates

- shared-types に runtime export を追加した方針を ADR-035 で記録 (今 PR には含めず)
- progress-pdf.ts の ASCII fallback ロジック (`buildProgressPdfFilename({name: null, ...}).replace(/[^\\x20-\\x7e]/g, "_")`) を専用ヘルパ化 — 現状 1 箇所のみ使用で YAGNI 判断、2 箇所目出現で抽出

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)