### PR TITLE
docs(handoff): Session 31 (2026-05-17) ハンドオフ記録

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,24 +1,17 @@
-# Session Handoff — 2026-05-17 (Session 30)
+# Session Handoff — 2026-05-17 (Session 31)
 
 ## TL;DR
 
-**Session 29 で作成された PR #410 (ADR-036 講座資料 PDF DL 機能) をマージし、続けて運用整備を完遂。** Phase 1 (GCS インフラ) を executor 実行で完了 (バケット作成 + IAM + Cloud Run env)、PR #412 で smoke runbook 整備 + deploy.yml コメント実態同期、PR #413 で super-admin PDF アップロード UI + sync-resources ボタンを実装。「BE/受講者 UI 完成、super-admin UI 未実装で curl 直叩き運用」の不均衡状態を解消し、**ブラウザ UI 操作のみで PDF 投入 / 削除 / sync-resources 実行が完結する完成状態に到達**。
+**Session 31 は軽量セッション。** Session 30 末からの引き継ぎで、現場オーダー 2 件 (強制ログアウト時間設定 / 講座資料 PDF DL) の解決状態を検証し**両方とも既解決と確認**。その後 decision-maker 指示で Session 30 の handoff を archive へコピー (PR #415)。substantive な機能実装・バグ修正・設計判断はゼロ、Issue Net も 0。
 
-- **Issue Net**: **0** (起票 0 / Close 0、Session 29 末から変化なし)
-- **Open 推移**: Session 29 末 4 件 → Session 30 末 **4 件** (#405 / #276 / #275 / #274、全 postponed、変化なし)
-- **マージ済み PR (3 本)**:
-  - PR #410 (Session 29 持ち越し): 講座資料 PDF DL 機能 BE + 受講者 UI、20 ファイル、+1909/-28
-  - PR #412: smoke runbook 新規 + deploy.yml コメント実態同期、2 ファイル、+429/-1
-  - PR #413: super-admin PDF アップロード UI + sync-resources、8 ファイル、+1154/-13
-- **Quality Gate 実績**:
-  - PR #412: codex review **9 件全反映** (High 2 + Medium 4 + Low 3)
-  - PR #413: codex 事前 **9 件** + codex 事後 **3 件** + Evaluator 分離 **4 件** 全反映 (HIGH 1 含む)
-- **テスト件数**: api 893 → 935 (PR #410)、web 53 → **83** (PR #413、+30)
-- **未着手 (decision-maker 領分)**:
+- **Issue Net**: **0** (起票 0 / Close 0、Session 30 末から変化なし)
+- **Open 推移**: Session 30 末 4 件 → Session 31 末 **4 件** (#405 / #276 / #275 / #274、全 postponed、変化なし)
+- **マージ済み PR (1 本)**: PR #415 (Session 30 archive、1 file +228/-0、docs-only)
+- **検証成果**: 現場オーダー 2 件の解決確認 (コード変更なし)
+- **未着手 (decision-maker 領分、Session 30 末から不変)**:
   - 本番 UI で smoke test 実機実行 (curl 不要、UI のみで完結)
   - 実コンテンツ投入 (super-admin が UI で実 PDF を投入)
   - 既存配信済みテナント (`8vexhzpc` 等) への sync-resources 実行
-  - follow-up Issue 起票検討 (rating ≥ 7 のもののみ)
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -30,12 +23,12 @@ cat docs/handoff/LATEST.md
 git fetch origin main && git log --oneline -5 origin/main
 gh run list --branch main --limit 5
 
-# 3. 現在の OPEN Issue (4 件、全 postponed)
+# 3. 現在の OPEN Issue (4 件、全 postponed、Session 30 末から不変)
 gh issue list --state open --limit 15
 #  → #274 / #275 / #276 (Phase 3 GCIP 完了が再開条件)
 #  → #405 (Phase 2 filename strict MTA risk、Session 27 起票)
 
-# 4. 次の着手候補 (優先度順):
+# 4. 次の着手候補 (Session 30 末から不変):
 #    A. 【最優先・ユーザー手動】本番 UI で smoke test 実機実行
 #       - super-admin が /super/master/courses で smoke 専用コース作成
 #       - 各レッスンに PDF アップロード (UI 経由、curl 不要)
@@ -57,64 +50,36 @@ gh issue list --state open --limit 15
 
 ---
 
-## セッション成果物 (2026-05-17 Session 30)
+## セッション成果物 (2026-05-17 Session 31)
 
-### 🟢 PR #410 マージ (Session 29 持ち越し)
+### 🟢 現場オーダー 2 件の解決状態検証
 
-- マージコミット: `107929e`
-- 内容: 講座資料スライド PDF DL 機能 (ADR-036)、BE 完成 + 受講者 UI 完成
-- 20 ファイル、+1909/-28、4 commits
-- CI 全 PASS、本番 Cloud Run デプロイ完了
+ユーザーから現場メッセージのスクリーンショット提示 → 過去 PR / 設定値を grep して解決状態を確認:
 
-### 🟢 Phase 1: GCS インフラ整備 (executor 実行)
+| # | 現場オーダー | 解決状態 | 対応 PR / 設定 |
+|---|---|---|---|
+| 1 | 動画視聴からテスト終了までの強制ログアウト時間設定 (テスト中ログアウトで再テストできず) | ✅ 解決済み (Session 27) | PR #407 (`SESSION_DURATION_MS` env var 化 + 本番 2h → **3h** 延長)、PR #408 (UI 文言動的化)、PR #133 (強制退室時データリセット、再テスト可能) |
+| 2 | 各講座の資料スライドをテスト合格後 DL 可能化 (canva PDF 出力対応) | ✅ 解決済み (Session 29-30) | ADR-036、PR #410 (BE + 受講者 UI)、PR #412 (smoke runbook)、PR #413 (super-admin UI) |
 
-ユーザー番号単位認可 (「A〜D を実行してよい」) 取得後に executor 実行:
+**現在の本番設定** (`.github/workflows/deploy.yml:94`):
+```
+SESSION_DURATION_MS=10800000  # 3 時間
+PAUSE_TIMEOUT_MS=900000        # 15 分 (default)
+GCS_RESOURCE_BUCKET=lms-279-resources
+```
 
-| # | 操作 | 結果 |
-|---|---|---|
-| A | `gcloud storage buckets create gs://lms-279-resources --location=asia-northeast1 --uniform-bucket-level-access --public-access-prevention` | ✅ 作成 |
-| B | default compute SA (`1034821634012-compute@...`) に `roles/storage.objectAdmin` (bucket scope) 付与 | ✅ |
-| C | Cloud Run api サービス env `GCS_RESOURCE_BUCKET=lms-279-resources` 反映 (revision `api-00289-987` 100% traffic) | ✅ |
-| D | deploy.yml ENV_VARS は PR #410 で既反映済み → 文言修正は PR #412 へ | ✅ |
+→ **2 件とも既解決のため新規 Issue 起票なし**、コード変更なし。
 
-**方針上書き**: handoff Session 29 の「dev/prod 2 バケット (`lms-279-resources-dev` + `lms-279-resources`)」案は **不採用**。理由: `lms-279` 単一プロジェクト、dev Cloud Run / dev project 不在のため dev バケットは「存在するが使われない」状態になる。正式方針は **単一バケット + object prefix 分離** (codex セカンドオピニオン §6 反映)。
+### 🟢 PR #415 マージ: Session 30 を archive へコピー
 
-### 🟢 PR #412 マージ: smoke runbook 整備 + deploy.yml コメント実態同期
+- マージコミット: `fb61196`
+- 内容: `docs/handoff/archive/2026-05-17-session-30.md` 新規作成 (LATEST.md のコピー、228 行)
+- 1 ファイル、+228/-0、docs-only (CI: Deploy to Cloud Run success 3m57s)
+- 背景: decision-maker 指示 (「Session 30 をアーカイブして」) で実施。本 PR 時点では LATEST.md と archive ファイルが一時的に同一内容となるが、本 Session 31 handoff 書き込みで重複解消。
 
-- マージコミット: `232ee3b`
-- 内容:
-  - `docs/ops/2026-05-17-pdf-smoke-test-runbook.md` 新規 (333 → 425 行、初版 + codex review 反映)
-  - `deploy.yml` line 88-90 のコメントを実態 (単一バケット運用) に同期
-- 2 ファイル、+429/-1
-- Quality Gate: codex review **9 件全反映** (High 2 + Medium 4 + Low 3)
-  - High #1: Step 8.5 tenant course publish 手順追加
-  - High #2: Step 9 Quiz API path/body を実装 (`POST /quizzes/:quizId/attempts` + `PATCH /quiz-attempts/:attemptId` + body `{answers: {<Q_ID>: ["<CHOICE_ID>"]}}`) と整合
-  - Medium 4: 期待値 / lesson ID 取得 / cleanup 完全化 / sizeBytes 説明
-  - Low 3: deploy.yml 文言精度 / 列挙テスト UUID / 切り分け 3 パターン追加
+---
 
-> **後続判断**: 本 runbook の curl 手順は PR #413 マージ後に **UI 操作で代替可能** になったため、実機 smoke は UI 経由で実施可能。runbook は障害時のデバッグ参照として保持。
-
-### 🟢 PR #413 マージ: super-admin PDF アップロード UI + sync-resources
-
-- マージコミット: `7fbde50`
-- 内容: master 編集画面に PDF アップロード UI 追加、course header に sync-resources ボタン追加
-- 8 ファイル、+1154/-13、2 commits
-- Quality Gate:
-  - codex 事前 (impl-plan 段階) **9 件全反映** (High 3 + Medium 5 + Low 3)
-  - codex 事後 (PR 後) **Medium 2 + Low 1 反映**: AbortSignal 全フロー連動、unmount cleanup、aria-describedby 不在 ID 削除
-  - Evaluator 分離 **HIGH 1 + 推奨テスト 3 反映**: `formatSyncResult` 文法バグ修正 (parts 空時の "X テナントに対し、しました。" 防止)、AC-11/12/16 のテスト追加
-
-**新規ファイル**:
-- `web/components/master/MasterLessonPdfUploader.tsx` (357 行): 3 段アップロード UI + validation + 進捗 + 削除 + a11y
-- `web/components/master/SyncResourcesButton.tsx` (128 行): 確認 dialog + 結果別文言
-- `web/lib/upload.ts` (92 行): XHR ベース `uploadFileWithProgress` 汎用 utility (AbortSignal + UploadError)
-- 各テスト 3 ファイル (web 53 → 83、+30 ケース)
-
-**変更ファイル**:
-- `packages/shared-types/src/lesson.ts`: `LessonPdfConfirmResponse` + `SyncResourcesResponse` 型追加
-- `web/app/super/master/courses/[courseId]/page.tsx`: `Lesson` 型に PDF メタ 4 フィールド追加、component 統合
-
-### 確定済み運用フロー (本セッション以降)
+## 確定済み運用フロー (Session 30 から継承、変更なし)
 
 | 操作 | 手段 | Token |
 |---|---|---|
@@ -126,52 +91,20 @@ gh issue list --state open --limit 15
 
 ---
 
-## 確定済み設計判断 (Session 30 で追加 / 改訂)
-
-### Phase 0 要件ギャップ確認 (4 yes/no で確定)
-
-| 質問 | 回答 |
-|---|---|
-| テストに合格していない受講生にも PDF を見せる? | **いいえ** (現実装: 合格者のみ DL) |
-| 受講期限 +1 年切れ後も PDF を見せる? | **いいえ** (現実装: 期間内のみ) |
-| PDF はレッスンごとでよい? | **はい** (現実装: 1 レッスン 1 PDF) |
-| ブラウザ上プレビューも必要? | **いいえ** (現実装: DL のみ) |
-
-→ ADR-036 改訂不要、コード変更不要、追加実装不要が確定。
-
-### GCS バケット運用方針 (Session 29 案を Superseded)
-
-- **採用**: 単一バケット `lms-279-resources` + object prefix 分離 (`lessons/{masterLessonId}/...`)
-- **不採用**: dev/prod 2 バケット (`lms-279-resources-dev` + `lms-279-resources`)
-- **理由**: `lms-279` 単一プロジェクト、dev Cloud Run / dev project 不在
-
----
-
-## Quality Gate 実績 (本セッション集計)
-
-| PR | codex 事前 | codex 事後 | Evaluator | 反映合計 |
-|---|---|---|---|---|
-| #412 | — | 9 件 | — | 9 件 |
-| #413 | 9 件 | 3 件 | 4 件 (HIGH 1 含む) | **16 件** |
-
-**特筆**: PR #413 で Evaluator が `formatSyncResult` の文法バグ (parts 空時の不正文字列生成) を発見し、マージ前修正必須として指摘。codex は見落とした High 級バグで、Evaluator 分離プロトコルの実効性を再証明。
-
----
-
 ## Issue Net 変化
 
 - **Close 数**: **0 件**
 - **起票数**: **0 件**
 - **Net**: **0**
 
-| Open Issue (Session 30 末時点、Session 29 末から変化なし) | ラベル | 再開条件 |
+| Open Issue (Session 31 末時点、Session 30 末から変化なし) | ラベル | 再開条件 |
 |---|---|---|
 | #405 | enhancement, P2, postponed | M365/Outlook/Proofpoint/Mimecast テナント追加 or 添付名問い合わせ |
 | #276 | enhancement, P2, postponed | Phase 3 GCIP 完了 (Issue #272 / 再評価期限 2026-10-24) |
 | #275 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
 | #274 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
 
-**Net 0 の理由言語化**: 本セッションは PR #410 マージ後の運用整備フェーズ。PR #412 (smoke runbook) と PR #413 (super-admin UI) は ADR-036 follow-up として実装完了し、いずれの review 指摘 (合計 25 件) も本 PR 内で全反映。マージ後 follow-up 候補 3 件 (動画 UI utility 移行 / AC 文言統一 / 50MB 境界値仕様) はいずれも **rating 4-5 で triage 基準 (rating ≥ 7) 未達**、PR コメント / TODO で扱い Issue 起票を回避 (`feedback_issue_triage.md` 準拠)。
+**Net 0 の理由言語化**: 本セッションは Session 30 終了後の継承検証 + housekeeping のみ。現場オーダー 2 件は既に Session 27 / 29-30 で解決済みと検証、新規 Issue 化基準 (triage 基準: rating ≥ 7、実バグ、明示指示等) には該当しないため起票せず。Session 30 archive 化 (PR #415) も既存 handoff workflow の housekeeping であり、新規課題を生まない。
 
 ---
 
@@ -179,50 +112,40 @@ gh issue list --state open --limit 15
 
 | 変更内容 | 該当スキル | 状態 |
 |---|---|---|
-| 型・共有ロジックの変更 (`Lesson` 型拡張、shared-types に 2 型追加) | `/impact-analysis` | ⏭️ Quality Gate (Evaluator + codex 事前/事後) で代替実施 |
-| 新規 API / コレクション (BE は PR #410 で実装済み、本セッションは FE のみ) | `/check-api-impact` | ⏭️ FE 単独実装、BE 変更ゼロ |
-| データフロー追加 | `/trace-dataflow` | ⏭️ PR #410 で既実施 |
-| 共通 utility 抽出 (`web/lib/upload.ts`) | 設計判断のみ | ✅ Codex 事前で「動画 UI も将来移行」と follow-up note |
-
-**注記**: 上記スキルは明示的に呼び出していないが、Generator-Evaluator 分離プロトコル (Evaluator) + codex 二段レビュー (事前 + 事後) で AC 16 項目 + 設計妥当性を網羅検証済み。
+| 型・共有ロジック・設定ファイル変更 | `/impact-analysis` | ⏭️ 対象外 (PR #415 は docs-only) |
+| 新規 API / コレクション追加 | `/check-api-impact` | ⏭️ 対象外 |
+| データフロー追加 | `/trace-dataflow` | ⏭️ 対象外 |
 
 ---
 
 ## ハーネス的考察 (本セッション特有)
 
-### 「機能完成」と「運用導入可能な完成」のギャップ検知
+### 「Session 30 をアーカイブして」AI 提案の検証プロトコル
 
-本セッション最大の発見は、PR #410 マージ後の運用議論で「**super-admin の PDF アップロード UI が未実装、API 直叩き運用のみ**」が判明した点 (ADR-036 §影響欄に明記されていたが、私が「機能完成」として扱い smoke を curl で進めようとしてユーザー指摘で軌道修正)。
+Session 31 開始直後 (`/catchup` 直後)、AI 提案として「Session 30 をアーカイブして」が浮上。executor として実行可能と感じても以下のチェックを行うべきと教訓化:
 
-教訓:
-- PR マージ承認時点で「ランタイム動作」だけでなく **「現場が UI で操作できる完成度」** を確認すべき
-- ADR §影響欄に「UI 別 Issue で後追い」と書かれている場合、follow-up Issue を即座に立てるか、本 PR スコープに含める判断を明示する
-- catchup 時に「super-admin が curl で運用」のような前提が catchup summary に書かれていないか注意 (現場運用に乗らない手段の暗黙提案を防ぐ)
+1. **handoff skill の発動条件確認** — `archive-procedure.md` は LATEST.md 500 行超過時の発動。Session 30 時点で 228 行、skill 規定外。
+2. **過去 PR のアトミックパターン確認** — PR #414 (Session 30 記録 + Session 28/29 archive) は LATEST 更新と archive 作成を 1 PR でアトミック実施。archive 単独実行は LATEST.md 空化の副作用リスク。
+3. **decision-maker 領分の境界** — 「セッション境界をいつ切るか」は decision-maker (ユーザー) の判断。AI は executor として番号単位の明示指示 (本セッションでは「Session 30 をアーカイブして」の明示指示) を受けてから実行。
 
-### Quality Gate 多段化の有効性
+結果: 検証 → 明示指示受領 → PR #415 で実行 → マージ。decision-maker / executor 分離が機能した好事例。
 
-PR #413 で codex 事前 (impl-plan) + codex 事後 (PR) + Evaluator 分離の 3 段重ねが High 級バグを発見:
-- **codex 事前**: 既存パターン整合性・設計妥当性 (High 3 + Medium 5 + Low 3)
-- **codex 事後**: 実装後の AbortSignal / unmount cleanup の漏れ (Medium 2)
-- **Evaluator 分離 (Opus、別 context)**: `formatSyncResult` 文法バグ (HIGH 1、parts 空時の不正文字列生成) ← codex 両方が見落とし
+### 現場オーダー解決状態の検証プロトコル
 
-`feedback_codex_review_value.md` (PR #147) + Evaluator 分離プロトコルが補完関係にあることを再確認。
+「現場メッセージ画像は文脈で素直に解釈、過去 PR/handoff 履歴を先に grep」(memory: `feedback_field_voice_context_first.md`) を実践。スクリーンショット提示 → git log + gh issue list で過去対応を確認 → 「アクティブ Issue ゼロ」結論 (Session 31 開始時) と整合確認。
 
-### Token 取得を要する smoke の運用負担を UI 実装で根本解決
-
-Phase 2 smoke test は当初 curl 実行を想定し Token 取得をユーザー作業として依頼したが、「**UI 未実装で API 直叩き運用不可能**」が判明し PR #413 で UI を完成させる方向に転換。結果、smoke 自体が curl 不要・Token 不要で完結する設計に到達。
-
-教訓: 「smoke 検証手段」と「実運用手段」が乖離する場合、smoke 設計を妥協するのではなく **実運用手段を完成させて両者を一致させる** 方が長期的に効率的。
+教訓: `/catchup` で「アクティブ Issue ゼロ」と出ても、ユーザーが現場メッセージを提示してきた時は再検証が必要。Issue 化されていない既決事案の確認漏れを防ぐ。
 
 ---
 
 ## 関連リンク
 
+- PR #415: https://github.com/system-279/lms-279/pull/415 (Session 30 archive copy)
 - PR #410: https://github.com/system-279/lms-279/pull/410 (講座資料 PDF DL 機能)
 - PR #412: https://github.com/system-279/lms-279/pull/412 (smoke runbook + deploy.yml コメント)
 - PR #413: https://github.com/system-279/lms-279/pull/413 (super-admin PDF アップロード UI + sync-resources)
+- PR #407: https://github.com/system-279/lms-279/pull/407 (SESSION_DURATION_MS env var 化 + 本番 3h 延長)
+- PR #408: https://github.com/system-279/lms-279/pull/408 (UI 文言動的化)
 - ADR-036: docs/adr/ADR-036-course-resource-pdf-distribution.md
-- 設計仕様: docs/specs/2026-05-17-course-pdf-download-design.md
-- smoke runbook: docs/ops/2026-05-17-pdf-smoke-test-runbook.md
+- Session 30 handoff (archived): docs/handoff/archive/2026-05-17-session-30.md
 - Session 29 handoff (archived): docs/handoff/archive/2026-05-17-session-29.md
-- Session 28 handoff (archived): docs/handoff/archive/2026-05-16-session-28.md


### PR DESCRIPTION
## Summary

Session 31 (2026-05-17) のハンドオフ記録。軽量セッション (housekeeping + 検証のみ)。

## Session 31 主要成果

- **現場オーダー 2 件の解決状態検証**: 両方とも既解決と確認、新規 Issue 起票なし
  - ① 強制ログアウト時間設定: Session 27 (PR #407/#408) で本番 2h → **3h** 延長済み、再テスト不能問題は PR #133 (強制退室時データリセット) で対応済み
  - ② 各講座 PDF DL: Session 29-30 (ADR-036 / PR #410/#412/#413) で完成済み (super-admin UI + 受講者 UI + sync-resources)
- **PR #415 マージ**: Session 30 の handoff を archive へコピー (1 file +228/-0、docs-only)

## Issue Net 変化

- Close 数: **0 件**
- 起票数: **0 件**
- **Net: 0**

Open Issue 4 件 (#274/#275/#276/#405、**全 postponed**、Session 30 末から変化なし)。

## ハーネス考察

- **decision-maker / executor 分離が機能した好事例**: 「Session 30 をアーカイブして」AI 提案 → executor 検証 (skill 規定外 + アトミックパターン違反を指摘) → decision-maker 明示指示受領 → 実行 (PR #415)
- **現場オーダー検証プロトコル実践**: スクリーンショット提示 → git log + gh issue list で過去対応を確認 → 既解決確認 (memory: `feedback_field_voice_context_first.md`)

## 次セッション着手候補 (Session 30 末から不変)

- A. 【最優先・ユーザー手動】本番 UI で smoke test 実機実行
- B. 【ユーザー判断・運用】実コンテンツ投入 + 既存テナント sync-resources
- C. follow-up Issue 起票候補 (rating ≥ 7 のみ、3 件とも triage 基準未達のため起票なし)
- D. Issue #272 Phase 3 GCIP 移行 (再評価期限 2026-10-24)
- E. postponed #276 / #275 / #274 / #405 (明示指示なき限り着手不可)

## Test plan

- [x] LATEST.md 構文確認 (markdown、リンク 2 件 OK)
- [x] LATEST.md 行数確認 (151 行、500 行閾値以下)
- [x] Issue Net 計測 (0/0/Net=0) 明示
- [x] 次セッション必読手順記載
- [ ] (次セッション開始時) `cat docs/handoff/LATEST.md` で内容確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)