### PR TITLE
fix(workflow): cleanup-stuck-quiz-attempts に npm ci ステップ追加

### DIFF
--- a/.github/workflows/cleanup-stuck-quiz-attempts.yml
+++ b/.github/workflows/cleanup-stuck-quiz-attempts.yml
@@ -56,9 +56,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3


### PR DESCRIPTION
## Summary

PR #426 の dry-run 実行で以下のエラー発生:
\`\`\`
Error: Cannot find module 'firebase-admin/app'
\`\`\`

\`scripts/\` は npm workspace 外のため、ルート依存（hoist 先）を \`npm ci\` でインストールしないと require が解決できない。

## 修正内容

既存 \`ci.yml\` と同パターンで以下を追加:
- \`actions/setup-node@v6\` + \`cache: 'npm'\`
- \`Install dependencies\` ステップで \`npm ci\`

## Test plan

- [ ] CI 完走確認
- [ ] マージ後 dry-run 再実行 → firebase-admin 解決 + 件数出力確認

## Refs

- Refs #422
- 修正対象: PR #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)