### PR TITLE
docs(handoff): Session 32 (2026-05-18) ハンドオフ記録 + Session 31 archive

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,17 +1,13 @@
-# Session Handoff — 2026-05-17 (Session 31)
+# Session Handoff — 2026-05-18 (Session 32)
 
 ## TL;DR
 
-**Session 31 は軽量セッション。** Session 30 末からの引き継ぎで、現場オーダー 2 件 (強制ログアウト時間設定 / 講座資料 PDF DL) の解決状態を検証し**両方とも既解決と確認**。その後 decision-maker 指示で Session 30 の handoff を archive へコピー (PR #415)。substantive な機能実装・バグ修正・設計判断はゼロ、Issue Net も 0。
+**現場フィードバック対応セッション。** super-admin の master レッスン PDF アップロード UI が分かりづらいという現場メッセージ (スクリーンショット) を受け、PR #417 で UI/UX を改善。ADR-036 機能変更なし。本番反映後にスクショで意図どおりの表示を確認。Issue Net 0。
 
-- **Issue Net**: **0** (起票 0 / Close 0、Session 30 末から変化なし)
-- **Open 推移**: Session 30 末 4 件 → Session 31 末 **4 件** (#405 / #276 / #275 / #274、全 postponed、変化なし)
-- **マージ済み PR (1 本)**: PR #415 (Session 30 archive、1 file +228/-0、docs-only)
-- **検証成果**: 現場オーダー 2 件の解決確認 (コード変更なし)
-- **未着手 (decision-maker 領分、Session 30 末から不変)**:
-  - 本番 UI で smoke test 実機実行 (curl 不要、UI のみで完結)
-  - 実コンテンツ投入 (super-admin が UI で実 PDF を投入)
-  - 既存配信済みテナント (`8vexhzpc` 等) への sync-resources 実行
+- **Issue Net**: **0** (起票 0 / Close 0)
+- **Open 推移**: Session 31 末 4 件 → Session 32 末 **4 件** (#405 / #276 / #275 / #274、全 postponed、変化なし)
+- **マージ済み PR (1 本)**: PR #417 (master PDF アップロード UI 改善、2 files +32/-17)
+- **本番反映**: ✅ Cloud Run デプロイ完了、UI スクショで意図どおり表示確認済み
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -23,15 +19,16 @@ cat docs/handoff/LATEST.md
 git fetch origin main && git log --oneline -5 origin/main
 gh run list --branch main --limit 5
 
-# 3. 現在の OPEN Issue (4 件、全 postponed、Session 30 末から不変)
+# 3. 現在の OPEN Issue (4 件、全 postponed、Session 31 末から不変)
 gh issue list --state open --limit 15
 #  → #274 / #275 / #276 (Phase 3 GCIP 完了が再開条件)
 #  → #405 (Phase 2 filename strict MTA risk、Session 27 起票)
 
-# 4. 次の着手候補 (Session 30 末から不変):
+# 4. 次の着手候補 (Session 31 から不変、executor 領分ゼロ):
 #    A. 【最優先・ユーザー手動】本番 UI で smoke test 実機実行
 #       - super-admin が /super/master/courses で smoke 専用コース作成
 #       - 各レッスンに PDF アップロード (UI 経由、curl 不要)
+#         → Session 32 PR #417 で UI が分かりやすくなったため操作容易
 #       - 配信先テナントへ配信 (既存 distribute UI)
 #       - 受講者ロールで quiz 合格後 DL ボタン → DL 確認
 #       - 未合格 disabled / 期限切れ hide の UX 確認
@@ -39,43 +36,38 @@ gh issue list --state open --limit 15
 #    B. 【ユーザー判断・運用】実コンテンツ投入
 #       - 実介護講座資料 PDF を super-admin が UI で master に投入
 #       - 既存配信済みテナント (8vexhzpc 等) への sync-resources 実行判断
-#    C. 【follow-up Issue 起票候補】triage 基準 (rating ≥ 7) 満たすもののみ起票
-#       - 動画アップロード UI を web/lib/upload.ts 共通 utility に移行 (rating 5、Low、PR #413 codex 指摘)
-#       - AC 文言と実装文言の統一 (AC-2/5/7、rating 4、Low)
-#       - 50 MB 境界値 (`>` vs `>=`) 仕様明文化 (rating 4、Low)
-#       - 上記いずれも triage 基準未達、PR コメント / TODO で扱う
-#    D. 【優先度低】Issue #272 Phase 3 GCIP 移行 — 再評価期限 2026-10-24
-#    E. 【着手不可】postponed #276 / #275 / #274 / #405 — 明示指示なき限り着手不可
+#    C. 【優先度低】Issue #272 Phase 3 GCIP 移行 — 再評価期限 2026-10-24
+#    D. 【着手不可】postponed #276 / #275 / #274 / #405 — 明示指示なき限り着手不可
 ```
 
 ---
 
-## セッション成果物 (2026-05-17 Session 31)
+## セッション成果物 (2026-05-18 Session 32)
 
-### 🟢 現場オーダー 2 件の解決状態検証
+### 🟢 PR #417 マージ: master レッスン PDF アップロード UI 改善
 
-ユーザーから現場メッセージのスクリーンショット提示 → 過去 PR / 設定値を grep して解決状態を確認:
+- マージコミット: `6d9dcc2`
+- ファイル: 2 (`web/app/super/master/courses/[courseId]/page.tsx` + `web/components/master/MasterLessonPdfUploader.tsx`)
+- 差分: +32 / -17 行
+- CI: Build / Lint / Type Check / Test 4/4 PASS、E2E Tests success (1m23s)
 
-| # | 現場オーダー | 解決状態 | 対応 PR / 設定 |
-|---|---|---|---|
-| 1 | 動画視聴からテスト終了までの強制ログアウト時間設定 (テスト中ログアウトで再テストできず) | ✅ 解決済み (Session 27) | PR #407 (`SESSION_DURATION_MS` env var 化 + 本番 2h → **3h** 延長)、PR #408 (UI 文言動的化)、PR #133 (強制退室時データリセット、再テスト可能) |
-| 2 | 各講座の資料スライドをテスト合格後 DL 可能化 (canva PDF 出力対応) | ✅ 解決済み (Session 29-30) | ADR-036、PR #410 (BE + 受講者 UI)、PR #412 (smoke runbook)、PR #413 (super-admin UI) |
+#### 改善内容 (現場フィードバック対応)
 
-**現在の本番設定** (`.github/workflows/deploy.yml:94`):
-```
-SESSION_DURATION_MS=10800000  # 3 時間
-PAUSE_TIMEOUT_MS=900000        # 15 分 (default)
-GCS_RESOURCE_BUCKET=lms-279-resources
-```
+| 項目 | 改善前 | 改善後 |
+|------|-------|-------|
+| タイトル | 外側 `<h3>` と内側 `<p>` で「講座資料 (PDF)」二重表示 | 内側のみに一本化 |
+| ファイル選択 | ネイティブ「ファイルを選択 選択されていません」(ブラウザデフォルト) | shadcn `<Button variant=outline>`「PDF ファイルを選択」/ 「別の PDF を選択」+ 補助テキスト「PDF 形式 / 最大 50 MB」 |
+| 選択後 | text + ボタン羅列 | 破線ボーダー + muted 背景ブロックに「選択中: file.pdf (X.X MB)」+ アクションボタン |
 
-→ **2 件とも既解決のため新規 Issue 起票なし**、コード変更なし。
+#### a11y / テスト互換
 
-### 🟢 PR #415 マージ: Session 30 を archive へコピー
+- `<label htmlFor>` + `<input id>` は `sr-only` で残し既存 `getByLabelText(/PDF ファイル/)` を破壊しない
+- ボタン名 `アップロード` は維持 (既存テスト 12/12 PASS)
 
-- マージコミット: `fb61196`
-- 内容: `docs/handoff/archive/2026-05-17-session-30.md` 新規作成 (LATEST.md のコピー、228 行)
-- 1 ファイル、+228/-0、docs-only (CI: Deploy to Cloud Run success 3m57s)
-- 背景: decision-maker 指示 (「Session 30 をアーカイブして」) で実施。本 PR 時点では LATEST.md と archive ファイルが一時的に同一内容となるが、本 Session 31 handoff 書き込みで重複解消。
+#### 本番反映確認
+
+- 本番 UI スクリーンショットで意図どおりの表示を確認 (タイトル重複なし / ボタン明示化 / 補助テキスト表示)
+- 受講者側 `LessonPdfButton` は変更なし
 
 ---
 
@@ -83,7 +75,7 @@ GCS_RESOURCE_BUCKET=lms-279-resources
 
 | 操作 | 手段 | Token |
 |---|---|---|
-| super-admin が master PDF 投入 | **UI のみ** (Chrome ログイン中) | 不要 |
+| super-admin が master PDF 投入 | **UI のみ** (Chrome ログイン中) ※ Session 32 PR #417 で UX 改善 | 不要 |
 | super-admin が PDF 削除 | **UI のみ** | 不要 |
 | 既存配信先への sync-resources | **UI 1 クリック** (course header) | 不要 |
 | 受講者が DL ボタンで取得 | **UI のみ** (PR #410 既存) | 不要 |
@@ -97,14 +89,14 @@ GCS_RESOURCE_BUCKET=lms-279-resources
 - **起票数**: **0 件**
 - **Net**: **0**
 
-| Open Issue (Session 31 末時点、Session 30 末から変化なし) | ラベル | 再開条件 |
+| Open Issue (Session 32 末時点、Session 31 末から変化なし) | ラベル | 再開条件 |
 |---|---|---|
 | #405 | enhancement, P2, postponed | M365/Outlook/Proofpoint/Mimecast テナント追加 or 添付名問い合わせ |
 | #276 | enhancement, P2, postponed | Phase 3 GCIP 完了 (Issue #272 / 再評価期限 2026-10-24) |
 | #275 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
 | #274 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
 
-**Net 0 の理由言語化**: 本セッションは Session 30 終了後の継承検証 + housekeeping のみ。現場オーダー 2 件は既に Session 27 / 29-30 で解決済みと検証、新規 Issue 化基準 (triage 基準: rating ≥ 7、実バグ、明示指示等) には該当しないため起票せず。Session 30 archive 化 (PR #415) も既存 handoff workflow の housekeeping であり、新規課題を生まない。
+**Net 0 の理由言語化**: 本セッションは現場フィードバック (UI/UX 改善) 1 件への直接対応で完結。Issue 起票せず PR #417 で即修正 → マージ → 本番反映確認。triage 基準上、UX 改善は実害バグでも CI 破壊でもないが、ユーザーから明示的に問題提示 (スクリーンショット) があったため 1-PR スコープで即対応するのが ROI 最大 (Issue 化のオーバーヘッドが対応コストを上回る)。新規課題発見もなし。
 
 ---
 
@@ -112,40 +104,52 @@ GCS_RESOURCE_BUCKET=lms-279-resources
 
 | 変更内容 | 該当スキル | 状態 |
 |---|---|---|
-| 型・共有ロジック・設定ファイル変更 | `/impact-analysis` | ⏭️ 対象外 (PR #415 は docs-only) |
-| 新規 API / コレクション追加 | `/check-api-impact` | ⏭️ 対象外 |
+| 型・共有ロジック・設定ファイル変更 | `/impact-analysis` | ⏭️ 対象外 (PR #417 は UI コンポーネント単体修正) |
+| 新規 API / コレクション追加 | `/check-api-impact` | ⏭️ 対象外 (API 契約変更なし) |
 | データフロー追加 | `/trace-dataflow` | ⏭️ 対象外 |
 
 ---
 
 ## ハーネス的考察 (本セッション特有)
 
-### 「Session 30 をアーカイブして」AI 提案の検証プロトコル
+### 現場 1-shot フィードバックの最短経路対応
 
-Session 31 開始直後 (`/catchup` 直後)、AI 提案として「Session 30 をアーカイブして」が浮上。executor として実行可能と感じても以下のチェックを行うべきと教訓化:
+スクリーンショット + 一言コメント (「アップロードの為のファイラーを開くなどのUIUXがとても分かりづらいです」) を受領 → **Issue 化を経由せず**、直接ブランチ切り → 修正 → PR → CI green → 番号単位明示認可 → マージ → 本番反映確認の流れで完結。
 
-1. **handoff skill の発動条件確認** — `archive-procedure.md` は LATEST.md 500 行超過時の発動。Session 30 時点で 228 行、skill 規定外。
-2. **過去 PR のアトミックパターン確認** — PR #414 (Session 30 記録 + Session 28/29 archive) は LATEST 更新と archive 作成を 1 PR でアトミック実施。archive 単独実行は LATEST.md 空化の副作用リスク。
-3. **decision-maker 領分の境界** — 「セッション境界をいつ切るか」は decision-maker (ユーザー) の判断。AI は executor として番号単位の明示指示 (本セッションでは「Session 30 をアーカイブして」の明示指示) を受けてから実行。
+判断根拠:
+- スコープ明確 (2 ファイル / 49 行)
+- 実装期間 < 30 分
+- triage 基準で「ユーザー明示指示」に該当するが、PR 1 本で完結するため Issue 起票はオーバーヘッド
+- decision-maker (ユーザー) が即座にスクショで結果を確認できる
 
-結果: 検証 → 明示指示受領 → PR #415 で実行 → マージ。decision-maker / executor 分離が機能した好事例。
+教訓: **小スコープ + 明示要望 + 即時検証可能なケースは Issue を挟まず PR 直行**が ROI 最大。Issue net KPI も悪化させない。
 
-### 現場オーダー解決状態の検証プロトコル
+### CI 待機 → 明示認可 → マージのフロー定着
 
-「現場メッセージ画像は文脈で素直に解釈、過去 PR/handoff 履歴を先に grep」(memory: `feedback_field_voice_context_first.md`) を実践。スクリーンショット提示 → git log + gh issue list で過去対応を確認 → 「アクティブ Issue ゼロ」結論 (Session 31 開始時) と整合確認。
+PR #417 では:
+1. PR 作成直後に CI 4 ジョブ pending
+2. `Monitor` ツールで CI 完走待ち (Build/Lint/Type Check pass → 最終 Test も pass)
+3. CI green 確認後、ユーザーから「PR #417 をマージしてよい」の番号単位明示認可
+4. `gh pr merge 417 --squash --delete-branch` 実行
 
-教訓: `/catchup` で「アクティブ Issue ゼロ」と出ても、ユーザーが現場メッセージを提示してきた時は再検証が必要。Issue 化されていない既決事案の確認漏れを防ぐ。
+→ feedback_pr_merge_authorization.md の MUST (番号単位明示認可) を機械的に遵守。AI から能動的なマージ提案はせず、CI green 報告のみに留めた。
+
+### shadcn Button + sr-only input パターンの再利用性
+
+ネイティブ `<input type="file">` を `sr-only` で隠して `Button.onClick` で `inputRef.click()` 起動するパターンは、a11y (label/input 関連付け維持) + 既存テスト互換 (`getByLabelText`) を両立できる。今後 web 内で同様のファイル選択 UI が必要になった際の参考実装。
 
 ---
 
 ## 関連リンク
 
+- PR #417: https://github.com/system-279/lms-279/pull/417 (master PDF アップロード UI 改善、Session 32 本セッション)
 - PR #415: https://github.com/system-279/lms-279/pull/415 (Session 30 archive copy)
 - PR #410: https://github.com/system-279/lms-279/pull/410 (講座資料 PDF DL 機能)
 - PR #412: https://github.com/system-279/lms-279/pull/412 (smoke runbook + deploy.yml コメント)
-- PR #413: https://github.com/system-279/lms-279/pull/413 (super-admin PDF アップロード UI + sync-resources)
+- PR #413: https://github.com/system-279/lms-279/pull/413 (super-admin PDF アップロード UI + sync-resources、PR #417 の前段)
 - PR #407: https://github.com/system-279/lms-279/pull/407 (SESSION_DURATION_MS env var 化 + 本番 3h 延長)
 - PR #408: https://github.com/system-279/lms-279/pull/408 (UI 文言動的化)
 - ADR-036: docs/adr/ADR-036-course-resource-pdf-distribution.md
+- Session 31 handoff (archived): docs/handoff/archive/2026-05-17-session-31.md
 - Session 30 handoff (archived): docs/handoff/archive/2026-05-17-session-30.md
 - Session 29 handoff (archived): docs/handoff/archive/2026-05-17-session-29.md

--- a/docs/handoff/archive/2026-05-17-session-31.md
+++ b/docs/handoff/archive/2026-05-17-session-31.md
@@ -1,0 +1,151 @@
+# Session Handoff — 2026-05-17 (Session 31)
+
+## TL;DR
+
+**Session 31 は軽量セッション。** Session 30 末からの引き継ぎで、現場オーダー 2 件 (強制ログアウト時間設定 / 講座資料 PDF DL) の解決状態を検証し**両方とも既解決と確認**。その後 decision-maker 指示で Session 30 の handoff を archive へコピー (PR #415)。substantive な機能実装・バグ修正・設計判断はゼロ、Issue Net も 0。
+
+- **Issue Net**: **0** (起票 0 / Close 0、Session 30 末から変化なし)
+- **Open 推移**: Session 30 末 4 件 → Session 31 末 **4 件** (#405 / #276 / #275 / #274、全 postponed、変化なし)
+- **マージ済み PR (1 本)**: PR #415 (Session 30 archive、1 file +228/-0、docs-only)
+- **検証成果**: 現場オーダー 2 件の解決確認 (コード変更なし)
+- **未着手 (decision-maker 領分、Session 30 末から不変)**:
+  - 本番 UI で smoke test 実機実行 (curl 不要、UI のみで完結)
+  - 実コンテンツ投入 (super-admin が UI で実 PDF を投入)
+  - 既存配信済みテナント (`8vexhzpc` 等) への sync-resources 実行
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+# 1. 状況復元
+cat docs/handoff/LATEST.md
+
+# 2. main 最新と CI 状況
+git fetch origin main && git log --oneline -5 origin/main
+gh run list --branch main --limit 5
+
+# 3. 現在の OPEN Issue (4 件、全 postponed、Session 30 末から不変)
+gh issue list --state open --limit 15
+#  → #274 / #275 / #276 (Phase 3 GCIP 完了が再開条件)
+#  → #405 (Phase 2 filename strict MTA risk、Session 27 起票)
+
+# 4. 次の着手候補 (Session 30 末から不変):
+#    A. 【最優先・ユーザー手動】本番 UI で smoke test 実機実行
+#       - super-admin が /super/master/courses で smoke 専用コース作成
+#       - 各レッスンに PDF アップロード (UI 経由、curl 不要)
+#       - 配信先テナントへ配信 (既存 distribute UI)
+#       - 受講者ロールで quiz 合格後 DL ボタン → DL 確認
+#       - 未合格 disabled / 期限切れ hide の UX 確認
+#       - sync-resources ボタンの動作確認 (master course 編集画面 header)
+#    B. 【ユーザー判断・運用】実コンテンツ投入
+#       - 実介護講座資料 PDF を super-admin が UI で master に投入
+#       - 既存配信済みテナント (8vexhzpc 等) への sync-resources 実行判断
+#    C. 【follow-up Issue 起票候補】triage 基準 (rating ≥ 7) 満たすもののみ起票
+#       - 動画アップロード UI を web/lib/upload.ts 共通 utility に移行 (rating 5、Low、PR #413 codex 指摘)
+#       - AC 文言と実装文言の統一 (AC-2/5/7、rating 4、Low)
+#       - 50 MB 境界値 (`>` vs `>=`) 仕様明文化 (rating 4、Low)
+#       - 上記いずれも triage 基準未達、PR コメント / TODO で扱う
+#    D. 【優先度低】Issue #272 Phase 3 GCIP 移行 — 再評価期限 2026-10-24
+#    E. 【着手不可】postponed #276 / #275 / #274 / #405 — 明示指示なき限り着手不可
+```
+
+---
+
+## セッション成果物 (2026-05-17 Session 31)
+
+### 🟢 現場オーダー 2 件の解決状態検証
+
+ユーザーから現場メッセージのスクリーンショット提示 → 過去 PR / 設定値を grep して解決状態を確認:
+
+| # | 現場オーダー | 解決状態 | 対応 PR / 設定 |
+|---|---|---|---|
+| 1 | 動画視聴からテスト終了までの強制ログアウト時間設定 (テスト中ログアウトで再テストできず) | ✅ 解決済み (Session 27) | PR #407 (`SESSION_DURATION_MS` env var 化 + 本番 2h → **3h** 延長)、PR #408 (UI 文言動的化)、PR #133 (強制退室時データリセット、再テスト可能) |
+| 2 | 各講座の資料スライドをテスト合格後 DL 可能化 (canva PDF 出力対応) | ✅ 解決済み (Session 29-30) | ADR-036、PR #410 (BE + 受講者 UI)、PR #412 (smoke runbook)、PR #413 (super-admin UI) |
+
+**現在の本番設定** (`.github/workflows/deploy.yml:94`):
+```
+SESSION_DURATION_MS=10800000  # 3 時間
+PAUSE_TIMEOUT_MS=900000        # 15 分 (default)
+GCS_RESOURCE_BUCKET=lms-279-resources
+```
+
+→ **2 件とも既解決のため新規 Issue 起票なし**、コード変更なし。
+
+### 🟢 PR #415 マージ: Session 30 を archive へコピー
+
+- マージコミット: `fb61196`
+- 内容: `docs/handoff/archive/2026-05-17-session-30.md` 新規作成 (LATEST.md のコピー、228 行)
+- 1 ファイル、+228/-0、docs-only (CI: Deploy to Cloud Run success 3m57s)
+- 背景: decision-maker 指示 (「Session 30 をアーカイブして」) で実施。本 PR 時点では LATEST.md と archive ファイルが一時的に同一内容となるが、本 Session 31 handoff 書き込みで重複解消。
+
+---
+
+## 確定済み運用フロー (Session 30 から継承、変更なし)
+
+| 操作 | 手段 | Token |
+|---|---|---|
+| super-admin が master PDF 投入 | **UI のみ** (Chrome ログイン中) | 不要 |
+| super-admin が PDF 削除 | **UI のみ** | 不要 |
+| 既存配信先への sync-resources | **UI 1 クリック** (course header) | 不要 |
+| 受講者が DL ボタンで取得 | **UI のみ** (PR #410 既存) | 不要 |
+| smoke test | **UI で実施可能** (curl/Postman/Firestore コンソール手動操作 全て不要) | 不要 |
+
+---
+
+## Issue Net 変化
+
+- **Close 数**: **0 件**
+- **起票数**: **0 件**
+- **Net**: **0**
+
+| Open Issue (Session 31 末時点、Session 30 末から変化なし) | ラベル | 再開条件 |
+|---|---|---|
+| #405 | enhancement, P2, postponed | M365/Outlook/Proofpoint/Mimecast テナント追加 or 添付名問い合わせ |
+| #276 | enhancement, P2, postponed | Phase 3 GCIP 完了 (Issue #272 / 再評価期限 2026-10-24) |
+| #275 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
+| #274 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
+
+**Net 0 の理由言語化**: 本セッションは Session 30 終了後の継承検証 + housekeeping のみ。現場オーダー 2 件は既に Session 27 / 29-30 で解決済みと検証、新規 Issue 化基準 (triage 基準: rating ≥ 7、実バグ、明示指示等) には該当しないため起票せず。Session 30 archive 化 (PR #415) も既存 handoff workflow の housekeeping であり、新規課題を生まない。
+
+---
+
+## 構造的整合性チェック
+
+| 変更内容 | 該当スキル | 状態 |
+|---|---|---|
+| 型・共有ロジック・設定ファイル変更 | `/impact-analysis` | ⏭️ 対象外 (PR #415 は docs-only) |
+| 新規 API / コレクション追加 | `/check-api-impact` | ⏭️ 対象外 |
+| データフロー追加 | `/trace-dataflow` | ⏭️ 対象外 |
+
+---
+
+## ハーネス的考察 (本セッション特有)
+
+### 「Session 30 をアーカイブして」AI 提案の検証プロトコル
+
+Session 31 開始直後 (`/catchup` 直後)、AI 提案として「Session 30 をアーカイブして」が浮上。executor として実行可能と感じても以下のチェックを行うべきと教訓化:
+
+1. **handoff skill の発動条件確認** — `archive-procedure.md` は LATEST.md 500 行超過時の発動。Session 30 時点で 228 行、skill 規定外。
+2. **過去 PR のアトミックパターン確認** — PR #414 (Session 30 記録 + Session 28/29 archive) は LATEST 更新と archive 作成を 1 PR でアトミック実施。archive 単独実行は LATEST.md 空化の副作用リスク。
+3. **decision-maker 領分の境界** — 「セッション境界をいつ切るか」は decision-maker (ユーザー) の判断。AI は executor として番号単位の明示指示 (本セッションでは「Session 30 をアーカイブして」の明示指示) を受けてから実行。
+
+結果: 検証 → 明示指示受領 → PR #415 で実行 → マージ。decision-maker / executor 分離が機能した好事例。
+
+### 現場オーダー解決状態の検証プロトコル
+
+「現場メッセージ画像は文脈で素直に解釈、過去 PR/handoff 履歴を先に grep」(memory: `feedback_field_voice_context_first.md`) を実践。スクリーンショット提示 → git log + gh issue list で過去対応を確認 → 「アクティブ Issue ゼロ」結論 (Session 31 開始時) と整合確認。
+
+教訓: `/catchup` で「アクティブ Issue ゼロ」と出ても、ユーザーが現場メッセージを提示してきた時は再検証が必要。Issue 化されていない既決事案の確認漏れを防ぐ。
+
+---
+
+## 関連リンク
+
+- PR #415: https://github.com/system-279/lms-279/pull/415 (Session 30 archive copy)
+- PR #410: https://github.com/system-279/lms-279/pull/410 (講座資料 PDF DL 機能)
+- PR #412: https://github.com/system-279/lms-279/pull/412 (smoke runbook + deploy.yml コメント)
+- PR #413: https://github.com/system-279/lms-279/pull/413 (super-admin PDF アップロード UI + sync-resources)
+- PR #407: https://github.com/system-279/lms-279/pull/407 (SESSION_DURATION_MS env var 化 + 本番 3h 延長)
+- PR #408: https://github.com/system-279/lms-279/pull/408 (UI 文言動的化)
+- ADR-036: docs/adr/ADR-036-course-resource-pdf-distribution.md
+- Session 30 handoff (archived): docs/handoff/archive/2026-05-17-session-30.md
+- Session 29 handoff (archived): docs/handoff/archive/2026-05-17-session-29.md


### PR DESCRIPTION
## Summary

- Session 32 (2026-05-18) のハンドオフ記録を `docs/handoff/LATEST.md` に書き込み
- Session 31 LATEST.md を `docs/handoff/archive/2026-05-17-session-31.md` にコピー
- PR #414 と同じアトミックパターン (1 PR で archive + LATEST 更新)

## Session 32 サマリ

| 項目 | 値 |
|------|-----|
| マージ済み PR | PR #417 (master PDF アップロード UI 改善、2 files +32/-17) |
| Issue Net | **0** (起票 0 / Close 0) |
| Open Issue | 4 件 (全 postponed、Session 31 末から変化なし) |
| 本番反映 | ✅ Cloud Run デプロイ済み、UI スクショで意図どおり表示確認 |

## Test plan

- [x] LATEST.md 構文確認 (Markdown レンダリング)
- [x] archive コピー (`diff` で内容一致確認)
- [ ] CI: Lint / Build / Type Check / Test (docs-only PR だが workflow は走る、設定ファイル変更なしのため green 想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)