### PR TITLE
fix(super): 進捗 PDF の文字色コントラストを向上 (視認性改善)

### DIFF
--- a/services/api/src/services/progress-pdf-document.tsx
+++ b/services/api/src/services/progress-pdf-document.tsx
@@ -37,13 +37,18 @@ function ensureFontRegistered() {
   fontRegistered = true;
 }
 
+// 本文 / 副次情報 / 構造線 のコントラスト階層 (印刷時の視認性を確保)
+const COLOR_BODY = "#000000"; // 本文 (純黒、紙印刷で最大コントラスト)
+const COLOR_SUB = "#374151"; // 副次情報 / ラベル (gray-700、本文との対比は維持しつつ十分な濃度)
+const COLOR_BORDER = "#9ca3af"; // 構造線 (gray-400)
+
 const styles = StyleSheet.create({
-  page: { fontFamily: "NotoSansJP", fontSize: 10, padding: 32, color: "#1f2937" },
+  page: { fontFamily: "NotoSansJP", fontSize: 10, padding: 32, color: COLOR_BODY },
   h1: { fontSize: 18, fontWeight: 700, marginBottom: 4 },
-  h2: { fontSize: 13, fontWeight: 700, marginTop: 14, marginBottom: 6, borderBottom: 1, borderColor: "#d1d5db", paddingBottom: 2 },
-  meta: { fontSize: 9, color: "#6b7280", marginBottom: 8 },
+  h2: { fontSize: 13, fontWeight: 700, marginTop: 14, marginBottom: 6, borderBottom: 1, borderColor: COLOR_BORDER, paddingBottom: 2 },
+  meta: { fontSize: 9, color: COLOR_SUB, marginBottom: 8 },
   row: { flexDirection: "row", marginBottom: 2 },
-  label: { width: 100, color: "#6b7280" },
+  label: { width: 100, color: COLOR_SUB },
   value: { flex: 1 },
   section: { marginBottom: 6 },
   courseHeader: { fontSize: 11, fontWeight: 700, marginTop: 8, marginBottom: 4 },
@@ -52,7 +57,7 @@ const styles = StyleSheet.create({
   lessonRow: { flexDirection: "row", marginBottom: 1.5, paddingVertical: 1 },
   lessonCheck: { width: 16, fontWeight: 700 },
   lessonTitle: { flex: 1 },
-  lessonMeta: { width: 80, color: "#6b7280", fontSize: 9, textAlign: "right" },
+  lessonMeta: { width: 80, color: COLOR_SUB, fontSize: 9, textAlign: "right" },
   expired: { color: "#dc2626", fontWeight: 700 },
   caution: { color: "#f59e0b" },
 });


### PR DESCRIPTION
## Summary

- 本番運用テスト (受信メール経由 PDF 表示) で本文 / ラベル / meta テキストが gray-500 でやや薄く、視認性が低いというフィードバックを反映
- `services/api/src/services/progress-pdf-document.tsx` の色階層を 3 段に整理 + 全体的に濃度を上げる

## 変更内容

| スタイル | 旧 | 新 |
|---|---|---|
| `page.color` (本文) | `#1f2937` (gray-800) | `#000000` (純黒) |
| `label.color` (氏名/メール/テナント等) | `#6b7280` (gray-500) | `#374151` (gray-700) |
| `meta.color` (TEST / 発行日…) | `#6b7280` (gray-500) | `#374151` (gray-700) |
| `lessonMeta.color` | `#6b7280` (gray-500) | `#374151` (gray-700) |
| `h2.borderColor` | `#d1d5db` (gray-300) | `#9ca3af` (gray-400) |

定数化: `COLOR_BODY` / `COLOR_SUB` / `COLOR_BORDER` で 3 段の階層を明示。

その他色 (progressBar / expired / caution) は意味色のため維持。

## Test plan

- [x] services/api 全テスト PASS (899 / 899) — レイアウト・data 構造変更なしのため既存テスト破壊なし
- [x] lint 0 errors / 0 warnings
- [x] type-check clean
- [ ] **マージ後**: Cloud Run デプロイ完了を待機
- [ ] **マージ後**: Playwright MCP で進捗 PDF 生成 → 受信メール表示で視認性向上を確認

## 関連

- Issue #389 完全解決後の品質改善 (連続検証で発見)
- ADR-032 (super admin progress pdf) のレンダリング層変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)