### PR TITLE
docs(handoff): Session 36 (2026-05-19) ハンドオフ記録 + Session 35 archive

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,14 +1,14 @@
-# Session Handoff — 2026-05-19 (Session 35)
+# Session Handoff — 2026-05-19 (Session 36)
 
 ## TL;DR
 
-**現場フィードバック対応セッション 2 連続（福の種テナント atali82i ログイン不可調査）。** 福の種様から「ユーザー管理画面のメールアドレスは正しいのに 2 名がログインできない」との連絡を受け、サーバー側の状態を read-only audit で切り分け → tenant 配下の `users` / `allowed_emails` / `auth_error_logs` を本番 Firestore に直接 read。**結論: サーバー側は正規登録済み、直近 30 日で tenant 全体に拒否ログ 0 件**。原因はクライアント側 or URL 到達前と確定。福の種様への返信文案を提示し本田さん承認、送付準備中（送付は decision-maker 領分）。
+**受講者進捗 PDF Gmail 下書きの宛先ロジック改訂セッション。** 現場から「個人ごとの送付先が手動入力で誤送信リスクがある」との要望を受け、案 B (To=受講者本人 / CC=テナント管理者、CC は省略可) で改訂。Phase 2 元実装 (PR #358) は To=ownerEmail のみで、UI フロー (userId 指定) と宛先が不整合だった点を修正。Codex review (plan / code 各 1 回) + /simplify 3 並列 + /safe-refactor + Evaluator 分離プロトコル + Codex code review (実装後) の **5 段階品質ゲート** を全通過、AC 15/15 PASS、テスト 1062 件 PASS、CI success で squash merge 完了。
 
-- **Issue Net**: **0** (起票 0 / Close 0)
-- **Open 推移**: Session 34 末 6 件 → Session 35 末 **6 件** (変化なし)
-- **マージ済み PR (2 本)**: #430 (audit-allowlist-status workflow, +682/-0), #431 (audit-tenant-auth-errors workflow, +530/-0)
-- **本番反映**: ✅ 両 workflow とも main にマージ済、read-only のため Cloud Run デプロイ不要
-- **調査結果**: 該当 2 email (`y-mizuno@fuku-no-tane.com` / `c-yazawa@fuku-no-tane.com`) ともに `users` / `allowed_emails` 正規登録済み、firebaseUid 未紐付け（初回ログイン未完了）、直近 30 日の拒否ログ 0 件
+- **Issue Net**: **+3** (起票 4 件 / Close 1 件)
+- **Open 推移**: Session 35 末 6 件 → Session 36 末 **9 件** (active 5 / postponed 4)
+- **マージ済み PR**: #434 (受講者進捗 PDF Gmail draft 宛先改訂、12 files +789/-71)
+- **新規 follow-up Issue**: #435 [P1] idempotency umbrella / #436 [P1] accessToken owner 検証 / #437 [P2] Gmail PII フィルタ — いずれも Phase 2 元実装 (PR #358) からの継承課題、Codex code review で rating ≥ 7 / triage #4 該当のため起票
+- **本番反映**: ✅ main push 後 Cloud Run Deploy success (4m8s)
 
 ## 🚀 次セッション開始時の必読手順
 
@@ -20,119 +20,128 @@ cat docs/handoff/LATEST.md
 git fetch origin main && git log --oneline -10 origin/main
 gh run list --branch main --limit 5
 
-# 3. 現在の OPEN Issue (6 件、Session 34 から不変)
+# 3. 現在の OPEN Issue (9 件: active 5 / postponed 4)
 gh issue list --state open --limit 15
 
 # 4. 次の着手候補:
 #    A. 【ユーザー判断・最優先】福の種様への返信送信状況確認 + 返信受領時の追加切り分け
-#       - 返信文面は Session 35 で本田さん承認済（本ファイル末尾）
+#       - 返信文面は Session 35 で本田さん承認済 (archive/2026-05-19-session-35.md 参照)
 #       - スクショ・URL・ブラウザ情報を受領後、原因切り分け継続
-#    B. 【active Issue】#424 PATCH /quiz-attempts セッション再確認の abandoned 未対応
-#    C. 【active Issue】#425 Firestore transient エラー用リトライ共通ユーティリティ
-#    D. 【postponed・着手不可】#276 / #275 / #274 / #405 — 明示指示なき限り着手不可
+#    B. 【新規 Issue 着手判断】(decision-maker 領分):
+#       - #435 [P1] idempotency 非アトミック + 判定強化 umbrella
+#       - #436 [P1] accessToken owner 検証
+#       - #437 [P2] Gmail API エラーメッセージ PII フィルタ
+#    C. 【active Issue】#424 PATCH /quiz-attempts セッション再確認の abandoned 未対応
+#    D. 【active Issue】#425 Firestore transient エラー用リトライ共通ユーティリティ
+#    E. 【postponed・着手不可】#276 / #275 / #274 / #405 — 明示指示なき限り着手不可
 
-# 5. 福の種様調査の再 audit が必要な場合（参考コマンド）
-gh workflow run audit-allowlist-status.yml \
-  -f tenant_id=atali82i \
-  -f emails="y-mizuno@fuku-no-tane.com,c-yazawa@fuku-no-tane.com" \
-  -f since_hours=720
-
-gh workflow run audit-tenant-auth-errors.yml \
-  -f tenant_id=atali82i \
-  -f since_hours=720 \
-  -f email_filter_domain=fuku-no-tane.com
+# 5. PR #434 後の動作確認 (必要なら本番で実施)
+#    - /super/progress/[tenantId]/[userId]/print で「Gmail 下書き作成」を押下
+#    - To=受講者本人 / CC=テナント管理者 (or 未設定なら CC 省略) が自動入力されることを確認
+#    - 本文に「{userName} 様」呼びかけ + (ownerEmail 設定時のみ) CC 注記が含まれることを確認
 ```
 
 ---
 
-## セッション成果物 (2026-05-19 Session 35)
+## セッション成果物 (2026-05-19 Session 36)
 
-### 🟢 PR #430 マージ: 特定 email の登録状態確認 audit (read-only)
+### 🟢 PR #434 マージ: 受講者進捗 PDF Gmail 下書きの宛先を案 B に改訂
 
-- マージコミット: `1db86e9` (squash)
-- ファイル: 3 (script + smoke test + workflow yaml)
-- 差分: +682 / -0
-- CI: Build / Lint / Type Check / Test 4/4 PASS
+- マージコミット: `d8a151e` (squash)
+- ファイル: 12 (実装 6 + テスト 5 + ADR 1)
+- 差分: +789 / -71
+- CI: Build / Lint / Type Check / Test 全 PASS、Deploy to Cloud Run 4m8s success
 
-#### 構成
-- `scripts/audit-allowlist-status.ts`: 入力 email 配列について `users` / `allowed_emails` / `auth_error_logs` の状態を表示、純粋関数 `parseEmails` / `computeDiagnosis` / `buildPerEmailReport`
-- `scripts/__tests__/audit-allowlist-status.smoke.ts`: 14 ケース全 PASS
-- `.github/workflows/audit-allowlist-status.yml`: workflow_dispatch + WIF、inputs は env 経由（command injection 対策）
+#### 改訂の核心 (旧 → 新)
+| 項目 | 旧 (Phase 2 元実装) | 新 (案 B) |
+|---|---|---|
+| To 宛先 | `tenants/{tenantId}.ownerEmail` (テナント管理者) | `users/{userId}.email` (受講者本人) |
+| CC 宛先 | (なし) | `tenants/{tenantId}.ownerEmail` (未設定なら CC ヘッダ省略) |
+| UI/宛先整合 | ❌ UI は受講者単体だが宛先は管理者 | ✅ 整合 |
+| ownerEmail 未設定挙動 | ❌ 400 で送信不可 | ✅ CC 省略で送信成功 |
+| user.email 未設定挙動 | (チェックなし) | ✅ 400 `user_email_not_configured` |
+| ヘッダインジェクション防御 | To のみ | ✅ To/CC 両方 |
+| 本文呼びかけ | 「{userName} さん」 | 「{userName} 様」+ CC 設定時のみ注記 |
+| 監査ログ | `ownerEmailHash` のみ | dual-write: `recipientToHash` / `recipientCcHash` + 旧 `ownerEmailHash` 維持 |
 
-#### 診断ロジック（優先順位）
-1. `recent_auth_error_reason=<reason>`: 直近の auth_error_logs から reason 取得（最優先）
-2. `user_not_found_in_users_collection`
-3. `allowed_email_case_or_whitespace_mismatch`: 完全一致なし + ケース違いあり
-4. `not_in_allowlist_suspected`: allowed_emails に該当なし
-5. `no_firebase_uid_yet_user_has_not_logged_in`: 登録あるが初回ログイン未完了
-6. `no_recent_auth_error_logs_user_may_have_other_issue`: 全て揃っているがログなし
+#### 主要変更ファイル
+- `packages/shared-types/src/progress-pdf.ts`: エラーコード `user_email_not_configured` / `invalid_owner_email` 追加
+- `services/api/src/services/gmail-draft.ts`: `cc?: string` 引数、MIME `Cc:` 行、CRLF/サロゲート assert を CC にも適用
+- `services/api/src/routes/super/progress-pdf-draft.ts`: `validateRecipientEmail` (5 拒否理由 + 形式チェック) + To/CC ロジック改修
+- `services/api/src/services/progress-pdf-mail-template.ts`: 「{userName} 様」呼びかけ + ownerEmail 有時のみ CC 注記 (虚偽記載防止)
+- `services/api/src/services/pdf-draft-audit.ts`: dual-write (`recipientToHash` / `recipientCcHash` 追加、`ownerEmailHash` 残置)
+- `web/app/super/progress/[tenantId]/[userId]/print/page.tsx`: 宛先 (To) / CC 表示、disable 条件を `userEmail.trim()` 空に変更
+- `docs/adr/ADR-034-phase2-gmail-draft.md`: §2 図 / §5 宛先 / §7 監査ログ / §8 エラー改訂 + 改訂履歴セクション追加
 
-### 🟢 PR #431 マージ: tenant 全体 auth_error_logs 集計 audit (read-only)
+#### Acceptance Criteria (15 件、全 PASS)
 
-- マージコミット: `242e3e7` (squash)
-- ファイル: 3 (script + smoke test + workflow yaml)
-- 差分: +530 / -0
-- CI: Build / Lint / Type Check / Test 4/4 PASS
+| # | 内容 | 検証 |
+|---|---|---|
+| AC-1 | To=user.email (trim 後) が MIME に入る | 統合 + gmail-draft 単体 |
+| AC-2 | ownerEmail 設定済なら CC: に入る | 統合 + gmail-draft 単体 |
+| AC-3 | ownerEmail null/空文字なら CC 省略で送信成功 | 統合 (3 ケース) |
+| AC-4 | user.email 未設定/空白なら BE 400 + FE disabled | 統合 + FE component |
+| AC-5 | CC への CRLF インジェクション拒否 | gmail-draft 単体 |
+| AC-6 | 監査ログに recipientToHash / recipientCcHash 記録 | audit + 統合 |
+| AC-7 | 既存 Phase 2 元 AC 退行なし | 既存テスト 47 件 PASS 維持 |
+| AC-8 | FE 画面に「宛先 (To) / CC」表示 | FE component |
+| AC-9 | mail-template の「{userName} 様」+ ownerEmail 時のみ CC 注記 | mail-template 単体 |
+| AC-10 | user.email が trim 後空 / CRLF / カンマ / 制御文字含みなら 400 | 統合 (5 ケース) |
+| AC-11 | ownerEmail null/空でも本文 CC 注記省略 (虚偽記載防止) | mail-template + 統合 |
+| AC-12 | ownerEmail が CRLF/カンマ/制御文字なら 400 invalid_owner_email | 統合 (3 ケース) |
+| AC-13 | 旧スキーマ idempotency ログでも 200 を返す | 統合 |
+| AC-14 | raw email は保存されずハッシュのみ | audit |
+| AC-15 | FE は userEmail trim 空で disabled、ownerEmail 未設定では disabled にしない | FE component |
 
-#### 構成
-- `scripts/audit-tenant-auth-errors.ts`: tenant 配下 auth_error_logs を直近 N 時間で取得、reason 別件数 + (domain 指定時のみ) email 別件数を集計、純粋関数 `aggregateLogs`
-- `scripts/__tests__/audit-tenant-auth-errors.smoke.ts`: 7 ケース全 PASS
-- `.github/workflows/audit-tenant-auth-errors.yml`: workflow_dispatch + WIF
-- email 別表示は `email_filter_domain` 指定時に限定（不特定多数 email 漏洩防止）
+#### 品質ゲート実績 (5 段階)
 
-### 🔍 調査結果（本番 atali82i tenant 直接 read）
+| 段階 | 結果 |
+|---|---|
+| Codex plan review (impl-plan 段階) | Important 7 件反映 + 追加 AC 6 件採用 → 計 15 AC |
+| `/simplify` (3 並列 agent: reuse / quality / efficiency) | Critical 0 件、Important 6 件反映 |
+| `/safe-refactor` | MEDIUM 1 件容認 (バリデーション失敗時の Firestore 監査ログ非書込 → 既存方針との整合性) |
+| Evaluator 分離プロトコル (別 context Claude) | AC 15/15 PASS、Important 3 件反映 |
+| Codex code review (実装後) | Critical 0 件 / High 2 件 / Medium 4 件 — **全て Phase 2 元実装 (PR #358) 継承課題で本 PR スコープ外**、follow-up Issue 3 件として起票 |
 
-#### PR #430 audit-allowlist-status 実行（since_hours=72 → 720 で 2 回）
-| 項目 | 髙良 佑風 (`y-mizuno@fuku-no-tane.com`) | 矢澤 知穂 (`c-yazawa@fuku-no-tane.com`) |
-|------|---|---|
-| `users` 登録 | ✅ id=Vw3L7CfCVIm9Q4s9j4Hr, role=student, name="髙良　佑風" | ✅ id=GlB07XM5JxVF2yW4xcs7, role=student, name="矢澤　知穂" |
-| `allowed_emails` 登録 | ✅ id=rl1RiPRXEZb9SiXn89e8 | ✅ id=vIXJLnZoI11lFM5Z13E8 |
-| `firebaseUid` 紐付け | ❌ 未紐付け | ❌ 未紐付け |
-| 直近 30 日 `auth_error_logs` | **0 件** | **0 件** |
-| 診断 | `no_firebase_uid_yet_user_has_not_logged_in` | `no_firebase_uid_yet_user_has_not_logged_in` |
+### 🟠 Follow-up Issue 起票 3 件 (Codex code review で検出された Phase 2 元実装継承課題)
 
-#### PR #431 audit-tenant-auth-errors 実行（since_hours=720, domain=fuku-no-tane.com）
-- 取得件数: **0 件**
-- reason 別件数: (該当ログなし)
-- email 別件数 (fuku-no-tane.com): unique=0、(該当 domain での拒否ログなし)
+#### #435 [P1 enhancement] idempotency 非アトミック + 判定強化 umbrella (H1 + M1 + M2)
+- 現状 `get → Gmail draft 作成 → set` の 3 段階で、同一 requestId の並行リクエストが両方 `exists=false` を見て二重作成可能
+- 解決策案: `pending` を `create()` で先取り or Firestore transaction でロック
+- 追加: idempotency 判定が status + draftId のみで、userId / 宛先 hash を見ない
+- 追加: idempotency 確認失敗時のフォールスルーで Firestore 障害時に重複 draft
 
-#### 確定事項
-1. サーバー側登録は両者とも完全に正常（ログイン受け入れ可能な状態）
-2. 該当 2 email のログイン試行はサーバーまで一切到達していない（30 日間 0 件）
-3. **別 email で試している可能性は否定**（fuku-no-tane.com domain で他 email の拒否ログも 0 件）
-4. **tenant 全体で 30 日拒否ログ 0 件**（他テナント user も初回ログインを試みていない or 既ログイン継続）
+#### #436 [P1 enhancement/security] Gmail draft の accessToken owner 検証 (H2)
+- 現状、accessToken の Google アカウント所有者と superAdmin.email の一致を BE で検証していない
+- API 直叩きで別 Google アカウントの token を渡すと、その mailbox に draft 作成可能 → 監査ログ信頼性低下
+- 解決策案: `oauth2.tokeninfo` で token owner email 取得 → superAdmin.email と一致しない場合 403
 
-### 📨 福の種様への返信文案（本田さん承認済、送付準備中）
+#### #437 [P2 enhancement/security] Gmail API エラーメッセージ PII フィルタ (M4)
+- Gmail API の raw `message` が logger.error + HTTP レスポンスに流れる
+- response.data.error.message に宛先 / MIME 断片 / アカウント情報が含まれる可能性 → PII 漏洩リスク
+- 解決策案: GmailDraftError を internal/public message に分離
 
-```
-福の種様
-
-ご連絡ありがとうございます。サーバー側で 2 名様の登録状況を確認しましたが、
-いずれもメールアドレスは正規に登録済みで、ログイン可能な状態でした。直近
-30 日のサーバー側ログを確認しましたが、2 名様によるログイン試行が一度も
-システム側で記録されていない状況です。
-
-お手数ですが、原因切り分けのため下記をご教示ください:
-1. ログインのどのステップで止まっておられるか（URL を開く / ログインボタンを
-   押す / Google の画面が出る / アカウント選択する / その後の画面 — のどの段階か）
-2. 画面のスクリーンショット（特にエラー表示や、白画面のままの場合はその状態）
-3. アクセスされている URL（https://web-3zcica5euq-an.a.run.app/atali82i/
-   で始まる形になっているか）
-4. ご利用のブラウザ（Safari / Chrome 等）と端末（PC / スマホ）
-
-取り急ぎご報告まで。
-```
+### 📐 ADR-034 改訂内容
+- Status: **Proposed → Accepted** (PR #358 で実装済、本セッションで案 B 改訂)
+- 改訂履歴セクション追加 (2026-05-19 改訂、Issue #433)
+- §2 アーキテクチャ図: To/CC 二段化
+- §5 宛先決定: 案 B 採用理由マトリクス + バリデーションルール (5 拒否理由) 追記
+- §7 監査ログスキーマ: dual-write 戦略 (recipientToHash / recipientCcHash / 旧 ownerEmailHash) 明文化
+- §8 エラー分類テーブル: 新 2 エラーコード + 旧 owner_email_not_set (deprecated) 注記
 
 ---
 
 ## Issue Net 変化
 
-- **Close 数**: **0 件**
-- **起票数**: **0 件**
-- **Net**: **0 件**
+- **Close 数**: **1 件** (#433)
+- **起票数**: **4 件** (#433 / #435 / #436 / #437)
+- **Net**: **+3 件**
 
-| Open Issue (Session 35 末、Session 34 末から不変) | ラベル | 状態 |
+| Open Issue (Session 36 末、9 件) | ラベル | 状態 |
 |---|---|---|
+| #437 | enhancement, P2 | active (本セッション起票、Gmail PII フィルタ) |
+| #436 | enhancement, P1 | active (本セッション起票、accessToken owner 検証) |
+| #435 | enhancement, P1 | active (本セッション起票、idempotency umbrella) |
 | #425 | enhancement, P2 | active (Session 34 起票、Firestore transient リトライ共通ユーティリティ) |
 | #424 | bug, P2 | active (Session 34 起票、PATCH session 再確認の abandoned 未対応) |
 | #405 | enhancement, P2, postponed | M365/Outlook/Proofpoint/Mimecast テナント追加 or 添付名問い合わせ |
@@ -140,7 +149,12 @@ gh workflow run audit-tenant-auth-errors.yml \
 | #275 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
 | #274 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
 
-**Net 0 の理由言語化**: 本セッションは現場 1-shot 問い合わせ（福の種様ログイン不可）を受けた調査セッション。原因がサーバー側に存在しないことが確定したため、追加 Issue 起票なし。read-only audit workflow 2 本は将来の同種問い合わせの調査効率化のための恒久ツールとして残置（feedback_firestore_prod_admin_via_workflow.md §「責務集約」観点では別 workflow 量産になるが、責務が異なるため許容）。Session 34 末の active 2 件 + postponed 4 件はそのまま継承。
+**Net +3 の理由言語化**: 本 PR #434 は宛先ロジック改訂 1 件で #433 を close したが、Codex code review (実装後) で **Phase 2 元実装 (PR #358) からの脆弱性 3 件** が新規可視化された:
+- idempotency 非アトミック (PII 重複 + Gmail quota 消費リスク)
+- accessToken owner 不一致 (監査ログ信頼性)
+- Gmail エラーメッセージ PII 漏洩
+
+いずれも本 PR スコープ外 (宛先ロジックは Critical/High なし、5 段階品質ゲートで検証済)。CLAUDE.md triage 基準 #4 (rating ≥ 7 / confidence ≥ 80) を確実に満たすため起票。**過剰起票ではなく、隠れていた脆弱性を可視化した価値と引き換えの Net 逆行**。decision-maker による着手優先度判断材料が増えた状態。
 
 ---
 
@@ -148,67 +162,77 @@ gh workflow run audit-tenant-auth-errors.yml \
 
 | 変更内容 | 該当スキル | 状態 |
 |---|---|---|
-| 型・共有ロジック変更 | `/impact-analysis` | ⏭️ 対象外 (新規 admin script のみ、既存型/ロジックに影響なし) |
-| 新規 API / コレクション追加 | `/check-api-impact` | ⏭️ 対象外 (API 追加なし、既存 Firestore コレクションを read のみ) |
-| データフロー追加 | `/trace-dataflow` | ⏭️ 対象外 (新規データフローなし) |
-| statusField 状態遷移管理 | 状態遷移図 | ⏭️ 対象外 (read-only audit のみ) |
-| Partial Update テスト | undefined 検出 | ⏭️ 対象外 (Firestore 書き込みなし) |
+| 型・共有ロジック変更 | `/impact-analysis` | ✅ type-check 全 4 workspace PASS で integration 担保 (shared-types ProgressPdfDraftErrorCode 追加は FE/BE 両方で型強制) |
+| 新規 API / コレクション追加 | `/check-api-impact` | ⏭️ 対象外 (既存 endpoint `/progress-pdf-draft` の挙動変更のみ、新規 endpoint なし) |
+| データフロー追加 | `/trace-dataflow` | ⏭️ 対象外 (既存 `ProgressPdfData` の `user.email` を新規利用、データソースは Phase 1 から再利用) |
+| statusField 状態遷移管理 | 状態遷移図 | ⏭️ 対象外 (status は draft 1 状態) |
+| Partial Update テスト | undefined 検出 | ⏭️ 対象外 (監査ログは新規 set のみ、Partial Update なし) |
 
 ---
 
-## ハーネス的考察（本セッション特有）
+## ハーネス的考察 (本セッション特有)
 
-### 「すべて AI 側でチェック」明示指示時の workflow 経由 read-only 調査パターン
+### 5 段階品質ゲートの実効性
 
-本田さんから「現場ヒアリングなしで AI 完結で原因切り分けしてほしい」との明示指示。本番 Firestore admin SDK アクセスは `feedback_firestore_prod_admin_via_workflow.md` に従い **ローカル `node -e` 直結ではなく workflow_dispatch + CI SA** で実行が原則。本セッションでこのパターンを LMS-279 で初確立:
+本セッションで初めて **5 段階品質ゲート (Codex plan / simplify / safe-refactor / Evaluator / Codex code review)** を 1 PR で全実施。各段階の付加価値は重複しなかった:
 
-| 構成要素 | 採用パターン |
-|---|---|
-| 認証 | WIF (workload_identity_provider) + CI SA (`github-actions@lms-279`) |
-| 認証コード分岐 | JSON `type` field 判定（`service_account` → `cert()`、`external_account` → `applicationDefault()`、`cleanup-stuck-quiz-attempts.ts` 流用） |
-| 入力 | workflow_dispatch inputs → env 経由（command injection 対策） |
-| 出力規範 | PII 漏洩防止のため email 別表示は domain フィルタ指定時に限定、件数 + reason 集計を基本 |
-| read-only 担保 | スクリプトに書き込み API なし、workflow に execute フラグなし |
-| PR 単位 | 1 PR = 1 script + 1 workflow + 1 smoke test の責務集約セット |
+| 段階 | 役割 | 本 PR での実効指摘 |
+|---|---|---|
+| Codex plan review | 計画段階の設計レビュー | Important 7 件 + 追加 AC 6 件 (実装前のスコープ拡張) |
+| /simplify (3 並列) | reuse / quality / efficiency の 3 観点同時 | hashEmail 重複削減、3 段ネスト解消、reason 露出削除など 6 件 |
+| /safe-refactor | 型安全性 / エラー処理 | MEDIUM 1 件 (既存方針整合のため容認) |
+| Evaluator (別 context) | AC 検証 + 第三者視点 | AC 15/15 PASS、validatedToEmail null 初期化など 3 件 |
+| Codex code review (実装後) | 別モデル視点でセキュリティ・後方互換 | High 2 / Medium 4 全て本 PR スコープ外の Phase 2 元実装継承課題 → follow-up Issue 化 |
 
-Session 34 (`cleanup-stuck-quiz-attempts.yml` destructive write workflow) のパターンを read-only 版に転用。今後同種の「特定 email/tenant の本番状態を read-only で確認する」要件は本パターンで対応可能。
+特に **Codex code review が「実装後の別モデル視点」として Phase 2 元実装の脆弱性 3 件を可視化** したのは収穫。Claude 系の 4 段階レビュー (simplify / safe-refactor / Evaluator / Codex plan) では捕捉できなかった「実装スコープ外の関連既存課題」を補完する役割を果たした。
 
-### 「読み書き 2 種類」の workflow 設計境界
+### case B 採用判断の構造 (UI/宛先整合の発見)
 
-本セッションで気づいた設計判断: **read-only audit と write migration を 1 workflow に詰め込まない**。理由:
-- 入力に `execute` フラグを足すと「うっかり書き込み」リスクが残る
-- read-only と write は責務 / 安全機構 / レビュー基準が異なる（書き込みには件数アサーション、バックアップ artifact、二段階運用が必要、read-only には不要）
-- 1 PR = 1 責務で diff が小さく、レビュー精度が上がる
+ユーザーから「個人ごとの送付先が手動」との 1 段階目フィードバック → 私が「実は実装済」と返答 → ユーザーが画像で「個人ごとの Gmail 確認した」と再確認 → 私が「UI 単位は受講者なのに宛先は管理者で不整合」を指摘 → ユーザーが「最適解な予感」で案 B を提示 → 採用確定。
 
-Session 34 で `cleanup-stuck-quiz-attempts.yml` を write 専用に設計、Session 35 で `audit-allowlist-status.yml` / `audit-tenant-auth-errors.yml` を read-only 専用として分離 → この境界が運用上のリスク低減に寄与。
+この対話パターンは「**現場の表面要望を技術設計の整合性まで掘り下げる Socratic 進行**」として記録すべきと判断。`/brainstorm` skill の本来の用途と一致。
 
-### 「サーバー側で 0 件 = 試行が到達していない」という強い結論の取り方
+### Follow-up Issue 3 件起票判断 (CLAUDE.md GitHub Issues #5 / triage #4)
 
-直近 30 日 + tenant 全体 + domain 全 email で **拒否ログ 0 件** という結果は、サーバー側の問題ではないことを強く示唆する。`auth_error_logs` の網羅性（全 403 経路で 1 件以上書き込まれる設計、`tenant-auth.ts:138-168`）を確認した上で「サーバーまで届いていない」と結論できる。クライアント側の問題切り分けには現場ヒアリング（スクショ・URL・ブラウザ情報）が不可欠。AI 側で完結する調査の限界点として記録。
+本 PR の Codex code review で Phase 2 元実装 (PR #358) の脆弱性 3 件を可視化したが、これらは本 PR スコープ外。以下の選択肢を比較:
+
+1. ❌ 本 PR で全て fix → スコープ拡大、レビューやり直し、merge 遅延
+2. ✅ 別 Issue で起票 → 1 PR 1 目的、追跡性確保、decision-maker が優先度判断
+3. ❌ Issue 化せず TODO コメントだけ → 隠れて忘れられるリスク
+
+→ 案 2 採用。Codex review rating ≥ 7 / confidence ≥ 80 で triage 基準 #4 該当のため、ユーザー明示認可を得て起票。Net +3 は handoff KPI 逆行だが、隠れていた脆弱性を可視化した価値と引き換え。
 
 ---
 
-## 残タスク（次セッションへ）
+## 残タスク (次セッションへ)
 
 ### 即実施推奨
-- 福の種様への返信送付状況確認 + 返信受領時の追加切り分け（本田さん領分、送付済 or 未送付）
-- 現場情報受領後の原因特定（クライアント側 / URL / ブラウザ / 端末）
+- 福の種様への返信送付状況確認 + 返信受領時の追加切り分け (本田さん領分、Session 35 から継続)
+- PR #434 実装の本番動作確認 (decision-maker 領分、Cloud Run デプロイ済)
+  - スーパー管理者ログイン → `/super/progress/[tenantId]/[userId]/print` → Gmail 下書き作成 → To/CC の自動入力確認
 
-### Active Issue（Session 34 起票、本セッションでは未着手）
+### Active Issue (本セッション起票、優先度判断要)
+- #435 [P1] idempotency 非アトミック + 判定強化 umbrella (本番障害リスク中)
+- #436 [P1] accessToken owner 検証 (監査信頼性 + API 直叩き抜け穴)
+- #437 [P2] Gmail API エラーメッセージ PII フィルタ (PII 漏洩リスク中)
+
+### Active Issue (Session 34 起票、未着手)
 - #424 PATCH /quiz-attempts セッション再確認の abandoned 未対応 (bug, P2)
 - #425 Firestore transient エラー用リトライ共通ユーティリティ (enhancement, P2)
 
-### Postponed Issue（着手不可、明示指示なき限り保留）
-- #276 / #275 / #274: Phase 3 GCIP 完了が再開条件（再評価期限 2026-10-24）
+### Postponed Issue (着手不可、明示指示なき限り保留)
+- #276 / #275 / #274: Phase 3 GCIP 完了が再開条件 (再評価期限 2026-10-24)
 - #405: Phase 2 filename strict MTA risk
 
 ---
 
 ## 関連リンク
 
-- PR #430: https://github.com/system-279/lms-279/pull/430 (audit-allowlist-status workflow)
-- PR #431: https://github.com/system-279/lms-279/pull/431 (audit-tenant-auth-errors workflow)
-- audit-allowlist-status run #1 (72h): https://github.com/system-279/lms-279/actions/runs/26075862372
-- audit-allowlist-status run #2 (720h): https://github.com/system-279/lms-279/actions/runs/26075907026
-- audit-tenant-auth-errors run (720h, fuku-no-tane.com): https://github.com/system-279/lms-279/actions/runs/26076156456
-- Session 34 handoff (archived): docs/handoff/archive/2026-05-19-session-34.md
+- PR #434: https://github.com/system-279/lms-279/pull/434 (受講者進捗 PDF Gmail draft 宛先案 B 改訂)
+- Issue #433 (closed): https://github.com/system-279/lms-279/issues/433
+- Issue #435 (active): https://github.com/system-279/lms-279/issues/435 (idempotency umbrella)
+- Issue #436 (active): https://github.com/system-279/lms-279/issues/436 (accessToken owner 検証)
+- Issue #437 (active): https://github.com/system-279/lms-279/issues/437 (Gmail PII フィルタ)
+- ADR-034 (Accepted): docs/adr/ADR-034-phase2-gmail-draft.md
+- Cloud Run Deploy run: https://github.com/system-279/lms-279/actions/runs/26100557179
+- Session 35 handoff (archived): docs/handoff/archive/2026-05-19-session-35.md

--- a/docs/handoff/archive/2026-05-19-session-35.md
+++ b/docs/handoff/archive/2026-05-19-session-35.md
@@ -1,0 +1,214 @@
+# Session Handoff — 2026-05-19 (Session 35)
+
+## TL;DR
+
+**現場フィードバック対応セッション 2 連続（福の種テナント atali82i ログイン不可調査）。** 福の種様から「ユーザー管理画面のメールアドレスは正しいのに 2 名がログインできない」との連絡を受け、サーバー側の状態を read-only audit で切り分け → tenant 配下の `users` / `allowed_emails` / `auth_error_logs` を本番 Firestore に直接 read。**結論: サーバー側は正規登録済み、直近 30 日で tenant 全体に拒否ログ 0 件**。原因はクライアント側 or URL 到達前と確定。福の種様への返信文案を提示し本田さん承認、送付準備中（送付は decision-maker 領分）。
+
+- **Issue Net**: **0** (起票 0 / Close 0)
+- **Open 推移**: Session 34 末 6 件 → Session 35 末 **6 件** (変化なし)
+- **マージ済み PR (2 本)**: #430 (audit-allowlist-status workflow, +682/-0), #431 (audit-tenant-auth-errors workflow, +530/-0)
+- **本番反映**: ✅ 両 workflow とも main にマージ済、read-only のため Cloud Run デプロイ不要
+- **調査結果**: 該当 2 email (`y-mizuno@fuku-no-tane.com` / `c-yazawa@fuku-no-tane.com`) ともに `users` / `allowed_emails` 正規登録済み、firebaseUid 未紐付け（初回ログイン未完了）、直近 30 日の拒否ログ 0 件
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+# 1. 状況復元
+cat docs/handoff/LATEST.md
+
+# 2. main 最新と CI 状況
+git fetch origin main && git log --oneline -10 origin/main
+gh run list --branch main --limit 5
+
+# 3. 現在の OPEN Issue (6 件、Session 34 から不変)
+gh issue list --state open --limit 15
+
+# 4. 次の着手候補:
+#    A. 【ユーザー判断・最優先】福の種様への返信送信状況確認 + 返信受領時の追加切り分け
+#       - 返信文面は Session 35 で本田さん承認済（本ファイル末尾）
+#       - スクショ・URL・ブラウザ情報を受領後、原因切り分け継続
+#    B. 【active Issue】#424 PATCH /quiz-attempts セッション再確認の abandoned 未対応
+#    C. 【active Issue】#425 Firestore transient エラー用リトライ共通ユーティリティ
+#    D. 【postponed・着手不可】#276 / #275 / #274 / #405 — 明示指示なき限り着手不可
+
+# 5. 福の種様調査の再 audit が必要な場合（参考コマンド）
+gh workflow run audit-allowlist-status.yml \
+  -f tenant_id=atali82i \
+  -f emails="y-mizuno@fuku-no-tane.com,c-yazawa@fuku-no-tane.com" \
+  -f since_hours=720
+
+gh workflow run audit-tenant-auth-errors.yml \
+  -f tenant_id=atali82i \
+  -f since_hours=720 \
+  -f email_filter_domain=fuku-no-tane.com
+```
+
+---
+
+## セッション成果物 (2026-05-19 Session 35)
+
+### 🟢 PR #430 マージ: 特定 email の登録状態確認 audit (read-only)
+
+- マージコミット: `1db86e9` (squash)
+- ファイル: 3 (script + smoke test + workflow yaml)
+- 差分: +682 / -0
+- CI: Build / Lint / Type Check / Test 4/4 PASS
+
+#### 構成
+- `scripts/audit-allowlist-status.ts`: 入力 email 配列について `users` / `allowed_emails` / `auth_error_logs` の状態を表示、純粋関数 `parseEmails` / `computeDiagnosis` / `buildPerEmailReport`
+- `scripts/__tests__/audit-allowlist-status.smoke.ts`: 14 ケース全 PASS
+- `.github/workflows/audit-allowlist-status.yml`: workflow_dispatch + WIF、inputs は env 経由（command injection 対策）
+
+#### 診断ロジック（優先順位）
+1. `recent_auth_error_reason=<reason>`: 直近の auth_error_logs から reason 取得（最優先）
+2. `user_not_found_in_users_collection`
+3. `allowed_email_case_or_whitespace_mismatch`: 完全一致なし + ケース違いあり
+4. `not_in_allowlist_suspected`: allowed_emails に該当なし
+5. `no_firebase_uid_yet_user_has_not_logged_in`: 登録あるが初回ログイン未完了
+6. `no_recent_auth_error_logs_user_may_have_other_issue`: 全て揃っているがログなし
+
+### 🟢 PR #431 マージ: tenant 全体 auth_error_logs 集計 audit (read-only)
+
+- マージコミット: `242e3e7` (squash)
+- ファイル: 3 (script + smoke test + workflow yaml)
+- 差分: +530 / -0
+- CI: Build / Lint / Type Check / Test 4/4 PASS
+
+#### 構成
+- `scripts/audit-tenant-auth-errors.ts`: tenant 配下 auth_error_logs を直近 N 時間で取得、reason 別件数 + (domain 指定時のみ) email 別件数を集計、純粋関数 `aggregateLogs`
+- `scripts/__tests__/audit-tenant-auth-errors.smoke.ts`: 7 ケース全 PASS
+- `.github/workflows/audit-tenant-auth-errors.yml`: workflow_dispatch + WIF
+- email 別表示は `email_filter_domain` 指定時に限定（不特定多数 email 漏洩防止）
+
+### 🔍 調査結果（本番 atali82i tenant 直接 read）
+
+#### PR #430 audit-allowlist-status 実行（since_hours=72 → 720 で 2 回）
+| 項目 | 髙良 佑風 (`y-mizuno@fuku-no-tane.com`) | 矢澤 知穂 (`c-yazawa@fuku-no-tane.com`) |
+|------|---|---|
+| `users` 登録 | ✅ id=Vw3L7CfCVIm9Q4s9j4Hr, role=student, name="髙良　佑風" | ✅ id=GlB07XM5JxVF2yW4xcs7, role=student, name="矢澤　知穂" |
+| `allowed_emails` 登録 | ✅ id=rl1RiPRXEZb9SiXn89e8 | ✅ id=vIXJLnZoI11lFM5Z13E8 |
+| `firebaseUid` 紐付け | ❌ 未紐付け | ❌ 未紐付け |
+| 直近 30 日 `auth_error_logs` | **0 件** | **0 件** |
+| 診断 | `no_firebase_uid_yet_user_has_not_logged_in` | `no_firebase_uid_yet_user_has_not_logged_in` |
+
+#### PR #431 audit-tenant-auth-errors 実行（since_hours=720, domain=fuku-no-tane.com）
+- 取得件数: **0 件**
+- reason 別件数: (該当ログなし)
+- email 別件数 (fuku-no-tane.com): unique=0、(該当 domain での拒否ログなし)
+
+#### 確定事項
+1. サーバー側登録は両者とも完全に正常（ログイン受け入れ可能な状態）
+2. 該当 2 email のログイン試行はサーバーまで一切到達していない（30 日間 0 件）
+3. **別 email で試している可能性は否定**（fuku-no-tane.com domain で他 email の拒否ログも 0 件）
+4. **tenant 全体で 30 日拒否ログ 0 件**（他テナント user も初回ログインを試みていない or 既ログイン継続）
+
+### 📨 福の種様への返信文案（本田さん承認済、送付準備中）
+
+```
+福の種様
+
+ご連絡ありがとうございます。サーバー側で 2 名様の登録状況を確認しましたが、
+いずれもメールアドレスは正規に登録済みで、ログイン可能な状態でした。直近
+30 日のサーバー側ログを確認しましたが、2 名様によるログイン試行が一度も
+システム側で記録されていない状況です。
+
+お手数ですが、原因切り分けのため下記をご教示ください:
+1. ログインのどのステップで止まっておられるか（URL を開く / ログインボタンを
+   押す / Google の画面が出る / アカウント選択する / その後の画面 — のどの段階か）
+2. 画面のスクリーンショット（特にエラー表示や、白画面のままの場合はその状態）
+3. アクセスされている URL（https://web-3zcica5euq-an.a.run.app/atali82i/
+   で始まる形になっているか）
+4. ご利用のブラウザ（Safari / Chrome 等）と端末（PC / スマホ）
+
+取り急ぎご報告まで。
+```
+
+---
+
+## Issue Net 変化
+
+- **Close 数**: **0 件**
+- **起票数**: **0 件**
+- **Net**: **0 件**
+
+| Open Issue (Session 35 末、Session 34 末から不変) | ラベル | 状態 |
+|---|---|---|
+| #425 | enhancement, P2 | active (Session 34 起票、Firestore transient リトライ共通ユーティリティ) |
+| #424 | bug, P2 | active (Session 34 起票、PATCH session 再確認の abandoned 未対応) |
+| #405 | enhancement, P2, postponed | M365/Outlook/Proofpoint/Mimecast テナント追加 or 添付名問い合わせ |
+| #276 | enhancement, P2, postponed | Phase 3 GCIP 完了 (#272 / 再評価期限 2026-10-24) |
+| #275 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
+| #274 | enhancement, P2, postponed | Phase 3 GCIP 完了 |
+
+**Net 0 の理由言語化**: 本セッションは現場 1-shot 問い合わせ（福の種様ログイン不可）を受けた調査セッション。原因がサーバー側に存在しないことが確定したため、追加 Issue 起票なし。read-only audit workflow 2 本は将来の同種問い合わせの調査効率化のための恒久ツールとして残置（feedback_firestore_prod_admin_via_workflow.md §「責務集約」観点では別 workflow 量産になるが、責務が異なるため許容）。Session 34 末の active 2 件 + postponed 4 件はそのまま継承。
+
+---
+
+## 構造的整合性チェック
+
+| 変更内容 | 該当スキル | 状態 |
+|---|---|---|
+| 型・共有ロジック変更 | `/impact-analysis` | ⏭️ 対象外 (新規 admin script のみ、既存型/ロジックに影響なし) |
+| 新規 API / コレクション追加 | `/check-api-impact` | ⏭️ 対象外 (API 追加なし、既存 Firestore コレクションを read のみ) |
+| データフロー追加 | `/trace-dataflow` | ⏭️ 対象外 (新規データフローなし) |
+| statusField 状態遷移管理 | 状態遷移図 | ⏭️ 対象外 (read-only audit のみ) |
+| Partial Update テスト | undefined 検出 | ⏭️ 対象外 (Firestore 書き込みなし) |
+
+---
+
+## ハーネス的考察（本セッション特有）
+
+### 「すべて AI 側でチェック」明示指示時の workflow 経由 read-only 調査パターン
+
+本田さんから「現場ヒアリングなしで AI 完結で原因切り分けしてほしい」との明示指示。本番 Firestore admin SDK アクセスは `feedback_firestore_prod_admin_via_workflow.md` に従い **ローカル `node -e` 直結ではなく workflow_dispatch + CI SA** で実行が原則。本セッションでこのパターンを LMS-279 で初確立:
+
+| 構成要素 | 採用パターン |
+|---|---|
+| 認証 | WIF (workload_identity_provider) + CI SA (`github-actions@lms-279`) |
+| 認証コード分岐 | JSON `type` field 判定（`service_account` → `cert()`、`external_account` → `applicationDefault()`、`cleanup-stuck-quiz-attempts.ts` 流用） |
+| 入力 | workflow_dispatch inputs → env 経由（command injection 対策） |
+| 出力規範 | PII 漏洩防止のため email 別表示は domain フィルタ指定時に限定、件数 + reason 集計を基本 |
+| read-only 担保 | スクリプトに書き込み API なし、workflow に execute フラグなし |
+| PR 単位 | 1 PR = 1 script + 1 workflow + 1 smoke test の責務集約セット |
+
+Session 34 (`cleanup-stuck-quiz-attempts.yml` destructive write workflow) のパターンを read-only 版に転用。今後同種の「特定 email/tenant の本番状態を read-only で確認する」要件は本パターンで対応可能。
+
+### 「読み書き 2 種類」の workflow 設計境界
+
+本セッションで気づいた設計判断: **read-only audit と write migration を 1 workflow に詰め込まない**。理由:
+- 入力に `execute` フラグを足すと「うっかり書き込み」リスクが残る
+- read-only と write は責務 / 安全機構 / レビュー基準が異なる（書き込みには件数アサーション、バックアップ artifact、二段階運用が必要、read-only には不要）
+- 1 PR = 1 責務で diff が小さく、レビュー精度が上がる
+
+Session 34 で `cleanup-stuck-quiz-attempts.yml` を write 専用に設計、Session 35 で `audit-allowlist-status.yml` / `audit-tenant-auth-errors.yml` を read-only 専用として分離 → この境界が運用上のリスク低減に寄与。
+
+### 「サーバー側で 0 件 = 試行が到達していない」という強い結論の取り方
+
+直近 30 日 + tenant 全体 + domain 全 email で **拒否ログ 0 件** という結果は、サーバー側の問題ではないことを強く示唆する。`auth_error_logs` の網羅性（全 403 経路で 1 件以上書き込まれる設計、`tenant-auth.ts:138-168`）を確認した上で「サーバーまで届いていない」と結論できる。クライアント側の問題切り分けには現場ヒアリング（スクショ・URL・ブラウザ情報）が不可欠。AI 側で完結する調査の限界点として記録。
+
+---
+
+## 残タスク（次セッションへ）
+
+### 即実施推奨
+- 福の種様への返信送付状況確認 + 返信受領時の追加切り分け（本田さん領分、送付済 or 未送付）
+- 現場情報受領後の原因特定（クライアント側 / URL / ブラウザ / 端末）
+
+### Active Issue（Session 34 起票、本セッションでは未着手）
+- #424 PATCH /quiz-attempts セッション再確認の abandoned 未対応 (bug, P2)
+- #425 Firestore transient エラー用リトライ共通ユーティリティ (enhancement, P2)
+
+### Postponed Issue（着手不可、明示指示なき限り保留）
+- #276 / #275 / #274: Phase 3 GCIP 完了が再開条件（再評価期限 2026-10-24）
+- #405: Phase 2 filename strict MTA risk
+
+---
+
+## 関連リンク
+
+- PR #430: https://github.com/system-279/lms-279/pull/430 (audit-allowlist-status workflow)
+- PR #431: https://github.com/system-279/lms-279/pull/431 (audit-tenant-auth-errors workflow)
+- audit-allowlist-status run #1 (72h): https://github.com/system-279/lms-279/actions/runs/26075862372
+- audit-allowlist-status run #2 (720h): https://github.com/system-279/lms-279/actions/runs/26075907026
+- audit-tenant-auth-errors run (720h, fuku-no-tane.com): https://github.com/system-279/lms-279/actions/runs/26076156456
+- Session 34 handoff (archived): docs/handoff/archive/2026-05-19-session-34.md


### PR DESCRIPTION
## Summary

Session 36 ハンドオフ記録。PR #434 (受講者進捗 PDF Gmail 下書き宛先案 B 改訂、Issue #433 close) + follow-up Issue #435/#436/#437 起票の総括。

## 主な変更

- `docs/handoff/LATEST.md`: Session 36 内容で書き換え (238 行)
- `docs/handoff/archive/2026-05-19-session-35.md`: Session 35 を archive へ移動

## Issue Net 変化 (handoff KPI)

| | 件数 |
|---|---|
| Close 数 | 1 件 (#433) |
| 起票数 | 4 件 (#433, #435, #436, #437) |
| **Net** | **+3** |

**Net +3 の理由言語化**: 本セッションの PR #434 は宛先ロジック改訂 1 件で #433 を close したが、Codex code review (実装後) で Phase 2 元実装 (PR #358) からの脆弱性 3 件を可視化した結果、follow-up Issue として起票した。**過剰起票ではなく、隠れていた脆弱性を可視化した価値と引き換えの Net 逆行**。

## Test plan

設定/ドキュメントのみの PR なので構文検証 + 次セッション確認:

- [x] LATEST.md 行数チェック: 238 行 (500 行以下 OK)
- [x] archive ディレクトリへ Session 35 移動完了 (`git mv`)
- [x] 関連リンクの整合性 (PR #434 / Issue #433/#435/#436/#437 全て存在確認済)
- [ ] 次セッション `/catchup` 実行時に LATEST.md が正しく読み込まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)