### PR TITLE
fix(api): セッション終了時に in_progress quiz_attempt を timed_out 化（Issue #422）

### DIFF
--- a/services/api/src/__tests__/integration/lesson-session.test.ts
+++ b/services/api/src/__tests__/integration/lesson-session.test.ts
@@ -47,6 +47,47 @@ describe("lesson-session service", () => {
     return { course, lesson, video };
   }
 
+  // レッスン + quiz + in_progress attempt を作成するヘルパー
+  async function setupLessonWithInProgressAttempt(userId: string) {
+    const setup = await setupLesson();
+    const quiz = await ds.createQuiz({
+      lessonId: setup.lesson.id,
+      courseId: setup.course.id,
+      title: "Test Quiz",
+      passThreshold: 70,
+      maxAttempts: 3,
+      timeLimitSec: null,
+      randomizeQuestions: false,
+      randomizeAnswers: false,
+      requireVideoCompletion: false,
+      questions: [
+        {
+          id: "q1",
+          text: "Q1",
+          type: "single",
+          options: [
+            { id: "a", text: "A", isCorrect: true },
+            { id: "b", text: "B", isCorrect: false },
+          ],
+          points: 100,
+          explanation: "",
+        },
+      ],
+    });
+    const attempt = await ds.createQuizAttempt({
+      quizId: quiz.id,
+      userId,
+      attemptNumber: 1,
+      status: "in_progress",
+      answers: { q1: ["a"] },
+      score: null,
+      isPassed: null,
+      startedAt: new Date().toISOString(),
+      submittedAt: null,
+    });
+    return { ...setup, quiz, attempt };
+  }
+
   describe("createSession", () => {
     it("creates an active session with correct fields", async () => {
       const { lesson, video } = await setupLesson();
@@ -110,6 +151,88 @@ describe("lesson-session service", () => {
       const exited = await forceExitSession(ds, session.id, "time_limit");
 
       expect(exited.exitReason).toBe("time_limit");
+    });
+
+    // Issue #422: forceExitSession 後に in_progress attempt が残ると次回テスト開始不能になる
+    it("cleans up in_progress quiz attempts to timed_out (sessionVideoCompleted=true path)", async () => {
+      const { lesson, video, attempt } = await setupLessonWithInProgressAttempt("user1");
+      const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
+
+      // 動画完了済みフラグを立てて、resetLessonDataForUser がスキップされる経路をシミュレート
+      await ds.updateLessonSession(session.id, { sessionVideoCompleted: true });
+
+      await forceExitSession(ds, session.id, "time_limit");
+
+      const cleaned = await ds.getQuizAttemptById(attempt.id);
+      expect(cleaned).not.toBeNull();
+      expect(cleaned!.status).toBe("timed_out");
+      expect(cleaned!.submittedAt).toBeTruthy();
+    });
+
+    it("preserves answers when cleaning up in_progress attempts (audit trail)", async () => {
+      const { lesson, video, attempt } = await setupLessonWithInProgressAttempt("user1");
+      const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
+      await ds.updateLessonSession(session.id, { sessionVideoCompleted: true });
+
+      await forceExitSession(ds, session.id, "time_limit");
+
+      const cleaned = await ds.getQuizAttemptById(attempt.id);
+      expect(cleaned!.answers).toEqual({ q1: ["a"] }); // 既存値が保持される
+      expect(cleaned!.score).toBeNull();
+      expect(cleaned!.isPassed).toBeNull();
+      expect(cleaned!.attemptNumber).toBe(1);
+    });
+
+    it("allows creating a new attempt after force-exit (regression for stuck-in-progress bug)", async () => {
+      const { lesson, video, quiz } = await setupLessonWithInProgressAttempt("user1");
+      const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
+      await ds.updateLessonSession(session.id, { sessionVideoCompleted: true });
+
+      await forceExitSession(ds, session.id, "time_limit");
+
+      // 次の attempt 作成が成功すること（in_progress 一意性制約を超えられる）
+      const result = await ds.createQuizAttemptAtomic(
+        quiz.id,
+        "user1",
+        quiz.maxAttempts,
+        quiz.timeLimitSec,
+        {
+          quizId: quiz.id,
+          userId: "user1",
+          status: "in_progress",
+          answers: {},
+          score: null,
+          isPassed: null,
+          startedAt: new Date().toISOString(),
+          submittedAt: null,
+        }
+      );
+      expect(result).not.toBeNull();
+      expect(result!.existing).toBe(false);
+      expect(result!.attempt.attemptNumber).toBe(2);
+    });
+
+    it("does not affect other users' in_progress attempts", async () => {
+      const { lesson, video, quiz } = await setupLessonWithInProgressAttempt("user1");
+      // 別ユーザーの in_progress attempt
+      const otherAttempt = await ds.createQuizAttempt({
+        quizId: quiz.id,
+        userId: "user2",
+        attemptNumber: 1,
+        status: "in_progress",
+        answers: {},
+        score: null,
+        isPassed: null,
+        startedAt: new Date().toISOString(),
+        submittedAt: null,
+      });
+      const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
+      await ds.updateLessonSession(session.id, { sessionVideoCompleted: true });
+
+      await forceExitSession(ds, session.id, "time_limit");
+
+      const other = await ds.getQuizAttemptById(otherAttempt.id);
+      expect(other!.status).toBe("in_progress"); // 他ユーザーには影響しない
     });
   });
 
@@ -211,6 +334,44 @@ describe("lesson-session service", () => {
       await expect(abandonSession(ds, "nonexistent-id")).rejects.toThrow("not found");
     });
 
+    // Issue #422: abandonSession 後も in_progress attempt が残ると次回テスト開始不能になる
+    it("cleans up in_progress quiz attempts to timed_out (Issue #422 path 5)", async () => {
+      const { lesson, video, attempt } = await setupLessonWithInProgressAttempt("user1");
+      const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
+
+      await abandonSession(ds, session.id);
+
+      const cleaned = await ds.getQuizAttemptById(attempt.id);
+      expect(cleaned!.status).toBe("timed_out");
+      expect(cleaned!.answers).toEqual({ q1: ["a"] }); // 証跡保持
+    });
+
+    it("allows creating a new attempt after abandon", async () => {
+      const { lesson, video, quiz } = await setupLessonWithInProgressAttempt("user1");
+      const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
+
+      await abandonSession(ds, session.id);
+
+      const result = await ds.createQuizAttemptAtomic(
+        quiz.id,
+        "user1",
+        quiz.maxAttempts,
+        quiz.timeLimitSec,
+        {
+          quizId: quiz.id,
+          userId: "user1",
+          status: "in_progress",
+          answers: {},
+          score: null,
+          isPassed: null,
+          startedAt: new Date().toISOString(),
+          submittedAt: null,
+        }
+      );
+      expect(result).not.toBeNull();
+      expect(result!.existing).toBe(false);
+    });
+
     it("returns session as-is if already completed (TOCTOU safety)", async () => {
       const { lesson, video } = await setupLesson();
       const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
@@ -251,6 +412,23 @@ describe("lesson-session service", () => {
 
       const result = await handleStaleSession(ds, session);
       expect(result.status).toBe("active");
+    });
+
+    // Issue #422: stale session を回収する際も in_progress attempt をクリーンアップする
+    it("cleans up in_progress attempt when force-exiting stale session", async () => {
+      const { lesson, video, attempt } = await setupLessonWithInProgressAttempt("user1");
+      const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
+
+      await ds.updateLessonSession(session.id, {
+        sessionVideoCompleted: true,
+        deadlineAt: new Date(Date.now() - 1000).toISOString(),
+      });
+
+      const stale = await ds.getLessonSession(session.id);
+      await handleStaleSession(ds, stale!);
+
+      const cleaned = await ds.getQuizAttemptById(attempt.id);
+      expect(cleaned!.status).toBe("timed_out");
     });
   });
 });

--- a/services/api/src/__tests__/integration/lesson-session.test.ts
+++ b/services/api/src/__tests__/integration/lesson-session.test.ts
@@ -234,6 +234,127 @@ describe("lesson-session service", () => {
       const other = await ds.getQuizAttemptById(otherAttempt.id);
       expect(other!.status).toBe("in_progress"); // 他ユーザーには影響しない
     });
+
+    // Issue #422: 動画完了済みデータ（video_analytics）が保護されることの回帰検証
+    it("preserves video_analytics when sessionVideoCompleted=true (data protection)", async () => {
+      const { lesson, video } = await setupLessonWithInProgressAttempt("user1");
+      await ds.upsertVideoAnalytics("user1", video.id, {
+        coverageRatio: 0.98,
+        isComplete: true,
+        watchedRanges: [{ start: 0, end: 294 }],
+        totalWatchTimeSec: 294,
+        seekCount: 0,
+        suspiciousFlags: [],
+      });
+      const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
+      await ds.updateLessonSession(session.id, { sessionVideoCompleted: true });
+
+      await forceExitSession(ds, session.id, "time_limit");
+
+      const analytics = await ds.getVideoAnalytics("user1", video.id);
+      expect(analytics).not.toBeNull();
+      expect(analytics!.coverageRatio).toBe(0.98); // 動画データは保護される
+      expect(analytics!.isComplete).toBe(true);
+    });
+
+    // Issue #422: maxAttempts 除外の不変条件（救済による受験回数消費なし）
+    it("timed_out from cleanup is excluded from maxAttempts (recovery does not consume attempts)", async () => {
+      const setup = await setupLesson();
+      const quiz = await ds.createQuiz({
+        lessonId: setup.lesson.id,
+        courseId: setup.course.id,
+        title: "Test Quiz maxAttempts=2",
+        passThreshold: 70,
+        maxAttempts: 2,
+        timeLimitSec: null,
+        randomizeQuestions: false,
+        randomizeAnswers: false,
+        requireVideoCompletion: false,
+        questions: [
+          {
+            id: "q1",
+            text: "Q1",
+            type: "single",
+            options: [
+              { id: "a", text: "A", isCorrect: true },
+              { id: "b", text: "B", isCorrect: false },
+            ],
+            points: 100,
+            explanation: "",
+          },
+        ],
+      });
+      await ds.createQuizAttempt({
+        quizId: quiz.id,
+        userId: "user1",
+        attemptNumber: 1,
+        status: "in_progress",
+        answers: {},
+        score: null,
+        isPassed: null,
+        startedAt: new Date().toISOString(),
+        submittedAt: null,
+      });
+      const session = await createSession(ds, "user1", setup.lesson.id, setup.course.id, setup.video.id, "token-1");
+      await ds.updateLessonSession(session.id, { sessionVideoCompleted: true });
+
+      await forceExitSession(ds, session.id, "time_limit");
+
+      // 2回目作成（救済で消費されていないなら成功）
+      const second = await ds.createQuizAttemptAtomic(
+        quiz.id, "user1", quiz.maxAttempts, quiz.timeLimitSec,
+        {
+          quizId: quiz.id,
+          userId: "user1",
+          status: "in_progress",
+          answers: {},
+          score: null,
+          isPassed: null,
+          startedAt: new Date().toISOString(),
+          submittedAt: null,
+        }
+      );
+      expect(second).not.toBeNull();
+      expect(second!.attempt.attemptNumber).toBe(2);
+    });
+
+    // TOCTOU 対策: 並行 PATCH 提出で submitted になった attempt を上書きしない
+    it("does not overwrite submitted attempts (TOCTOU safety via conditional update)", async () => {
+      const { lesson, video, attempt } = await setupLessonWithInProgressAttempt("user1");
+      const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
+      await ds.updateLessonSession(session.id, { sessionVideoCompleted: true });
+
+      // PATCH 提出が cleanup より先に完了したシナリオ
+      await ds.updateQuizAttempt(attempt.id, {
+        status: "submitted",
+        score: 100,
+        isPassed: true,
+        submittedAt: new Date().toISOString(),
+      });
+
+      await forceExitSession(ds, session.id, "time_limit");
+
+      const after = await ds.getQuizAttemptById(attempt.id);
+      expect(after!.status).toBe("submitted"); // timed_out で上書きされない
+      expect(after!.score).toBe(100);
+      expect(after!.isPassed).toBe(true);
+    });
+
+    // エラーパス: cleanup 内の例外は session 終了を止めない
+    it("completes session even when getQuizByLessonId throws", async () => {
+      const { lesson, video } = await setupLessonWithInProgressAttempt("user1");
+      const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
+      await ds.updateLessonSession(session.id, { sessionVideoCompleted: true });
+
+      const original = ds.getQuizByLessonId.bind(ds);
+      ds.getQuizByLessonId = async () => { throw new Error("simulated firestore error"); };
+      try {
+        const result = await forceExitSession(ds, session.id, "time_limit");
+        expect(result.status).toBe("force_exited"); // session 終了は完了する
+      } finally {
+        ds.getQuizByLessonId = original;
+      }
+    });
   });
 
   describe("completeSession", () => {
@@ -335,7 +456,7 @@ describe("lesson-session service", () => {
     });
 
     // Issue #422: abandonSession 後も in_progress attempt が残ると次回テスト開始不能になる
-    it("cleans up in_progress quiz attempts to timed_out (Issue #422 path 5)", async () => {
+    it("cleans up in_progress quiz attempts to timed_out (browser_close path)", async () => {
       const { lesson, video, attempt } = await setupLessonWithInProgressAttempt("user1");
       const session = await createSession(ds, "user1", lesson.id, lesson.courseId, video.id, "token-1");
 

--- a/services/api/src/__tests__/integration/session-quiz-integration.test.ts
+++ b/services/api/src/__tests__/integration/session-quiz-integration.test.ts
@@ -201,6 +201,51 @@ describe("Quiz submission × Session integration", () => {
   });
 
   // =========================================================
+  // 3-bis. Issue #422: 期限切れ拒否後に新規 attempt 作成が可能になること（回帰テスト）
+  // =========================================================
+  it("session_time_exceeded 拒否後、新規 attempt 作成が 409 ではなく成功する (Issue #422 path 1)", async () => {
+    // sessionVideoCompleted=true 経路をシミュレートするため動画完了状態を作る
+    const sessionRes = await studentRequest
+      .post("/lesson-sessions")
+      .send({
+        lessonId,
+        videoId: "dummy-video",
+        sessionToken: "issue-422-token",
+      });
+    const sessionId = sessionRes.body.session.id;
+
+    // attempt 作成
+    const attemptRes = await studentRequest
+      .post(`/quizzes/${quizId}/attempts`)
+      .send({});
+    expect(attemptRes.status).toBe(201);
+    const attemptId = attemptRes.body.attempt.id;
+
+    // session を期限切れ + 動画完了済みに（resetLessonDataForUser がスキップされる経路）
+    await ds.updateLessonSession(sessionId, {
+      deadlineAt: new Date(Date.now() - 1000).toISOString(),
+      sessionVideoCompleted: true,
+    });
+
+    // 提出 → 403 + forceExitSession が走る
+    const submitRes = await studentRequest
+      .patch(`/quiz-attempts/${attemptId}`)
+      .send({ answers: { q1: ["q1-a"] } });
+    expect(submitRes.status).toBe(403);
+
+    // attempt が cleanup で timed_out 化されていること
+    const oldAttempt = await ds.getQuizAttemptById(attemptId);
+    expect(oldAttempt!.status).toBe("timed_out");
+
+    // 新規 attempt 作成が成功すること（旧バグなら 409 attempt_in_progress）
+    const newAttemptRes = await studentRequest
+      .post(`/quizzes/${quizId}/attempts`)
+      .send({});
+    expect(newAttemptRes.status).toBe(201);
+    expect(newAttemptRes.body.attempt.attemptNumber).toBe(2);
+  });
+
+  // =========================================================
   // 4. セッション強制退室APIのテスト
   // =========================================================
   it("PATCH /lesson-sessions/:id/force-exit でセッションが強制退室になる", async () => {

--- a/services/api/src/datasource/firestore.ts
+++ b/services/api/src/datasource/firestore.ts
@@ -1313,6 +1313,29 @@ export class FirestoreDataSource implements DataSource {
     return this.toQuizAttempt(updated.id, updated.data()!);
   }
 
+  async transitionQuizAttemptToTimedOut(
+    attemptId: string
+  ): Promise<{ transitioned: boolean; attempt: QuizAttempt | null }> {
+    return this.db.runTransaction(async (tx) => {
+      const docRef = this.collection("quiz_attempts").doc(attemptId);
+      const doc = await tx.get(docRef);
+      if (!doc.exists) return { transitioned: false, attempt: null };
+
+      const current = this.toQuizAttempt(doc.id, doc.data()!);
+      if (current.status !== "in_progress") {
+        return { transitioned: false, attempt: current };
+      }
+
+      const submittedAt = new Date().toISOString();
+      tx.update(docRef, { status: "timed_out", submittedAt });
+
+      return {
+        transitioned: true,
+        attempt: { ...current, status: "timed_out", submittedAt },
+      };
+    });
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private toQuizAttempt(id: string, data: any): QuizAttempt {
     return {

--- a/services/api/src/datasource/in-memory.ts
+++ b/services/api/src/datasource/in-memory.ts
@@ -1050,6 +1050,24 @@ export class InMemoryDataSource implements DataSource {
     return this.quizAttempts[index];
   }
 
+  async transitionQuizAttemptToTimedOut(
+    attemptId: string
+  ): Promise<{ transitioned: boolean; attempt: QuizAttempt | null }> {
+    this.throwIfReadOnly();
+    const index = this.quizAttempts.findIndex((a) => a.id === attemptId);
+    if (index === -1) return { transitioned: false, attempt: null };
+    const current = this.quizAttempts[index];
+    if (current.status !== "in_progress") {
+      return { transitioned: false, attempt: current };
+    }
+    this.quizAttempts[index] = {
+      ...current,
+      status: "timed_out",
+      submittedAt: new Date().toISOString(),
+    };
+    return { transitioned: true, attempt: this.quizAttempts[index] };
+  }
+
   // User Progress
   async getUserProgress(userId: string, lessonId: string): Promise<UserProgress | null> {
     const key = `${userId}_${lessonId}`;

--- a/services/api/src/datasource/interface.ts
+++ b/services/api/src/datasource/interface.ts
@@ -275,6 +275,15 @@ export interface DataSource {
     data: Omit<QuizAttempt, "id" | "attemptNumber">
   ): Promise<{ attempt: QuizAttempt; existing: boolean } | null>;
   updateQuizAttempt(id: string, data: Partial<Omit<QuizAttempt, "id">>): Promise<QuizAttempt | null>;
+  /**
+   * quiz attempt を in_progress から timed_out へ条件付きで遷移させる（TOCTOU 安全）。
+   * - in_progress 以外（submitted / timed_out 等）の場合は更新せず transitioned: false を返す
+   * - 存在しない場合は { transitioned: false, attempt: null }
+   * - submittedAt を now にセット、answers / score / isPassed は触らない（既存値保持・監査証跡）
+   *
+   * Issue #422: cleanup と並行 PATCH 提出が競合した場合の submitted → timed_out 上書きを防ぐ。
+   */
+  transitionQuizAttemptToTimedOut(attemptId: string): Promise<{ transitioned: boolean; attempt: QuizAttempt | null }>;
 
   // User Progress
   getUserProgress(userId: string, lessonId: string): Promise<UserProgress | null>;

--- a/services/api/src/services/lesson-session.ts
+++ b/services/api/src/services/lesson-session.ts
@@ -82,9 +82,57 @@ export async function getOrCreateSession(
 }
 
 /**
+ * セッション終了時、同一ユーザー・同一レッスンの in_progress quiz_attempt を
+ * timed_out に遷移させ、再受験を可能にする（Issue #422）。
+ *
+ * sessionVideoCompleted=true で resetLessonDataForUser がスキップされる経路でも
+ * attempt のロックが残らないよう、session 終了処理と独立に attempt を終端化する。
+ * answers は監査証跡として保持し、score/isPassed は null のまま、submittedAt のみ now を入れる。
+ * timed_out は maxAttempts カウントから除外されるため、救済による受験回数消費はない。
+ */
+async function cleanupInProgressAttempts(
+  ds: DataSource,
+  userId: string,
+  lessonId: string
+): Promise<void> {
+  let quiz;
+  try {
+    quiz = await ds.getQuizByLessonId(lessonId);
+  } catch (err) {
+    console.error(`cleanupInProgressAttempts: failed to load quiz for lesson ${lessonId}:`, err);
+    return;
+  }
+  if (!quiz) return;
+
+  let attempts;
+  try {
+    attempts = await ds.getQuizAttempts({ quizId: quiz.id, userId });
+  } catch (err) {
+    console.error(`cleanupInProgressAttempts: failed to load attempts for quiz ${quiz.id}:`, err);
+    return;
+  }
+
+  const now = new Date().toISOString();
+  for (const attempt of attempts) {
+    if (attempt.status !== "in_progress") continue;
+    try {
+      await ds.updateQuizAttempt(attempt.id, {
+        status: "timed_out",
+        submittedAt: now,
+      });
+    } catch (err) {
+      // 1件失敗しても他は続行
+      console.error(`cleanupInProgressAttempts: failed to cleanup attempt ${attempt.id}:`, err);
+    }
+  }
+}
+
+/**
  * セッションを強制退室にし、レッスンの学習データを完全リセットする。
  * リセット対象: video_analytics, video_events, quiz_attempts, user_progress
  * （1 セッション内で動画視聴→テスト送信まで完了させる要件のため。セッション上限は SESSION_DURATION_MS）
+ *
+ * Issue #422: in_progress な quiz_attempt のロック解除も実施する（reset スキップ経路の救済）。
  */
 export async function forceExitSession(
   ds: DataSource,
@@ -109,6 +157,9 @@ export async function forceExitSession(
     await ds.resetLessonDataForUser(session.userId, session.lessonId, session.courseId);
     await updateCourseProgress(ds, session.userId, session.courseId);
   }
+
+  // attempt ロック解除（reset スキップ時の救済 / reset 実施時は noop）
+  await cleanupInProgressAttempts(ds, session.userId, session.lessonId);
 
   return updated!;
 }
@@ -139,6 +190,10 @@ export async function abandonSession(
   if (!updated) {
     throw new Error(`Session ${sessionId} not found`);
   }
+
+  // Issue #422: ブラウザクローズ後も in_progress attempt が残ると次回テスト開始不能になるため終端化
+  await cleanupInProgressAttempts(ds, session.userId, session.lessonId);
+
   return updated;
 }
 

--- a/services/api/src/services/lesson-session.ts
+++ b/services/api/src/services/lesson-session.ts
@@ -4,8 +4,9 @@
  */
 
 import type { DataSource } from "../datasource/interface.js";
-import type { LessonSession, SessionExitReason } from "../types/entities.js";
+import type { LessonSession, Quiz, QuizAttempt, SessionExitReason } from "../types/entities.js";
 import { parsePositiveDurationMs } from "../utils/env-config.js";
+import { logger } from "../utils/logger.js";
 import { updateCourseProgress } from "./progress.js";
 
 // セッション制限時間（ミリ秒、正の整数）。env var SESSION_DURATION_MS で上書き可、デフォルト 2 時間、本番運用は 3 時間（10800000）。
@@ -88,42 +89,112 @@ export async function getOrCreateSession(
  * sessionVideoCompleted=true で resetLessonDataForUser がスキップされる経路でも
  * attempt のロックが残らないよう、session 終了処理と独立に attempt を終端化する。
  * answers は監査証跡として保持し、score/isPassed は null のまま、submittedAt のみ now を入れる。
- * timed_out は maxAttempts カウントから除外されるため、救済による受験回数消費はない。
+ *
+ * timed_out が maxAttempts カウントから除外される責務は createQuizAttemptAtomic
+ * （services/quiz-attempt-utils.ts の countEffectiveAttempts）が持つため、
+ * 救済による受験回数消費はない。
+ *
+ * 並行 PATCH 提出との競合対策として transitionQuizAttemptToTimedOut の条件付き更新
+ * （in_progress 状態のみ遷移）を使用。submitted attempt を timed_out で上書きしない。
+ *
+ * 失敗ハンドリング: 本ヘルパー内のエラーは呼び出し元（forceExitSession / abandonSession）に
+ * propagate せず、session 終了処理を継続する。cleanup 失敗の検知は Cloud Logging の
+ * `errorType=cleanup_in_progress_attempts_*` フィルタで行うこと。
+ * 個別 attempt の cleanup 失敗 = 該当 user の次回テスト開始失敗を意味するため要監視。
  */
 async function cleanupInProgressAttempts(
   ds: DataSource,
   userId: string,
   lessonId: string
 ): Promise<void> {
-  let quiz;
+  let quiz: Quiz | null;
   try {
     quiz = await ds.getQuizByLessonId(lessonId);
   } catch (err) {
-    console.error(`cleanupInProgressAttempts: failed to load quiz for lesson ${lessonId}:`, err);
+    logger.error("cleanupInProgressAttempts: failed to load quiz", {
+      errorType: "cleanup_in_progress_attempts_quiz_load_failed",
+      userId,
+      lessonId,
+      error: err instanceof Error ? err : new Error(String(err)),
+    });
     return;
   }
-  if (!quiz) return;
+  if (!quiz) {
+    // lesson に quiz が紐づかないケース（quiz 削除済み + 過去の in_progress 残留など）は
+    // 正常運用では起きにくいため warn で観測可能化
+    logger.warn("cleanupInProgressAttempts: quiz not found for lesson; skipping", {
+      errorType: "cleanup_in_progress_attempts_quiz_missing",
+      userId,
+      lessonId,
+    });
+    return;
+  }
 
-  let attempts;
+  let attempts: QuizAttempt[];
   try {
     attempts = await ds.getQuizAttempts({ quizId: quiz.id, userId });
   } catch (err) {
-    console.error(`cleanupInProgressAttempts: failed to load attempts for quiz ${quiz.id}:`, err);
+    logger.error("cleanupInProgressAttempts: failed to load attempts", {
+      errorType: "cleanup_in_progress_attempts_load_failed",
+      userId,
+      lessonId,
+      quizId: quiz.id,
+      error: err instanceof Error ? err : new Error(String(err)),
+    });
     return;
   }
 
-  const now = new Date().toISOString();
+  let cleaned = 0;
+  let failed = 0;
+  let skipped = 0;
+  const failedAttemptIds: string[] = [];
+
   for (const attempt of attempts) {
     if (attempt.status !== "in_progress") continue;
     try {
-      await ds.updateQuizAttempt(attempt.id, {
-        status: "timed_out",
-        submittedAt: now,
-      });
+      const result = await ds.transitionQuizAttemptToTimedOut(attempt.id);
+      if (result.transitioned) {
+        cleaned++;
+      } else {
+        // 並行 PATCH 提出で submitted に遷移済 / 別経路で timed_out 化済の場合
+        skipped++;
+      }
     } catch (err) {
-      // 1件失敗しても他は続行
-      console.error(`cleanupInProgressAttempts: failed to cleanup attempt ${attempt.id}:`, err);
+      // 部分救済 > 全停止: 1件失敗しても他の attempt の救済は続行
+      failed++;
+      failedAttemptIds.push(attempt.id);
+      logger.error("cleanupInProgressAttempts: failed to transition attempt", {
+        errorType: "cleanup_in_progress_attempts_individual_failed",
+        userId,
+        lessonId,
+        quizId: quiz.id,
+        attemptId: attempt.id,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
     }
+  }
+
+  if (failed > 0) {
+    // ユーザーの次回テスト開始失敗を意味するため別 errorType でアラート可能に
+    logger.error("cleanupInProgressAttempts: partial failure", {
+      errorType: "cleanup_in_progress_attempts_partial_failure",
+      userId,
+      lessonId,
+      quizId: quiz.id,
+      cleaned,
+      failed,
+      skipped,
+      failedAttemptIds,
+    });
+  } else if (cleaned > 0) {
+    logger.info("cleanupInProgressAttempts: success", {
+      eventType: "cleanup_in_progress_attempts_success",
+      userId,
+      lessonId,
+      quizId: quiz.id,
+      cleaned,
+      skipped,
+    });
   }
 }
 
@@ -149,19 +220,23 @@ export async function forceExitSession(
     exitAt: new Date().toISOString(),
     exitReason: reason,
   });
+  if (!updated) {
+    throw new Error(`Session ${sessionId} not found`);
+  }
 
   // 動画完了済みセッションでは学習データをリセットしない。
   // HTML5 videoのendedはpause状態を伴うため、完了後のpauseタイムアウトや
   // ページリロード等でデータが全消去されるのを防止する。
-  if (!session.sessionVideoCompleted) {
+  if (session.sessionVideoCompleted) {
+    // Issue #422: reset スキップ経路では attempt が残るため明示的に終端化
+    await cleanupInProgressAttempts(ds, session.userId, session.lessonId);
+  } else {
+    // reset 経路: resetLessonDataForUser が quiz_attempts を全削除するため cleanup 不要
     await ds.resetLessonDataForUser(session.userId, session.lessonId, session.courseId);
     await updateCourseProgress(ds, session.userId, session.courseId);
   }
 
-  // attempt ロック解除（reset スキップ時の救済 / reset 実施時は noop）
-  await cleanupInProgressAttempts(ds, session.userId, session.lessonId);
-
-  return updated!;
+  return updated;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `forceExitSession` / `abandonSession` 後に `quiz_attempt` が `in_progress` のまま残り、以降テスト開始しようとすると HTTP 409 `attempt_in_progress`（「現在進行中のテストがあります。先に提出してください」）で永続的に詰まる不具合を修正
- 動画完了済みデータ保護経路（`resetLessonDataForUser` スキップ）でも attempt ロックを解除するため、共通ヘルパー `cleanupInProgressAttempts` を追加して `forceExitSession` / `abandonSession` から呼び出し
- Codex セカンドオピニオン（threadId: 019e3ddb-5f9f-7491-a912-5efed807b964）で推奨された案 D を採用。5経路すべてを発生源で解決

## 影響経路（Issue #422 詳細）

| # | 経路 | トリガー |
|---|------|---------|
| 1 | 解答中に session 期限超過 | PATCH /quiz-attempts/:id (time_limit 分岐) |
| 2 | リロード時の stale session 検出 | GET /lesson-sessions/active → handleStaleSession |
| 3 | 別端末・再入室時の新 session 作成 | POST /lesson-sessions |
| 4 | 明示的 force-exit API 呼び出し | PATCH /lesson-sessions/:id/force-exit |
| 5 | ブラウザクローズで abandon | POST /lesson-sessions/:id/abandon |

## 変更内容

### `services/api/src/services/lesson-session.ts`
- `cleanupInProgressAttempts(ds, userId, lessonId)` ヘルパーを追加
  - 同一 user+lesson の `in_progress` attempt を `timed_out` に遷移
  - `answers` は監査証跡として保持
  - `score` / `isPassed` は null 維持、`submittedAt` のみ now を入れる
  - エラーは内部 try/catch で吸収し、session 終了処理を止めない
- `forceExitSession` から呼び出し（reset 実施経路では noop、スキップ経路で救済）
- `abandonSession` から呼び出し（経路5対応）

### `services/api/src/__tests__/integration/lesson-session.test.ts`
- `setupLessonWithInProgressAttempt` ヘルパー追加
- テスト追加 5件:
  - forceExitSession (sessionVideoCompleted=true) で attempt が timed_out になる
  - answers が保持される（監査証跡）
  - 次回 attempt 作成が成功する（回帰テスト）
  - 他ユーザーの in_progress attempt に影響しない
  - abandonSession でも cleanup される + 次回 attempt 作成可能
  - handleStaleSession 経由でも cleanup される（経路2）

## 設計判断

### `timed_out` を選んだ理由
- 既存実装で `timed_out` は maxAttempts カウントから除外されるため、救済による受験回数消費なし
- `force_exited` や `abandoned` 等の専用 status を quiz_attempt に追加するより、既存ステータスで意味論的に整合

### `answers` を保持する理由
- 監査証跡として保存（CS 対応や不正調査時に必要）
- `null` で上書きすると Firestore で既存値が消える（`production-data-safety.md` §1）

## 別 PR (Follow-up)

- [ ] 一括救済 admin workflow（既詰まりユーザーへの遡及対応、`workflow_dispatch` + admin SDK）
  - Issue #422 のコメントで進捗管理
  - 本 PR マージ + 本番デプロイ後に着手

## Test plan

- [x] `npx vitest run services/api/src/__tests__/integration/lesson-session.test.ts` PASS (23/23)
- [x] `npx vitest run services/api/src/__tests__/integration/` PASS (291/291、全 API integration test)
- [x] `npm run test -w @lms-279/web` PASS (83/83)
- [x] `npm run type-check` PASS (api / web / shared-types / notification)
- [x] `npm run lint` 既存 warning 1件のみ（本 PR 無関係）
- [ ] CI（deploy.yml / e2e.yml）の自動チェック完走確認
- [ ] dev 環境デプロイ後、UI で以下を確認:
  - 強制終了後にテスト再開できること
  - 動画完了済みの video_analytics が引き続き保護されていること

## Refs

- Closes #422
- ADR-019（動画完了ゲート）
- ADR-027（出席管理・セッション制限時間）

🤖 Generated with [Claude Code](https://claude.com/claude-code)