### PR TITLE
docs(handoff): Session 27 (2026-05-15〜16) 記録 + Session 26 アーカイブ

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,12 +1,12 @@
-# Session Handoff — 2026-05-15 (Session 26)
+# Session Handoff — 2026-05-15 〜 2026-05-16 (Session 27)
 
 ## TL;DR
 
-**Session 25 末ハンドオフ「優先度1: PR #358 follow-up I2 (originalError 設計改善)」を消化、PR #387 で `GmailDraftError.originalError` フィールドを完全削除してマージ。**Session 20 から続いた I1/I2/I5 トリオの最後の 1 件 (I2) が解消され、handoff 内 Open follow-up は記録上ゼロ件化。コード変更は 2 ファイル / +14 / -13 行の小規模リファクタで、PR CI / main CI / E2E Tests いずれも PASS、Cloud Run Deploy も in_progress（コード起因の障害は想定されず）。GitHub Actions の 2026-05-15 08:13 UTC partial outage は完全復旧確認済。
+**Session 26 末で記録上ゼロ化していた handoff 内 follow-up に対し、ユーザー依頼「進捗状況 PDF → Gmail 下書き → PDF 自動貼付フローを Playwright で実機テスト」を実施。検証の過程で 2 系統の連鎖品質課題を発見し 4 PR (#391 / #393 / #392 / #403) で完全解決、Playwright MCP 実機検証で Gmail 受信メール経由の PDF DL までフル PASS。**Issue #389 を起票し PR #391 で auto-close、その後 PR #393 マージで完全解消、PR #403 で文字濃度の真因 (Variable Font default = Thin) を解消。session を通して 1 Issue 起票 / 1 close で Issue Net ±0、しかし Phase 2 Gmail Draft 機能の本番運用品質を実機エビデンス付きで大きく押し上げた。
 
-- **Issue Net**: **±0** (Close 0 / 起票 0、リファクタ PR のため KPI 上は進捗なし)
-- **Open 推移**: Session 25 末 3 件 → Session 26 末 **3 件** (全 postponed: #276 / #275 / #274 — 変化なし)
-- **本セッション成果**: PR 1 件マージ (#387) / handoff 内 follow-up 1 件消化 / token 漏洩ベクタを構造的に除去
+- **Issue Net**: **±0** (Close 1 件 / 起票 1 件 — いずれも #389)
+- **Open 推移**: Session 26 末 3 件 → Session 27 末 **3 件** (全 postponed: #276 / #275 / #274 — 変化なし)
+- **本セッション成果**: PR 4 件マージ (#391 / #392 / #393 / #403) / Variable Font 真因解明 / 2026 業界 best practice (filename 生 Unicode dual-form) 採用 / Playwright MCP 実機検証完遂
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -14,129 +14,163 @@
 # 1. 状況復元
 cat docs/handoff/LATEST.md
 
-# 2. main CI 状況確認（本セッション末で Deploy in_progress、コード起因問題なし）
+# 2. main CI 状況確認 (本セッション末で Deploy success: 25942250679 / 3m58s)
 gh run list --branch main --limit 5
-#  → 25915712995 (Deploy to Cloud Run) が success に遷移していることを確認
 
-# 3. 現在の OPEN Issue (3 件、全 postponed、Session 24 末から変化なし)
+# 3. 現在の OPEN Issue (3 件、全 postponed、変化なし)
 gh issue list --state open --limit 15
 
-# 4. 現在の OPEN Dependabot PR (Session 24 末で全消化済)
-gh pr list --author "app/dependabot" --state open
-
-# 5. 次の着手候補（優先度順、Session 26 末で実作業対象は実質ゼロ件）:
-#    A. 【優先度1】Issue #272 Phase 3 GCIP 移行 — 再評価期限 2026-10-24
+# 4. 次の着手候補 (優先度順):
+#    A. 【完了済】Issue #389 系列 — 本セッションで PR #391/#392/#393/#403 マージ
+#       + Playwright MCP 実機検証完遂。実作業候補なし。
+#    B. 【優先度1】Issue #272 Phase 3 GCIP 移行 — 再評価期限 2026-10-24
 #       — 期限到達まで着手不可、postponed #276 / #275 / #274 の再開条件
-#    B. 【優先度2】postponed #276 / #275 / #274 — Phase 3 GCIP 完了が再開条件
+#    C. 【優先度2】postponed #276 / #275 / #274 — Phase 3 GCIP 完了が再開条件
 #       — 明示指示なき限り着手不可
-#    C. 【優先度3】Dependabot semver-major 全 ignore 設定の月次/四半期棚卸し運用
-#       — Codex review (PR #369) で指摘、Issue 化見送り。`/handoff` で記録継続中
-#       — 次回 weekly review で `npm outdated` / GitHub Insights / `gh api`
-#         で major 候補リストを抽出し、必要なら個別 PR を手動で起こす
-#    D. 【優先度4】PR #381 (playwright 1.58.2 → 1.60.0、CONFLICTING で自動 close)
-#       — lockfile は ^1.60.0 caret range 経由で 1.60.0 解決済、実害なし
-#       — 次回 Dependabot weekly で再 PR 来るか観察 (なければ手動 PR 不要)
-#    E. 【消化済】PR #358 follow-up I2 (originalError 設計改善)
-#       — Session 26 で PR #387 マージ完了。handoff 内 Open follow-up はゼロ件化
+#    D. 【優先度3】Dependabot semver-major 全 ignore 設定の月次/四半期棚卸し運用
 ```
 
 ---
 
-## セッション成果物 (2026-05-15 Session 26)
+## セッション成果物 (2026-05-15 〜 2026-05-16 Session 27)
 
-### 🟢 PR #387: refactor(api): drop GmailDraftError.originalError to remove access token leak vector (I2)
+### 検証フロー (Playwright MCP)
 
-- ブランチ: `refactor/gmail-draft-error-drop-original-error` (削除済)
-- 変更: 2 ファイル, +14 / -13 行 (1 commit)
-- 状態: **MERGED (2026-05-15T11:36 頃, squash, commit `4143095`)**
-- PR CI: 全 4 check (Build 49s / Lint 36s / Test 1m26s / Type Check 43s) PASS
-- main CI: CI 1m42s success / E2E Tests 1m26s success / Deploy to Cloud Run in_progress（コード起因問題なし）
+ユーザー依頼「進捗状況 PDF の生成から下書きメールの生成とそのPDFの自動貼付まで Playwright でテストしてほしい」に対し、本番 Cloud Run + Playwright MCP で実機検証を実施。経路:
 
-#### 変更内容
+```
+https://web-3zcica5euq-an.a.run.app
+  → Google ログイン (system@279279.net、user 主導 OAuth)
+  → /super/progress/qos4c4ka/uXMEFBo5Jdd3uok3C3kb/print (TEST テナント / 受講者「テスト」)
+  → PDF 生成ボタン (ローカル DL 検証)
+  → Gmail 下書き作成ボタン → gmail.compose 同意 (user 主導)
+  → 受信メールで添付 DL + 開封確認
+```
 
-1. **`services/api/src/services/gmail-draft.ts`**
-   - `GmailDraftError` コンストラクタから 4 引数目 (`originalError?: unknown`) を削除
-   - `classifyGmailError` 内 5 箇所 + `createGmailDraft` 内 1 箇所の `new GmailDraftError(..., err)` を 3 引数化
-   - セキュリティ意図 (`raw GaxiosError 参照を持たない`) をクラス上のコメントに明記:
-     `// SECURITY (I2 / ADR-034): GaxiosError は config.headers.Authorization に access token を保持するため、本クラスは raw error への参照を持たない。`
+### 🟢 PR #391: ASCII fallback を email base にして UUID 化を回避 (Issue #389)
 
-2. **`services/api/src/routes/super/progress-pdf-draft.ts`**
-   - L402-404 の `Evaluator HIGH-1 対応` コメントを設計反映後の表現に更新
-     - 旧: 「originalError には Authorization ヘッダを含む config が残存する可能性があるため access token を含む raw error はログに渡さない」
-     - 新: 「GmailDraftError は raw GaxiosError 参照を持たない設計のため、ここでは分類済みの errorCode / httpStatus / message のみを記録する」
+- ブランチ: `fix/gmail-draft-mime-filename-rfc2231` → `fix/gmail-draft-ascii-fallback-meaningful`
+- 状態: **MERGED** (`6fe1a31`)
+- 経緯: PR #390 の RFC 6266 dual-form 化だけでは Gmail 受信側が `filename*=UTF-8''` を解釈せず ASCII fallback の `_` 連続 (`progress-___-2026-05-15.pdf`) で UUID にフォールバックすると判明。`MimeAttachment.asciiFallbackFilename` を追加し、route 側で email-base な意味のある ASCII fallback (`progress-y.honda@279279.net-2026-05-15.pdf`) を渡すよう変更
+- 効果: ダウンロード時のファイル名が拡張子付き ASCII safe 名で取得可能に。Issue #389 auto-close
 
-#### なぜ今やったか
+### 🟢 PR #392: PDF 文字色 (#1f2937 → #000) 視認性改善
 
-Session 20 `/review-pr` (silent-failure-hunter agent) で発見、Session 22 `/codex` 計画レビュー (質問 3) で「分離継続が妥当」と判定された Important 級指摘 (rating 7)。Session 22〜25 の 4 セッションにわたり handoff 内 follow-up として記録継続中だった項目を、Session 26 で decision-maker 判断 (案 A: 完全削除) 確定後に消化。読み手ゼロ件 (grep 確認済) + YAGNI 適用 + 構造的に絶対漏れない設計を選択。
+- ブランチ: `fix/progress-pdf-text-color-contrast`
+- 状態: **MERGED** (`9db7647`)
+- 内容: page.color を #1f2937 (gray-800) → #000000 (純黒)、label/meta/lessonMeta を #6b7280 (gray-500) → #374151 (gray-700)、定数化 `COLOR_BODY` / `COLOR_SUB` / `COLOR_BORDER`
+- 反省: 本 PR は **真因 (Variable Font Thin) を見落とした表面修正**。視覚的改善が小さく、PR #403 で根本対応
 
-#### 設計判断の比較表
+### 🟢 PR #393: filename 生 Unicode quoted-string + filename*= dual-form (2026 best practice)
 
-| 案 | 採用 | 理由 |
-|---|---|---|
-| **A. 完全削除** | ✅ | 読み手ゼロ件、YAGNI、構造的に絶対に漏れない、最小 diff |
-| B. narrow 型に絞る | ❌ | デバッグ情報のために YAGNI を許容する根拠なし、複雑度増 |
-| C. 衛生化 helper | ❌ | redact 漏れリスク、本質は「持たない」で解決可能 |
-| D. 現状維持 + ESLint | ❌ | 検出止まり、予防にならない |
+- ブランチ: `fix/progress-pdf-readability-and-unicode-filename`
+- 状態: **MERGED** (`9a89867`)
+- 内容:
+  - `buildFilenameParam` を改修。非 ASCII を含む場合、生 Unicode を quoted-string で直接 filename に出力 + filename*= 併記
+  - RFC 5322 §3.2.4 厳密違反だが、Gmail / Outlook / Apple Mail が RFC 5987 を完全準拠していない 2026 業界 de facto
+  - 旧 `asciiFallbackFilename` / `assertValidAsciiFallback` / `asciiOverride` を削除 (dual-form では不要)
+  - `Content-Type: name=` を削除 (RFC 2046 deprecated)
+- 効果: Gmail UI 上の添付名表示が `progress-テスト-2026-05-15.pdf` (日本語そのまま)、ダウンロード時もファイル名 + 拡張子付きで保存
 
-CLAUDE.md「Don't add error handling, fallbacks, or validation for scenarios that can't happen」「Don't design for hypothetical future requirements」に整合。
+### 🟢 PR #403: NotoSansJP を Variable Font から static Regular/Bold OTF に切替 (文字濃度真因解消)
+
+- ブランチ: `fix/progress-pdf-static-fonts`
+- 状態: **MERGED** (`12d4f7a`)
+- 根本原因の発見: 本番 PDF を `pdffonts` で検査 → `NotoSansJP-Thin` 1 種類のみ embedded を確認 → `@react-pdf/font` の Variable Font weight axis 補間 (`getVariation`) 未実装 + `NotoSansJP-VariableFont.ttf` の default wght = Thin (100) で全テキストが Thin 描画されていた事実が判明
+- 修正:
+  - `NotoSansJP-VariableFont.ttf` を削除
+  - `NotoSansJP-Regular.otf` (fontWeight 400) + `NotoSansJP-Bold.otf` (fontWeight 700) を追加 (notofonts/noto-cjk Sans 2.004 公式リリース由来、SIL OFL 1.1)
+  - Font.register に 2 ファイル別パスで登録
+- 効果: 本番 PDF を `pdffonts` で検査 → `NotoSansJP-Regular` + `NotoSansJP-Bold` 両 weight embedded を確認、Gmail で開いた PDF も Bold/Regular の階層がはっきり視認可能 (実機 Image エビデンスで確認)
+
+### 連続 PR の教訓
+
+「テスト PASS だが本番で問題」が 3 回連続 (PR #390 → #391 / PR #392 / PR #393) して再発。要因:
+
+1. **Gmail / Variable Font の実挙動を確認せず仕様だけ追って実装**: PR #390/#391/#392 各時点で「テスト 887/887 PASS」を根拠に妥当性主張、本番 Playwright で初めて NG が露呈
+2. **真因に到達するまで複数の表面修正を経由**: PDF 文字色問題は #392 (色変更) → #393 (font weight 700) → #403 (Variable Font 問題発見) と 3 段階
+3. **silent-failure-hunter の PR #393 レビューが「Variable Font 500 は no-op」を正確に予言**したが、当時の対処 (700 に変更) は本質を解決しなかった
+
+教訓は memory に記録した方が良い (本セッション handoff 内に止め、別途 catchup で参照):
+- 「PDF / メール添付 など描画/受信側挙動が絡む機能は、テスト PASS だけでなく実機 (受信側 client / PDF viewer) での検証エビデンスを必須化」
+- 「Variable Font は @react-pdf/font では axis 補間が効かない (2026-05 時点)」
 
 ---
 
-## handoff 内 follow-up 消化状況（Session 20〜26 トリオ完結）
+## Playwright MCP 実機検証エビデンス
 
-| ID | 概要 | rating | 消化 PR | セッション |
-|---|---|---|---|---|
-| I1 | `classifyGmailError` の `??` チェーンで `ECONNRESET`/`ETIMEDOUT` 等が permanent に誤分類 | 7 | PR #364 | Session 22 |
-| I2 | `GmailDraftError.originalError` が GaxiosError raw を保持 → logger 経由で Authorization 漏洩リスク | 7 | **PR #387** | **Session 26** |
-| I5 | FE `window.open === null` 未チェック → Safari/Firefox popup ブロックでサイレント失敗 | 7 | PR #364 | Session 22 |
+最終確認 (PR #403 デプロイ後):
 
-**Open follow-up は記録上ゼロ件**。次セッション開始時点で handoff 内に未消化指摘なし。
+| 検証項目 | 結果 | エビデンス |
+|---|---|---|
+| Gmail UI 添付名表示 | ✅ `progress-テスト-2026-05-15.pdf` | Image (Session 27 ユーザー提示) |
+| 受信メール経由 PDF DL | ✅ 同名で開ける | Image (Session 27 ユーザー提示) |
+| PDF 内 embedded font | ✅ `NotoSansJP-Bold` + `NotoSansJP-Regular` | `pdffonts` 出力 |
+| 見出し (h1/h2/courseHeader) | ✅ Bold で濃い | Image 12 |
+| 本文値 (テスト / y.honda@279279.net / TEST / 日付) | ✅ Bold で読みやすい | Image 12 |
+| ラベル (氏名 / メール / テナント) | ✅ Regular で階層維持 | Image 12 |
+| ファイルサイズ | 85 KB (Subset OTF 込み) | DL ファイル |
+
+ローカル DL 経路でも `progress-テスト-2026-05-15.pdf` で日本語ファイル名が保存される (Content-Disposition: filename + filename*= dual-form 効果)。
+
+---
+
+## 設計判断の整理
+
+### filename ヘッダ採用形式の変遷
+
+| PR | filename 値 | filename*= | 結果 |
+|---|---|---|---|
+| #358 (Phase 2 初版) | RFC 2047 `=?UTF-8?B?...?=` encoded | なし | UUID 化 (RFC 2047 §5 違反) |
+| #390 | RFC 2047 encoded (改良なし) | UTF-8'' percent-encoded 追加 | UUID 化 (filename 側の違反が決定打) |
+| #391 | ASCII fallback (email base) | UTF-8'' percent-encoded | DL OK だが UI 表示が email base で UX 劣 |
+| **#393 (最終)** | **生 Unicode quoted-string** | **UTF-8'' percent-encoded** | **UI / DL 共に日本語ファイル名** |
+
+業界 best practice 採用は ADR 化を後追いで検討する余地あり (本 PR 内ではコメント / README に留めた)。
+
+### 採用フォント
+
+- 旧: `NotoSansJP-VariableFont.ttf` (9.6 MB、Variable Font、wght axis 100..900、default Thin)
+- 新: `NotoSansJP-Regular.otf` (4.5 MB) + `NotoSansJP-Bold.otf` (4.7 MB)、計 9.2 MB
+- 出典: [notofonts/noto-cjk Sans 2.004](https://github.com/notofonts/noto-cjk/releases/tag/Sans2.004) (`16_NotoSansJP.zip`)
+- ライセンス: SIL Open Font License 1.1 (既存 `LICENSE.txt`)
 
 ---
 
 ## Issue Net 変化
 
-- Close 数: **0 件**
-- 起票数: **0 件**
-- **Net: 0 件 (KPI 上は進捗ゼロ扱い)**
+- **Close 数**: **1 件** (#389 Phase 2 Gmail draft の MIME 添付ファイル名 RFC 違反)
+- **起票数**: **1 件** (#389、同 Issue を本セッション内で起票)
+- **Net**: **±0**
 
-triage 評価:
-- 本セッションは handoff 内 follow-up の I2 消化が主目的で、新規バグ・rating ≥ 7 review agent 提案・ユーザー明示指示の個別タスクは発生せず
-- I2 自体は handoff 内記録のみで Issue 化していなかったため、消化しても close 対象 Issue がない（feedback_issue_triage.md §「rating 7 以上でも実害ゼロなら起票しない、handoff で記録継続」運用に準拠）
-- 結果 Net 0 だが、**handoff 内 follow-up を「1 件減 (3→0)」した実質進捗あり** — Session 20〜26 を通じて Open follow-up を完全消化したマイルストーンセッション
-- postponed 3 件 (#276 / #275 / #274) は据え置き — Phase 3 GCIP 完了が再開条件、2026-10-24 再評価まで保留
+| Issue | 起票 | 起票理由 | Close PR |
+|---|---|---|---|
+| #389 | Session 27 (実機検証中) | triage #1 #2 #4 #5 該当 (実害 / 再現可能 / rating ≥7 / ユーザー明示指示) | PR #391 で auto-close、PR #393 で完全解消、PR #403 で文字濃度真因解消 |
 
----
-
-## 教訓・気づき
-
-### 1. Session 22 の「分離継続が妥当」判定が正しく機能
-
-Session 22 で Codex / silent-failure-hunter の二段判定により「I2 を PR #358 に含めない」決定をしたことで、PR #358 のレビュー焦点が分散せず、I1 / I5 と一括で消化することも避けられた。**Important 級でも実害ゼロなら scope 分離して別 PR 化** という運用が、レビュー品質・focus 維持・decision-maker への判断委譲のすべてで機能した好例。
-
-### 2. 「読み手ゼロ件」の確認が設計選択肢を絞る決定打
-
-`originalError` フィールドの設計改善 4 案 (A: 削除 / B: narrow / C: sanitize / D: lint) のうち、実装着手前の grep で「src / tests / dist いずれにも `.originalError` 参照ゼロ」を確認したことで、案 A (完全削除) が即決可能になった。**`grep -rn ".originalError"` を impl-plan の前段で実行** することで、YAGNI 適用の根拠が機械的に得られる。
-
-### 3. 小規模 PR (2 files, +14/-13) は lightweight review で十分
-
-post-pr-review hook が `/review-pr` 軽量経路 (security + code-quality の 2 エージェントに絞る) を推奨。CLAUDE.md memory `feedback_simplify_vs_review.md` の「1-2 ファイル / 30 行未満は /simplify スキップ」と整合。リファクタ PR は手動チェックリストで完結し、フルセット 6 エージェントの実行コストを節約。
-
-### 4. PR マージは番号単位の明示認可 + 要約付き形式が機能
-
-`PR #387 — refactor(api): drop GmailDraftError.originalError (2 files, +14/-13) をマージしてよい` 形式での明示認可を受領後にマージ実行。CLAUDE.md AI 駆動開発 4 原則 §3「安全装置の skip は番号単位の明示認可でのみ可」「承認依頼時は PR #番号 — タイトル (N files, +X/-Y) 形式で要約必須」が機能した好例。
+triage 基準は CLAUDE.md「GitHub Issues」セクション準拠。rating 5-6 の review agent 提案は本セッション内で発見されたものも含めて Issue 化せず、PR 内修正で対応した (`silent-failure-hunter` C1/C2/C3 / `code-reviewer` I1/I2 等は PR コメント / 追加 commit で消化済)。
 
 ---
 
-## 環境状態 (本セッション終了時)
+## ハーネス的考察 (本セッション特有)
 
-- main ブランチ: HEAD `4143095` (PR #387 squash merge)
-- ローカル: handoff feature ブランチ作成中、未コミット変更は handoff のみ
-- Cloud Run / E2E: ✅ CI / E2E Tests PASS、Deploy in_progress（コード起因問題なし）
-- 残留プロセス: なし
+本セッションは「**Playwright で実機テストしてほしい**」というユーザー依頼の解釈で初期に揺れがあった (spec ファイル自動化 vs Playwright MCP 経由実機検証)。ユーザー意図確認の結果、**Playwright MCP 経由の実機検証フロー自体がテスト依頼への応答**であり、本セッションで実行した検証がそのまま受け渡しエビデンスとなる。
+
+将来のリグレッション検出は以下に依存:
+
+1. **既存 e2e/tests/** (5 spec) → AUTH_MODE=dev での API 表面の動作確認 (本機能は Firestore 依存のため未カバー)
+2. **services/api/src/services/__tests__/** (890 unit + integration) → MIME ヘッダ / フォント登録 weight pin 等
+3. **手動 Playwright MCP 検証** → Gmail OAuth + 実 Gmail 送信を含む E2E フロー (本セッションのアプローチ)
+
+(3) を spec ファイル化するには storageState + テスト用 Google アカウント + Secret Manager 連携が必要で、本セッションスコープ外。次回以降の品質投資判断として残置。
 
 ---
 
-## Session 25 のアーカイブ
+## 関連リンク
 
-旧 LATEST.md (Session 25) は `docs/handoff/archive/2026-05-15-session-25.md` に保存済み。
+- PR #391: https://github.com/system-279/lms-279/pull/391
+- PR #392: https://github.com/system-279/lms-279/pull/392
+- PR #393: https://github.com/system-279/lms-279/pull/393
+- PR #403: https://github.com/system-279/lms-279/pull/403
+- Issue #389 (Closed): https://github.com/system-279/lms-279/issues/389
+- ADR-034 (Phase 2 Gmail API Draft 方式採用): docs/adr/ADR-034-phase2-gmail-draft.md
+- Session 26 handoff (archived): docs/handoff/archive/2026-05-15-session-26.md

--- a/docs/handoff/archive/2026-05-15-session-26.md
+++ b/docs/handoff/archive/2026-05-15-session-26.md
@@ -1,0 +1,142 @@
+# Session Handoff — 2026-05-15 (Session 26)
+
+## TL;DR
+
+**Session 25 末ハンドオフ「優先度1: PR #358 follow-up I2 (originalError 設計改善)」を消化、PR #387 で `GmailDraftError.originalError` フィールドを完全削除してマージ。**Session 20 から続いた I1/I2/I5 トリオの最後の 1 件 (I2) が解消され、handoff 内 Open follow-up は記録上ゼロ件化。コード変更は 2 ファイル / +14 / -13 行の小規模リファクタで、PR CI / main CI / E2E Tests いずれも PASS、Cloud Run Deploy も in_progress（コード起因の障害は想定されず）。GitHub Actions の 2026-05-15 08:13 UTC partial outage は完全復旧確認済。
+
+- **Issue Net**: **±0** (Close 0 / 起票 0、リファクタ PR のため KPI 上は進捗なし)
+- **Open 推移**: Session 25 末 3 件 → Session 26 末 **3 件** (全 postponed: #276 / #275 / #274 — 変化なし)
+- **本セッション成果**: PR 1 件マージ (#387) / handoff 内 follow-up 1 件消化 / token 漏洩ベクタを構造的に除去
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+# 1. 状況復元
+cat docs/handoff/LATEST.md
+
+# 2. main CI 状況確認（本セッション末で Deploy in_progress、コード起因問題なし）
+gh run list --branch main --limit 5
+#  → 25915712995 (Deploy to Cloud Run) が success に遷移していることを確認
+
+# 3. 現在の OPEN Issue (3 件、全 postponed、Session 24 末から変化なし)
+gh issue list --state open --limit 15
+
+# 4. 現在の OPEN Dependabot PR (Session 24 末で全消化済)
+gh pr list --author "app/dependabot" --state open
+
+# 5. 次の着手候補（優先度順、Session 26 末で実作業対象は実質ゼロ件）:
+#    A. 【優先度1】Issue #272 Phase 3 GCIP 移行 — 再評価期限 2026-10-24
+#       — 期限到達まで着手不可、postponed #276 / #275 / #274 の再開条件
+#    B. 【優先度2】postponed #276 / #275 / #274 — Phase 3 GCIP 完了が再開条件
+#       — 明示指示なき限り着手不可
+#    C. 【優先度3】Dependabot semver-major 全 ignore 設定の月次/四半期棚卸し運用
+#       — Codex review (PR #369) で指摘、Issue 化見送り。`/handoff` で記録継続中
+#       — 次回 weekly review で `npm outdated` / GitHub Insights / `gh api`
+#         で major 候補リストを抽出し、必要なら個別 PR を手動で起こす
+#    D. 【優先度4】PR #381 (playwright 1.58.2 → 1.60.0、CONFLICTING で自動 close)
+#       — lockfile は ^1.60.0 caret range 経由で 1.60.0 解決済、実害なし
+#       — 次回 Dependabot weekly で再 PR 来るか観察 (なければ手動 PR 不要)
+#    E. 【消化済】PR #358 follow-up I2 (originalError 設計改善)
+#       — Session 26 で PR #387 マージ完了。handoff 内 Open follow-up はゼロ件化
+```
+
+---
+
+## セッション成果物 (2026-05-15 Session 26)
+
+### 🟢 PR #387: refactor(api): drop GmailDraftError.originalError to remove access token leak vector (I2)
+
+- ブランチ: `refactor/gmail-draft-error-drop-original-error` (削除済)
+- 変更: 2 ファイル, +14 / -13 行 (1 commit)
+- 状態: **MERGED (2026-05-15T11:36 頃, squash, commit `4143095`)**
+- PR CI: 全 4 check (Build 49s / Lint 36s / Test 1m26s / Type Check 43s) PASS
+- main CI: CI 1m42s success / E2E Tests 1m26s success / Deploy to Cloud Run in_progress（コード起因問題なし）
+
+#### 変更内容
+
+1. **`services/api/src/services/gmail-draft.ts`**
+   - `GmailDraftError` コンストラクタから 4 引数目 (`originalError?: unknown`) を削除
+   - `classifyGmailError` 内 5 箇所 + `createGmailDraft` 内 1 箇所の `new GmailDraftError(..., err)` を 3 引数化
+   - セキュリティ意図 (`raw GaxiosError 参照を持たない`) をクラス上のコメントに明記:
+     `// SECURITY (I2 / ADR-034): GaxiosError は config.headers.Authorization に access token を保持するため、本クラスは raw error への参照を持たない。`
+
+2. **`services/api/src/routes/super/progress-pdf-draft.ts`**
+   - L402-404 の `Evaluator HIGH-1 対応` コメントを設計反映後の表現に更新
+     - 旧: 「originalError には Authorization ヘッダを含む config が残存する可能性があるため access token を含む raw error はログに渡さない」
+     - 新: 「GmailDraftError は raw GaxiosError 参照を持たない設計のため、ここでは分類済みの errorCode / httpStatus / message のみを記録する」
+
+#### なぜ今やったか
+
+Session 20 `/review-pr` (silent-failure-hunter agent) で発見、Session 22 `/codex` 計画レビュー (質問 3) で「分離継続が妥当」と判定された Important 級指摘 (rating 7)。Session 22〜25 の 4 セッションにわたり handoff 内 follow-up として記録継続中だった項目を、Session 26 で decision-maker 判断 (案 A: 完全削除) 確定後に消化。読み手ゼロ件 (grep 確認済) + YAGNI 適用 + 構造的に絶対漏れない設計を選択。
+
+#### 設計判断の比較表
+
+| 案 | 採用 | 理由 |
+|---|---|---|
+| **A. 完全削除** | ✅ | 読み手ゼロ件、YAGNI、構造的に絶対に漏れない、最小 diff |
+| B. narrow 型に絞る | ❌ | デバッグ情報のために YAGNI を許容する根拠なし、複雑度増 |
+| C. 衛生化 helper | ❌ | redact 漏れリスク、本質は「持たない」で解決可能 |
+| D. 現状維持 + ESLint | ❌ | 検出止まり、予防にならない |
+
+CLAUDE.md「Don't add error handling, fallbacks, or validation for scenarios that can't happen」「Don't design for hypothetical future requirements」に整合。
+
+---
+
+## handoff 内 follow-up 消化状況（Session 20〜26 トリオ完結）
+
+| ID | 概要 | rating | 消化 PR | セッション |
+|---|---|---|---|---|
+| I1 | `classifyGmailError` の `??` チェーンで `ECONNRESET`/`ETIMEDOUT` 等が permanent に誤分類 | 7 | PR #364 | Session 22 |
+| I2 | `GmailDraftError.originalError` が GaxiosError raw を保持 → logger 経由で Authorization 漏洩リスク | 7 | **PR #387** | **Session 26** |
+| I5 | FE `window.open === null` 未チェック → Safari/Firefox popup ブロックでサイレント失敗 | 7 | PR #364 | Session 22 |
+
+**Open follow-up は記録上ゼロ件**。次セッション開始時点で handoff 内に未消化指摘なし。
+
+---
+
+## Issue Net 変化
+
+- Close 数: **0 件**
+- 起票数: **0 件**
+- **Net: 0 件 (KPI 上は進捗ゼロ扱い)**
+
+triage 評価:
+- 本セッションは handoff 内 follow-up の I2 消化が主目的で、新規バグ・rating ≥ 7 review agent 提案・ユーザー明示指示の個別タスクは発生せず
+- I2 自体は handoff 内記録のみで Issue 化していなかったため、消化しても close 対象 Issue がない（feedback_issue_triage.md §「rating 7 以上でも実害ゼロなら起票しない、handoff で記録継続」運用に準拠）
+- 結果 Net 0 だが、**handoff 内 follow-up を「1 件減 (3→0)」した実質進捗あり** — Session 20〜26 を通じて Open follow-up を完全消化したマイルストーンセッション
+- postponed 3 件 (#276 / #275 / #274) は据え置き — Phase 3 GCIP 完了が再開条件、2026-10-24 再評価まで保留
+
+---
+
+## 教訓・気づき
+
+### 1. Session 22 の「分離継続が妥当」判定が正しく機能
+
+Session 22 で Codex / silent-failure-hunter の二段判定により「I2 を PR #358 に含めない」決定をしたことで、PR #358 のレビュー焦点が分散せず、I1 / I5 と一括で消化することも避けられた。**Important 級でも実害ゼロなら scope 分離して別 PR 化** という運用が、レビュー品質・focus 維持・decision-maker への判断委譲のすべてで機能した好例。
+
+### 2. 「読み手ゼロ件」の確認が設計選択肢を絞る決定打
+
+`originalError` フィールドの設計改善 4 案 (A: 削除 / B: narrow / C: sanitize / D: lint) のうち、実装着手前の grep で「src / tests / dist いずれにも `.originalError` 参照ゼロ」を確認したことで、案 A (完全削除) が即決可能になった。**`grep -rn ".originalError"` を impl-plan の前段で実行** することで、YAGNI 適用の根拠が機械的に得られる。
+
+### 3. 小規模 PR (2 files, +14/-13) は lightweight review で十分
+
+post-pr-review hook が `/review-pr` 軽量経路 (security + code-quality の 2 エージェントに絞る) を推奨。CLAUDE.md memory `feedback_simplify_vs_review.md` の「1-2 ファイル / 30 行未満は /simplify スキップ」と整合。リファクタ PR は手動チェックリストで完結し、フルセット 6 エージェントの実行コストを節約。
+
+### 4. PR マージは番号単位の明示認可 + 要約付き形式が機能
+
+`PR #387 — refactor(api): drop GmailDraftError.originalError (2 files, +14/-13) をマージしてよい` 形式での明示認可を受領後にマージ実行。CLAUDE.md AI 駆動開発 4 原則 §3「安全装置の skip は番号単位の明示認可でのみ可」「承認依頼時は PR #番号 — タイトル (N files, +X/-Y) 形式で要約必須」が機能した好例。
+
+---
+
+## 環境状態 (本セッション終了時)
+
+- main ブランチ: HEAD `4143095` (PR #387 squash merge)
+- ローカル: handoff feature ブランチ作成中、未コミット変更は handoff のみ
+- Cloud Run / E2E: ✅ CI / E2E Tests PASS、Deploy in_progress（コード起因問題なし）
+- 残留プロセス: なし
+
+---
+
+## Session 25 のアーカイブ
+
+旧 LATEST.md (Session 25) は `docs/handoff/archive/2026-05-15-session-25.md` に保存済み。


### PR DESCRIPTION
## Summary

- 本セッション (Issue #389 系列の Playwright MCP 実機検証 + 4 PR マージ完遂) を docs/handoff/LATEST.md として書き起こし
- 旧 Session 26 を docs/handoff/archive/2026-05-15-session-26.md に移動

## セッション成果概要

- **PR #391** (`6fe1a31`): ASCII fallback を email base に → UUID 化回避
- **PR #392** (`9db7647`): 文字色 #1f2937 → #000 (表面修正、後の #403 で真因対応)
- **PR #393** (`9a89867`): filename 生 Unicode + filename*= dual-form (2026 業界 best practice)
- **PR #403** (`12d4f7a`): Variable Font Thin 真因解消、static Regular/Bold OTF 採用

## Issue Net

- Close 数: 1 件 (#389)
- 起票数: 1 件 (#389)
- Net: ±0
- Open 推移: 3 件 → 3 件 (全 postponed)

## Test plan

- [x] docs/handoff/LATEST.md が 176 行 (目標 500 行以下)
- [x] docs/handoff/archive/2026-05-15-session-26.md として Session 26 をアーカイブ
- [x] 関連リンク (PR #391/#392/#393/#403、Issue #389、ADR-034) の URL を含める

## 関連

- PR #391/#392/#393/#403 で消化した Issue #389 系列の最終記録

🤖 Generated with [Claude Code](https://claude.com/claude-code)