### PR TITLE
feat(scripts): in_progress quiz_attempt 一括救済 workflow + script 追加（Issue #422 follow-up）

### DIFF
--- a/.github/workflows/cleanup-stuck-quiz-attempts.yml
+++ b/.github/workflows/cleanup-stuck-quiz-attempts.yml
@@ -1,0 +1,95 @@
+name: Cleanup Stuck Quiz Attempts
+
+# Issue #422 follow-up: in_progress のまま詰まった quiz_attempt を timed_out に救済する管理 workflow。
+# PR #423 の恒久対応では未来の発生を防ぐが、既詰まりユーザーは自動回復しないため本 workflow が必要。
+#
+# 実行方法:
+#   GitHub Actions UI > Cleanup Stuck Quiz Attempts > Run workflow
+#   インプット未指定で dry-run（全テナント横断、件数 + サンプル表示のみ）
+#   execute=true で実際に更新
+#
+# 安全機構:
+#   - dry-run 既定（execute 入力で apply）
+#   - スコープ絞り込み（tenant_id / user_email / user_id）
+#   - 件数アサーション（max_targets を超えると中断）
+#   - 更新前バックアップを artifact に保存
+#
+# セキュリティ: workflow_dispatch 入力はすべて env 経由で受け、run: 内で直接補間しない
+# (https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/)
+
+on:
+  workflow_dispatch:
+    inputs:
+      execute:
+        description: '実更新モード（false=dry-run / true=apply）'
+        type: boolean
+        default: false
+      tenant_id:
+        description: 'テナント ID で絞り込み（空 = 全テナント横断）'
+        required: false
+        type: string
+      user_email:
+        description: 'ユーザー email で絞り込み（user_id と排他）'
+        required: false
+        type: string
+      user_id:
+        description: 'ユーザー ID で絞り込み（user_email と排他）'
+        required: false
+        type: string
+      max_targets:
+        description: '救済対象の上限件数（既定 1000、超えると中断）'
+        required: false
+        default: '1000'
+        type: string
+
+jobs:
+  cleanup:
+    name: Cleanup
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      FIREBASE_PROJECT_ID: lms-279
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/1034821634012/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-actions@lms-279.iam.gserviceaccount.com
+
+      - name: Run cleanup script
+        env:
+          GOOGLE_CLOUD_PROJECT: lms-279
+          EXECUTE: ${{ inputs.execute }}
+          TENANT_ID: ${{ inputs.tenant_id }}
+          USER_EMAIL: ${{ inputs.user_email }}
+          USER_ID: ${{ inputs.user_id }}
+          MAX_TARGETS: ${{ inputs.max_targets }}
+        run: |
+          set -euo pipefail
+          FLAGS=()
+          if [ "$EXECUTE" = "true" ]; then FLAGS+=("--execute"); fi
+          if [ -n "$TENANT_ID" ]; then FLAGS+=("--tenant-id=$TENANT_ID"); fi
+          if [ -n "$USER_EMAIL" ]; then FLAGS+=("--user-email=$USER_EMAIL"); fi
+          if [ -n "$USER_ID" ]; then FLAGS+=("--user-id=$USER_ID"); fi
+          if [ -n "$MAX_TARGETS" ]; then FLAGS+=("--max-targets=$MAX_TARGETS"); fi
+          echo "Running with flags: ${FLAGS[*]:-(none)}"
+          npx tsx scripts/cleanup-stuck-quiz-attempts.ts "${FLAGS[@]}"
+
+      - name: Upload backup artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cleanup-backup-${{ github.run_id }}
+          path: cleanup-stuck-backup-*.json
+          if-no-files-found: ignore
+          retention-days: 30

--- a/scripts/__tests__/cleanup-stuck-quiz-attempts.smoke.ts
+++ b/scripts/__tests__/cleanup-stuck-quiz-attempts.smoke.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env npx tsx
+/**
+ * `scripts/cleanup-stuck-quiz-attempts.ts#isStuckAttempt` の smoke test。
+ *
+ * 位置づけ:
+ *   - scripts/ 配下は vitest workspace 対象外のため、node:assert で最低限の回帰検知。
+ *
+ * 実行方法:
+ *   npx tsx scripts/__tests__/cleanup-stuck-quiz-attempts.smoke.ts
+ */
+
+import assert from "node:assert/strict";
+import {
+  isStuckAttempt,
+  type AttemptInfo,
+  type SessionInfo,
+} from "../cleanup-stuck-quiz-attempts.ts";
+
+const nowMs = Date.parse("2026-05-19T03:00:00Z");
+const future = new Date(nowMs + 60 * 60 * 1000).toISOString();
+const past = new Date(nowMs - 60 * 60 * 1000).toISOString();
+
+const baseAttempt: AttemptInfo = {
+  id: "a1",
+  status: "in_progress",
+  startedAt: past,
+  quizId: "q1",
+  userId: "u1",
+};
+
+type Case = {
+  name: string;
+  attempt: AttemptInfo;
+  sessions: SessionInfo[];
+  expected: boolean;
+};
+
+const cases: Case[] = [
+  {
+    name: "status != in_progress は対象外 (submitted)",
+    attempt: { ...baseAttempt, status: "submitted" },
+    sessions: [],
+    expected: false,
+  },
+  {
+    name: "status != in_progress は対象外 (timed_out)",
+    attempt: { ...baseAttempt, status: "timed_out" },
+    sessions: [{ id: "s1", status: "force_exited", deadlineAt: past }],
+    expected: false,
+  },
+  {
+    name: "関連 session 不在 → 対象（孤児 attempt）",
+    attempt: baseAttempt,
+    sessions: [],
+    expected: true,
+  },
+  {
+    name: "全 session が force_exited → 対象",
+    attempt: baseAttempt,
+    sessions: [
+      { id: "s1", status: "force_exited", deadlineAt: past },
+      { id: "s2", status: "force_exited", deadlineAt: past },
+    ],
+    expected: true,
+  },
+  {
+    name: "全 session が abandoned → 対象",
+    attempt: baseAttempt,
+    sessions: [{ id: "s1", status: "abandoned", deadlineAt: past }],
+    expected: true,
+  },
+  {
+    name: "全 session が completed → 対象（active 不在）",
+    attempt: baseAttempt,
+    sessions: [{ id: "s1", status: "completed", deadlineAt: past }],
+    expected: true,
+  },
+  {
+    name: "active session が deadline 内（未来）→ 対象外（まだ使用中）",
+    attempt: baseAttempt,
+    sessions: [{ id: "s1", status: "active", deadlineAt: future }],
+    expected: false,
+  },
+  {
+    name: "active session が deadline 超過 → 対象（期限切れ active）",
+    attempt: baseAttempt,
+    sessions: [{ id: "s1", status: "active", deadlineAt: past }],
+    expected: true,
+  },
+  {
+    name: "active と force_exited が混在、active が deadline 内 → 対象外",
+    attempt: baseAttempt,
+    sessions: [
+      { id: "s1", status: "force_exited", deadlineAt: past },
+      { id: "s2", status: "active", deadlineAt: future },
+    ],
+    expected: false,
+  },
+  {
+    name: "active と force_exited が混在、active が deadline 超過 → 対象",
+    attempt: baseAttempt,
+    sessions: [
+      { id: "s1", status: "force_exited", deadlineAt: past },
+      { id: "s2", status: "active", deadlineAt: past },
+    ],
+    expected: true,
+  },
+];
+
+let pass = 0;
+let fail = 0;
+for (const tc of cases) {
+  try {
+    const actual = isStuckAttempt(tc.attempt, tc.sessions, nowMs);
+    assert.equal(actual, tc.expected, `${tc.name}: expected=${tc.expected} actual=${actual}`);
+    console.log(`  PASS: ${tc.name}`);
+    pass++;
+  } catch (err) {
+    console.error(`  FAIL: ${tc.name}`);
+    console.error(`    ${err instanceof Error ? err.message : err}`);
+    fail++;
+  }
+}
+
+console.log(`\n=== ${pass} passed, ${fail} failed ===`);
+if (fail > 0) process.exit(1);

--- a/scripts/cleanup-stuck-quiz-attempts.ts
+++ b/scripts/cleanup-stuck-quiz-attempts.ts
@@ -1,0 +1,379 @@
+#!/usr/bin/env npx tsx
+/**
+ * 進行中のまま詰まった quiz_attempt の一括救済スクリプト（Issue #422 follow-up）
+ *
+ * 検出ロジック:
+ * 全テナント横断（または指定スコープ内）で以下を満たす quiz_attempt を抽出:
+ *   - status == "in_progress"
+ *   - 関連する lesson_sessions が以下のいずれか:
+ *     - 全 session が終了済み（active が一つもない: force_exited / abandoned / completed）
+ *     - active session の deadlineAt < now（期限切れ active）
+ *     - 関連 session 不在（一度も session が作成されていない）
+ *
+ * 更新内容:
+ *   - status: "timed_out"
+ *   - submittedAt: now
+ *   - その他フィールド (answers / score / isPassed / attemptNumber / startedAt / quizId / userId) は触らない
+ *
+ * 安全機構:
+ *   1. dry-run 既定（--execute で実行）
+ *   2. スコープ絞り込み（--tenant-id / --user-id / --user-email、排他）
+ *   3. 件数アサーション（--max-targets で過剰更新防止、既定 1000）
+ *   4. バックアップ JSON 出力（更新前 attempt の snapshot）
+ *   5. 条件付き更新 transaction（並行更新で submitted になった attempt は上書きしない）
+ *   6. PR #423 で追加した DataSource.transitionQuizAttemptToTimedOut と同等のロジックを admin SDK で実装
+ *
+ * 使用方法:
+ *   # dry-run（全テナント横断、件数 + サンプル表示）
+ *   GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json npx tsx scripts/cleanup-stuck-quiz-attempts.ts
+ *
+ *   # 特定テナントのみ
+ *   npx tsx scripts/cleanup-stuck-quiz-attempts.ts --tenant-id=xxx
+ *
+ *   # 特定ユーザー（email、全テナント検索で解決）
+ *   npx tsx scripts/cleanup-stuck-quiz-attempts.ts --user-email=foo@bar.com
+ *
+ *   # 実行
+ *   npx tsx scripts/cleanup-stuck-quiz-attempts.ts --execute
+ */
+
+import {
+  initializeApp,
+  cert,
+  applicationDefault,
+  type ServiceAccount,
+} from "firebase-admin/app";
+import { getFirestore, type Firestore } from "firebase-admin/firestore";
+import { readFileSync, writeFileSync } from "fs";
+import { resolve } from "path";
+
+// ============================================================
+// 純粋関数（smoke test 対象）
+// ============================================================
+
+export interface AttemptInfo {
+  id: string;
+  status: string;
+  startedAt: string;
+  quizId: string;
+  userId: string;
+}
+
+export interface SessionInfo {
+  id: string;
+  status: string;
+  deadlineAt: string;
+}
+
+/**
+ * 救済対象判定（純粋関数）
+ * - status != "in_progress" は対象外
+ * - 関連 session 不在 → 対象（孤児 attempt）
+ * - 全 session が非 active → 対象（session 終了済み）
+ * - active session の deadlineAt < now → 対象（期限切れ active）
+ */
+export function isStuckAttempt(
+  attempt: AttemptInfo,
+  relatedSessions: SessionInfo[],
+  nowMs: number
+): boolean {
+  if (attempt.status !== "in_progress") return false;
+  if (relatedSessions.length === 0) return true;
+
+  const activeSessions = relatedSessions.filter((s) => s.status === "active");
+  if (activeSessions.length === 0) return true;
+
+  // active がある場合、すべて期限切れなら対象
+  return activeSessions.every((s) => new Date(s.deadlineAt).getTime() < nowMs);
+}
+
+// ============================================================
+// CLI 引数パース（top-level）
+// ============================================================
+
+const KNOWN_FLAGS = [
+  "--execute",
+  "--tenant-id=",
+  "--user-id=",
+  "--user-email=",
+  "--max-targets=",
+  "--no-backup",
+];
+
+// テスト import 時の副作用回避: main 実行は明示エントリーポイントで分岐
+const isMainEntry = import.meta.url === `file://${process.argv[1]}`;
+
+if (isMainEntry) {
+  void runCli();
+}
+
+async function runCli(): Promise<void> {
+  const args = process.argv.slice(2);
+  const unknownArgs = args.filter(
+    (a) => !KNOWN_FLAGS.some((k) => a === k || a.startsWith(k))
+  );
+  if (unknownArgs.length > 0) {
+    console.error(`[FATAL] 未知のフラグ: ${unknownArgs.join(", ")}`);
+    console.error(`  既知のフラグ: ${KNOWN_FLAGS.join(" / ")}`);
+    process.exit(1);
+  }
+
+  const execute = args.includes("--execute");
+  const tenantId = args.find((a) => a.startsWith("--tenant-id="))?.split("=")[1];
+  const userId = args.find((a) => a.startsWith("--user-id="))?.split("=")[1];
+  const userEmail = args
+    .find((a) => a.startsWith("--user-email="))
+    ?.split("=")[1]
+    ?.trim()
+    .toLowerCase();
+  const noBackup = args.includes("--no-backup");
+
+  const rawMaxTargets = args
+    .find((a) => a.startsWith("--max-targets="))
+    ?.split("=")[1];
+  const maxTargets = rawMaxTargets !== undefined ? Number(rawMaxTargets) : 1000;
+  if (!Number.isFinite(maxTargets) || maxTargets < 1) {
+    console.error(
+      `[FATAL] --max-targets は 1 以上の数値が必要です: 受け取った値="${rawMaxTargets}"`
+    );
+    process.exit(1);
+  }
+
+  if (userId && userEmail) {
+    console.error("[FATAL] --user-id と --user-email は同時指定できません");
+    process.exit(1);
+  }
+
+  // Firebase 初期化
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  try {
+    if (credPath) {
+      const jsonPath = resolve(process.cwd(), credPath);
+      const serviceAccount = JSON.parse(
+        readFileSync(jsonPath, "utf8")
+      ) as ServiceAccount;
+      initializeApp({ credential: cert(serviceAccount) });
+      console.log(`認証: サービスアカウントJSON (${jsonPath})`);
+    } else {
+      initializeApp({ credential: applicationDefault() });
+      console.log("認証: Application Default Credentials");
+    }
+  } catch (err) {
+    console.error(
+      `[FATAL] Firebase初期化失敗: ${err instanceof Error ? err.message : err}`
+    );
+    process.exit(1);
+  }
+
+  const db = getFirestore();
+
+  console.log("=== 進行中 quiz_attempt 一括救済 ===");
+  console.log(`モード: ${execute ? "EXECUTE（実更新）" : "DRY-RUN（レポートのみ）"}`);
+  console.log(`スコープ: tenant=${tenantId ?? "ALL"} userId=${userId ?? "-"} userEmail=${userEmail ?? "-"}`);
+  console.log(`最大対象件数: ${maxTargets}`);
+  console.log(`バックアップ: ${noBackup ? "無効" : "有効"}\n`);
+
+  // ユーザー解決（--user-email 指定時）
+  let scopedUserId = userId;
+  let scopedTenantId = tenantId;
+  if (userEmail) {
+    const resolved = await resolveUserIdFromEmail(db, userEmail, scopedTenantId);
+    if (!resolved) {
+      console.error(`[FATAL] ユーザーが見つかりません: ${userEmail}`);
+      process.exit(1);
+    }
+    scopedUserId = resolved.userId;
+    scopedTenantId = resolved.tenantId;
+    console.log(
+      `ユーザー解決: ${userEmail} → tenantId=${scopedTenantId} userId=${scopedUserId}\n`
+    );
+  }
+
+  // 対象テナント一覧
+  const tenantsSnap = await db.collection("tenants").get();
+  if (tenantsSnap.empty) {
+    console.error("[FATAL] tenants コレクションが空です。権限/プロジェクトID 確認してください。");
+    process.exit(1);
+  }
+  const tenantIds = scopedTenantId
+    ? [scopedTenantId]
+    : tenantsSnap.docs.map((d) => d.id);
+
+  // 抽出
+  const stuckList = await findStuckAttempts(db, tenantIds, scopedUserId);
+  console.log(`\n=== 抽出結果 ===`);
+  console.log(`救済対象: ${stuckList.length} 件`);
+
+  if (stuckList.length === 0) {
+    console.log("救済対象なし");
+    return;
+  }
+
+  // バックアップ
+  if (!noBackup) {
+    const backupPath = `cleanup-stuck-backup-${Date.now()}.json`;
+    writeFileSync(backupPath, JSON.stringify(stuckList, null, 2));
+    console.log(`バックアップ: ${backupPath}`);
+  }
+
+  // 件数アサーション
+  if (stuckList.length > maxTargets) {
+    console.error(
+      `[FATAL] 救済対象が ${maxTargets} 件を超えています (${stuckList.length} 件)`
+    );
+    console.error("  --max-targets で上限を上げるか、--tenant-id/--user-id でスコープ絞り込みしてください");
+    process.exit(1);
+  }
+
+  // サンプル表示
+  console.log("\n=== サンプル（最大10件） ===");
+  for (const { tenantId: tid, attempt, sessions } of stuckList.slice(0, 10)) {
+    console.log(
+      `  tenant=${tid} attempt=${attempt.id} user=${attempt.userId} quiz=${attempt.quizId} sessions=${sessions.length}`
+    );
+  }
+
+  if (!execute) {
+    console.log("\nDRY-RUN: --execute で実行");
+    return;
+  }
+
+  // 実行
+  console.log("\n=== 実行 ===");
+  let cleaned = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const { tenantId: tid, attempt } of stuckList) {
+    const ref = db.collection(`tenants/${tid}/quiz_attempts`).doc(attempt.id);
+    try {
+      const result = await db.runTransaction(async (tx) => {
+        const doc = await tx.get(ref);
+        if (!doc.exists) return "skipped";
+        const current = doc.data()!;
+        if (current.status !== "in_progress") return "skipped";
+        tx.update(ref, {
+          status: "timed_out",
+          submittedAt: new Date().toISOString(),
+        });
+        return "cleaned";
+      });
+      if (result === "cleaned") cleaned++;
+      else skipped++;
+    } catch (err) {
+      failed++;
+      console.error(
+        `  失敗: tenant=${tid} attempt=${attempt.id}: ${err instanceof Error ? err.message : err}`
+      );
+    }
+  }
+
+  console.log(`\n=== 完了 ===`);
+  console.log(`  cleaned: ${cleaned}`);
+  console.log(`  skipped: ${skipped} (並行更新等で in_progress でなくなっていたもの)`);
+  console.log(`  failed:  ${failed}`);
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+// ============================================================
+// Firestore 連携（dry-run と execute で共通）
+// ============================================================
+
+async function resolveUserIdFromEmail(
+  db: Firestore,
+  email: string,
+  tenantId?: string
+): Promise<{ userId: string; tenantId: string } | null> {
+  const tenants = tenantId
+    ? [tenantId]
+    : (await db.collection("tenants").get()).docs.map((d) => d.id);
+  for (const tid of tenants) {
+    const snap = await db
+      .collection(`tenants/${tid}/users`)
+      .where("email", "==", email)
+      .limit(1)
+      .get();
+    if (!snap.empty) {
+      return { userId: snap.docs[0].id, tenantId: tid };
+    }
+  }
+  return null;
+}
+
+interface StuckEntry {
+  tenantId: string;
+  attempt: AttemptInfo;
+  sessions: SessionInfo[];
+}
+
+async function findStuckAttempts(
+  db: Firestore,
+  tenantIds: string[],
+  scopedUserId?: string
+): Promise<StuckEntry[]> {
+  const result: StuckEntry[] = [];
+  const nowMs = Date.now();
+
+  for (const tid of tenantIds) {
+    let attemptsQuery = db
+      .collection(`tenants/${tid}/quiz_attempts`)
+      .where("status", "==", "in_progress");
+    if (scopedUserId) {
+      attemptsQuery = attemptsQuery.where("userId", "==", scopedUserId);
+    }
+    const attemptsSnap = await attemptsQuery.get();
+    if (attemptsSnap.empty) continue;
+
+    for (const doc of attemptsSnap.docs) {
+      const data = doc.data();
+      const attempt: AttemptInfo = {
+        id: doc.id,
+        status: data.status,
+        startedAt: data.startedAt,
+        quizId: data.quizId,
+        userId: data.userId,
+      };
+
+      // quiz から lessonId を解決
+      const quizDoc = await db
+        .collection(`tenants/${tid}/quizzes`)
+        .doc(attempt.quizId)
+        .get();
+
+      // quiz 削除済み → 関連 session なし扱いで救済対象
+      if (!quizDoc.exists) {
+        if (isStuckAttempt(attempt, [], nowMs)) {
+          result.push({ tenantId: tid, attempt, sessions: [] });
+        }
+        continue;
+      }
+
+      const lessonId = quizDoc.data()!.lessonId as string;
+
+      // 関連 sessions 取得
+      const sessionsSnap = await db
+        .collection(`tenants/${tid}/lesson_sessions`)
+        .where("userId", "==", attempt.userId)
+        .where("lessonId", "==", lessonId)
+        .get();
+
+      const sessions: SessionInfo[] = sessionsSnap.docs.map((d) => {
+        const sd = d.data();
+        return {
+          id: d.id,
+          status: sd.status,
+          deadlineAt: sd.deadlineAt,
+        };
+      });
+
+      if (isStuckAttempt(attempt, sessions, nowMs)) {
+        result.push({ tenantId: tid, attempt, sessions });
+      }
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- PR #423 で「これから発生する詰まり」は防げるようになったが、**既に詰まっているユーザーは自動回復しない**ため、admin SDK 経由の救済 workflow を追加
- 個別救済（`--user-email` でピンポイント）と一括救済（全テナント横断）を同一スクリプトで兼用
- 緊急対応とリグレッション検出を同一基盤で

## 検出ロジック

`quiz_attempts.status == "in_progress"` かつ関連 `lesson_sessions` が以下のいずれか:

| ケース | 例 |
|--------|-----|
| 全 session 非 active | force_exited / abandoned / completed のみ |
| active session の deadlineAt < now | 期限切れ active |
| 関連 session 不在 | quiz 削除済み等の孤児 attempt |

## 更新内容

- `status: "timed_out"`
- `submittedAt: now`
- `answers / score / isPassed / attemptNumber / startedAt / quizId / userId` は保持（監査証跡）

PR #423 で追加した `DataSource.transitionQuizAttemptToTimedOut` と同等のロジックを admin SDK の Firestore transaction で実装し、並行更新で `submitted` になった attempt の上書きを防ぐ（TOCTOU 安全）。

## 安全機構

| # | 機構 | 目的 |
|---|------|------|
| 1 | dry-run 既定（`--execute` で apply） | 誤実行防止 |
| 2 | スコープ絞り込み（`--tenant-id` / `--user-email` / `--user-id`、排他） | 影響範囲限定 |
| 3 | 件数アサーション（`--max-targets`、既定 1000） | 過剰更新中断 |
| 4 | バックアップ JSON 出力 + artifact 保存（30日） | ロールバック準備 |
| 5 | 未知フラグ検知 | typo silent failure 防止 |
| 6 | tenants 空 → 中断 | 異常事態検知 |

## ファイル

| ファイル | 役割 |
|---------|------|
| `scripts/cleanup-stuck-quiz-attempts.ts` | 純粋関数 `isStuckAttempt` + CLI 実装 |
| `scripts/__tests__/cleanup-stuck-quiz-attempts.smoke.ts` | 境界テスト 10 ケース |
| `.github/workflows/cleanup-stuck-quiz-attempts.yml` | `workflow_dispatch` + WIF。inputs は env 経由でコマンドインジェクション対策 |

## 使い方

### GitHub UI から
Actions > **Cleanup Stuck Quiz Attempts** > Run workflow

- 入力未指定: dry-run（全テナント横断、件数 + サンプル表示）
- `execute=true`: 実更新
- `user_email=foo@bar.com`: 特定ユーザー個別救済
- `tenant_id=xxx`: 特定テナントに限定

### ローカル CLI から
```bash
# dry-run
GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json npx tsx scripts/cleanup-stuck-quiz-attempts.ts

# 特定ユーザー
npx tsx scripts/cleanup-stuck-quiz-attempts.ts --user-email=foo@bar.com

# 実行
npx tsx scripts/cleanup-stuck-quiz-attempts.ts --execute
```

## Test plan

- [x] `npx tsx scripts/__tests__/cleanup-stuck-quiz-attempts.smoke.ts` PASS (10/10)
- [x] `npm run test:scripts` PASS（既存 smoke test と合わせて 19/19）
- [x] `npm run type-check` PASS
- [x] `npm run lint` 既存 warning 1件のみ（無関係）
- [ ] CI 完走確認
- [ ] **マージ後、本番で dry-run 実行 → 件数確認**（番号単位の認可後）
- [ ] **問題なければ apply 実行**（dry-run 結果と件数アサーション確認後、別途認可）

## マージ後の運用フロー

1. **dry-run 全テナント**: 詰まっているユーザー総数を把握
2. **問い合わせユーザー個別救済**: `user_email` 指定で先行救済
3. **dry-run 結果に応じて一括救済 apply**: 件数妥当性を decision-maker が判断後

## Refs

- Refs #422
- 関連: PR #423（恒久対応の発生源修正）
- Codex 設計レビュー（threadId: 019e3ddb-5f9f-7491-a912-5efed807b964）

🤖 Generated with [Claude Code](https://claude.com/claude-code)