### PR TITLE
fix(super-admin): マスターレッスン PDF 周辺 UI の専門用語を平易な日本語に書き換え

### DIFF
--- a/web/app/super/master/courses/[courseId]/page.tsx
+++ b/web/app/super/master/courses/[courseId]/page.tsx
@@ -884,6 +884,13 @@ export default function MasterCourseDetailPage() {
                       ) : (
                         <Badge variant="outline">テストなし</Badge>
                       )}
+                      {lesson.pdfFileName ? (
+                        <Badge className="bg-emerald-100 text-emerald-800 border-emerald-200">
+                          資料あり
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline">資料なし</Badge>
+                      )}
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
@@ -898,7 +905,7 @@ export default function MasterCourseDetailPage() {
                       size="sm"
                       onClick={() => toggleExpanded(lesson.id)}
                     >
-                      {isExpanded ? "閉じる" : "動画/テスト管理"}
+                      {isExpanded ? "閉じる" : "動画 / テスト / 資料 を編集"}
                     </Button>
                     <Button
                       variant="outline"

--- a/web/components/master/MasterLessonPdfUploader.tsx
+++ b/web/components/master/MasterLessonPdfUploader.tsx
@@ -345,8 +345,8 @@ export function MasterLessonPdfUploader({
             <DialogTitle>PDF を削除しますか?</DialogTitle>
             <DialogDescription>
               この資料の情報をマスター側で削除します。配信済みテナント側からは、
-              上のボタン「配信済みテナントに資料情報を反映」を実行したタイミングで
-              見えなくなります (実行するまでは表示されたままです)。
+              上のボタン「配信済みテナントに資料情報を反映」を実行するまでは
+              表示されたままです。
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/web/components/master/MasterLessonPdfUploader.tsx
+++ b/web/components/master/MasterLessonPdfUploader.tsx
@@ -344,8 +344,9 @@ export function MasterLessonPdfUploader({
           <DialogHeader>
             <DialogTitle>PDF を削除しますか?</DialogTitle>
             <DialogDescription>
-              マスター側 PDF メタを削除します。配信済みテナント側のメタは
-              `sync-resources` 実行時に消えます (即時削除されません)。
+              この資料の情報をマスター側で削除します。配信済みテナント側からは、
+              上のボタン「配信済みテナントに資料情報を反映」を実行したタイミングで
+              見えなくなります (実行するまでは表示されたままです)。
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/web/components/master/SyncResourcesButton.tsx
+++ b/web/components/master/SyncResourcesButton.tsx
@@ -24,7 +24,7 @@ function formatSyncResult(result: SyncResourcesResponse): string {
   if (lessonsCount === 0 && removedCount === 0) {
     return tenantsCount === 0
       ? "このコースを配信しているテナントがありません。"
-      : `配信先の ${tenantsCount} テナントには、更新対象の資料がありませんでした。`;
+      : `配信先の ${tenantsCount} 件のテナントには、更新対象の資料がありませんでした。`;
   }
   const parts: string[] = [];
   if (lessonsCount > 0) parts.push(`${lessonsCount} 件のレッスン資料を反映`);

--- a/web/components/master/SyncResourcesButton.tsx
+++ b/web/components/master/SyncResourcesButton.tsx
@@ -23,22 +23,22 @@ function formatSyncResult(result: SyncResourcesResponse): string {
   // 配信先 0 件 OR 更新対象 0 件は同一文言で扱う (Evaluator HIGH 指摘: parts 空時の文法バグ防止)
   if (lessonsCount === 0 && removedCount === 0) {
     return tenantsCount === 0
-      ? "配信先テナントが見つかりませんでした。"
-      : `配信先 ${tenantsCount} テナントには PDF メタ更新対象のレッスンがありませんでした。`;
+      ? "このコースを配信しているテナントがありません。"
+      : `配信先の ${tenantsCount} テナントには、更新対象の資料がありませんでした。`;
   }
   const parts: string[] = [];
-  if (lessonsCount > 0) parts.push(`PDF メタを ${lessonsCount} レッスンに反映`);
-  if (removedCount > 0) parts.push(`${removedCount} レッスンの PDF メタを削除`);
-  return `${tenantsCount} テナントに対し、${parts.join("、")}しました。`;
+  if (lessonsCount > 0) parts.push(`${lessonsCount} 件のレッスン資料を反映`);
+  if (removedCount > 0) parts.push(`${removedCount} 件のレッスン資料を削除`);
+  return `${tenantsCount} 件のテナントに対し、${parts.join("、")}しました。`;
 }
 
 function formatSyncError(err: unknown): string {
   if (err instanceof ApiError) {
     if (err.code === "not_found") return "マスターコースが見つかりません。";
-    return err.message || "同期に失敗しました。";
+    return err.message || "反映に失敗しました。";
   }
   if (err instanceof Error) return err.message;
-  return "同期に失敗しました。";
+  return "反映に失敗しました。";
 }
 
 export function SyncResourcesButton({
@@ -79,7 +79,7 @@ export function SyncResourcesButton({
           setConfirmOpen(true);
         }}
       >
-        既存配信先に PDF メタを反映
+        配信済みテナントに資料情報を反映
       </Button>
 
       {result && (
@@ -95,12 +95,13 @@ export function SyncResourcesButton({
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>PDF メタを既存配信先に反映しますか?</DialogTitle>
+            <DialogTitle>資料情報を、配信済みテナントに反映しますか?</DialogTitle>
             <DialogDescription>
-              本コースの配信済みテナント全てに対し、マスターレッスンの PDF メタ
-              (ファイル名 / サイズ / 更新日時) を遡及反映します。マスター側で
-              PDF を削除済みのレッスンは、テナント側のメタもクリアします。
-              GCS のファイル本体は移動しません。
+              このコースを既に配信しているテナントすべてに、各レッスンの資料
+              PDF の情報 (ファイル名・サイズ・更新日時) を最新に揃えます。
+              マスター側で削除した PDF は、テナント側でも見えなくなります。
+              クラウドに保存されている PDF ファイル本体はそのままで、移動も
+              削除もされません。
             </DialogDescription>
           </DialogHeader>
           {error && (

--- a/web/components/master/__tests__/SyncResourcesButton.test.tsx
+++ b/web/components/master/__tests__/SyncResourcesButton.test.tsx
@@ -22,16 +22,16 @@ describe("SyncResourcesButton", () => {
     });
     render(<SyncResourcesButton courseId="C1" />);
     fireEvent.click(
-      screen.getByRole("button", { name: /既存配信先に PDF メタを反映/ }),
+      screen.getByRole("button", { name: /配信済みテナントに資料情報を反映/ }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "実行する" }));
     await waitFor(() => expect(superFetchMock).toHaveBeenCalled());
     expect(
-      await screen.findByText(/3 テナント.*10 レッスン.*反映/),
+      await screen.findByText(/3 件のテナント.*10 件のレッスン資料を反映/),
     ).toBeInTheDocument();
   });
 
-  it("AC-14 配信先 0 件 (tenantsCount=0): 「配信先テナントが見つかりません」文言", async () => {
+  it("AC-14 配信先 0 件 (tenantsCount=0): 「コースを配信しているテナントがありません」文言", async () => {
     superFetchMock.mockResolvedValueOnce({
       tenantsCount: 0,
       lessonsCount: 0,
@@ -39,11 +39,11 @@ describe("SyncResourcesButton", () => {
     });
     render(<SyncResourcesButton courseId="C1" />);
     fireEvent.click(
-      screen.getByRole("button", { name: /既存配信先に PDF メタを反映/ }),
+      screen.getByRole("button", { name: /配信済みテナントに資料情報を反映/ }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "実行する" }));
     expect(
-      await screen.findByText(/配信先テナントが見つかりませんでした/),
+      await screen.findByText(/このコースを配信しているテナントがありません/),
     ).toBeInTheDocument();
   });
 
@@ -55,11 +55,11 @@ describe("SyncResourcesButton", () => {
     });
     render(<SyncResourcesButton courseId="C1" />);
     fireEvent.click(
-      screen.getByRole("button", { name: /既存配信先に PDF メタを反映/ }),
+      screen.getByRole("button", { name: /配信済みテナントに資料情報を反映/ }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "実行する" }));
     expect(
-      await screen.findByText(/配信先 3 テナントには PDF メタ更新対象のレッスンがありませんでした/),
+      await screen.findByText(/配信先の 3 テナントには、更新対象の資料がありませんでした/),
     ).toBeInTheDocument();
     // 文法バグ防止: "X テナントに対し、しました。" のような不正文字列が出ないこと
     expect(screen.queryByText(/に対し、しました/)).toBeNull();
@@ -73,11 +73,11 @@ describe("SyncResourcesButton", () => {
     });
     render(<SyncResourcesButton courseId="C1" />);
     fireEvent.click(
-      screen.getByRole("button", { name: /既存配信先に PDF メタを反映/ }),
+      screen.getByRole("button", { name: /配信済みテナントに資料情報を反映/ }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "実行する" }));
     expect(
-      await screen.findByText(/2 テナント.*5 レッスン.*PDF メタを削除/),
+      await screen.findByText(/2 件のテナント.*5 件のレッスン資料を削除/),
     ).toBeInTheDocument();
   });
 
@@ -87,7 +87,7 @@ describe("SyncResourcesButton", () => {
     );
     render(<SyncResourcesButton courseId="C1" />);
     fireEvent.click(
-      screen.getByRole("button", { name: /既存配信先に PDF メタを反映/ }),
+      screen.getByRole("button", { name: /配信済みテナントに資料情報を反映/ }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "実行する" }));
     const alert = await screen.findByRole("alert");
@@ -97,7 +97,7 @@ describe("SyncResourcesButton", () => {
   it("確認 dialog でキャンセル → API 未呼出", async () => {
     render(<SyncResourcesButton courseId="C1" />);
     fireEvent.click(
-      screen.getByRole("button", { name: /既存配信先に PDF メタを反映/ }),
+      screen.getByRole("button", { name: /配信済みテナントに資料情報を反映/ }),
     );
     fireEvent.click(
       await screen.findByRole("button", { name: "キャンセル" }),

--- a/web/components/master/__tests__/SyncResourcesButton.test.tsx
+++ b/web/components/master/__tests__/SyncResourcesButton.test.tsx
@@ -59,7 +59,7 @@ describe("SyncResourcesButton", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "実行する" }));
     expect(
-      await screen.findByText(/配信先の 3 テナントには、更新対象の資料がありませんでした/),
+      await screen.findByText(/配信先の 3 件のテナントには、更新対象の資料がありませんでした/),
     ).toBeInTheDocument();
     // 文法バグ防止: "X テナントに対し、しました。" のような不正文字列が出ないこと
     expect(screen.queryByText(/に対し、しました/)).toBeNull();


### PR DESCRIPTION
## Summary
- 現場 (非エンジニア) フィードバックを受け、マスターレッスン PDF 周辺の UI から技術用語を排除
- 「動画/テスト管理」の中に隠れていた **講座資料 (PDF)** をレッスン一覧バッジで可視化
- 「PDF メタ」「遡及反映」「GCS」等を、誰でも読める日本語に書き換え

## 背景
PR #417 で操作容易化したが、現場確認で以下の指摘:
- 「**講座資料 (PDF)** の場所を発見するのが分かりづらい」(動画/テスト管理ボタンの中に入っているため気付けない)
- 「**PDF メタ** など、よく分からない言葉を使われても非エンジニアには分からない」

## 変更内容

### 1. 動線改善 (`web/app/super/master/courses/[courseId]/page.tsx`)
- レッスン一覧に **資料あり/なし バッジ** 追加 (既存「動画あり」「テストあり」と並列、`lesson.pdfFileName` で判定)
- 展開ボタン: `動画/テスト管理` → **`動画 / テスト / 資料 を編集`**

### 2. SyncResourcesButton (PDF 同期ボタン) の用語見直し

| 種別 | Before | After |
|---|---|---|
| ボタン | `既存配信先に PDF メタを反映` | **`配信済みテナントに資料情報を反映`** |
| Dialog タイトル | `PDF メタを既存配信先に反映しますか?` | **`資料情報を、配信済みテナントに反映しますか?`** |
| Dialog 本文 | `マスターレッスンの PDF メタ (ファイル名 / サイズ / 更新日時) を遡及反映...GCS のファイル本体は移動しません。` | **`各レッスンの資料 PDF の情報 (ファイル名・サイズ・更新日時) を最新に揃えます...クラウドに保存されている PDF ファイル本体はそのままで、移動も削除もされません。`** |
| 結果 (空) | `配信先テナントが見つかりませんでした。` | **`このコースを配信しているテナントがありません。`** |
| 結果 (対象0) | `配信先 N テナントには PDF メタ更新対象のレッスンがありませんでした。` | **`配信先の N テナントには、更新対象の資料がありませんでした。`** |
| 結果 (反映) | `PDF メタを N レッスンに反映` | **`N 件のレッスン資料を反映`** |
| 結果 (削除) | `N レッスンの PDF メタを削除` | **`N 件のレッスン資料を削除`** |

### 3. MasterLessonPdfUploader 削除 Dialog
- 内部用語 `` `sync-resources` `` を実ボタン名で参照する自然な文章に書き換え

### 4. テスト追従
- `SyncResourcesButton.test.tsx` の 6 ケース全ての文言 assertion を新文言に更新 (PASS 確認済み)

## 「テナント」表記について
他の super-admin メニュー (`/super/tenants` テナント管理、`/super/distribute` テナント配信) との一貫性を維持するため、「テナント」呼称は変更せず据え置き。今回は文脈で意味が読み取れる文章構造に整えるアプローチを採用。

## 品質ゲート
- `npm run lint`: 0 errors (既存 1 warning は無関係ファイル)
- `npm run type-check`: PASS
- `npm test` (全 workspace): 935 + 83 = **1018 / 1018 PASS**

## Test plan
- [x] `npm run lint` / `type-check` / `test` 全 PASS
- [x] `SyncResourcesButton.test.tsx` 6 ケース PASS
- [ ] main マージ後、本番 `/super/master/courses/{id}` で以下を実機確認:
  - [ ] レッスン一覧に「資料あり/なし」バッジが表示される
  - [ ] 「動画 / テスト / 資料 を編集」ボタンで展開・閉じが動作
  - [ ] 「配信済みテナントに資料情報を反映」ボタン + Dialog の文言が新文言になっている
  - [ ] PDF 削除 Dialog の文言が新文言になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)