### PR TITLE
fix(scripts): cleanup-stuck-quiz-attempts を WIF (external_account) 認証に対応

### DIFF
--- a/scripts/cleanup-stuck-quiz-attempts.ts
+++ b/scripts/cleanup-stuck-quiz-attempts.ts
@@ -145,15 +145,27 @@ async function runCli(): Promise<void> {
   }
 
   // Firebase 初期化
+  // GOOGLE_APPLICATION_CREDENTIALS には以下のいずれかが入り得る:
+  //   1. type=service_account の JSON（ローカル開発時のサービスアカウントキー）→ cert() で初期化
+  //   2. type=external_account の JSON（GitHub Actions WIF 経由）→ applicationDefault() で初期化
+  // type を読まずに cert() を使うと WIF JSON で "project_id" property エラーになる
   const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
   try {
     if (credPath) {
       const jsonPath = resolve(process.cwd(), credPath);
-      const serviceAccount = JSON.parse(
-        readFileSync(jsonPath, "utf8")
-      ) as ServiceAccount;
-      initializeApp({ credential: cert(serviceAccount) });
-      console.log(`認証: サービスアカウントJSON (${jsonPath})`);
+      const credJson = JSON.parse(readFileSync(jsonPath, "utf8")) as {
+        type?: string;
+      };
+      if (credJson.type === "service_account") {
+        initializeApp({ credential: cert(credJson as ServiceAccount) });
+        console.log(`認証: サービスアカウントJSON (${jsonPath})`);
+      } else {
+        // External Account (WIF) は ADC 経由で初期化する
+        initializeApp({ credential: applicationDefault() });
+        console.log(
+          `認証: Application Default Credentials (cred file type=${credJson.type ?? "unknown"})`
+        );
+      }
     } else {
       initializeApp({ credential: applicationDefault() });
       console.log("認証: Application Default Credentials");


### PR DESCRIPTION
## Summary

PR #426 の dry-run 2 回目失敗対応:
\`\`\`
[FATAL] Firebase初期化失敗: Service account object must contain a string "project_id" property.
\`\`\`

## 原因

GitHub Actions Workload Identity Federation 経由で実行すると、\`google-github-actions/auth\` が書き出す \`GOOGLE_APPLICATION_CREDENTIALS\` は **type=external_account** の JSON。これを \`cert()\` に渡すと service_account JSON 期待のため失敗する。

## 修正

JSON の \`type\` フィールドで分岐:
- \`type=service_account\` → \`cert()\` で初期化（ローカル開発時のサービスアカウントキー）
- \`type=external_account\` 等 → \`applicationDefault()\` で初期化（WIF 経由）
- credPath 未設定 → \`applicationDefault()\`（ADC）

## Test plan

- [x] \`npm run test:scripts\` PASS（境界テスト全 PASS）
- [x] \`npm run type-check\` PASS
- [ ] CI 完走確認
- [ ] マージ後 dry-run 3回目実行 → 認証成功 + 件数出力確認

## 既存スクリプトとの違い

\`cleanup-orphan-auth-users.ts\` 等の既存スクリプトは type 判別をしていないが、それらは workflow から呼ばれない（ローカル CLI 実行のみ）ため WIF の問題に当たっていない。本 PR の修正パターンは将来 admin スクリプトを workflow 化する際の参考にもなる。

## Refs

- Refs #422
- 修正対象: PR #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)