### PR TITLE
feat(scripts): tenant auth_error_logs サマリ調査用 read-only workflow

### DIFF
--- a/.github/workflows/audit-tenant-auth-errors.yml
+++ b/.github/workflows/audit-tenant-auth-errors.yml
@@ -1,0 +1,84 @@
+name: Audit Tenant Auth Errors
+
+# tenant 配下の auth_error_logs を直近 N 時間で集計し、reason 別件数と
+# (email_filter_domain 指定時のみ) email 別件数を表示する切り分け workflow。
+#
+# 用途:
+#   audit-allowlist-status で「対象 email では拒否ログ 0 件」と判明したとき、
+#   別 email で拒否されている可能性を切り分ける（個人 Gmail で試している等）。
+#
+# 安全機構:
+#   - read-only スクリプト（書き込み一切なし）
+#   - tenant_id 入力必須
+#   - email 別表示は email_filter_domain 指定時に限定（PII 漏洩防止）
+#
+# セキュリティ: workflow_dispatch 入力はすべて env 経由で受け、run: 内で直接 inputs を
+# 補間しない（command injection 対策）。
+# 参考: https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+
+on:
+  workflow_dispatch:
+    inputs:
+      tenant_id:
+        description: 'テナント ID（必須）例: atali82i'
+        required: true
+        type: string
+      since_hours:
+        description: 'auth_error_logs を遡る時間（既定 72 時間、最大 720 時間=30 日）'
+        required: false
+        default: '72'
+        type: string
+      email_filter_domain:
+        description: 'email 別件数を表示する domain。例: fuku-no-tane.com。未指定なら reason 別のみ表示'
+        required: false
+        default: ''
+        type: string
+      top_emails:
+        description: 'email 別の上位件数（既定 20、最大 200）'
+        required: false
+        default: '20'
+        type: string
+
+jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      FIREBASE_PROJECT_ID: lms-279
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/1034821634012/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-actions@lms-279.iam.gserviceaccount.com
+
+      - name: Run audit script
+        env:
+          GOOGLE_CLOUD_PROJECT: lms-279
+          TENANT_ID: ${{ inputs.tenant_id }}
+          SINCE_HOURS: ${{ inputs.since_hours }}
+          EMAIL_FILTER_DOMAIN: ${{ inputs.email_filter_domain }}
+          TOP_EMAILS: ${{ inputs.top_emails }}
+        run: |
+          set -euo pipefail
+          FLAGS=("--tenant-id=$TENANT_ID")
+          if [ -n "$SINCE_HOURS" ]; then FLAGS+=("--since-hours=$SINCE_HOURS"); fi
+          if [ -n "$EMAIL_FILTER_DOMAIN" ]; then FLAGS+=("--email-filter-domain=$EMAIL_FILTER_DOMAIN"); fi
+          if [ -n "$TOP_EMAILS" ]; then FLAGS+=("--top-emails=$TOP_EMAILS"); fi
+          echo "Running with tenant=$TENANT_ID since-hours=$SINCE_HOURS domain=${EMAIL_FILTER_DOMAIN:-(none)} top-emails=$TOP_EMAILS"
+          npx tsx scripts/audit-tenant-auth-errors.ts "${FLAGS[@]}"

--- a/scripts/__tests__/audit-tenant-auth-errors.smoke.ts
+++ b/scripts/__tests__/audit-tenant-auth-errors.smoke.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env npx tsx
+/**
+ * `scripts/audit-tenant-auth-errors.ts#aggregateLogs` の smoke test。
+ *
+ * 実行方法:
+ *   npx tsx scripts/__tests__/audit-tenant-auth-errors.smoke.ts
+ */
+
+import assert from "node:assert/strict";
+import { aggregateLogs, type RawLog } from "../audit-tenant-auth-errors.ts";
+
+const ts = "2026-05-19T00:00:00.000Z";
+const log = (email: string | null, reason: string | null): RawLog => ({
+  email,
+  reason,
+  occurredAt: ts,
+});
+
+// --- domain フィルタなし: reason のみ集計、email は空 ---
+{
+  const s = aggregateLogs(
+    [
+      log("a@x.com", "not_in_allowlist"),
+      log("b@x.com", "not_in_allowlist"),
+      log("c@x.com", "email_not_verified"),
+    ],
+    null,
+    10
+  );
+  assert.equal(s.totalLogs, 3);
+  assert.deepEqual(s.reasonCounts, [
+    { reason: "not_in_allowlist", count: 2 },
+    { reason: "email_not_verified", count: 1 },
+  ]);
+  assert.deepEqual(s.filteredEmailCounts, []);
+  assert.equal(s.filteredEmailTruncated, 0);
+  assert.equal(s.filteredEmailUniqueCount, 0);
+}
+
+// --- reason null は (missing) として集計 ---
+{
+  const s = aggregateLogs([log("a@x.com", null)], null, 10);
+  assert.deepEqual(s.reasonCounts, [{ reason: "(missing)", count: 1 }]);
+}
+
+// --- domain フィルタあり: 該当 email のみ集計、降順 ---
+{
+  const s = aggregateLogs(
+    [
+      log("a@fuku.com", "not_in_allowlist"),
+      log("b@fuku.com", "not_in_allowlist"),
+      log("a@fuku.com", "email_not_verified"),
+      log("x@other.com", "not_in_allowlist"),
+      log(null, "not_in_allowlist"),
+    ],
+    "fuku.com",
+    10
+  );
+  assert.equal(s.totalLogs, 5);
+  // reason 全件集計
+  assert.deepEqual(s.reasonCounts, [
+    { reason: "not_in_allowlist", count: 4 },
+    { reason: "email_not_verified", count: 1 },
+  ]);
+  // email は fuku.com のみ、降順
+  assert.deepEqual(s.filteredEmailCounts, [
+    { email: "a@fuku.com", count: 2 },
+    { email: "b@fuku.com", count: 1 },
+  ]);
+  assert.equal(s.filteredEmailUniqueCount, 2);
+  assert.equal(s.filteredEmailTruncated, 0);
+}
+
+// --- top-emails で truncate ---
+{
+  const logs: RawLog[] = [];
+  for (let i = 0; i < 5; i++) logs.push(log(`u${i}@fuku.com`, "not_in_allowlist"));
+  // u0 は 3 件、u1 は 2 件 にして、件数順を検証する
+  logs.push(log("u0@fuku.com", "not_in_allowlist"));
+  logs.push(log("u0@fuku.com", "not_in_allowlist"));
+  logs.push(log("u1@fuku.com", "not_in_allowlist"));
+
+  const s = aggregateLogs(logs, "fuku.com", 2);
+  assert.equal(s.filteredEmailUniqueCount, 5);
+  assert.deepEqual(s.filteredEmailCounts, [
+    { email: "u0@fuku.com", count: 3 },
+    { email: "u1@fuku.com", count: 2 },
+  ]);
+  assert.equal(s.filteredEmailTruncated, 3);
+}
+
+// --- email 大文字/空白は trim+lowercase で同一エントリに集約 ---
+{
+  const s = aggregateLogs(
+    [
+      log("A@Fuku.com", "not_in_allowlist"),
+      log(" a@fuku.com ", "not_in_allowlist"),
+      log("a@fuku.com", "not_in_allowlist"),
+    ],
+    "fuku.com",
+    10
+  );
+  assert.equal(s.filteredEmailUniqueCount, 1);
+  assert.deepEqual(s.filteredEmailCounts, [
+    { email: "a@fuku.com", count: 3 },
+  ]);
+}
+
+// --- 該当 domain なし ---
+{
+  const s = aggregateLogs(
+    [log("x@other.com", "not_in_allowlist")],
+    "fuku.com",
+    10
+  );
+  assert.deepEqual(s.filteredEmailCounts, []);
+  assert.equal(s.filteredEmailUniqueCount, 0);
+  assert.equal(s.filteredEmailTruncated, 0);
+}
+
+// --- 空配列 ---
+{
+  const s = aggregateLogs([], "fuku.com", 10);
+  assert.equal(s.totalLogs, 0);
+  assert.deepEqual(s.reasonCounts, []);
+  assert.deepEqual(s.filteredEmailCounts, []);
+  assert.equal(s.filteredEmailUniqueCount, 0);
+}
+
+console.log("audit-tenant-auth-errors smoke test: PASS");

--- a/scripts/audit-tenant-auth-errors.ts
+++ b/scripts/audit-tenant-auth-errors.ts
@@ -1,0 +1,316 @@
+#!/usr/bin/env npx tsx
+/**
+ * tenant 配下 auth_error_logs サマリ調査スクリプト（read-only）
+ *
+ * 目的:
+ *   「該当 email では拒否ログが見つからないが、ご本人がログインできないと言っている」
+ *   ケースで、tenant 内の直近 auth_error_logs を集計し、別 email での拒否があるかを切り分ける。
+ *
+ * 安全機構:
+ *   - read-only（書き込み一切なし）
+ *   - tenant_id は必須入力
+ *   - email 別件数は --email-filter-domain 指定時のみ表示（PII 漏洩防止）
+ *     domain 未指定時は reason 別集計のみ
+ *
+ * 使用方法:
+ *   GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json \
+ *     npx tsx scripts/audit-tenant-auth-errors.ts \
+ *     --tenant-id=atali82i \
+ *     --since-hours=720 \
+ *     --email-filter-domain=fuku-no-tane.com \
+ *     --top-emails=20
+ *
+ * 環境変数:
+ *   GOOGLE_APPLICATION_CREDENTIALS  サービスアカウント JSON のパス（WIF 環境では external_account JSON）
+ *   GOOGLE_CLOUD_PROJECT            プロジェクト ID
+ */
+
+import {
+  initializeApp,
+  cert,
+  applicationDefault,
+  type ServiceAccount,
+} from "firebase-admin/app";
+import { getFirestore, type Firestore, Timestamp } from "firebase-admin/firestore";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+// ============================================================
+// 純粋関数（smoke test 対象）
+// ============================================================
+
+export interface RawLog {
+  email: string | null;
+  reason: string | null;
+  occurredAt: string;
+}
+
+export interface AggregatedSummary {
+  totalLogs: number;
+  /** reason → 件数（降順） */
+  reasonCounts: Array<{ reason: string; count: number }>;
+  /** domain でフィルタした後の email → 件数（降順、top N でカット） */
+  filteredEmailCounts: Array<{ email: string; count: number }>;
+  /** domain フィルタ後にカットされた残り件数 */
+  filteredEmailTruncated: number;
+  /** domain にマッチした unique email 数（top で切られても全体数として把握） */
+  filteredEmailUniqueCount: number;
+}
+
+/**
+ * 集計（純粋関数）。domain フィルタ未指定時は filteredEmailCounts は空配列。
+ *
+ * @param logs 取得済みログ
+ * @param emailDomainFilter "fuku-no-tane.com" 等の domain（小文字、@ なし）。null なら email 集計しない。
+ * @param topEmails domain フィルタ後の上位件数。1 以上。
+ */
+export function aggregateLogs(
+  logs: RawLog[],
+  emailDomainFilter: string | null,
+  topEmails: number
+): AggregatedSummary {
+  const reasonMap = new Map<string, number>();
+  for (const log of logs) {
+    const reason = log.reason ?? "(missing)";
+    reasonMap.set(reason, (reasonMap.get(reason) ?? 0) + 1);
+  }
+  const reasonCounts = Array.from(reasonMap.entries())
+    .map(([reason, count]) => ({ reason, count }))
+    .sort((a, b) => b.count - a.count);
+
+  if (!emailDomainFilter) {
+    return {
+      totalLogs: logs.length,
+      reasonCounts,
+      filteredEmailCounts: [],
+      filteredEmailTruncated: 0,
+      filteredEmailUniqueCount: 0,
+    };
+  }
+
+  const suffix = `@${emailDomainFilter}`;
+  const emailMap = new Map<string, number>();
+  for (const log of logs) {
+    const email = log.email?.trim().toLowerCase();
+    if (!email) continue;
+    if (!email.endsWith(suffix)) continue;
+    emailMap.set(email, (emailMap.get(email) ?? 0) + 1);
+  }
+  const allEmailEntries = Array.from(emailMap.entries())
+    .map(([email, count]) => ({ email, count }))
+    .sort((a, b) => b.count - a.count);
+  const filteredEmailCounts = allEmailEntries.slice(0, topEmails);
+  const filteredEmailTruncated = Math.max(
+    0,
+    allEmailEntries.length - filteredEmailCounts.length
+  );
+
+  return {
+    totalLogs: logs.length,
+    reasonCounts,
+    filteredEmailCounts,
+    filteredEmailTruncated,
+    filteredEmailUniqueCount: emailMap.size,
+  };
+}
+
+// ============================================================
+// CLI 引数パース
+// ============================================================
+
+const KNOWN_FLAGS = [
+  "--tenant-id=",
+  "--since-hours=",
+  "--email-filter-domain=",
+  "--top-emails=",
+];
+
+const isMainEntry = import.meta.url === `file://${process.argv[1]}`;
+
+if (isMainEntry) {
+  void runCli();
+}
+
+async function runCli(): Promise<void> {
+  const args = process.argv.slice(2);
+  const unknownArgs = args.filter(
+    (a) => !KNOWN_FLAGS.some((k) => a.startsWith(k))
+  );
+  if (unknownArgs.length > 0) {
+    console.error(`[FATAL] 未知のフラグ: ${unknownArgs.join(", ")}`);
+    console.error(`  既知のフラグ: ${KNOWN_FLAGS.join(" / ")}`);
+    process.exit(1);
+  }
+
+  const tenantId = args
+    .find((a) => a.startsWith("--tenant-id="))
+    ?.split("=")[1];
+  const sinceHoursRaw = args
+    .find((a) => a.startsWith("--since-hours="))
+    ?.split("=")[1];
+  const emailDomainRaw = args
+    .find((a) => a.startsWith("--email-filter-domain="))
+    ?.split("=")[1];
+  const topEmailsRaw = args
+    .find((a) => a.startsWith("--top-emails="))
+    ?.split("=")[1];
+
+  if (!tenantId) {
+    console.error("[FATAL] --tenant-id は必須です");
+    process.exit(1);
+  }
+
+  const sinceHours = sinceHoursRaw ? Number(sinceHoursRaw) : 72;
+  if (!Number.isFinite(sinceHours) || sinceHours <= 0 || sinceHours > 24 * 30) {
+    console.error(
+      `[FATAL] --since-hours は 1〜720 の数値: 受け取った値="${sinceHoursRaw}"`
+    );
+    process.exit(1);
+  }
+
+  const topEmails = topEmailsRaw ? Number(topEmailsRaw) : 20;
+  if (!Number.isFinite(topEmails) || topEmails <= 0 || topEmails > 200) {
+    console.error(
+      `[FATAL] --top-emails は 1〜200 の数値: 受け取った値="${topEmailsRaw}"`
+    );
+    process.exit(1);
+  }
+
+  const emailDomainFilter = emailDomainRaw
+    ? emailDomainRaw.trim().toLowerCase().replace(/^@/, "")
+    : null;
+  if (emailDomainFilter !== null && !/^[a-z0-9.-]+\.[a-z]{2,}$/i.test(emailDomainFilter)) {
+    console.error(
+      `[FATAL] --email-filter-domain の形式が不正: "${emailDomainRaw}"`
+    );
+    process.exit(1);
+  }
+
+  // Firebase 初期化（cleanup-stuck-quiz-attempts.ts と同じ WIF / SA JSON 兼用ロジック）
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  try {
+    if (credPath) {
+      const jsonPath = resolve(process.cwd(), credPath);
+      const credJson = JSON.parse(readFileSync(jsonPath, "utf8")) as {
+        type?: string;
+      };
+      if (credJson.type === "service_account") {
+        initializeApp({ credential: cert(credJson as ServiceAccount) });
+        console.log(`認証: サービスアカウントJSON (${jsonPath})`);
+      } else {
+        initializeApp({ credential: applicationDefault() });
+        console.log(
+          `認証: Application Default Credentials (cred file type=${credJson.type ?? "unknown"})`
+        );
+      }
+    } else {
+      initializeApp({ credential: applicationDefault() });
+      console.log("認証: Application Default Credentials");
+    }
+  } catch (err) {
+    console.error(
+      `[FATAL] Firebase 初期化失敗: ${err instanceof Error ? err.message : err}`
+    );
+    process.exit(1);
+  }
+
+  const db = getFirestore();
+
+  console.log("=== tenant 配下 auth_error_logs サマリ調査 ===");
+  console.log(`tenant: ${tenantId}`);
+  console.log(`参照範囲: 直近 ${sinceHours} 時間`);
+  console.log(
+    `email domain フィルタ: ${emailDomainFilter ?? "(未指定。email 別集計は表示しません)"}`
+  );
+  if (emailDomainFilter) {
+    console.log(`email 別表示上位件数: ${topEmails}`);
+  }
+  console.log();
+
+  const tenantRef = db.collection("tenants").doc(tenantId);
+  const tenantDoc = await tenantRef.get();
+  if (!tenantDoc.exists) {
+    console.error(`[FATAL] tenant not found: ${tenantId}`);
+    process.exit(1);
+  }
+  console.log(`tenant 確認: ${tenantId} (name="${tenantDoc.data()?.name ?? ""}")\n`);
+
+  const since = new Date(Date.now() - sinceHours * 60 * 60 * 1000);
+  const logs = await fetchAllLogsSince(db, tenantId, since);
+  console.log(`取得件数: ${logs.length}\n`);
+
+  const summary = aggregateLogs(logs, emailDomainFilter, topEmails);
+  printSummary(summary, emailDomainFilter);
+}
+
+// ============================================================
+// Firestore 取得（read-only）
+// ============================================================
+
+async function fetchAllLogsSince(
+  db: Firestore,
+  tenantId: string,
+  since: Date
+): Promise<RawLog[]> {
+  const snap = await db
+    .collection(`tenants/${tenantId}/auth_error_logs`)
+    .where("occurredAt", ">=", Timestamp.fromDate(since))
+    .orderBy("occurredAt", "desc")
+    .limit(2000)
+    .get();
+  return snap.docs.map((d) => {
+    const data = d.data() ?? {};
+    const ts = data.occurredAt;
+    const occurredAt =
+      ts instanceof Timestamp
+        ? ts.toDate().toISOString()
+        : typeof ts === "string"
+          ? ts
+          : new Date(0).toISOString();
+    return {
+      email: (data.email as string | undefined) ?? null,
+      reason: (data.reason as string | undefined) ?? null,
+      occurredAt,
+    };
+  });
+}
+
+// ============================================================
+// 出力
+// ============================================================
+
+function printSummary(
+  summary: AggregatedSummary,
+  emailDomainFilter: string | null
+): void {
+  console.log("=== reason 別件数 ===");
+  if (summary.reasonCounts.length === 0) {
+    console.log("  (該当ログなし)");
+  } else {
+    for (const { reason, count } of summary.reasonCounts) {
+      console.log(`  ${count.toString().padStart(5)}  ${reason}`);
+    }
+  }
+  console.log();
+
+  if (!emailDomainFilter) {
+    console.log(
+      "email 別集計: --email-filter-domain 未指定のため表示しません (PII 制限)"
+    );
+    return;
+  }
+
+  console.log(
+    `=== email 別件数 (domain=${emailDomainFilter}, unique=${summary.filteredEmailUniqueCount}) ===`
+  );
+  if (summary.filteredEmailCounts.length === 0) {
+    console.log(`  (該当 domain での拒否ログなし)`);
+  } else {
+    for (const { email, count } of summary.filteredEmailCounts) {
+      console.log(`  ${count.toString().padStart(5)}  ${email}`);
+    }
+    if (summary.filteredEmailTruncated > 0) {
+      console.log(`  ...他 ${summary.filteredEmailTruncated} email 省略`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

PR #430 の `audit-allowlist-status` で「対象 email では拒否ログ 0 件」と判明した際、
**別 email（個人 Gmail 等）で拒否されている可能性**を切り分けるための追加 read-only workflow。

### きっかけ
- 福の種テナント (atali82i) で 2 ユーザーがログイン不可
- PR #430 audit で該当 2 email の拒否ログは直近 30 日 0 件
- 「別 email でログイン試行している」の可能性を残すため、tenant 全体の auth_error_logs を集計する手段が必要

### 設計
- 既存 `audit-allowlist-status.yml` の WIF + CI SA パターンを踏襲
- read-only（書き込み一切なし）
- 入力: `tenant_id` (必須), `since_hours` (既定 72, 最大 720), `email_filter_domain` (省略可), `top_emails` (既定 20, 最大 200)
- 出力:
  - reason 別件数（常時）
  - email 別件数（`email_filter_domain` 指定時のみ、PII 漏洩防止）
- domain 形式バリデーション
- top_emails で truncate、unique 数も併記

### 純粋関数の smoke test
- domain フィルタなし / null reason / domain あり降順 / top で truncate / 大文字小文字・空白の正規化 / 該当 domain なし / 空配列
- 7 ケース、全 PASS 確認済

## Test plan

- [x] `npx tsx scripts/__tests__/audit-tenant-auth-errors.smoke.ts` → PASS
- [x] `npm run test:scripts` → 4 ファイル全 PASS
- [x] `npm run type-check` → 全 workspace PASS
- [x] `npm run lint` → 既存 warning のみ (本 PR 由来なし)
- [ ] **マージ後**: GitHub Actions UI から workflow_dispatch で実行
  - tenant_id=atali82i
  - since_hours=720
  - email_filter_domain=fuku-no-tane.com
  - top_emails=20

## 安全性

- read-only (Firestore への書き込みなし)
- workflow_dispatch のみ
- 入力は env 経由、run: で直接 \${{ inputs.* }} 補間なし (command injection 対策)
- email 別表示は domain フィルタ指定必須 → 不特定多数の email 漏洩を防ぐ

🤖 Generated with [Claude Code](https://claude.com/claude-code)