### PR TITLE
docs(adr-027): セッション時間設定変更とデータリセット機能を ADR / data-model に反映

### DIFF
--- a/docs/adr/ADR-027-lesson-session-attendance.md
+++ b/docs/adr/ADR-027-lesson-session-attendance.md
@@ -4,10 +4,11 @@
 承認済み（2026-05-16 改訂: セッション上限を環境変数化）
 
 ## 改訂履歴
-- **2026-05-16**: セッション上限 `SESSION_DURATION_MS` および一時停止上限 `PAUSE_TIMEOUT_MS` を環境変数で上書き可能化。本番運用で動画 60-80 分のレッスン + テスト解答時間が 2 時間制限内に収まらない事例が複数発生（kanjikai.or.jp テナント、5/3〜5/14 で `time_limit` 強制退室 7 件）。本番は `SESSION_DURATION_MS=10800000`（3 時間）にデプロイ。不正値は `logger.error` 後にデフォルトへフォールバック。受講者向け UI 文言の「2 時間」表記の動的化は別 PR で対応予定。長期的には動画完了後にテスト専用タイマーに切り替える設計案（"Phase 3" として議論中）も検討。
+- **2026-05-16**: セッション上限 `SESSION_DURATION_MS` および一時停止上限 `PAUSE_TIMEOUT_MS` を環境変数で上書き可能化（PR #407）。本番運用で動画 60-80 分のレッスン + テスト解答時間が 2 時間制限内に収まらない事例が複数発生（kanjikai.or.jp テナント、5/3〜5/14 で `time_limit` 強制退室 7 件）。本番は `SESSION_DURATION_MS=10800000`（3 時間）にデプロイ。不正値は `logger.error` 後にデフォルトへフォールバック。受講者向け UI 文言の「2 時間」表記の動的化は PR #408 で対応完了（`SessionRulesNotice` / `ForceExitDialog` / ヘルプ等を `deadlineAt - entryAt` から動的算出）。長期的には動画完了後にテスト専用タイマーに切り替える設計案（"Phase 3" として議論中）も検討。
+- **2026-03-30**: 強制退室発生時にそのレッスンの学習データ（`video_analytics` / `user_progress` / `quiz_attempts` の該当エントリ）を完全リセットする実装を追加（PR #134、Issue #133）。`exitReason` が `pause_timeout` / `time_limit` / `max_attempts_failed` のいずれかで `forceExitSession()` が呼ばれると、`resetLessonDataForUser()` が同期実行される。受講者は強制退室後に白紙状態から再受講可能。
 
 ## コンテキスト
-受講者の出席を「入室打刻（動画再生開始）」「退室打刻（テスト送信）」で管理する要件がある。不正防止のため、一時停止15分超過および入室から2時間超過で強制退室（セッションリセット）をかける。
+受講者の出席を「入室打刻（動画再生開始）」「退室打刻（テスト送信）」で管理する要件がある。不正防止のため、一時停止 15 分超過および入室からセッション上限（`SESSION_DURATION_MS`、デフォルト 2 時間 / 本番運用は 3 時間）超過で強制退室をかける。強制退室時はそのレッスンの学習データを完全リセットし、白紙状態から再受講可能とする（PR #134）。
 
 ## 決定
 `lesson_sessions` コレクションを新設し、既存の `video_analytics` / `user_progress` の上にオーバーレイする形で出席を管理する。
@@ -15,10 +16,17 @@
 ### セッションライフサイクル
 ```
 (なし) → [動画再生] → active → [テスト送信] → completed
-                          ├── [一時停止15分] → force_exited (pause_timeout)
-                          ├── [2時間経過] → force_exited (time_limit)
-                          └── [ブラウザ閉じ] → abandoned
+                          ├── [一時停止 PAUSE_TIMEOUT_MS]      → force_exited (pause_timeout)
+                          ├── [入室から SESSION_DURATION_MS]    → force_exited (time_limit)
+                          ├── [テスト受験回数上限超過で不合格]  → force_exited (max_attempts_failed)
+                          └── [ブラウザ閉じ]                    → abandoned
 ```
+
+`force_exited` 各遷移では `resetLessonDataForUser()` が同期実行され、該当レッスンの動画進捗・テスト解答記録を完全リセットする（PR #134、Issue #133）。受講者は再入室で白紙からやり直す。
+
+セッション制限値（デフォルト / 本番運用）:
+- `SESSION_DURATION_MS`: 2 時間 / 3 時間（`10800000`）
+- `PAUSE_TIMEOUT_MS`: 15 分 / 15 分（本番でも未設定 → default）
 
 ### 入室打刻
 - トリガー: 動画再生ボタン押下（最初のplayイベント）
@@ -29,9 +37,9 @@
 - `quiz-attempts` の PATCH ハンドラでセッションを `completed` に更新
 
 ### 強制退室
-- 一時停止15分: クライアントサイドカウントダウン → サーバーに force-exit 送信
-- 2時間制限: クライアントカウントダウン + サーバーサイドでテスト送信時に検証
-- 強制退室後は新規セッション（再入室）が必要
+- 一時停止 `PAUSE_TIMEOUT_MS`（デフォルト 15 分）: クライアントサイドカウントダウン → サーバーに force-exit 送信
+- セッション上限 `SESSION_DURATION_MS`（デフォルト 2 時間、本番運用 3 時間）: クライアントカウントダウン + サーバーサイドでテスト送信時に検証
+- 強制退室時はレッスン学習データを完全リセット（PR #134）。受講者は新規セッション（再入室）で白紙状態から再受講できる
 
 ### UI表示
 - 各レッスンページに受講ルールを常時表示
@@ -42,8 +50,10 @@
 ## 根拠
 - **別コレクション**: セッションは多対一（1レッスンに複数セッション）のため `user_progress` への埋め込みは不適切
 - **累積analytics維持**: `video_analytics` はAdmin向け累積データとして残し、セッション概念と分離
-- **サーバーサイド検証**: クライアントのカウントダウンだけでなく、テスト送信時にサーバーで2時間制限を検証（クライアント改ざん防止）
+- **サーバーサイド検証**: クライアントのカウントダウンだけでなく、テスト送信時にサーバーでセッション上限（`SESSION_DURATION_MS`）を検証（クライアント改ざん防止）
 - **ルール明記**: 受講者の混乱を防ぐため、各レッスンページにルールを常時表示
+- **env による上限調整**: ハードコード固定では現場運用差（動画長 + テスト所要時間）に追従できないため、`SESSION_DURATION_MS` / `PAUSE_TIMEOUT_MS` を環境変数化（PR #407）
+- **強制退室時のデータリセット**: 旧データが残ると再受講時の進捗判定が壊れ、受講者が「再テストできない」状態に陥るため、強制退室と同期で完全リセット（PR #134）
 
 ## 影響
 - 新コレクション: `lesson_sessions`
@@ -51,3 +61,5 @@
 - 既存API拡張: PATCH `/quiz-attempts/:attemptId` にセッション検証追加
 - フロントエンド: 4つの新コンポーネント（SessionRulesNotice, SessionTimer, PauseTimeoutOverlay, ForceExitDialog）
 - Firestoreインデックス: `(userId, lessonId, status)`, `(courseId, status, entryAt)`
+- 環境変数: `SESSION_DURATION_MS` / `PAUSE_TIMEOUT_MS`（CLAUDE.md / Cloud Run env vars 反映）
+- DataSource API 拡張: `resetLessonDataForUser()`（InMemory / Firestore 両実装）— 強制退室時に `video_analytics` / `user_progress` / `quiz_attempts` の該当エントリを batched delete

--- a/docs/adr/ADR-027-lesson-session-attendance.md
+++ b/docs/adr/ADR-027-lesson-session-attendance.md
@@ -4,8 +4,8 @@
 承認済み（2026-05-16 改訂: セッション上限を環境変数化）
 
 ## 改訂履歴
-- **2026-05-16**: セッション上限 `SESSION_DURATION_MS` および一時停止上限 `PAUSE_TIMEOUT_MS` を環境変数で上書き可能化（PR #407）。本番運用で動画 60-80 分のレッスン + テスト解答時間が 2 時間制限内に収まらない事例が複数発生（kanjikai.or.jp テナント、5/3〜5/14 で `time_limit` 強制退室 7 件）。本番は `SESSION_DURATION_MS=10800000`（3 時間）にデプロイ。不正値は `logger.error` 後にデフォルトへフォールバック。受講者向け UI 文言の「2 時間」表記の動的化は PR #408 で対応完了（`SessionRulesNotice` / `ForceExitDialog` / ヘルプ等を `deadlineAt - entryAt` から動的算出）。長期的には動画完了後にテスト専用タイマーに切り替える設計案（"Phase 3" として議論中）も検討。
-- **2026-03-30**: 強制退室発生時にそのレッスンの学習データ（`video_analytics` / `user_progress` / `quiz_attempts` の該当エントリ）を完全リセットする実装を追加（PR #134、Issue #133）。`exitReason` が `pause_timeout` / `time_limit` / `max_attempts_failed` のいずれかで `forceExitSession()` が呼ばれると、`resetLessonDataForUser()` が同期実行される。受講者は強制退室後に白紙状態から再受講可能。
+- **2026-05-16**: セッション上限 `SESSION_DURATION_MS` および一時停止上限 `PAUSE_TIMEOUT_MS` を環境変数で上書き可能化（PR #407）。本番運用で動画 60-80 分のレッスン + テスト解答時間が 2 時間制限内に収まらない事例が複数発生（kanjikai.or.jp テナント、5/3〜5/14 で `time_limit` 強制退室 7 件）。本番は `SESSION_DURATION_MS=10800000`（3 時間）にデプロイ。不正値は `logger.error` 後にデフォルトへフォールバック。受講者向け UI 文言の「2 時間」表記は PR #408 で対応完了（`SessionRulesNotice` は `deadlineAt - entryAt` から動的算出、`ForceExitDialog` / ヘルプ / API 403 message は時間値を明示しない汎用表現に変更）。長期的には動画完了後にテスト専用タイマーに切り替える設計案（"Phase 3" として議論中）も検討。
+- **2026-03-30**: 強制退室発生時にそのレッスンの学習データ（`video_analytics` / `video_events` / `quiz_attempts` / `user_progress` の該当エントリ）を完全リセットする実装を追加（PR #134、Issue #133）。`exitReason` が `pause_timeout` / `time_limit` / `max_attempts_failed` のいずれかで `forceExitSession()` が呼ばれると、`resetLessonDataForUser()` が同期実行される。**ただし `sessionVideoCompleted=true` のセッションはリセットを skip**（HTML5 video の `ended` が pause 状態を伴うため、完了後の自然な pause タイムアウトでデータが全消去されるのを防止）。受講者は強制退室後に白紙状態から再受講可能。
 
 ## コンテキスト
 受講者の出席を「入室打刻（動画再生開始）」「退室打刻（テスト送信）」で管理する要件がある。不正防止のため、一時停止 15 分超過および入室からセッション上限（`SESSION_DURATION_MS`、デフォルト 2 時間 / 本番運用は 3 時間）超過で強制退室をかける。強制退室時はそのレッスンの学習データを完全リセットし、白紙状態から再受講可能とする（PR #134）。
@@ -22,7 +22,11 @@
                           └── [ブラウザ閉じ]                    → abandoned
 ```
 
-`force_exited` 各遷移では `resetLessonDataForUser()` が同期実行され、該当レッスンの動画進捗・テスト解答記録を完全リセットする（PR #134、Issue #133）。受講者は再入室で白紙からやり直す。
+`force_exited` 各遷移では `resetLessonDataForUser()` が同期実行され、該当レッスンの動画進捗・テスト解答記録（`video_analytics` / `video_events` / `quiz_attempts` / `user_progress`）を完全リセットする（PR #134、Issue #133）。受講者は再入室で白紙からやり直す。
+
+ただし `sessionVideoCompleted=true` のセッションについては以下の例外がある:
+- `pause_timeout` 要求は受理せず active を維持（HTML5 video `ended` が pause を伴うため）
+- `forceExitSession()` が呼ばれた場合もリセットを skip（完了後のリセットを防止）
 
 セッション制限値（デフォルト / 本番運用）:
 - `SESSION_DURATION_MS`: 2 時間 / 3 時間（`10800000`）
@@ -39,7 +43,7 @@
 ### 強制退室
 - 一時停止 `PAUSE_TIMEOUT_MS`（デフォルト 15 分）: クライアントサイドカウントダウン → サーバーに force-exit 送信
 - セッション上限 `SESSION_DURATION_MS`（デフォルト 2 時間、本番運用 3 時間）: クライアントカウントダウン + サーバーサイドでテスト送信時に検証
-- 強制退室時はレッスン学習データを完全リセット（PR #134）。受講者は新規セッション（再入室）で白紙状態から再受講できる
+- 強制退室時はレッスン学習データを完全リセット（PR #134、`sessionVideoCompleted=true` のセッションは skip）。受講者は新規セッション（再入室）で白紙状態から再受講できる
 
 ### UI表示
 - 各レッスンページに受講ルールを常時表示
@@ -62,4 +66,4 @@
 - フロントエンド: 4つの新コンポーネント（SessionRulesNotice, SessionTimer, PauseTimeoutOverlay, ForceExitDialog）
 - Firestoreインデックス: `(userId, lessonId, status)`, `(courseId, status, entryAt)`
 - 環境変数: `SESSION_DURATION_MS` / `PAUSE_TIMEOUT_MS`（CLAUDE.md / Cloud Run env vars 反映）
-- DataSource API 拡張: `resetLessonDataForUser()`（InMemory / Firestore 両実装）— 強制退室時に `video_analytics` / `user_progress` / `quiz_attempts` の該当エントリを batched delete
+- DataSource API 拡張: `resetLessonDataForUser()`（InMemory / Firestore 両実装）— 強制退室時に `video_analytics` / `video_events` / `quiz_attempts` / `user_progress` の該当エントリを batched delete

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -153,7 +153,7 @@ questions配列の各要素:
 | status | string | active / completed / force_exited / abandoned |
 | entryAt | Timestamp | 入室打刻（動画再生開始時） |
 | exitAt | Timestamp? | 退室打刻（テスト送信 or 強制退室時） |
-| exitReason | string? | quiz_submitted / pause_timeout / time_limit / browser_close |
+| exitReason | string? | quiz_submitted / pause_timeout / time_limit / browser_close / max_attempts_failed |
 | deadlineAt | Timestamp | entryAt + セッション制限時間（事前計算、`SESSION_DURATION_MS` env で設定。デフォルト 2 時間、本番運用は 3 時間） |
 | pauseStartedAt | Timestamp? | 現在の一時停止開始時刻 |
 | longestPauseSec | number | セッション中の最長一時停止秒数 |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -154,7 +154,7 @@ questions配列の各要素:
 | entryAt | Timestamp | 入室打刻（動画再生開始時） |
 | exitAt | Timestamp? | 退室打刻（テスト送信 or 強制退室時） |
 | exitReason | string? | quiz_submitted / pause_timeout / time_limit / browser_close |
-| deadlineAt | Timestamp | entryAt + セッション制限時間（事前計算、`SESSION_DURATION_MS` env で設定。デフォルト 2 時間） |
+| deadlineAt | Timestamp | entryAt + セッション制限時間（事前計算、`SESSION_DURATION_MS` env で設定。デフォルト 2 時間、本番運用は 3 時間） |
 | pauseStartedAt | Timestamp? | 現在の一時停止開始時刻 |
 | longestPauseSec | number | セッション中の最長一時停止秒数 |
 | sessionVideoCompleted | boolean | セッション内で動画完了したか |

--- a/services/api/src/services/lesson-session.ts
+++ b/services/api/src/services/lesson-session.ts
@@ -8,9 +8,9 @@ import type { LessonSession, SessionExitReason } from "../types/entities.js";
 import { parsePositiveDurationMs } from "../utils/env-config.js";
 import { updateCourseProgress } from "./progress.js";
 
-// セッション制限時間（ミリ秒、正の整数）。env var SESSION_DURATION_MS で上書き可、デフォルト 2 時間。
+// セッション制限時間（ミリ秒、正の整数）。env var SESSION_DURATION_MS で上書き可、デフォルト 2 時間、本番運用は 3 時間（10800000）。
 // 不正値（NaN / 0 以下 / 非整数 / 単位付き文字列など）は logger.error 出力後デフォルトにフォールバック。
-// 動画 60-80 分 + テスト解答時間で詰まる現場運用に対応するため env で延長可能（本番は 3 時間運用）。
+// 動画 60-80 分 + テスト解答時間で詰まる現場運用に対応するため env で延長可能（ADR-027 / PR #407 参照）。
 export const SESSION_DURATION_MS = parsePositiveDurationMs(
   process.env.SESSION_DURATION_MS,
   2 * 60 * 60 * 1000,


### PR DESCRIPTION
## Summary

PR #134 / #407 / #408 の設計変更が ADR-027 / data-model.md に未反映だったため、設計ドキュメントを実装と同期させる。受講者からの「テストの再テストができない / 時間設定はどうなった」という問い合わせを受けて反映漏れが発覚。

- **PR #134** (2026-03-30): 強制退室時にレッスン学習データを完全リセット
- **PR #407** (2026-05-16): `SESSION_DURATION_MS` env 化 + 本番 2h → 3h
- **PR #408** (2026-05-16): UI 文言「2 時間」を動的化

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `docs/adr/ADR-027-lesson-session-attendance.md` | 改訂履歴に PR #134 / PR #408 完了を追記、本文の「2 時間」ハードコードを env 名に汎用化、状態遷移図に `max_attempts_failed` 遷移とリセット同期実行を追記、根拠・影響セクションに env 化 + DataSource API 拡張を追記 |
| `docs/data-model.md` | `lesson_sessions.deadlineAt` 説明に「本番運用は 3 時間」を追記し `docs/requirements.md` と粒度統一 |
| `services/api/src/services/lesson-session.ts` | `SESSION_DURATION_MS` コメントを ADR-027 / PR #407 参照付きに微調整（本番 3 時間明記） |

## Test plan

- [x] `npm run type-check` (全 workspace PASS)
- [x] `npm run lint` (0 errors, 既存 warning 1 件は本 PR と無関係)
- [x] `npm run test -w @lms-279/api` (935/935 PASS)

ドキュメント / コメントのみで機能影響なし。受講者向け UI / API 仕様 / Cloud Run env vars に変更なし。

## 反映漏れだった箇所のチェック（全箇所 ✅）

| 項目 | 反映前 | 反映後 |
|---|---|---|
| ADR-027 改訂履歴 PR #408 状態 | 「別 PR で対応予定」 | 「PR #408 で対応完了」 |
| ADR-027 改訂履歴 PR #134 | 記載なし | 2026-03-30 行で追記 |
| ADR-027 状態遷移図 `[2時間経過]` | ハードコード | `[入室から SESSION_DURATION_MS]` |
| ADR-027 強制退室セクション | データリセット説明なし | PR #134 リセット説明追加 |
| data-model.md `deadlineAt` | 「デフォルト 2 時間」のみ | 「デフォルト 2 時間、本番運用は 3 時間」 |

## ADR への ADR-013 / GCS 署名 URL 「2 時間有効」の扱い

`docs/adr/ADR-013-gcs-video-hosting-signed-url.md` / `services/api/src/services/gcs.ts` の「2 時間有効」は GCS 動画署名 URL の有効期限であり、本 PR のセッション制限時間とは別概念のため変更対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)