### PR TITLE
docs(handoff): Session 35 (2026-05-19) ハンドオフ記録 + Session 34 archive

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,14 +1,14 @@
-# Session Handoff — 2026-05-19 (Session 34)
+# Session Handoff — 2026-05-19 (Session 35)
 
 ## TL;DR
 
-**現場フィードバック対応セッション (テスト詰まりバグ救済)。** 受講者から「動画後のテスト解答中に時間切れになり、以降『現在進行中のテストがあります』で詰まる」という問い合わせを受け、コード調査で 5 経路の構造的バグを特定 → Codex セカンドオピニオン (plan) で網羅列挙 → PR #423 で恒久対応 + 5 レビュアー (Codex + 4 agent) 指摘反映 → PR #426 で一括救済 workflow + script 追加 → PR #427/#428 で WIF 認証修正 → 5 詰まりユーザーを一括救済完了 (cleaned 5/5、idempotency 検証 0 件)。
+**現場フィードバック対応セッション 2 連続（福の種テナント atali82i ログイン不可調査）。** 福の種様から「ユーザー管理画面のメールアドレスは正しいのに 2 名がログインできない」との連絡を受け、サーバー側の状態を read-only audit で切り分け → tenant 配下の `users` / `allowed_emails` / `auth_error_logs` を本番 Firestore に直接 read。**結論: サーバー側は正規登録済み、直近 30 日で tenant 全体に拒否ログ 0 件**。原因はクライアント側 or URL 到達前と確定。福の種様への返信文案を提示し本田さん承認、送付準備中（送付は decision-maker 領分）。
 
-- **Issue Net**: **-2** (起票 3 / Close 1)
-- **Open 推移**: Session 33 末 4 件 → Session 34 末 **6 件** (#424 #425 が新規 active、#422 起票後即 close)
-- **マージ済み PR (4 本)**: #423 (恒久対応, +311/-3 services/api), #426 (救済 workflow, +600), #427 (npm ci 追加, +5/-1), #428 (WIF 認証, +17/-5)
-- **救済結果**: 5 ユーザー (8vexhzpc 3 + qos4c4ka 2 ユーザー分) を `in_progress → timed_out` で再受験可能化、dry-run 再実行で 0 件確認 (idempotency)
-- **本番反映**: ✅ Cloud Run デプロイ完了、bugfix + 救済 workflow ともに稼働中
+- **Issue Net**: **0** (起票 0 / Close 0)
+- **Open 推移**: Session 34 末 6 件 → Session 35 末 **6 件** (変化なし)
+- **マージ済み PR (2 本)**: #430 (audit-allowlist-status workflow, +682/-0), #431 (audit-tenant-auth-errors workflow, +530/-0)
+- **本番反映**: ✅ 両 workflow とも main にマージ済、read-only のため Cloud Run デプロイ不要
+- **調査結果**: 該当 2 email (`y-mizuno@fuku-no-tane.com` / `c-yazawa@fuku-no-tane.com`) ともに `users` / `allowed_emails` 正規登録済み、firebaseUid 未紐付け（初回ログイン未完了）、直近 30 日の拒否ログ 0 件
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -20,128 +20,127 @@ cat docs/handoff/LATEST.md
 git fetch origin main && git log --oneline -10 origin/main
 gh run list --branch main --limit 5
 
-# 3. 現在の OPEN Issue (6 件)
+# 3. 現在の OPEN Issue (6 件、Session 34 から不変)
 gh issue list --state open --limit 15
-#  → #424 / #425: Session 34 で本セッション follow-up として起票 (active)
-#  → #274 / #275 / #276 (Phase 3 GCIP 完了が再開条件、postponed)
-#  → #405 (Phase 2 filename strict MTA risk、Session 27 起票、postponed)
 
 # 4. 次の着手候補:
-#    A. 【ユーザー判断】問い合わせユーザーへの返信送信 (本セッション未送信)
-#       - 返信文面ドラフトは Session 34 末で提示済 (本ファイル末尾)
-#       - 8vexhzpc / qos4c4ka テナントの該当ユーザーが対象 (個別特定済)
-#    B. 【active Issue】#424 PATCH /quiz-attempts セッション再確認の abandoned 未対応 (Codex M2)
-#       - rating: medium、レアケースだが #422 修正で発生確率 ↑
-#       - 修正案は Issue body 記載
+#    A. 【ユーザー判断・最優先】福の種様への返信送信状況確認 + 返信受領時の追加切り分け
+#       - 返信文面は Session 35 で本田さん承認済（本ファイル末尾）
+#       - スクショ・URL・ブラウザ情報を受領後、原因切り分け継続
+#    B. 【active Issue】#424 PATCH /quiz-attempts セッション再確認の abandoned 未対応
 #    C. 【active Issue】#425 Firestore transient エラー用リトライ共通ユーティリティ
-#       - silent-failure-hunter I-2 指摘、設計案は Issue body 記載
-#    D. 【postponed】#272 Phase 3 GCIP 移行 — 再評価期限 2026-10-24
-#    E. 【postponed・着手不可】#276 / #275 / #274 / #405 — 明示指示なき限り着手不可
+#    D. 【postponed・着手不可】#276 / #275 / #274 / #405 — 明示指示なき限り着手不可
+
+# 5. 福の種様調査の再 audit が必要な場合（参考コマンド）
+gh workflow run audit-allowlist-status.yml \
+  -f tenant_id=atali82i \
+  -f emails="y-mizuno@fuku-no-tane.com,c-yazawa@fuku-no-tane.com" \
+  -f since_hours=720
+
+gh workflow run audit-tenant-auth-errors.yml \
+  -f tenant_id=atali82i \
+  -f since_hours=720 \
+  -f email_filter_domain=fuku-no-tane.com
 ```
 
 ---
 
-## セッション成果物 (2026-05-19 Session 34)
+## セッション成果物 (2026-05-19 Session 35)
 
-### 🟢 PR #423 マージ: bugfix 恒久対応 (Issue #422)
+### 🟢 PR #430 マージ: 特定 email の登録状態確認 audit (read-only)
 
-- マージコミット: `ebd7ad9` (squash)
-- ファイル: 6 (lesson-session.ts + datasource interface/firestore/in-memory + 2 test files)
-- 差分: +527 / -3
-- CI: Build / Lint / Type Check / Test 4/4 PASS、Deploy to Cloud Run success
-
-#### 根本原因
-`forceExitSession` / `abandonSession` は session status を更新するが、関連 quiz_attempt の status を `in_progress` のまま残置。動画完了済み (`sessionVideoCompleted=true`) 経路では `resetLessonDataForUser` がスキップされ、attempt 削除も発火しない → 次回 POST /quizzes/:id/attempts が `409 attempt_in_progress` で永続的に失敗。
-
-#### 影響経路 (5 経路、Codex plan で網羅列挙)
-1. 解答中に session 期限超過 (PATCH /quiz-attempts/:id time_limit 分岐)
-2. リロード時の stale session 検出 (handleStaleSession)
-3. 別端末再入室時の新 session 作成
-4. 明示的 force-exit API
-5. ブラウザクローズ abandon (特に timeLimitSec=null quiz)
-
-#### 修正方針 (案 D 採用)
-`cleanupInProgressAttempts` 共通ヘルパーを `forceExitSession` / `abandonSession` から呼ぶ。動画完了データ保護 (reset スキップ) と attempt ロック解除を別責務として分離。5 経路すべてを発生源で解決。
-
-#### レビュー反映 Critical/Important 13 件
-- TOCTOU 対策: `DataSource.transitionQuizAttemptToTimedOut` 条件付き更新 API 追加 (Firestore は transaction、InMemory は同等のチェック付き更新)
-- 構造化ログ統一 (`console.error` → `logger.error`)、errorType 5 種定義
-- `quiz === null` early return → warn ログで観測可能化 (Issue #422 再生産経路を消去)
-- 部分失敗カウンタ + サマリログ
-- テスト名「path 5」→ 意味ベース表記
-- route-level テスト (経路 1: PATCH time_limit) + エラーパステスト追加
-- forceExitSession の updated! non-null assertion → 明示ガード
-- reset 経路では cleanup を skip (追加 DB クエリ削減)
-- maxAttempts 除外不変条件テスト + video_analytics 保護回帰テスト + TOCTOU 安全性テスト追加
-
-### 🟢 PR #426 マージ: 一括救済 workflow + script 追加
-
-- マージコミット: `ebfc35d`
+- マージコミット: `1db86e9` (squash)
 - ファイル: 3 (script + smoke test + workflow yaml)
-- 差分: +600 / -0
+- 差分: +682 / -0
+- CI: Build / Lint / Type Check / Test 4/4 PASS
 
 #### 構成
-- `scripts/cleanup-stuck-quiz-attempts.ts`: 純粋関数 `isStuckAttempt` + admin SDK CLI (dry-run 既定、scope 絞り込み、件数アサーション、バックアップ JSON)
-- `scripts/__tests__/cleanup-stuck-quiz-attempts.smoke.ts`: 境界 10 ケース全 PASS
-- `.github/workflows/cleanup-stuck-quiz-attempts.yml`: workflow_dispatch + WIF、inputs は env 経由でコマンドインジェクション対策
+- `scripts/audit-allowlist-status.ts`: 入力 email 配列について `users` / `allowed_emails` / `auth_error_logs` の状態を表示、純粋関数 `parseEmails` / `computeDiagnosis` / `buildPerEmailReport`
+- `scripts/__tests__/audit-allowlist-status.smoke.ts`: 14 ケース全 PASS
+- `.github/workflows/audit-allowlist-status.yml`: workflow_dispatch + WIF、inputs は env 経由（command injection 対策）
 
-#### 検出ロジック
-`quiz_attempts.status == "in_progress"` かつ関連 `lesson_sessions` が以下のいずれか:
-- 全 session 非 active (force_exited / abandoned / completed)
-- active session の deadlineAt < now (期限切れ active)
-- 関連 session 不在 (孤児 attempt)
+#### 診断ロジック（優先順位）
+1. `recent_auth_error_reason=<reason>`: 直近の auth_error_logs から reason 取得（最優先）
+2. `user_not_found_in_users_collection`
+3. `allowed_email_case_or_whitespace_mismatch`: 完全一致なし + ケース違いあり
+4. `not_in_allowlist_suspected`: allowed_emails に該当なし
+5. `no_firebase_uid_yet_user_has_not_logged_in`: 登録あるが初回ログイン未完了
+6. `no_recent_auth_error_logs_user_may_have_other_issue`: 全て揃っているがログなし
 
-### 🟢 PR #427 マージ: workflow に npm ci 追加
+### 🟢 PR #431 マージ: tenant 全体 auth_error_logs 集計 audit (read-only)
 
-- マージコミット: `35e3c11`
-- 差分: +5 / -1
-- 理由: PR #426 dry-run 1 回目で `Cannot find module 'firebase-admin/app'` → `scripts/` は npm workspace 外、ルート hoist 依存を `npm ci` でインストール必要
+- マージコミット: `242e3e7` (squash)
+- ファイル: 3 (script + smoke test + workflow yaml)
+- 差分: +530 / -0
+- CI: Build / Lint / Type Check / Test 4/4 PASS
 
-### 🟢 PR #428 マージ: WIF (external_account) 認証対応
+#### 構成
+- `scripts/audit-tenant-auth-errors.ts`: tenant 配下 auth_error_logs を直近 N 時間で取得、reason 別件数 + (domain 指定時のみ) email 別件数を集計、純粋関数 `aggregateLogs`
+- `scripts/__tests__/audit-tenant-auth-errors.smoke.ts`: 7 ケース全 PASS
+- `.github/workflows/audit-tenant-auth-errors.yml`: workflow_dispatch + WIF
+- email 別表示は `email_filter_domain` 指定時に限定（不特定多数 email 漏洩防止）
 
-- マージコミット: `2e9f616`
-- 差分: +17 / -5
-- 理由: PR #426 dry-run 2 回目で `Service account object must contain a string "project_id" property` → `google-github-actions/auth` の JSON は `type=external_account`、`cert()` 不可
-- 修正: JSON `type` フィールドで分岐 (service_account → cert / external_account 等 → applicationDefault)
+### 🔍 調査結果（本番 atali82i tenant 直接 read）
 
-### 🟢 一括救済 apply 実行
+#### PR #430 audit-allowlist-status 実行（since_hours=72 → 720 で 2 回）
+| 項目 | 髙良 佑風 (`y-mizuno@fuku-no-tane.com`) | 矢澤 知穂 (`c-yazawa@fuku-no-tane.com`) |
+|------|---|---|
+| `users` 登録 | ✅ id=Vw3L7CfCVIm9Q4s9j4Hr, role=student, name="髙良　佑風" | ✅ id=GlB07XM5JxVF2yW4xcs7, role=student, name="矢澤　知穂" |
+| `allowed_emails` 登録 | ✅ id=rl1RiPRXEZb9SiXn89e8 | ✅ id=vIXJLnZoI11lFM5Z13E8 |
+| `firebaseUid` 紐付け | ❌ 未紐付け | ❌ 未紐付け |
+| 直近 30 日 `auth_error_logs` | **0 件** | **0 件** |
+| 診断 | `no_firebase_uid_yet_user_has_not_logged_in` | `no_firebase_uid_yet_user_has_not_logged_in` |
 
-- workflow run #26073856892
-- 結果: **cleaned 5 / skipped 0 / failed 0**
+#### PR #431 audit-tenant-auth-errors 実行（since_hours=720, domain=fuku-no-tane.com）
+- 取得件数: **0 件**
+- reason 別件数: (該当ログなし)
+- email 別件数 (fuku-no-tane.com): unique=0、(該当 domain での拒否ログなし)
 
-| テナント | userId | quizId | sessions |
-|----------|--------|--------|----------|
-| 8vexhzpc | YpU6Dnvhm35HpDaAXTyb | Q1BSqE9MzGOCx5oZNCiQ | 8 |
-| 8vexhzpc | ZPhxGDHZS4pGOWYeF5Vk | cakIj066HiQ3ESnZn068 | 4 |
-| 8vexhzpc | pTuFpycK68igacAWcjR2 | fX79TSytJaFGfpHeGmw7 | 1 |
-| qos4c4ka | uXMEFBo5Jdd3uok3C3kb | ANAbnzfRHOMChpxKxV6j | 1 |
-| qos4c4ka | uXMEFBo5Jdd3uok3C3kb | cVbrCT0VxHcnGsXSHOMR | 1 |
+#### 確定事項
+1. サーバー側登録は両者とも完全に正常（ログイン受け入れ可能な状態）
+2. 該当 2 email のログイン試行はサーバーまで一切到達していない（30 日間 0 件）
+3. **別 email で試している可能性は否定**（fuku-no-tane.com domain で他 email の拒否ログも 0 件）
+4. **tenant 全体で 30 日拒否ログ 0 件**（他テナント user も初回ログインを試みていない or 既ログイン継続）
 
-#### 検証 (idempotency)
-apply 後に dry-run 再実行 (run #26074141331) → 救済対象 **0 件** 確認。Firestore 書き込み反映と判定ロジックの正確性を同時検証完了。
+### 📨 福の種様への返信文案（本田さん承認済、送付準備中）
+
+```
+福の種様
+
+ご連絡ありがとうございます。サーバー側で 2 名様の登録状況を確認しましたが、
+いずれもメールアドレスは正規に登録済みで、ログイン可能な状態でした。直近
+30 日のサーバー側ログを確認しましたが、2 名様によるログイン試行が一度も
+システム側で記録されていない状況です。
+
+お手数ですが、原因切り分けのため下記をご教示ください:
+1. ログインのどのステップで止まっておられるか（URL を開く / ログインボタンを
+   押す / Google の画面が出る / アカウント選択する / その後の画面 — のどの段階か）
+2. 画面のスクリーンショット（特にエラー表示や、白画面のままの場合はその状態）
+3. アクセスされている URL（https://web-3zcica5euq-an.a.run.app/atali82i/
+   で始まる形になっているか）
+4. ご利用のブラウザ（Safari / Chrome 等）と端末（PC / スマホ）
+
+取り急ぎご報告まで。
+```
 
 ---
 
 ## Issue Net 変化
 
-- **Close 数**: **1 件** (#422、PR #423 merge で auto-close)
-- **起票数**: **3 件** (#422 / #424 / #425)
-- **Net**: **-2** (active follow-up 2 件増)
+- **Close 数**: **0 件**
+- **起票数**: **0 件**
+- **Net**: **0 件**
 
-| Open Issue (Session 34 末) | ラベル | 状態 |
+| Open Issue (Session 35 末、Session 34 末から不変) | ラベル | 状態 |
 |---|---|---|
-| #425 | enhancement, P2 | active (本セッション起票、Firestore transient リトライ共通ユーティリティ) |
-| #424 | bug, P2 | active (本セッション起票、PATCH session 再確認の abandoned 未対応 = Codex M2) |
+| #425 | enhancement, P2 | active (Session 34 起票、Firestore transient リトライ共通ユーティリティ) |
+| #424 | bug, P2 | active (Session 34 起票、PATCH session 再確認の abandoned 未対応) |
 | #405 | enhancement, P2, postponed | M365/Outlook/Proofpoint/Mimecast テナント追加 or 添付名問い合わせ |
 | #276 | enhancement, P2, postponed | Phase 3 GCIP 完了 (#272 / 再評価期限 2026-10-24) |
 | #275 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
 | #274 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
 
-**Net -2 の理由言語化**: 本セッションは現場 1-shot 問い合わせ起点だが、調査で 5 経路の構造的バグが判明し恒久対応 PR を打った後、5 レビュアー (Codex + 4 agent) からの指摘で更に深掘りした結果、scope outside の follow-up が 2 件特定された:
-- **#424 (bug)**: Codex M2 指摘、PATCH 提出のセッション再確認が `force_exited` のみで `abandoned` 未対応。実害は限定的だが、PR #423 で `cleanupInProgressAttempts` を abandon にも追加したことで競合確率 ↑。triage 基準 #2 (再現可能なバグ) 該当
-- **#425 (enhancement)**: silent-failure-hunter I-2 指摘、Firestore transient エラー (UNAVAILABLE/DEADLINE_EXCEEDED/ABORTED/INTERNAL) のリトライ共通ユーティリティ。triage 基準 #5 (ユーザー明示指示) と #4 (rating 7 silent-failure-hunter) の境界、判断材料明確のため起票
-
-両 Issue は scope 拡張で本 PR に含めると差分が肥大化するため意図的に分離。`postponed` ではなく `active` として残し、次セッション以降の優先度判断対象に。rating 5-6 の他指摘 (code-reviewer の追加クエリコスト最適化等) は本 PR 内で対応済 (case-by-case で取捨選択)。
+**Net 0 の理由言語化**: 本セッションは現場 1-shot 問い合わせ（福の種様ログイン不可）を受けた調査セッション。原因がサーバー側に存在しないことが確定したため、追加 Issue 起票なし。read-only audit workflow 2 本は将来の同種問い合わせの調査効率化のための恒久ツールとして残置（feedback_firestore_prod_admin_via_workflow.md §「責務集約」観点では別 workflow 量産になるが、責務が異なるため許容）。Session 34 末の active 2 件 + postponed 4 件はそのまま継承。
 
 ---
 
@@ -149,100 +148,67 @@ apply 後に dry-run 再実行 (run #26074141331) → 救済対象 **0 件** 確
 
 | 変更内容 | 該当スキル | 状態 |
 |---|---|---|
-| 型・共有ロジック変更 | `/impact-analysis` | ⏭️ 対象外 (DataSource interface 拡張のみ、shared-types 影響なし、FE 利用箇所なし) |
-| 新規 API / コレクション追加 | `/check-api-impact` | ⏭️ 対象外 (新規 API なし、既存 PATCH 挙動は仕様内変更) |
-| データフロー追加 | `/trace-dataflow` | ⏭️ 対象外 (既存 quiz_attempts データパスの状態遷移修正のみ) |
-| statusField 状態遷移管理 | 状態遷移図 | ✅ 既存 ADR-027 で網羅済、本修正は status 遷移経路の漏れ補完 |
-| Partial Update テスト | undefined 検出 | ✅ `transitionQuizAttemptToTimedOut` は `status` `submittedAt` のみ更新、`answers` 保持テストで検証 |
+| 型・共有ロジック変更 | `/impact-analysis` | ⏭️ 対象外 (新規 admin script のみ、既存型/ロジックに影響なし) |
+| 新規 API / コレクション追加 | `/check-api-impact` | ⏭️ 対象外 (API 追加なし、既存 Firestore コレクションを read のみ) |
+| データフロー追加 | `/trace-dataflow` | ⏭️ 対象外 (新規データフローなし) |
+| statusField 状態遷移管理 | 状態遷移図 | ⏭️ 対象外 (read-only audit のみ) |
+| Partial Update テスト | undefined 検出 | ⏭️ 対象外 (Firestore 書き込みなし) |
 
 ---
 
-## ハーネス的考察 (本セッション特有)
+## ハーネス的考察（本セッション特有）
 
-### 「ユーザーが問題なく使えるか」の 4 回連続質問への対応進化
+### 「すべて AI 側でチェック」明示指示時の workflow 経由 read-only 調査パターン
 
-ユーザーから「bugfix 自体は完了？現在のユーザーも今なら問題なく使ってもらえる？」が **4 回連続** で投げられた:
+本田さんから「現場ヒアリングなしで AI 完結で原因切り分けしてほしい」との明示指示。本番 Firestore admin SDK アクセスは `feedback_firestore_prod_admin_via_workflow.md` に従い **ローカル `node -e` 直結ではなく workflow_dispatch + CI SA** で実行が原則。本セッションでこのパターンを LMS-279 で初確立:
 
-| 回 | 私の答え | 状態 |
-|----|---------|------|
-| 1 | NG (PR #426 未マージ + 未実行) | merge / 実行が必要 |
-| 2 | NG (PR #426 マージ済だが workflow 未実行) | dry-run 実行が必要 |
-| 3 | Yes (apply 成功) | **workflow ログのみ根拠、Firestore 反映未検証** |
-| 4 | "Yes" を撤回 (実機検証不足を認める) | dry-run 再実行で idempotency 検証 |
+| 構成要素 | 採用パターン |
+|---|---|
+| 認証 | WIF (workload_identity_provider) + CI SA (`github-actions@lms-279`) |
+| 認証コード分岐 | JSON `type` field 判定（`service_account` → `cert()`、`external_account` → `applicationDefault()`、`cleanup-stuck-quiz-attempts.ts` 流用） |
+| 入力 | workflow_dispatch inputs → env 経由（command injection 対策） |
+| 出力規範 | PII 漏洩防止のため email 別表示は domain フィルタ指定時に限定、件数 + reason 集計を基本 |
+| read-only 担保 | スクリプトに書き込み API なし、workflow に execute フラグなし |
+| PR 単位 | 1 PR = 1 script + 1 workflow + 1 smoke test の責務集約セット |
 
-**教訓**: 「workflow が success」と「実際の Firestore 状態が想定どおり」は別問題。書き込み workflow 完了後は **必ず dry-run 再実行で 0 件確認** (idempotency 検証) を実施するのが、destructive 操作の検証完了プロトコル。同じ apply を 2 回実行しても害がない設計 (条件付き更新) と組み合わせて検証可能。
+Session 34 (`cleanup-stuck-quiz-attempts.yml` destructive write workflow) のパターンを read-only 版に転用。今後同種の「特定 email/tenant の本番状態を read-only で確認する」要件は本パターンで対応可能。
 
-ユーザーの繰り返し質問は AI の確証バイアスを矯正する Generator-Evaluator パターンとして機能。「Yes」と即答する前に **検証エビデンスの自問** が executor の責務。
+### 「読み書き 2 種類」の workflow 設計境界
 
-### 連続失敗 3 回 Quality Gate の境界事例
+本セッションで気づいた設計判断: **read-only audit と write migration を 1 workflow に詰め込まない**。理由:
+- 入力に `execute` フラグを足すと「うっかり書き込み」リスクが残る
+- read-only と write は責務 / 安全機構 / レビュー基準が異なる（書き込みには件数アサーション、バックアップ artifact、二段階運用が必要、read-only には不要）
+- 1 PR = 1 責務で diff が小さく、レビュー精度が上がる
 
-PR #426 dry-run が 2 連続失敗:
-1. `firebase-admin/app` 未解決 (npm ci 不足)
-2. `Service account project_id 必須` (WIF 認証パターン誤り)
+Session 34 で `cleanup-stuck-quiz-attempts.yml` を write 専用に設計、Session 35 で `audit-allowlist-status.yml` / `audit-tenant-auth-errors.yml` を read-only 専用として分離 → この境界が運用上のリスク低減に寄与。
 
-CLAUDE.md MUST「同じエラーで 3 回失敗 → /codex 委譲」基準確認 → **異なる失敗種別**のため 3 連続基準に該当しないと判定。3 回目以降の失敗時に /codex 委譲を検討する旨を明示してから対応継続 → 3 回目 (dry-run 3 連目) は success で完了。**「同じエラー」の定義を狭めず広めず、失敗種別ごとに分解して評価** するのが正攻法。
+### 「サーバー側で 0 件 = 試行が到達していない」という強い結論の取り方
 
-### Generator-Evaluator パターンの定着
-
-本セッションで 5 レビュアー並列を 2 回実行:
-- **PR #423**: Codex (plan) + Codex (review) + code-reviewer + pr-test-analyzer + comment-analyzer + silent-failure-hunter
-  → Critical 7 + Important 6 を反映、肥大化を避けつつ品質確保
-- **PR #426**: small tier のため Codex review 省略、hook 提示の手動 checklist + smoke test で対応
-
-「全 PR で 6 エージェント並列」ではなく **PR tier ごとにレビュアー数を最適化** するパターンが定着。CLAUDE.md / quality-gate.md ともに整合的。
-
-### admin SDK workflow + WIF パターン確立
-
-本プロジェクト初の workflow 経由 admin スクリプト実行 (#426)。今後 admin SDK 操作を workflow 化する際の参考パターン:
-- WIF 認証 → JSON `type` 判別 → `applicationDefault()` 経路
-- workflow_dispatch inputs → env 経由でコマンドインジェクション対策
-- `npm ci` ステップ追加 (scripts/ は workspace 外)
-- dry-run / apply 二段階運用 + 件数アサーション + バックアップ artifact
-
-既存 `cleanup-orphan-auth-users.ts` 等の admin スクリプトを将来 workflow 化する際の移行テンプレートになる。
+直近 30 日 + tenant 全体 + domain 全 email で **拒否ログ 0 件** という結果は、サーバー側の問題ではないことを強く示唆する。`auth_error_logs` の網羅性（全 403 経路で 1 件以上書き込まれる設計、`tenant-auth.ts:138-168`）を確認した上で「サーバーまで届いていない」と結論できる。クライアント側の問題切り分けには現場ヒアリング（スクショ・URL・ブラウザ情報）が不可欠。AI 側で完結する調査の限界点として記録。
 
 ---
 
-## 残タスク (次セッションへ)
+## 残タスク（次セッションへ）
 
 ### 即実施推奨
-- 問い合わせユーザーへの返信送信 (decision-maker 判断、文面ドラフトは下記参照)
+- 福の種様への返信送付状況確認 + 返信受領時の追加切り分け（本田さん領分、送付済 or 未送付）
+- 現場情報受領後の原因特定（クライアント側 / URL / ブラウザ / 端末）
 
-### 返信文面ドラフト (パターン: 最小確約 + 復旧完了報告)
-
-```
-お問い合わせありがとうございます。
-
-ご報告いただいた「現在進行中のテストがあります。先に提出してください」という
-メッセージにつきまして、システム側の不具合であることを確認いたしました。
-動画視聴後のテスト解答中に時間切れとなった際、システム側で「テスト状態」が
-リセットされずに残ってしまっていたことが原因です。お客様の操作に問題は
-ございません。
-
-同様の状況にあった他の受講者様も含めて、サーバー側で復旧対応を完了いたしました。
-お手数ですが、改めてテスト画面を開いていただき、テストを開始できることを
-ご確認いただけますでしょうか。
-
-ご不便をおかけし申し訳ございませんでした。
-```
-
-### Active Issue (本セッション起票)
+### Active Issue（Session 34 起票、本セッションでは未着手）
 - #424 PATCH /quiz-attempts セッション再確認の abandoned 未対応 (bug, P2)
 - #425 Firestore transient エラー用リトライ共通ユーティリティ (enhancement, P2)
+
+### Postponed Issue（着手不可、明示指示なき限り保留）
+- #276 / #275 / #274: Phase 3 GCIP 完了が再開条件（再評価期限 2026-10-24）
+- #405: Phase 2 filename strict MTA risk
 
 ---
 
 ## 関連リンク
 
-- Issue #422: https://github.com/system-279/lms-279/issues/422 (closed、PR #423 で auto-close、救済完了コメント記録)
-- PR #423: https://github.com/system-279/lms-279/pull/423 (恒久対応 + テスト + レビュー指摘反映)
-- PR #426: https://github.com/system-279/lms-279/pull/426 (一括救済 workflow + script)
-- PR #427: https://github.com/system-279/lms-279/pull/427 (npm ci 追加)
-- PR #428: https://github.com/system-279/lms-279/pull/428 (WIF 認証対応)
-- Issue #424: https://github.com/system-279/lms-279/issues/424 (Codex M2 follow-up)
-- Issue #425: https://github.com/system-279/lms-279/issues/425 (transient リトライユーティリティ)
-- apply 実行 run: https://github.com/system-279/lms-279/actions/runs/26073856892
-- idempotency 検証 run: https://github.com/system-279/lms-279/actions/runs/26074141331
-- Codex plan セッション threadId: 019e3ddb-5f9f-7491-a912-5efed807b964
-- Codex review セッション threadId: 019e3dec-29a5-70d3-995c-b01541f342f5
-- Session 33 handoff (archived): docs/handoff/archive/2026-05-18-session-33.md
+- PR #430: https://github.com/system-279/lms-279/pull/430 (audit-allowlist-status workflow)
+- PR #431: https://github.com/system-279/lms-279/pull/431 (audit-tenant-auth-errors workflow)
+- audit-allowlist-status run #1 (72h): https://github.com/system-279/lms-279/actions/runs/26075862372
+- audit-allowlist-status run #2 (720h): https://github.com/system-279/lms-279/actions/runs/26075907026
+- audit-tenant-auth-errors run (720h, fuku-no-tane.com): https://github.com/system-279/lms-279/actions/runs/26076156456
+- Session 34 handoff (archived): docs/handoff/archive/2026-05-19-session-34.md

--- a/docs/handoff/archive/2026-05-19-session-34.md
+++ b/docs/handoff/archive/2026-05-19-session-34.md
@@ -1,0 +1,248 @@
+# Session Handoff — 2026-05-19 (Session 34)
+
+## TL;DR
+
+**現場フィードバック対応セッション (テスト詰まりバグ救済)。** 受講者から「動画後のテスト解答中に時間切れになり、以降『現在進行中のテストがあります』で詰まる」という問い合わせを受け、コード調査で 5 経路の構造的バグを特定 → Codex セカンドオピニオン (plan) で網羅列挙 → PR #423 で恒久対応 + 5 レビュアー (Codex + 4 agent) 指摘反映 → PR #426 で一括救済 workflow + script 追加 → PR #427/#428 で WIF 認証修正 → 5 詰まりユーザーを一括救済完了 (cleaned 5/5、idempotency 検証 0 件)。
+
+- **Issue Net**: **-2** (起票 3 / Close 1)
+- **Open 推移**: Session 33 末 4 件 → Session 34 末 **6 件** (#424 #425 が新規 active、#422 起票後即 close)
+- **マージ済み PR (4 本)**: #423 (恒久対応, +311/-3 services/api), #426 (救済 workflow, +600), #427 (npm ci 追加, +5/-1), #428 (WIF 認証, +17/-5)
+- **救済結果**: 5 ユーザー (8vexhzpc 3 + qos4c4ka 2 ユーザー分) を `in_progress → timed_out` で再受験可能化、dry-run 再実行で 0 件確認 (idempotency)
+- **本番反映**: ✅ Cloud Run デプロイ完了、bugfix + 救済 workflow ともに稼働中
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+# 1. 状況復元
+cat docs/handoff/LATEST.md
+
+# 2. main 最新と CI 状況
+git fetch origin main && git log --oneline -10 origin/main
+gh run list --branch main --limit 5
+
+# 3. 現在の OPEN Issue (6 件)
+gh issue list --state open --limit 15
+#  → #424 / #425: Session 34 で本セッション follow-up として起票 (active)
+#  → #274 / #275 / #276 (Phase 3 GCIP 完了が再開条件、postponed)
+#  → #405 (Phase 2 filename strict MTA risk、Session 27 起票、postponed)
+
+# 4. 次の着手候補:
+#    A. 【ユーザー判断】問い合わせユーザーへの返信送信 (本セッション未送信)
+#       - 返信文面ドラフトは Session 34 末で提示済 (本ファイル末尾)
+#       - 8vexhzpc / qos4c4ka テナントの該当ユーザーが対象 (個別特定済)
+#    B. 【active Issue】#424 PATCH /quiz-attempts セッション再確認の abandoned 未対応 (Codex M2)
+#       - rating: medium、レアケースだが #422 修正で発生確率 ↑
+#       - 修正案は Issue body 記載
+#    C. 【active Issue】#425 Firestore transient エラー用リトライ共通ユーティリティ
+#       - silent-failure-hunter I-2 指摘、設計案は Issue body 記載
+#    D. 【postponed】#272 Phase 3 GCIP 移行 — 再評価期限 2026-10-24
+#    E. 【postponed・着手不可】#276 / #275 / #274 / #405 — 明示指示なき限り着手不可
+```
+
+---
+
+## セッション成果物 (2026-05-19 Session 34)
+
+### 🟢 PR #423 マージ: bugfix 恒久対応 (Issue #422)
+
+- マージコミット: `ebd7ad9` (squash)
+- ファイル: 6 (lesson-session.ts + datasource interface/firestore/in-memory + 2 test files)
+- 差分: +527 / -3
+- CI: Build / Lint / Type Check / Test 4/4 PASS、Deploy to Cloud Run success
+
+#### 根本原因
+`forceExitSession` / `abandonSession` は session status を更新するが、関連 quiz_attempt の status を `in_progress` のまま残置。動画完了済み (`sessionVideoCompleted=true`) 経路では `resetLessonDataForUser` がスキップされ、attempt 削除も発火しない → 次回 POST /quizzes/:id/attempts が `409 attempt_in_progress` で永続的に失敗。
+
+#### 影響経路 (5 経路、Codex plan で網羅列挙)
+1. 解答中に session 期限超過 (PATCH /quiz-attempts/:id time_limit 分岐)
+2. リロード時の stale session 検出 (handleStaleSession)
+3. 別端末再入室時の新 session 作成
+4. 明示的 force-exit API
+5. ブラウザクローズ abandon (特に timeLimitSec=null quiz)
+
+#### 修正方針 (案 D 採用)
+`cleanupInProgressAttempts` 共通ヘルパーを `forceExitSession` / `abandonSession` から呼ぶ。動画完了データ保護 (reset スキップ) と attempt ロック解除を別責務として分離。5 経路すべてを発生源で解決。
+
+#### レビュー反映 Critical/Important 13 件
+- TOCTOU 対策: `DataSource.transitionQuizAttemptToTimedOut` 条件付き更新 API 追加 (Firestore は transaction、InMemory は同等のチェック付き更新)
+- 構造化ログ統一 (`console.error` → `logger.error`)、errorType 5 種定義
+- `quiz === null` early return → warn ログで観測可能化 (Issue #422 再生産経路を消去)
+- 部分失敗カウンタ + サマリログ
+- テスト名「path 5」→ 意味ベース表記
+- route-level テスト (経路 1: PATCH time_limit) + エラーパステスト追加
+- forceExitSession の updated! non-null assertion → 明示ガード
+- reset 経路では cleanup を skip (追加 DB クエリ削減)
+- maxAttempts 除外不変条件テスト + video_analytics 保護回帰テスト + TOCTOU 安全性テスト追加
+
+### 🟢 PR #426 マージ: 一括救済 workflow + script 追加
+
+- マージコミット: `ebfc35d`
+- ファイル: 3 (script + smoke test + workflow yaml)
+- 差分: +600 / -0
+
+#### 構成
+- `scripts/cleanup-stuck-quiz-attempts.ts`: 純粋関数 `isStuckAttempt` + admin SDK CLI (dry-run 既定、scope 絞り込み、件数アサーション、バックアップ JSON)
+- `scripts/__tests__/cleanup-stuck-quiz-attempts.smoke.ts`: 境界 10 ケース全 PASS
+- `.github/workflows/cleanup-stuck-quiz-attempts.yml`: workflow_dispatch + WIF、inputs は env 経由でコマンドインジェクション対策
+
+#### 検出ロジック
+`quiz_attempts.status == "in_progress"` かつ関連 `lesson_sessions` が以下のいずれか:
+- 全 session 非 active (force_exited / abandoned / completed)
+- active session の deadlineAt < now (期限切れ active)
+- 関連 session 不在 (孤児 attempt)
+
+### 🟢 PR #427 マージ: workflow に npm ci 追加
+
+- マージコミット: `35e3c11`
+- 差分: +5 / -1
+- 理由: PR #426 dry-run 1 回目で `Cannot find module 'firebase-admin/app'` → `scripts/` は npm workspace 外、ルート hoist 依存を `npm ci` でインストール必要
+
+### 🟢 PR #428 マージ: WIF (external_account) 認証対応
+
+- マージコミット: `2e9f616`
+- 差分: +17 / -5
+- 理由: PR #426 dry-run 2 回目で `Service account object must contain a string "project_id" property` → `google-github-actions/auth` の JSON は `type=external_account`、`cert()` 不可
+- 修正: JSON `type` フィールドで分岐 (service_account → cert / external_account 等 → applicationDefault)
+
+### 🟢 一括救済 apply 実行
+
+- workflow run #26073856892
+- 結果: **cleaned 5 / skipped 0 / failed 0**
+
+| テナント | userId | quizId | sessions |
+|----------|--------|--------|----------|
+| 8vexhzpc | YpU6Dnvhm35HpDaAXTyb | Q1BSqE9MzGOCx5oZNCiQ | 8 |
+| 8vexhzpc | ZPhxGDHZS4pGOWYeF5Vk | cakIj066HiQ3ESnZn068 | 4 |
+| 8vexhzpc | pTuFpycK68igacAWcjR2 | fX79TSytJaFGfpHeGmw7 | 1 |
+| qos4c4ka | uXMEFBo5Jdd3uok3C3kb | ANAbnzfRHOMChpxKxV6j | 1 |
+| qos4c4ka | uXMEFBo5Jdd3uok3C3kb | cVbrCT0VxHcnGsXSHOMR | 1 |
+
+#### 検証 (idempotency)
+apply 後に dry-run 再実行 (run #26074141331) → 救済対象 **0 件** 確認。Firestore 書き込み反映と判定ロジックの正確性を同時検証完了。
+
+---
+
+## Issue Net 変化
+
+- **Close 数**: **1 件** (#422、PR #423 merge で auto-close)
+- **起票数**: **3 件** (#422 / #424 / #425)
+- **Net**: **-2** (active follow-up 2 件増)
+
+| Open Issue (Session 34 末) | ラベル | 状態 |
+|---|---|---|
+| #425 | enhancement, P2 | active (本セッション起票、Firestore transient リトライ共通ユーティリティ) |
+| #424 | bug, P2 | active (本セッション起票、PATCH session 再確認の abandoned 未対応 = Codex M2) |
+| #405 | enhancement, P2, postponed | M365/Outlook/Proofpoint/Mimecast テナント追加 or 添付名問い合わせ |
+| #276 | enhancement, P2, postponed | Phase 3 GCIP 完了 (#272 / 再評価期限 2026-10-24) |
+| #275 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
+| #274 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
+
+**Net -2 の理由言語化**: 本セッションは現場 1-shot 問い合わせ起点だが、調査で 5 経路の構造的バグが判明し恒久対応 PR を打った後、5 レビュアー (Codex + 4 agent) からの指摘で更に深掘りした結果、scope outside の follow-up が 2 件特定された:
+- **#424 (bug)**: Codex M2 指摘、PATCH 提出のセッション再確認が `force_exited` のみで `abandoned` 未対応。実害は限定的だが、PR #423 で `cleanupInProgressAttempts` を abandon にも追加したことで競合確率 ↑。triage 基準 #2 (再現可能なバグ) 該当
+- **#425 (enhancement)**: silent-failure-hunter I-2 指摘、Firestore transient エラー (UNAVAILABLE/DEADLINE_EXCEEDED/ABORTED/INTERNAL) のリトライ共通ユーティリティ。triage 基準 #5 (ユーザー明示指示) と #4 (rating 7 silent-failure-hunter) の境界、判断材料明確のため起票
+
+両 Issue は scope 拡張で本 PR に含めると差分が肥大化するため意図的に分離。`postponed` ではなく `active` として残し、次セッション以降の優先度判断対象に。rating 5-6 の他指摘 (code-reviewer の追加クエリコスト最適化等) は本 PR 内で対応済 (case-by-case で取捨選択)。
+
+---
+
+## 構造的整合性チェック
+
+| 変更内容 | 該当スキル | 状態 |
+|---|---|---|
+| 型・共有ロジック変更 | `/impact-analysis` | ⏭️ 対象外 (DataSource interface 拡張のみ、shared-types 影響なし、FE 利用箇所なし) |
+| 新規 API / コレクション追加 | `/check-api-impact` | ⏭️ 対象外 (新規 API なし、既存 PATCH 挙動は仕様内変更) |
+| データフロー追加 | `/trace-dataflow` | ⏭️ 対象外 (既存 quiz_attempts データパスの状態遷移修正のみ) |
+| statusField 状態遷移管理 | 状態遷移図 | ✅ 既存 ADR-027 で網羅済、本修正は status 遷移経路の漏れ補完 |
+| Partial Update テスト | undefined 検出 | ✅ `transitionQuizAttemptToTimedOut` は `status` `submittedAt` のみ更新、`answers` 保持テストで検証 |
+
+---
+
+## ハーネス的考察 (本セッション特有)
+
+### 「ユーザーが問題なく使えるか」の 4 回連続質問への対応進化
+
+ユーザーから「bugfix 自体は完了？現在のユーザーも今なら問題なく使ってもらえる？」が **4 回連続** で投げられた:
+
+| 回 | 私の答え | 状態 |
+|----|---------|------|
+| 1 | NG (PR #426 未マージ + 未実行) | merge / 実行が必要 |
+| 2 | NG (PR #426 マージ済だが workflow 未実行) | dry-run 実行が必要 |
+| 3 | Yes (apply 成功) | **workflow ログのみ根拠、Firestore 反映未検証** |
+| 4 | "Yes" を撤回 (実機検証不足を認める) | dry-run 再実行で idempotency 検証 |
+
+**教訓**: 「workflow が success」と「実際の Firestore 状態が想定どおり」は別問題。書き込み workflow 完了後は **必ず dry-run 再実行で 0 件確認** (idempotency 検証) を実施するのが、destructive 操作の検証完了プロトコル。同じ apply を 2 回実行しても害がない設計 (条件付き更新) と組み合わせて検証可能。
+
+ユーザーの繰り返し質問は AI の確証バイアスを矯正する Generator-Evaluator パターンとして機能。「Yes」と即答する前に **検証エビデンスの自問** が executor の責務。
+
+### 連続失敗 3 回 Quality Gate の境界事例
+
+PR #426 dry-run が 2 連続失敗:
+1. `firebase-admin/app` 未解決 (npm ci 不足)
+2. `Service account project_id 必須` (WIF 認証パターン誤り)
+
+CLAUDE.md MUST「同じエラーで 3 回失敗 → /codex 委譲」基準確認 → **異なる失敗種別**のため 3 連続基準に該当しないと判定。3 回目以降の失敗時に /codex 委譲を検討する旨を明示してから対応継続 → 3 回目 (dry-run 3 連目) は success で完了。**「同じエラー」の定義を狭めず広めず、失敗種別ごとに分解して評価** するのが正攻法。
+
+### Generator-Evaluator パターンの定着
+
+本セッションで 5 レビュアー並列を 2 回実行:
+- **PR #423**: Codex (plan) + Codex (review) + code-reviewer + pr-test-analyzer + comment-analyzer + silent-failure-hunter
+  → Critical 7 + Important 6 を反映、肥大化を避けつつ品質確保
+- **PR #426**: small tier のため Codex review 省略、hook 提示の手動 checklist + smoke test で対応
+
+「全 PR で 6 エージェント並列」ではなく **PR tier ごとにレビュアー数を最適化** するパターンが定着。CLAUDE.md / quality-gate.md ともに整合的。
+
+### admin SDK workflow + WIF パターン確立
+
+本プロジェクト初の workflow 経由 admin スクリプト実行 (#426)。今後 admin SDK 操作を workflow 化する際の参考パターン:
+- WIF 認証 → JSON `type` 判別 → `applicationDefault()` 経路
+- workflow_dispatch inputs → env 経由でコマンドインジェクション対策
+- `npm ci` ステップ追加 (scripts/ は workspace 外)
+- dry-run / apply 二段階運用 + 件数アサーション + バックアップ artifact
+
+既存 `cleanup-orphan-auth-users.ts` 等の admin スクリプトを将来 workflow 化する際の移行テンプレートになる。
+
+---
+
+## 残タスク (次セッションへ)
+
+### 即実施推奨
+- 問い合わせユーザーへの返信送信 (decision-maker 判断、文面ドラフトは下記参照)
+
+### 返信文面ドラフト (パターン: 最小確約 + 復旧完了報告)
+
+```
+お問い合わせありがとうございます。
+
+ご報告いただいた「現在進行中のテストがあります。先に提出してください」という
+メッセージにつきまして、システム側の不具合であることを確認いたしました。
+動画視聴後のテスト解答中に時間切れとなった際、システム側で「テスト状態」が
+リセットされずに残ってしまっていたことが原因です。お客様の操作に問題は
+ございません。
+
+同様の状況にあった他の受講者様も含めて、サーバー側で復旧対応を完了いたしました。
+お手数ですが、改めてテスト画面を開いていただき、テストを開始できることを
+ご確認いただけますでしょうか。
+
+ご不便をおかけし申し訳ございませんでした。
+```
+
+### Active Issue (本セッション起票)
+- #424 PATCH /quiz-attempts セッション再確認の abandoned 未対応 (bug, P2)
+- #425 Firestore transient エラー用リトライ共通ユーティリティ (enhancement, P2)
+
+---
+
+## 関連リンク
+
+- Issue #422: https://github.com/system-279/lms-279/issues/422 (closed、PR #423 で auto-close、救済完了コメント記録)
+- PR #423: https://github.com/system-279/lms-279/pull/423 (恒久対応 + テスト + レビュー指摘反映)
+- PR #426: https://github.com/system-279/lms-279/pull/426 (一括救済 workflow + script)
+- PR #427: https://github.com/system-279/lms-279/pull/427 (npm ci 追加)
+- PR #428: https://github.com/system-279/lms-279/pull/428 (WIF 認証対応)
+- Issue #424: https://github.com/system-279/lms-279/issues/424 (Codex M2 follow-up)
+- Issue #425: https://github.com/system-279/lms-279/issues/425 (transient リトライユーティリティ)
+- apply 実行 run: https://github.com/system-279/lms-279/actions/runs/26073856892
+- idempotency 検証 run: https://github.com/system-279/lms-279/actions/runs/26074141331
+- Codex plan セッション threadId: 019e3ddb-5f9f-7491-a912-5efed807b964
+- Codex review セッション threadId: 019e3dec-29a5-70d3-995c-b01541f342f5
+- Session 33 handoff (archived): docs/handoff/archive/2026-05-18-session-33.md


### PR DESCRIPTION
## Summary

Session 35 ハンドオフ記録の追加と Session 34 のアーカイブ。

### 本セッション内容
**福の種テナント (atali82i) ログイン不可調査セッション。** 受講者 2 名（髙良 佑風 / 矢澤 知穂）のログイン不可問い合わせを受け、AI 側完結で本番 Firestore を read-only 調査:

- PR #430 (audit-allowlist-status) を新規追加・マージ・実行
- PR #431 (audit-tenant-auth-errors) を新規追加・マージ・実行
- 結論: サーバー側は正規登録済み + 直近 30 日で tenant 全体に拒否ログ 0 件 → クライアント側 or URL 到達前が原因
- 福の種様への返信文案を提示、本田さん承認済（送付は decision-maker 領分）

### Issue Net 変化
- Close 数: 0 件
- 起票数: 0 件
- Net: **0 件**
- Session 34 末 6 件 → Session 35 末 6 件（変化なし）

### 構造的整合性チェック
すべて ⏭️ 対象外（新規 admin script のみ、既存ロジックへの影響なし、read-only）

## Test plan

- [x] docs のみの変更、CI はドキュメント検証のみ
- [x] LATEST.md 行数: 200 行程度（500 以下目標達成）
- [x] Session 34 を archive ディレクトリへコピー、命名規則準拠 (2026-05-19-session-34.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)