### PR TITLE
fix(super-admin): master レッスン PDF アップロード UI を分かりやすく改善

### DIFF
--- a/web/app/super/master/courses/[courseId]/page.tsx
+++ b/web/app/super/master/courses/[courseId]/page.tsx
@@ -1368,7 +1368,6 @@ export default function MasterCourseDetailPage() {
 
                     {/* PDF section (ADR-036) */}
                     <div className="space-y-3">
-                      <h3 className="text-sm font-semibold">講座資料 (PDF)</h3>
                       <MasterLessonPdfUploader
                         lessonId={lesson.id}
                         resource={

--- a/web/components/master/MasterLessonPdfUploader.tsx
+++ b/web/components/master/MasterLessonPdfUploader.tsx
@@ -238,9 +238,9 @@ export function MasterLessonPdfUploader({
 
       {!uploading && (
         <div className="space-y-2">
-          <label className="text-xs text-muted-foreground" htmlFor={`pdf-input-${lessonId}`}>
-            PDF ファイル (最大 50 MB) を選択して
-            {resource ? "差し替え" : "アップロード"}
+          {/* label と input は a11y / 既存テスト (getByLabelText) 互換のため sr-only で残す */}
+          <label className="sr-only" htmlFor={`pdf-input-${lessonId}`}>
+            PDF ファイル (最大 50 MB)
           </label>
           <input
             ref={inputRef}
@@ -248,25 +248,41 @@ export function MasterLessonPdfUploader({
             type="file"
             accept="application/pdf"
             onChange={handleFileChange}
-            className="block w-full text-sm"
+            className="sr-only"
           />
-          {selectedFile && (
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-muted-foreground">
-                選択中: {selectedFile.name} (
-                {(selectedFile.size / (1024 * 1024)).toFixed(1)} MB)
-              </span>
-              <Button type="button" size="sm" onClick={handleUpload}>
-                アップロード
-              </Button>
+          {!selectedFile ? (
+            <div className="flex flex-wrap items-center gap-2">
               <Button
                 type="button"
+                variant="outline"
                 size="sm"
-                variant="ghost"
-                onClick={resetSelection}
+                onClick={() => inputRef.current?.click()}
               >
-                クリア
+                {resource ? "別の PDF を選択" : "PDF ファイルを選択"}
               </Button>
+              <span className="text-xs text-muted-foreground">
+                PDF 形式 / 最大 50 MB
+              </span>
+            </div>
+          ) : (
+            <div className="space-y-2 rounded-md border border-dashed bg-muted/30 p-3">
+              <p className="text-xs text-foreground">
+                <span className="font-medium">選択中:</span> {selectedFile.name} (
+                {(selectedFile.size / (1024 * 1024)).toFixed(1)} MB)
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button type="button" size="sm" onClick={handleUpload}>
+                  アップロード
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={resetSelection}
+                >
+                  クリア
+                </Button>
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

- 現場フィードバック (Session 32 / 2026-05-18) を受けて super-admin 講座資料 PDF アップロード UI を改善
- タイトル重複解消 + ネイティブ `<input type=file>` をボタンで隠蔽 + 選択前後の状態を視覚的に強調
- ADR-036 機能変更なし。UI/UX のみ

## 改善前/改善後

| 項目 | 改善前 | 改善後 |
|------|-------|-------|
| タイトル | 外側 `<h3>` と内側 `<p>` が「講座資料 (PDF)」を二重表示 | 内側のみに一本化 |
| ファイル選択 | ブラウザデフォルト「ファイルを選択 選択されていません」 | shadcn `<Button variant=outline>`「PDF ファイルを選択」(差替時は「別の PDF を選択」) + 補助テキスト「PDF 形式 / 最大 50 MB」 |
| 選択後 | 小さな text とボタンの羅列 | 破線ボーダー + muted 背景のブロック内に「選択中: file.pdf (X.X MB)」+「アップロード」「クリア」 |

## a11y / テスト互換

- `<label htmlFor>` + `<input id>` は `sr-only` で残し既存 `getByLabelText(/PDF ファイル/)` を破壊しない
- ボタン名 \`アップロード\` は維持 (既存テスト互換)

## Test plan

- [x] `npx vitest run components/master/__tests__/MasterLessonPdfUploader.test.tsx` → 12/12 PASS
- [x] `npm run type-check` → 0 errors
- [x] `npm run lint` → 既存 warning 1 件のみ (本修正と無関係)
- [ ] **本番 UI で実機確認** (super-admin として \`/super/master/courses/<id>\` を開き、PDF 未登録レッスン / 登録済レッスン双方で操作感を確認)
  - 受講者側 (\`LessonPdfButton\`) は今回変更なし

## 関連

- ADR-036 (講座資料 PDF 配信)
- PR #413 (master レッスン PDF アップロード UI + sync-resources ボタン) の follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)