### PR TITLE
refactor(api): drop GmailDraftError.originalError to remove access token leak vector (I2)

### DIFF
--- a/services/api/src/routes/super/progress-pdf-draft.ts
+++ b/services/api/src/routes/super/progress-pdf-draft.ts
@@ -399,9 +399,9 @@ router.post(
         });
       });
 
-      // Evaluator HIGH-1 対応: GaxiosError の originalError には Authorization ヘッダを
-      // 含む config が残存する可能性があるため、access token を含む raw error は
-      // ログに渡さない。errorCode / httpStatus / message のみを記録する。
+      // SECURITY (I2 / ADR-034): GmailDraftError は raw GaxiosError 参照を持たない
+      // 設計 (gmail-draft.ts §GmailDraftError) のため、ここでは分類済みの
+      // errorCode / httpStatus / message のみを記録する。
       logger.error("Gmail draft creation failed", {
         errorType: "gmail_draft_failed",
         tenantId,

--- a/services/api/src/services/gmail-draft.ts
+++ b/services/api/src/services/gmail-draft.ts
@@ -12,12 +12,14 @@
 import { google } from "googleapis";
 import type { ProgressPdfDraftErrorCode } from "@lms-279/shared-types";
 
+// SECURITY (I2 / ADR-034): GaxiosError は config.headers.Authorization に
+// access token を保持するため、本クラスは raw error への参照を持たない。
+// 分類済みの errorCode / httpStatus / message のみを公開する。
 export class GmailDraftError extends Error {
   constructor(
     message: string,
     public errorCode: ProgressPdfDraftErrorCode,
     public httpStatus: number,
-    public originalError?: unknown,
   ) {
     super(message);
     this.name = "GmailDraftError";
@@ -231,13 +233,13 @@ export function classifyGmailError(err: unknown): GmailDraftError {
       typeof e.cause?.code === "string" ? e.cause.code : undefined;
     const networkCode = transportCodeFromError ?? transportCodeFromCause;
     if (networkCode && TRANSIENT_NETWORK_CODES.has(networkCode)) {
-      return new GmailDraftError(message, "gmail_api_transient", 503, err);
+      return new GmailDraftError(message, "gmail_api_transient", 503);
     }
   }
 
   // 401: invalid_access_token
   if (status === 401) {
-    return new GmailDraftError(message, "invalid_access_token", 401, err);
+    return new GmailDraftError(message, "invalid_access_token", 401);
   }
 
   // 403: scope 不足の判定
@@ -248,28 +250,28 @@ export function classifyGmailError(err: unknown): GmailDraftError {
       /insufficient/i.test(message) ||
       /scope/i.test(message)
     ) {
-      return new GmailDraftError(message, "gmail_scope_required", 403, err);
+      return new GmailDraftError(message, "gmail_scope_required", 403);
     }
-    return new GmailDraftError(message, "gmail_api_error", 403, err);
+    return new GmailDraftError(message, "gmail_api_error", 403);
   }
 
   // 429: quota / rate limit
   if (status === 429) {
-    return new GmailDraftError(message, "gmail_quota_exceeded", 429, err);
+    return new GmailDraftError(message, "gmail_quota_exceeded", 429);
   }
 
   // 503: transient
   if (status === 503) {
-    return new GmailDraftError(message, "gmail_api_transient", 503, err);
+    return new GmailDraftError(message, "gmail_api_transient", 503);
   }
 
   // 5xx 全般
   if (status >= 500 && status < 600) {
-    return new GmailDraftError(message, "gmail_api_error", 502, err);
+    return new GmailDraftError(message, "gmail_api_error", 502);
   }
 
   // それ以外 (4xx 含む) は gmail_api_error
-  return new GmailDraftError(message, "gmail_api_error", status || 502, err);
+  return new GmailDraftError(message, "gmail_api_error", status || 502);
 }
 
 /**
@@ -316,7 +318,6 @@ export async function createGmailDraft(
         "Gmail API returned no draft id",
         "gmail_api_error",
         502,
-        response,
       );
     }
 


### PR DESCRIPTION
## Summary

- PR #358 follow-up **I2 (originalError 設計改善)** を**完全削除方針**で消化
- `GmailDraftError` クラスから `originalError?: unknown` フィールドを削除し、access token がインスタンスに格納される構造を排除
- 唯一の caller (progress-pdf-draft.ts) は HIGH-1 対応で既に originalError を logger に渡さない方針 → 現状の実害はゼロだったが、将来別 caller が `logger.X("...", { err })` の形で書いた瞬間に Authorization ヘッダが漏れるフットガンを構造的に排除

## 設計判断

| 案 | 採用 | 理由 |
|---|---|---|
| **A. 完全削除** | ✅ | 読み手ゼロ件 (grep 確認済)、YAGNI、構造的に絶対に漏れない |
| B. narrow 型に絞る | ❌ | デバッグ情報のために YAGNI を許容する根拠なし、複雑度が増す |
| C. 衛生化 helper | ❌ | redact 漏れリスク、本質は「持たない」ことで解決可能 |
| D. 現状維持 + ESLint | ❌ | 検出止まりで予防にならない |

CLAUDE.md「Don't add error handling, fallbacks, or validation for scenarios that can't happen」「Don't design for hypothetical future requirements」に整合。

## 変更

### `services/api/src/services/gmail-draft.ts`
- `GmailDraftError` コンストラクタから 4 引数目 (`originalError?: unknown`) を削除
- `classifyGmailError` 内 5 箇所 + `createGmailDraft` 内 1 箇所の `new GmailDraftError(..., err)` を 3 引数化
- セキュリティ意図 (`raw GaxiosError 参照を持たない`) をクラス上のコメントに明記

### `services/api/src/routes/super/progress-pdf-draft.ts`
- L402-404 の `Evaluator HIGH-1 対応` コメントを設計反映後の表現に更新（"raw error を ログに渡さない" → "GmailDraftError は raw GaxiosError 参照を持たない設計"）

## なぜ今やったか

Session 20 の `/review-pr` で発見、Session 22 末で「分離継続が妥当」と判断され handoff 内 follow-up として記録継続中だった項目。Session 25 末ハンドオフで decision-maker 判断待ちとして優先度1に位置付けられ、Session 26 で方向性 (案A: 完全削除) 確定後に消化。

## Test plan

- [x] `npm run lint` 全 PASS
- [x] `npm run type-check` 全 4 workspace PASS (shared-types / api / web / notification)
- [x] `npm test -w @lms-279/api`: 863 件 PASS (回帰なし、Phase 2 関連 51 件 + 統合 27 件含む)
- [x] `npm test -w @lms-279/web`: 40 件 PASS

## 関連

- PR #358 (Phase 2 本体) — follow-up I2 を本 PR で消化
- Session 20 / 22 / 23 / 24 / 25 handoff の follow-up 候補リスト → 本 PR マージで Open follow-up は記録上ゼロ件化
- ADR-034 §SECURITY — 「raw GaxiosError 参照を持たない」設計判断を実コードに反映

Refs #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)