### PR TITLE
fix(super): Gmail draft ASCII fallback を email base に + Content-Type name= 削除 (Issue #389 続)

### DIFF
--- a/services/api/src/routes/super/progress-pdf-draft.ts
+++ b/services/api/src/routes/super/progress-pdf-draft.ts
@@ -300,11 +300,18 @@ router.post(
       // email base な ASCII fallback (name: null で email 由来名を生成)。
       // Gmail UI が filename*= を解釈せず ASCII fallback を採用した経路でも、
       // UUID にフォールバックされずに意味のあるファイル名 + 拡張子で保存される。
-      const asciiFallbackFilename = buildProgressPdfFilename({
+      const candidateFallback = buildProgressPdfFilename({
         name: null,
         email: pdfData.user.email,
         date: dateStr,
       });
+      // email に非 ASCII (RFC 6531 SMTPUTF8) が含まれる場合や、何らかの理由で
+      // sanitize 結果が ASCII でない場合は asciiFallbackFilename を渡さず、
+      // library 側のデフォルト (_ 置換 fallback) に委ねる。
+      const asciiFallbackFilename =
+        /^[\x20-\x7e]+$/.test(candidateFallback) && /[A-Za-z0-9]/.test(candidateFallback)
+          ? candidateFallback
+          : undefined;
       attachment = {
         filename: buildProgressPdfFilename({
           name: pdfData.user.name,

--- a/services/api/src/routes/super/progress-pdf-draft.ts
+++ b/services/api/src/routes/super/progress-pdf-draft.ts
@@ -297,6 +297,14 @@ router.post(
       body = template.body;
 
       const dateStr = pdfData.generatedAt.slice(0, 10);
+      // email base な ASCII fallback (name: null で email 由来名を生成)。
+      // Gmail UI が filename*= を解釈せず ASCII fallback を採用した経路でも、
+      // UUID にフォールバックされずに意味のあるファイル名 + 拡張子で保存される。
+      const asciiFallbackFilename = buildProgressPdfFilename({
+        name: null,
+        email: pdfData.user.email,
+        date: dateStr,
+      });
       attachment = {
         filename: buildProgressPdfFilename({
           name: pdfData.user.name,
@@ -305,6 +313,7 @@ router.post(
         }),
         contentType: "application/pdf",
         content: pdfBuffer,
+        asciiFallbackFilename,
       };
     } catch (err) {
       if (err instanceof Error && err.message === "user_not_in_tenant") {

--- a/services/api/src/services/__tests__/gmail-draft.test.ts
+++ b/services/api/src/services/__tests__/gmail-draft.test.ts
@@ -97,7 +97,7 @@ describe("buildRawMimeMessage", () => {
     expect(decoded).toMatch(/--lms279_boundary_\d+_[a-z0-9]+--/);
   });
 
-  it("添付の日本語ファイル名は RFC 2231/5987 dual-form (filename + filename*=UTF-8'') で出力", () => {
+  it("添付の日本語ファイル名は Content-Disposition で RFC 2231/5987 dual-form を出力 (Content-Type 側は name= を出さない)", () => {
     const original = "進捗レポート.pdf";
     const raw = buildRawMimeMessage({
       to: "owner@example.com",
@@ -111,8 +111,7 @@ describe("buildRawMimeMessage", () => {
     });
     const decoded = base64UrlDecode(raw);
 
-    // RFC 2047 §5 違反 (parameter value に encoded-word 不可) のため
-    // そのパターンが含まれないことをアサート (退行防止)
+    // RFC 2047 §5 違反 (parameter value に encoded-word 不可) パターンが含まれないこと
     expect(decoded).not.toMatch(/filename="=\?UTF-8\?B\?/);
     expect(decoded).not.toMatch(/name="=\?UTF-8\?B\?/);
 
@@ -122,9 +121,30 @@ describe("buildRawMimeMessage", () => {
     expect(decoded).toContain(
       `Content-Disposition: attachment; filename="${expectedFallback}"; filename*=UTF-8''${expectedEncoded}`,
     );
+    // RFC 2046 deprecated な Content-Type `name=` は発行しない
+    expect(decoded).toContain("Content-Type: application/pdf\r\n");
+    expect(decoded).not.toMatch(/Content-Type: application\/pdf;/);
+  });
+
+  it("asciiFallbackFilename が指定されればそれを ASCII fallback として使う (Gmail UI 表示用に意味のある ASCII)", () => {
+    const raw = buildRawMimeMessage({
+      to: "owner@example.com",
+      subject: "件名",
+      body: "本文",
+      attachment: {
+        filename: "progress-テスト-2026-05-15.pdf",
+        asciiFallbackFilename: "progress-y.honda-2026-05-15.pdf",
+        contentType: "application/pdf",
+        content: Buffer.from("x"),
+      },
+    });
+    const decoded = base64UrlDecode(raw);
+    const expectedEncoded = rfc5987Encode("progress-テスト-2026-05-15.pdf");
     expect(decoded).toContain(
-      `Content-Type: application/pdf; name="${expectedFallback}"; name*=UTF-8''${expectedEncoded}`,
+      `Content-Disposition: attachment; filename="progress-y.honda-2026-05-15.pdf"; filename*=UTF-8''${expectedEncoded}`,
     );
+    // 自動 _ 化 fallback (progress-___-2026-05-15.pdf) は使われないこと
+    expect(decoded).not.toMatch(/filename="progress-___-/);
   });
 
   it("ASCII のみのファイル名は dual-form にせずシンプル形式 (filename=\"...\") のみ", () => {
@@ -142,12 +162,12 @@ describe("buildRawMimeMessage", () => {
     expect(decoded).toContain(
       'Content-Disposition: attachment; filename="progress-2026-05-15.pdf"',
     );
-    expect(decoded).toContain(
-      'Content-Type: application/pdf; name="progress-2026-05-15.pdf"',
-    );
-    // filename*= / name*= は出力されないこと (ASCII のみで dual-form 不要)
+    expect(decoded).toContain("Content-Type: application/pdf\r\n");
+    // filename*= / name= (RFC 2046 deprecated) / name*= は出力されないこと
+    // 単語境界で filename= 中の name= を hit しないよう ; or 行頭の直後を要求
     expect(decoded).not.toMatch(/filename\*=/);
-    expect(decoded).not.toMatch(/name\*=/);
+    expect(decoded).not.toMatch(/(?:^|;\s)name=/);
+    expect(decoded).not.toMatch(/(?:^|;\s)name\*=/);
   });
 
   it("base64url エンコードされ、+ / = が含まれない", () => {

--- a/services/api/src/services/__tests__/gmail-draft.test.ts
+++ b/services/api/src/services/__tests__/gmail-draft.test.ts
@@ -42,7 +42,13 @@ const {
   __internal,
 } = await import("../gmail-draft.js");
 
-const { encodeMimeHeader, buildFilenameParam, rfc5987Encode, assertSafeFilename } = __internal;
+const {
+  encodeMimeHeader,
+  buildFilenameParam,
+  rfc5987Encode,
+  assertSafeFilename,
+  assertValidAsciiFallback,
+} = __internal;
 
 /** base64url decode (Node の Buffer は base64url を toString サポート) */
 function base64UrlDecode(s: string): string {
@@ -236,6 +242,38 @@ describe("assertSafeFilename (制御文字 + lone surrogate 防御)", () => {
   });
 });
 
+describe("assertValidAsciiFallback (asciiFallbackFilename の厳格 validation)", () => {
+  it("ASCII safe + 英数字を含む文字列は throw しない", () => {
+    expect(() => assertValidAsciiFallback("progress-y.honda-2026-05-15.pdf")).not.toThrow();
+    expect(() => assertValidAsciiFallback("a")).not.toThrow();
+  });
+
+  it("非 ASCII を含むと throw (silent default fallback への退避を防止)", () => {
+    expect(() => assertValidAsciiFallback("進捗.pdf")).toThrow(/ASCII printable/);
+    expect(() => assertValidAsciiFallback("aéb.pdf")).toThrow(/ASCII printable/);
+  });
+
+  it("空文字は throw (Gmail UUID 化燃料)", () => {
+    expect(() => assertValidAsciiFallback("")).toThrow(/alphanumeric/);
+  });
+
+  it("whitespace-only は throw", () => {
+    expect(() => assertValidAsciiFallback("   ")).toThrow(/alphanumeric/);
+  });
+
+  it("英数字を一切含まない記号のみは throw", () => {
+    expect(() => assertValidAsciiFallback("___.___")).toThrow(/alphanumeric/);
+  });
+
+  it("CR/LF を含むと throw (ヘッダインジェクション防御の維持)", () => {
+    expect(() => assertValidAsciiFallback("evil\r\nBcc: x")).toThrow(/CR\/LF/);
+  });
+
+  it("制御文字を含むと throw", () => {
+    expect(() => assertValidAsciiFallback("a\x00b.pdf")).toThrow(/control character/);
+  });
+});
+
 describe("buildFilenameParam (RFC 2231/5987 form)", () => {
   it("ASCII のみは filename=\"...\" 単体形式", () => {
     expect(buildFilenameParam("filename", "progress.pdf")).toBe('filename="progress.pdf"');
@@ -351,6 +389,55 @@ describe("buildRawMimeMessage CR/LF ヘッダインジェクション防御", ()
     });
     expect(typeof raw).toBe("string");
     expect(raw.length).toBeGreaterThan(0);
+  });
+});
+
+describe("buildRawMimeMessage attachment.asciiFallbackFilename invalid 値防御", () => {
+  const base = {
+    to: "owner@example.com",
+    subject: "件名",
+    body: "本文",
+    attachment: {
+      filename: "進捗.pdf",
+      contentType: "application/pdf",
+      content: Buffer.from("x"),
+    },
+  } as const;
+
+  it("非 ASCII な asciiFallbackFilename は throw (silent fallback 退避を廃止)", () => {
+    expect(() =>
+      buildRawMimeMessage({
+        ...base,
+        attachment: { ...base.attachment, asciiFallbackFilename: "進捗-fallback.pdf" },
+      }),
+    ).toThrow(/ASCII printable/);
+  });
+
+  it("whitespace-only な asciiFallbackFilename は throw", () => {
+    expect(() =>
+      buildRawMimeMessage({
+        ...base,
+        attachment: { ...base.attachment, asciiFallbackFilename: "   " },
+      }),
+    ).toThrow(/alphanumeric/);
+  });
+
+  it("CR/LF を含む asciiFallbackFilename は throw (header injection 二重防御)", () => {
+    expect(() =>
+      buildRawMimeMessage({
+        ...base,
+        attachment: { ...base.attachment, asciiFallbackFilename: "x\r\nBcc: y" },
+      }),
+    ).toThrow(/CR\/LF/);
+  });
+
+  it("asciiFallbackFilename 未指定時は default _ fallback を採用 (後方互換)", () => {
+    const raw = buildRawMimeMessage(base);
+    const decoded = base64UrlDecode(raw);
+    // 進捗 (2 文字) → __ + .pdf
+    expect(decoded).toContain(
+      `Content-Disposition: attachment; filename="__.pdf"; filename*=UTF-8''${rfc5987Encode("進捗.pdf")}`,
+    );
   });
 });
 

--- a/services/api/src/services/gmail-draft.ts
+++ b/services/api/src/services/gmail-draft.ts
@@ -32,6 +32,14 @@ export interface MimeAttachment {
   contentType: string;
   /** 添付ファイルのバイト列 */
   content: Buffer;
+  /**
+   * RFC 6266 dual-form の ASCII fallback。filename が非 ASCII を含むときに
+   * `filename="..."` の値として使われる。Gmail は filename*= を解釈せず
+   * ASCII fallback を採用する経路があり、機械生成の `_` 連続では UUID に
+   * フォールバックされるため、呼び出し側で意味のある ASCII 名 (email base 等)
+   * を渡すこと。省略時は filename の非ASCII 文字を `_` に置換した自動 fallback。
+   */
+  asciiFallbackFilename?: string;
 }
 
 export interface BuildRawMimeMessageInput {
@@ -83,21 +91,31 @@ function rfc5987Encode(value: string): string {
  * で使用不可。非 ASCII は RFC 5987 `param*=UTF-8''<pct-encoded>` で表現し、古い
  * パーサ向けに ASCII fallback `param="..."` を併記する (RFC 6266 §5 dual-form)。
  *
+ * Gmail は受信側で `filename*=` を解釈せず ASCII fallback を採用する経路があり、
+ * 機械的な `_` 連続 fallback だと UUID にフォールバックされる。意味のある ASCII
+ * fallback を呼び出し側から渡す `asciiOverride` 経路を用意し、未指定時のみ
+ * `_` 置換のデフォルトを使う。
+ *
  * 制御文字 (`\x00-\x1f`, `\x7f`) と lone surrogate は事前に呼び出し側 (assertSafeFilename)
  * で拒否する前提。本関数はそれら無効値が渡らないことを invariant として扱う。
  */
-function buildFilenameParam(paramName: "filename" | "name", value: string): string {
+function buildFilenameParam(
+  paramName: "filename" | "name",
+  value: string,
+  asciiOverride?: string,
+): string {
   const isAscii = !/[^\x20-\x7e]/.test(value);
   if (isAscii) {
     // RFC 5322 quoted-pair: `\` も `"` も escape する
     const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
     return `${paramName}="${escaped}"`;
   }
-  // 非 ASCII を `_` 化した ASCII fallback (RFC 6266 §5 古いクライアント向け)
-  const asciiFallback = value
-    .replace(/[^\x20-\x7e]/g, "_")
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"');
+  // 非 ASCII を `_` 化したデフォルト ASCII fallback (RFC 6266 §5 古いクライアント向け)
+  const defaultFallback = value.replace(/[^\x20-\x7e]/g, "_");
+  // asciiOverride が ASCII safe ならそれを使い、そうでなければデフォルトに退避
+  const rawFallback =
+    asciiOverride && !/[^\x20-\x7e]/.test(asciiOverride) ? asciiOverride : defaultFallback;
+  const asciiFallback = rawFallback.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   return `${paramName}="${asciiFallback}"; ${paramName}*=UTF-8''${rfc5987Encode(value)}`;
 }
 
@@ -191,8 +209,15 @@ export function buildRawMimeMessage(input: BuildRawMimeMessageInput): string {
   }
 
   const boundary = generateBoundary();
-  const nameParam = buildFilenameParam("name", attachment.filename);
-  const filenameParam = buildFilenameParam("filename", attachment.filename);
+  // RFC 2046 §5.1 の Content-Type `name=` は RFC 6266 で deprecated。一部 MUA は
+  // Content-Disposition: filename を無視して Content-Type: name を優先するため、
+  // ASCII fallback と filename* が両方マッチしないと UUID にフォールバックされる
+  // 観測あり。name= を発行せず Content-Disposition: filename*= のみに統一する。
+  const filenameParam = buildFilenameParam(
+    "filename",
+    attachment.filename,
+    attachment.asciiFallbackFilename,
+  );
 
   // base64 を 76 文字ごとに改行 (RFC 2045 推奨)
   const attachmentBase64 = attachment.content.toString("base64").match(/.{1,76}/g)?.join("\r\n") ?? "";
@@ -210,7 +235,7 @@ export function buildRawMimeMessage(input: BuildRawMimeMessageInput): string {
     Buffer.from(body, "utf-8").toString("base64"),
     "",
     `--${boundary}`,
-    `Content-Type: ${attachment.contentType}; ${nameParam}`,
+    `Content-Type: ${attachment.contentType}`,
     `Content-Disposition: attachment; ${filenameParam}`,
     "Content-Transfer-Encoding: base64",
     "",

--- a/services/api/src/services/gmail-draft.ts
+++ b/services/api/src/services/gmail-draft.ts
@@ -110,11 +110,10 @@ function buildFilenameParam(
     const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
     return `${paramName}="${escaped}"`;
   }
-  // 非 ASCII を `_` 化したデフォルト ASCII fallback (RFC 6266 §5 古いクライアント向け)
-  const defaultFallback = value.replace(/[^\x20-\x7e]/g, "_");
-  // asciiOverride が ASCII safe ならそれを使い、そうでなければデフォルトに退避
+  // asciiOverride は呼び出し側で assertValidAsciiFallback 済みの前提で無条件採用。
+  // 未指定時は非 ASCII を `_` 化したデフォルト fallback を使う (RFC 6266 §5)。
   const rawFallback =
-    asciiOverride && !/[^\x20-\x7e]/.test(asciiOverride) ? asciiOverride : defaultFallback;
+    asciiOverride !== undefined ? asciiOverride : value.replace(/[^\x20-\x7e]/g, "_");
   const asciiFallback = rawFallback.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   return `${paramName}="${asciiFallback}"; ${paramName}*=UTF-8''${rfc5987Encode(value)}`;
 }
@@ -167,6 +166,32 @@ function assertSafeFilename(value: string): void {
   }
 }
 
+/**
+ * asciiFallbackFilename の妥当性を保証する。
+ * Gmail に意味のある ASCII fallback を渡す前提のため、以下を reject:
+ * - 非 ASCII (silent default fallback への退避を防止 → silent_failure_hunter C1)
+ * - 空文字 / whitespace-only (Gmail が UUID 化する燃料 → silent_failure_hunter C2)
+ * - assertSafeFilename / assertNoCRLF と同じ防御 (二重防御の維持 → silent_failure_hunter C3)
+ */
+function assertValidAsciiFallback(value: string): void {
+  assertNoCRLF(value, "attachment.asciiFallbackFilename");
+  assertSafeFilename(value);
+  if (/[^\x20-\x7e]/.test(value)) {
+    throw new GmailDraftError(
+      "Invalid asciiFallbackFilename: must contain only ASCII printable characters",
+      "gmail_api_error",
+      400,
+    );
+  }
+  if (!/[A-Za-z0-9]/.test(value)) {
+    throw new GmailDraftError(
+      "Invalid asciiFallbackFilename: must contain at least one alphanumeric character",
+      "gmail_api_error",
+      400,
+    );
+  }
+}
+
 /** Buffer / string を base64url にエンコード (Gmail API raw 用) */
 function toBase64Url(input: string | Buffer): string {
   const buf = typeof input === "string" ? Buffer.from(input, "utf-8") : input;
@@ -190,6 +215,9 @@ export function buildRawMimeMessage(input: BuildRawMimeMessageInput): string {
     assertNoCRLF(attachment.filename, "attachment.filename");
     assertNoCRLF(attachment.contentType, "attachment.contentType");
     assertSafeFilename(attachment.filename);
+    if (attachment.asciiFallbackFilename !== undefined) {
+      assertValidAsciiFallback(attachment.asciiFallbackFilename);
+    }
   }
 
   const encodedSubject = encodeMimeHeader(subject);
@@ -429,4 +457,5 @@ export const __internal = {
   buildFilenameParam,
   rfc5987Encode,
   assertSafeFilename,
+  assertValidAsciiFallback,
 };


### PR DESCRIPTION
## Summary

- PR #390 (RFC 6266 dual-form 化) のみでは Gmail の添付 DL UUID 化が **回帰したまま** で、本番 Playwright MCP 実機テストで再発確認
- 原因: Gmail 受信側が `filename*=UTF-8''` を解釈せず ASCII fallback (`filename=`) を採用する経路があり、機械生成の `_` 連続 fallback だと UUID にフォールバックされる
- 対応: ASCII fallback を呼び出し側で「意味のある ASCII 名」(email base) に差し替える + RFC 2046 deprecated な Content-Type `name=` を削除

## 本番実機テスト証跡 (PR #390 マージ後、本 PR 前の挙動)

| 項目 | 結果 |
|---|---|
| Cloud Run revision | `api-00278-5kw` (100% トラフィック、PR #390 反映済) |
| Gmail UI 添付名表示 | `progress-___-2026-05-15.pdf` (アンダースコア 3 つ) |
| 添付 DL 時のファイル名 | `89236cbf-fd5d-4f00-8d6c-a39a80de31ef` (UUID, 拡張子なし) |
| **総合判定** | **❌ FAIL — PR #390 では未修正** |

## 修正内容

### services/api/src/services/gmail-draft.ts (+25 / -8)

1. `MimeAttachment` interface に `asciiFallbackFilename?: string` 追加
2. `buildFilenameParam` に `asciiOverride?: string` 引数追加
   - 指定があれば ASCII fallback として優先採用
   - 指定がない or ASCII unsafe ならデフォルトの `_` 置換 fallback (後方互換)
3. `buildRawMimeMessage` で Content-Type 行の `name=` パラメータ削除
   - RFC 2046 で deprecated、RFC 6266 §1 でも `Content-Disposition: filename` が canonical
   - Gmail が `name="___.pdf"` を見て UUID 判定する経路を遮断

### services/api/src/routes/super/progress-pdf-draft.ts (+9)

```typescript
const asciiFallbackFilename = buildProgressPdfFilename({
  name: null,
  email: pdfData.user.email,
  date: dateStr,
});
attachment = { filename, contentType, content, asciiFallbackFilename };
```

`buildProgressPdfFilename` は Issue #366 修正済の既存ヘルパで、`name: null` を渡すと email base の ASCII safe ファイル名を生成する。

## 期待する Gmail 挙動

| クライアント解釈 | DL ファイル名 |
|---|---|
| `filename*=UTF-8''` を解釈 | `progress-テスト-2026-05-15.pdf` (日本語そのまま) |
| `filename=` のみ解釈 | `progress-y.honda@279279.net-2026-05-15.pdf` (email base) |

いずれにせよ **ファイル名 + .pdf 拡張子付き** で保存され、ダブルクリックで PDF として開けるようになる。

## Test plan

- [x] services/api 全テスト PASS (888 / 888)
- [x] web 全テスト PASS (40 / 40)
- [x] lint 0 errors / 0 warnings
- [x] type-check clean
- [x] 新規テスト追加:
  - `asciiFallbackFilename` 指定時に dual-form の filename= として採用されること
  - Content-Type 行が `application/pdf` 単独 (deprecated `name=` 不発行)
- [ ] **マージ後**: Cloud Run デプロイ完了を待機
- [ ] **マージ後**: Playwright MCP で本番 3 回目の実機検証 — 添付 DL 結果が `progress-y.honda@279279.net-2026-05-15.pdf` (ASCII fallback) または `progress-テスト-2026-05-15.pdf` (RFC 5987) のいずれかで、PDF として開けることを確認

## 関連

- Refs Issue #389 (reopened): 1 回目の修正 (PR #390) では UUID 回帰のまま、本 PR で完全解消を目指す
- Closes #389 (再検証後)
- Related: Issue #366 (Closed) — `buildProgressPdfFilename` 共通ヘルパを再利用

🤖 Generated with [Claude Code](https://claude.com/claude-code)