### PR TITLE
docs(handoff): Session 25 (2026-05-15) 記録 + Session 24 アーカイブ

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,12 +1,12 @@
-# Session Handoff — 2026-05-15 (Session 24)
+# Session Handoff — 2026-05-15 (Session 25)
 
 ## TL;DR
 
-**Session 23 末ハンドオフ「優先候補 A (PR #376 react-dom) / B (PR #377 vertexai) / C (Issue #382 vitest)」を完遂、計 3 PR をマージ + Issue #382 を解消理由付きで close。**Issue #382 は Dependabot rebase によって前提となっていた TS2339 17 件のエラーが解消済みであることをローカル検証 (type-check 0 件 / test 40/40 PASS) で確認、コメントに検証ログを残して close。本番 deps 2 件 (react-dom 19.2.6 / @google-cloud/vertexai 1.12.0) を含む全 3 PR がマージ後 main で CI / E2E Tests / Deploy to Cloud Run すべて SUCCESS。
+**Session 24 末ハンドオフ「優先度6: shared-types runtime export 責務境界明文化」を消化、PR #385 で ADR-035 + `packages/shared-types/README.md` を新規追加してマージ。**コード変更ゼロのドキュメント PR で、ローカル type-check / PR CI (Build/Lint/Test/Type Check) は全 PASS。マージ後の main トリガ workflow (CI / Deploy to Cloud Run / E2E Tests) は **GitHub Actions 障害 (2026-05-15 08:13 UTC〜 partial outage)** に巻き込まれて 3 件すべて失敗 / queued スタックとなったが、本 PR はドキュメントのみのため Cloud Run 動作・実害ゼロ。コード起因ではないため再実行はスキップし、次回コード PR 時に main の自動 CI で再検証される想定。
 
-- **Issue Net**: **-1** (Close 1 件 #382、起票 0 件 → Net -1、KPI 進捗あり)
-- **Open 推移**: Session 23 末 4 件 → Session 24 末 **3 件** (全 postponed: #276 / #275 / #274 — Phase 3 GCIP 完了が再開条件)
-- **本セッション成果**: PR 3 件マージ / Issue 1 件 close / Cloud Run 本番デプロイ反映済 / アクティブ Issue 0 件達成
+- **Issue Net**: **±0** (Close 0 / 起票 0、ドキュメント PR のため KPI 進捗なしは想定通り)
+- **Open 推移**: Session 24 末 3 件 → Session 25 末 **3 件** (全 postponed: #276 / #275 / #274 — 変化なし)
+- **本セッション成果**: PR 1 件マージ (#385) / ADR 1 件追加 (ADR-035) / shared-types README 新規 / GitHub Actions infra 障害観測と記録
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -14,16 +14,22 @@
 # 1. 状況復元
 cat docs/handoff/LATEST.md
 
-# 2. main CI / Cloud Run / E2E が緑であることを確認
+# 2. GitHub Actions 障害復旧確認 (本セッション末で未復旧)
 gh run list --branch main --limit 5
+#  → run 25907042156 (E2E Tests) が queued のまま放置されていないか
+#  → 復旧していたら以下で再実行 (任意、ドキュメントのみで実害なし):
+#    gh run rerun 25907042161  # CI
+#    gh run rerun 25907042163  # Deploy to Cloud Run
+#    gh run rerun 25907042156  # E2E Tests
+#  GitHub Status: https://www.githubstatus.com/
 
-# 3. 現在の OPEN Issue (3 件、全 postponed)
+# 3. 現在の OPEN Issue (3 件、全 postponed、Session 24 末から変化なし)
 gh issue list --state open --limit 15
 
-# 4. 現在の OPEN Dependabot PR (0 件、Session 24 末で全消化済)
+# 4. 現在の OPEN Dependabot PR (Session 24 末で全消化済)
 gh pr list --author "app/dependabot" --state open
 
-# 5. 次の着手候補（優先度順）:
+# 5. 次の着手候補（優先度順、Session 24 末からほぼ不変、(6) のみ消化済）:
 #    A. 【優先度1】PR #358 follow-up I2 (originalError 設計改善)
 #       — Session 22 から継続、decision-maker 判断待ち
 #       — 着手前に PR #358 body と Codex review コメントを読み返し、
@@ -39,140 +45,147 @@ gh pr list --author "app/dependabot" --state open
 #    E. 【優先度5】PR #381 (playwright 1.58.2 → 1.60.0、CONFLICTING で自動 close)
 #       — lockfile は ^1.60.0 caret range 経由で 1.60.0 解決済、実害なし
 #       — 次回 Dependabot weekly で再 PR 来るか観察 (なければ手動 PR 不要)
-#    F. 【優先度6】shared-types runtime export の責務境界明文化
-#       — PR #368 で初の runtime helper (`buildProgressPdfFilename`) export 追加
-#       — ADR-035 or `packages/shared-types/README.md` 更新で方針記録
-#       — Codex は許容と評価したが、責務境界の方針転換として記録すべき
+#    F. 【優先度6 ✅ 消化済】shared-types runtime export 責務境界明文化
+#       — PR #385 で ADR-035 + packages/shared-types/README.md 追加完了
 ```
 
 ---
 
-## セッション成果物 (2026-05-15 Session 24)
+## セッション成果物 (2026-05-15 Session 25)
 
-### 🟢 PR #376: chore(deps): bump react-dom from 19.2.3 to 19.2.6
+### 🟢 PR #385: docs(adr): ADR-035 shared-types runtime export 責務境界の明文化
 
-- 変更: 2 ファイル, +28 / -9 行
-- 状態: **MERGED (2026-05-15T05:54:44Z, squash, commit `f4fc8d1`)**
-- CI 全 PASS / MERGEABLE / CLEAN
+- ブランチ: `docs/adr-035-shared-types-runtime-export` (削除済)
+- 変更: 2 ファイル, +157 / -0 行 (1 commit)
+- 状態: **MERGED (2026-05-15T07:56:21Z, squash, commit `32b50f3`)**
+- PR CI: 全 4 check (Build 52s / Lint 29s / Test 1m27s / Type Check 45s) PASS
 
-#### 内容
+#### 追加内容
 
-3 patch リリース統合 (19.2.4 / 19.2.5 / 19.2.6):
-- React Server Components の DoS mitigation (Server Actions ハードニング)
-- cycle protections 追加
-- 型ハードニング + performance 改善
+1. **`docs/adr/ADR-035-shared-types-runtime-export-boundary.md`**
+   - shared-types パッケージの責務を「型のみ」から「型 + 純粋ロジック helper」に拡張する判断を明文化
+   - 許可条件 C1〜C5:
+     - C1: FE/BE 両方から呼ばれる (既存呼出 ≥ 2 箇所)
+     - C2: 副作用なし (DOM/Node API/fetch/fs/Firestore/GCS/Buffer 依存ゼロ)
+     - C3: 外部依存なし (dependencies/peerDependencies を増やさない)
+     - C4: 小さい (1 ファイル / 1 export / 100 行以内)
+     - C5: ロジック不一致が即バグ (Issue/PR で証明)
+   - 除外条件: HTTP クライアント / 環境固有 / ビジネスロジック / 大規模 / ライブラリ依存
+   - 既存 `filename.ts` (PR #368) の遡及確認 → C1〜C5 全て満たす
+   - 不採用案 Alt-1 (別パッケージ `shared-utils` 化) / Alt-2 (FE/BE 個別実装)
+   - 再評価トリガ: runtime helper 3 ファイル超 / ライブラリ依存 helper 必要 / FE バンドル +10KB 観測
 
-#### 評価判断
+2. **`packages/shared-types/README.md`**
+   - 責務 (型定義 / 純粋ロジック helper) を 2 カテゴリで明示
+   - 利用方法 (`import type` / `import` の使い分け、サブパス import 非採用)
+   - runtime helper 追加前チェックリスト (ADR-035 の C1〜C5 を抜粋)
+   - 開発コマンド + ファイル構成
 
-- **注意**: react 自体は 19.2.3 のまま、Dependabot は同期 PR 未生成 (peer 依存解決のため react-dom 単独 PR)
-- React 19.2.x patch 範囲内なので互換性問題のリスクは低い
-- マージ後 main で E2E Tests SUCCESS、Deploy to Cloud Run SUCCESS で SSR/hydration 影響なしを確認
+#### なぜ今やったか
 
----
-
-### 🟢 PR #377: chore(deps): bump @google-cloud/vertexai from 1.10.2 to 1.12.0
-
-- 変更: 2 ファイル, +5 / -6 行
-- 状態: **MERGED (2026-05-15T05:55:37Z, squash, commit `654dc8f`)**
-- CI 全 PASS / MERGEABLE / CLEAN
-
-#### 内容
-
-minor x2 統合 (1.10.3 / 1.10.4 / 1.11.0 / 1.12.0):
-- Memory Bank / Agent Engine の機能追加 (RetrieveProfiles / ingest_events / structured data 等)
-- Breaking change の記載なし
-
-#### 利用箇所確認
-
-`services/api/src/services/quiz-generator.ts:1` および `quiz-import.ts:2` で:
-- `VertexAI` クラスコンストラクタ
-- `getGenerativeModel`
-- `generateContent`
-
-の 3 API のみ使用。これらは 1.12.0 でも signature 不変。マージ後 Cloud Run デプロイ完了、AI 連携 smoke は次回利用時の動作確認に委ねる。
+Session 23 末ハンドオフの「優先度6」消化。Codex review (PR #368) は許容範囲と評価したが、責務境界が暗黙ルールのままだと将来 helper が雪だるま式に追加されて shared-utils 化する懸念があり、機械的にチェック可能な条件を明示。次回 runtime helper 追加 PR では impl-plan 段階で C1〜C5 チェックが必須となる。
 
 ---
 
-### 🟢 PR #370: chore(deps): bump vitest from 4.1.0 to 4.1.6 (Issue #382 解消)
+## ⚠️ GitHub Actions 障害 (本セッション末で未復旧)
 
-- 変更: 4 ファイル, package-lock.json + 3 workspace の package.json
-- 状態: **MERGED (2026-05-15T05:58:44Z, squash, commit `1a693c0`)**
-- マージ前: Dependabot rebase 経由で `9c420fb → a0f468f` に更新、CI 全 PASS
+### 観測タイムライン
 
-#### Issue #382 解消検証
-
-Session 23 で起票された **Issue #382 (vitest 4.1.6 で @testing-library/jest-dom matcher の TS2339 エラー 17 件)** が rebase 後に解消済みであることを以下で検証:
-
-| 検証 | 結果 |
+| 時刻 (UTC) | 出来事 |
 |---|---|
-| ローカル `npm run type-check -w @lms-279/web` | ✅ エラー 0 件 |
-| ローカル `npm run test -w @lms-279/web` | ✅ 40 / 40 PASS (vitest v4.1.6) |
-| CI Type Check (Dependabot rebase 後 run 25892471430) | ✅ SUCCESS |
-| マージ後 main CI / E2E / Deploy | ✅ 全 SUCCESS |
+| 07:56:21 | PR #385 squash merge → main commit `32b50f3` |
+| 07:56:23 | main の 3 workflow (CI / Deploy to Cloud Run / E2E Tests) 起動 |
+| 08:13 | **GitHub 公式: Actions partial outage** + Pages major outage を investigating で公表 |
+| 08:13:11 | CI run 25907042161 が 4 jobs (Build/Lint/Test/Type Check) 全て `queued` のまま failure 完了 |
+| ~08:14 | Deploy run 25907042163 が一部 job (Lint `in_progress` / Deploy Web `queued` / Deploy API `queued`) を残したまま failure 完了 |
+| 08:30 過ぎ | E2E Tests run 25907042156 が `queued` のまま `updated_at` も `run_started_at` から動かず完全スタック |
 
-#### Issue #382 close 操作
+### 影響範囲
 
-`gh issue close 382 --reason completed` でコメント付き close。コメントに検証手順 (ローカル type-check / test) + 推定原因 (Dependabot rebase で最新 main `ed3d57d` = PR #375 eslint-config-next 反映後に再ベースされ、周辺パッケージの版整合が修正された) + 再発時の対応 (再 open) を記録。
+- **コード起因ではない**: PR #385 はドキュメントのみで src/ 変更ゼロ、PR CI は全 PASS 済 (PR の Check と main push 後の Check は同一 workflow を別 run で実行する構造)
+- **Cloud Run 反映**: 未実施 (Deploy Web / Deploy API が queued のままキャンセル) だが、本 PR は docs/ + README のみで Cloud Run 動作には影響なし
+- **実害**: ゼロ
+
+### 対応判断: スキップ (CLAUDE.md `rules/workflow.md §3` 選択肢 C)
+
+- A. 即 rerun: runner 障害中の rerun は再失敗確実
+- B. 復旧待ち rerun: ドキュメント PR で実害なし、次回コード push で main CI が自動再検証される
+- **C. スキップ (採用)**: 0 コスト、次回セッション開始時に `gh run list` で復旧確認するだけ
+- D. 監視継続: タイムアウトコスト割に合わず
+
+### 復旧確認手順 (次回セッション)
+
+```bash
+# GitHub 復旧確認
+curl -s https://www.githubstatus.com/api/v2/summary.json | jq '.components[] | select(.name=="Actions") | .status'
+# "operational" になっていれば復旧
+
+# main の最新 run が緑か確認
+gh run list --branch main --limit 5
+
+# 必要なら個別 rerun (任意)
+gh run rerun 25907042161  # CI
+gh run rerun 25907042163  # Deploy to Cloud Run
+gh run rerun 25907042156  # E2E Tests
+```
 
 ---
 
-## ⚠️ 残 open PR と Issue (次セッション要対応)
+## 残 open PR と Issue (次セッション要対応)
 
 ### 残 open PR
 
-**0 件** (Session 24 末で全消化済)
-
-### CLOSED (人為的でない)
-- #381: playwright 1.58.2 → 1.60.0 — Dependabot 自動 close (CONFLICTING、Session 23 末から状態維持)
-  - **実害なし**: package.json は `^1.57.0` のまま、lockfile は `1.60.0` で実 install 済 (caret range が 1.60.0 を許容)
-  - 次回 Dependabot weekly で再 PR 来るか観察
+**0 件**
 
 ### 起票 Issue (本セッション)
 
 **0 件**
 
-### Close Issue (1 件、本セッション)
+### Close Issue (本セッション)
 
-- **#382** [deps] vitest 4.1.0 → 4.1.6 minor upgrade で @testing-library/jest-dom matcher の型解決が失敗 — Dependabot rebase で解消済み (検証 OK)、PR #370 マージ完了で実害ゼロ
+**0 件**
 
 ### 残 active Issue
 
-**0 件** (Open 3 件はすべて `postponed`、Phase 3 GCIP 完了が再開条件)
+**0 件** (Open 3 件はすべて `postponed`、Phase 3 GCIP 完了が再開条件、Session 24 末から変化なし)
 
 ---
 
 ## Issue Net 変化
 
-- Close 数: **1 件** (#382)
+- Close 数: **0 件**
 - 起票数: **0 件**
-- **Net: -1 件 (KPI 進捗あり)**
+- **Net: 0 件 (KPI 進捗なし、ドキュメント PR のため想定通り)**
 
-triage 評価: 本セッションは依存ライブラリ更新のみで、機械的な Issue 化や rating 5-6 の review agent 提案の取り込みは発生しなかった。Issue #382 の close 判断は (1) Dependabot rebase で前提エラーが解消、(2) ローカルと CI で再現性ゼロを確認、(3) コメントに検証ログを残して再 open しやすい状態を維持、という 3 段階で慎重に判定。
+triage 評価: 本セッションはドキュメント整備のみで、新規バグ・rating ≥ 7 review agent 提案・ユーザー明示指示の個別タスクは発生せず。GitHub Actions 障害は GitHub 側 infra 起因のため Issue 化対象外 (実害ゼロ・自プロジェクト範囲外)。Net 0 だが、ADR-035 で将来の runtime helper 追加判断を機械化できるため、長期的な技術負債抑止効果あり。
 
 ---
 
 ## 教訓・気づき
 
-### 1. Dependabot rebase は前提となる Issue の解消経路になる
-PR #370 起票時点で CI Type Check FAIL → Issue #382 起票という流れだったが、後続の Dependabot rebase で最新 main に再ベースされた結果 CI 全 PASS に転じた。Issue close 前に **「起票時の CI Run と最新 CI Run の差分を必ず確認」**するプロトコルが有効。本セッションでは `gh pr checks 370` で latest run id を取得 → 起票時 run id (Issue body 記載) と比較して状態変化を検出。
+### 1. PR CI と main push CI は別 run
 
-### 2. 並行マージ時の Dependabot 自動 rebase 待ち
-PR #376 マージ後、PR #370 が package-lock.json コンフリクトで `mergeable: CONFLICTING / mergeStateStatus: DIRTY` に転じた。`@dependabot rebase` コメントで Bot に依頼 → 30 秒間隔の polling で `MERGEABLE / CLEAN` 復帰を検知 (約 90-120 秒)。PR #377 は影響を受けず直接マージ可能。**同一 lockfile を変更する複数 PR の並行マージは順次 + Bot 経由 rebase が安全**。
+PR #385 は PR 上の 4 check (Build/Lint/Test/Type Check) を全 PASS で確認・マージしたが、squash merge 後 main に push されると **同じ workflow が main 用 run として再度起動される**。これが今回 GitHub Actions 障害発生時刻と重なって failure になった。**PR CI 緑 = main CI 緑 ではない** ことを再認識。今後 main 緑確認は `gh run list --branch main` で別途必須。
 
-### 3. ローカル検証の戻し漏れ防止
-PR #370 の type-check / test をローカルで検証するため `git checkout pr-370-vitest -- web/package.json package-lock.json` でファイルを取得 → 検証完了後 `git checkout main -- web/package.json package-lock.json && npm install` で原状復帰 → `git status` で clean 確認、というルーチンを徹底。検証ブランチも `git branch -D pr-370-vitest` で確実に削除。
+### 2. GitHub Actions partial outage 時の job 振る舞い
+
+「jobs が `queued` のまま run が `failure`」「一部 jobs だけ success / 一部 queued でキャンセル」は **GitHub Actions runner 割当障害の典型症状**。`gh run view --json jobs` で全 job の `status` を見れば一発で「runner 不足 / infra 障害」と切り分けられる (jobs 内のスクリプトエラーなら job ごとに `conclusion: failure` + step ログがある)。
+
+### 3. CLAUDE.md `rules/workflow.md §3` の 4 択を機械的に適用
+
+サービスエラー (今回は GitHub infra) 遭遇時に「a) 再実行 b) 待って再実行 c) スキップ」の 3 択 (本ハンドオフでは d) 監視継続 を追加した 4 択) をユーザーに提示する運用が機能。AI 側で勝手に rerun ループを回したり「手動同等チェック」に走らず、decision-maker (ユーザー) に判断を渡せた。AI 駆動開発 4 原則 §1 (executor / decision-maker 分離) の好事例。
 
 ---
 
 ## 環境状態 (本セッション終了時)
 
-- main ブランチ: HEAD `1a693c0` (PR #370 squash merge)
-- ローカル: main + handoff feature ブランチ作成、未コミット変更は handoff のみ
-- Cloud Run / E2E: PR #370 マージ後 Deploy success (run 25902951312, 3m56s, 2026-05-15T05:58:46Z)
+- main ブランチ: HEAD `32b50f3` (PR #385 squash merge)
+- ローカル: handoff feature ブランチ作成中、未コミット変更は handoff のみ
+- Cloud Run / E2E: **未確認** (GitHub Actions 障害で run 失敗、復旧後に確認)
 - 残留プロセス: なし
 
 ---
 
-## Session 23 のアーカイブ
+## Session 24 のアーカイブ
 
-旧 LATEST.md (Session 23) は `docs/handoff/archive/2026-05-15-session-23.md` に保存済み。
+旧 LATEST.md (Session 24) は `docs/handoff/archive/2026-05-15-session-24.md` に保存済み。

--- a/docs/handoff/archive/2026-05-15-session-24.md
+++ b/docs/handoff/archive/2026-05-15-session-24.md
@@ -1,0 +1,178 @@
+# Session Handoff — 2026-05-15 (Session 24)
+
+## TL;DR
+
+**Session 23 末ハンドオフ「優先候補 A (PR #376 react-dom) / B (PR #377 vertexai) / C (Issue #382 vitest)」を完遂、計 3 PR をマージ + Issue #382 を解消理由付きで close。**Issue #382 は Dependabot rebase によって前提となっていた TS2339 17 件のエラーが解消済みであることをローカル検証 (type-check 0 件 / test 40/40 PASS) で確認、コメントに検証ログを残して close。本番 deps 2 件 (react-dom 19.2.6 / @google-cloud/vertexai 1.12.0) を含む全 3 PR がマージ後 main で CI / E2E Tests / Deploy to Cloud Run すべて SUCCESS。
+
+- **Issue Net**: **-1** (Close 1 件 #382、起票 0 件 → Net -1、KPI 進捗あり)
+- **Open 推移**: Session 23 末 4 件 → Session 24 末 **3 件** (全 postponed: #276 / #275 / #274 — Phase 3 GCIP 完了が再開条件)
+- **本セッション成果**: PR 3 件マージ / Issue 1 件 close / Cloud Run 本番デプロイ反映済 / アクティブ Issue 0 件達成
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+# 1. 状況復元
+cat docs/handoff/LATEST.md
+
+# 2. main CI / Cloud Run / E2E が緑であることを確認
+gh run list --branch main --limit 5
+
+# 3. 現在の OPEN Issue (3 件、全 postponed)
+gh issue list --state open --limit 15
+
+# 4. 現在の OPEN Dependabot PR (0 件、Session 24 末で全消化済)
+gh pr list --author "app/dependabot" --state open
+
+# 5. 次の着手候補（優先度順）:
+#    A. 【優先度1】PR #358 follow-up I2 (originalError 設計改善)
+#       — Session 22 から継続、decision-maker 判断待ち
+#       — 着手前に PR #358 body と Codex review コメントを読み返し、
+#         I2 (originalError 設計改善) の方向性をユーザーに提示してから実装
+#    B. 【優先度2】Issue #272 Phase 3 GCIP 移行 — 再評価期限 2026-10-24
+#       — 期限到達まで着手不可、postponed #276 / #275 / #274 の再開条件
+#    C. 【優先度3】postponed #276 / #275 / #274 — Phase 3 GCIP 完了が再開条件
+#       — 明示指示なき限り着手不可
+#    D. 【優先度4】Dependabot semver-major 全 ignore 設定の月次/四半期棚卸し運用
+#       — Codex review (PR #369) で指摘、Issue 化見送り。`/handoff` で記録継続中
+#       — 次回 weekly review で `npm outdated` / GitHub Insights / `gh api`
+#         で major 候補リストを抽出し、必要なら個別 PR を手動で起こす
+#    E. 【優先度5】PR #381 (playwright 1.58.2 → 1.60.0、CONFLICTING で自動 close)
+#       — lockfile は ^1.60.0 caret range 経由で 1.60.0 解決済、実害なし
+#       — 次回 Dependabot weekly で再 PR 来るか観察 (なければ手動 PR 不要)
+#    F. 【優先度6】shared-types runtime export の責務境界明文化
+#       — PR #368 で初の runtime helper (`buildProgressPdfFilename`) export 追加
+#       — ADR-035 or `packages/shared-types/README.md` 更新で方針記録
+#       — Codex は許容と評価したが、責務境界の方針転換として記録すべき
+```
+
+---
+
+## セッション成果物 (2026-05-15 Session 24)
+
+### 🟢 PR #376: chore(deps): bump react-dom from 19.2.3 to 19.2.6
+
+- 変更: 2 ファイル, +28 / -9 行
+- 状態: **MERGED (2026-05-15T05:54:44Z, squash, commit `f4fc8d1`)**
+- CI 全 PASS / MERGEABLE / CLEAN
+
+#### 内容
+
+3 patch リリース統合 (19.2.4 / 19.2.5 / 19.2.6):
+- React Server Components の DoS mitigation (Server Actions ハードニング)
+- cycle protections 追加
+- 型ハードニング + performance 改善
+
+#### 評価判断
+
+- **注意**: react 自体は 19.2.3 のまま、Dependabot は同期 PR 未生成 (peer 依存解決のため react-dom 単独 PR)
+- React 19.2.x patch 範囲内なので互換性問題のリスクは低い
+- マージ後 main で E2E Tests SUCCESS、Deploy to Cloud Run SUCCESS で SSR/hydration 影響なしを確認
+
+---
+
+### 🟢 PR #377: chore(deps): bump @google-cloud/vertexai from 1.10.2 to 1.12.0
+
+- 変更: 2 ファイル, +5 / -6 行
+- 状態: **MERGED (2026-05-15T05:55:37Z, squash, commit `654dc8f`)**
+- CI 全 PASS / MERGEABLE / CLEAN
+
+#### 内容
+
+minor x2 統合 (1.10.3 / 1.10.4 / 1.11.0 / 1.12.0):
+- Memory Bank / Agent Engine の機能追加 (RetrieveProfiles / ingest_events / structured data 等)
+- Breaking change の記載なし
+
+#### 利用箇所確認
+
+`services/api/src/services/quiz-generator.ts:1` および `quiz-import.ts:2` で:
+- `VertexAI` クラスコンストラクタ
+- `getGenerativeModel`
+- `generateContent`
+
+の 3 API のみ使用。これらは 1.12.0 でも signature 不変。マージ後 Cloud Run デプロイ完了、AI 連携 smoke は次回利用時の動作確認に委ねる。
+
+---
+
+### 🟢 PR #370: chore(deps): bump vitest from 4.1.0 to 4.1.6 (Issue #382 解消)
+
+- 変更: 4 ファイル, package-lock.json + 3 workspace の package.json
+- 状態: **MERGED (2026-05-15T05:58:44Z, squash, commit `1a693c0`)**
+- マージ前: Dependabot rebase 経由で `9c420fb → a0f468f` に更新、CI 全 PASS
+
+#### Issue #382 解消検証
+
+Session 23 で起票された **Issue #382 (vitest 4.1.6 で @testing-library/jest-dom matcher の TS2339 エラー 17 件)** が rebase 後に解消済みであることを以下で検証:
+
+| 検証 | 結果 |
+|---|---|
+| ローカル `npm run type-check -w @lms-279/web` | ✅ エラー 0 件 |
+| ローカル `npm run test -w @lms-279/web` | ✅ 40 / 40 PASS (vitest v4.1.6) |
+| CI Type Check (Dependabot rebase 後 run 25892471430) | ✅ SUCCESS |
+| マージ後 main CI / E2E / Deploy | ✅ 全 SUCCESS |
+
+#### Issue #382 close 操作
+
+`gh issue close 382 --reason completed` でコメント付き close。コメントに検証手順 (ローカル type-check / test) + 推定原因 (Dependabot rebase で最新 main `ed3d57d` = PR #375 eslint-config-next 反映後に再ベースされ、周辺パッケージの版整合が修正された) + 再発時の対応 (再 open) を記録。
+
+---
+
+## ⚠️ 残 open PR と Issue (次セッション要対応)
+
+### 残 open PR
+
+**0 件** (Session 24 末で全消化済)
+
+### CLOSED (人為的でない)
+- #381: playwright 1.58.2 → 1.60.0 — Dependabot 自動 close (CONFLICTING、Session 23 末から状態維持)
+  - **実害なし**: package.json は `^1.57.0` のまま、lockfile は `1.60.0` で実 install 済 (caret range が 1.60.0 を許容)
+  - 次回 Dependabot weekly で再 PR 来るか観察
+
+### 起票 Issue (本セッション)
+
+**0 件**
+
+### Close Issue (1 件、本セッション)
+
+- **#382** [deps] vitest 4.1.0 → 4.1.6 minor upgrade で @testing-library/jest-dom matcher の型解決が失敗 — Dependabot rebase で解消済み (検証 OK)、PR #370 マージ完了で実害ゼロ
+
+### 残 active Issue
+
+**0 件** (Open 3 件はすべて `postponed`、Phase 3 GCIP 完了が再開条件)
+
+---
+
+## Issue Net 変化
+
+- Close 数: **1 件** (#382)
+- 起票数: **0 件**
+- **Net: -1 件 (KPI 進捗あり)**
+
+triage 評価: 本セッションは依存ライブラリ更新のみで、機械的な Issue 化や rating 5-6 の review agent 提案の取り込みは発生しなかった。Issue #382 の close 判断は (1) Dependabot rebase で前提エラーが解消、(2) ローカルと CI で再現性ゼロを確認、(3) コメントに検証ログを残して再 open しやすい状態を維持、という 3 段階で慎重に判定。
+
+---
+
+## 教訓・気づき
+
+### 1. Dependabot rebase は前提となる Issue の解消経路になる
+PR #370 起票時点で CI Type Check FAIL → Issue #382 起票という流れだったが、後続の Dependabot rebase で最新 main に再ベースされた結果 CI 全 PASS に転じた。Issue close 前に **「起票時の CI Run と最新 CI Run の差分を必ず確認」**するプロトコルが有効。本セッションでは `gh pr checks 370` で latest run id を取得 → 起票時 run id (Issue body 記載) と比較して状態変化を検出。
+
+### 2. 並行マージ時の Dependabot 自動 rebase 待ち
+PR #376 マージ後、PR #370 が package-lock.json コンフリクトで `mergeable: CONFLICTING / mergeStateStatus: DIRTY` に転じた。`@dependabot rebase` コメントで Bot に依頼 → 30 秒間隔の polling で `MERGEABLE / CLEAN` 復帰を検知 (約 90-120 秒)。PR #377 は影響を受けず直接マージ可能。**同一 lockfile を変更する複数 PR の並行マージは順次 + Bot 経由 rebase が安全**。
+
+### 3. ローカル検証の戻し漏れ防止
+PR #370 の type-check / test をローカルで検証するため `git checkout pr-370-vitest -- web/package.json package-lock.json` でファイルを取得 → 検証完了後 `git checkout main -- web/package.json package-lock.json && npm install` で原状復帰 → `git status` で clean 確認、というルーチンを徹底。検証ブランチも `git branch -D pr-370-vitest` で確実に削除。
+
+---
+
+## 環境状態 (本セッション終了時)
+
+- main ブランチ: HEAD `1a693c0` (PR #370 squash merge)
+- ローカル: main + handoff feature ブランチ作成、未コミット変更は handoff のみ
+- Cloud Run / E2E: PR #370 マージ後 Deploy success (run 25902951312, 3m56s, 2026-05-15T05:58:46Z)
+- 残留プロセス: なし
+
+---
+
+## Session 23 のアーカイブ
+
+旧 LATEST.md (Session 23) は `docs/handoff/archive/2026-05-15-session-23.md` に保存済み。


### PR DESCRIPTION
## Summary

- Session 25 ハンドオフを `docs/handoff/LATEST.md` に記録
- 旧 Session 24 LATEST を `docs/handoff/archive/2026-05-15-session-24.md` に移動

## Session 25 概要

Session 23 末「優先度6: shared-types runtime export 責務境界明文化」を消化:

- **PR #385**: ADR-035 + `packages/shared-types/README.md` 新規追加で **MERGED** (commit `32b50f3`)
  - 許可条件 C1〜C5 / 除外条件 / 既存 `filename.ts` 遡及確認 / 不採用案 / 再評価トリガ
  - 既存コード変更ゼロ、PR CI 全 PASS、ローカル type-check PASS

## ⚠️ GitHub Actions 障害観測 (2026-05-15 08:13 UTC〜)

PR #385 マージ後の main トリガ workflow 3 件:
- CI run 25907042161: **failure** (4 jobs queued のまま)
- Deploy to Cloud Run run 25907042163: **failure** (一部 success / 一部 queued でキャンセル)
- E2E Tests run 25907042156: **queued のままスタック**

GitHub Status で Actions partial outage を確認、コード起因ではない。ドキュメントのみで実害ゼロのため CLAUDE.md `rules/workflow.md §3` の選択肢 C (スキップ) を採択。次セッションで復旧確認。

## Issue Net 変化

- Close 数: 0 件
- 起票数: 0 件
- **Net: 0 件** (ドキュメント PR のため KPI 進捗なしは想定通り、ADR-035 で長期的な技術負債抑止)

## 教訓 (LATEST.md に詳述)

1. PR CI 緑 = main CI 緑 ではない (squash merge 後の main push で同じ workflow が別 run として再実行)
2. GitHub Actions partial outage 時の job 振る舞い (`queued` 多数 + run `failure` パターン)
3. CLAUDE.md `rules/workflow.md §3` の 4 択を機械的に適用 (executor / decision-maker 分離の好事例)

## Test plan

- [x] LATEST.md 行数 < 500 行
- [x] Session 24 を archive へ移動 (実施: `cp` で複製)
- [x] Open Issue リストの差分が反映されている (Session 24 末 3 件 → Session 25 末 3 件、全 postponed)
- [ ] レビュア確認: 次セッションで GitHub Actions 復旧確認手順が再開可能か

🤖 Generated with [Claude Code](https://claude.com/claude-code)