### PR TITLE
docs(adr-027): 「ルール緩和は本末転倒」判断記録 + Phase A 効果測定 workflow

### DIFF
--- a/.github/workflows/audit-session-force-exits.yml
+++ b/.github/workflows/audit-session-force-exits.yml
@@ -1,0 +1,80 @@
+name: Audit Session Force Exits
+
+# tenant 配下の lesson_sessions force_exited を直近 N 日で集計し、
+# reason 別件数と time_limit の sessionVideoCompleted 別内訳（ケース E / B）、
+# ケース E の lessonId 別上位件数を表示する read-only workflow。
+#
+# 用途:
+#   ADR-027 改訂履歴（2026-05-20）の Phase A 効果測定。
+#   3 時間延長（PR #407、2026-05-16 デプロイ）後にケース E（動画再生中の time_limit で
+#   sessionVideoCompleted=false、全リセット）がどの程度発生しているかを観察し、
+#   恒久対応（コンテンツ側のレッスン分割）の優先度判断に使う。
+#
+# 安全機構:
+#   - read-only スクリプト（書き込み一切なし）
+#   - tenant_id 入力必須
+#   - userId / email は表示せず、lessonId 別件数のみ表示（PII 制限）
+#
+# セキュリティ: workflow_dispatch 入力はすべて env 経由で受け、run: 内で直接 inputs を
+# 補間しない（command injection 対策）。
+# 参考: https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+
+on:
+  workflow_dispatch:
+    inputs:
+      tenant_id:
+        description: 'テナント ID（必須）例: 8vexhzpc'
+        required: true
+        type: string
+      since_days:
+        description: 'lesson_sessions を遡る日数（既定 30 日、最大 90 日）'
+        required: false
+        default: '30'
+        type: string
+      top_lessons:
+        description: 'ケース E（動画未完了 time_limit）の lesson 別上位件数（既定 20、最大 200）'
+        required: false
+        default: '20'
+        type: string
+
+jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      FIREBASE_PROJECT_ID: lms-279
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/1034821634012/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-actions@lms-279.iam.gserviceaccount.com
+
+      - name: Run audit script
+        env:
+          GOOGLE_CLOUD_PROJECT: lms-279
+          TENANT_ID: ${{ inputs.tenant_id }}
+          SINCE_DAYS: ${{ inputs.since_days }}
+          TOP_LESSONS: ${{ inputs.top_lessons }}
+        run: |
+          set -euo pipefail
+          FLAGS=("--tenant-id=$TENANT_ID")
+          if [ -n "$SINCE_DAYS" ]; then FLAGS+=("--since-days=$SINCE_DAYS"); fi
+          if [ -n "$TOP_LESSONS" ]; then FLAGS+=("--top-lessons=$TOP_LESSONS"); fi
+          echo "Running with tenant=$TENANT_ID since-days=$SINCE_DAYS top-lessons=$TOP_LESSONS"
+          npx tsx scripts/audit-session-force-exits.ts "${FLAGS[@]}"

--- a/.github/workflows/audit-session-force-exits.yml
+++ b/.github/workflows/audit-session-force-exits.yml
@@ -10,9 +10,15 @@ name: Audit Session Force Exits
 #   sessionVideoCompleted=false、全リセット）がどの程度発生しているかを観察し、
 #   恒久対応（コンテンツ側のレッスン分割）の優先度判断に使う。
 #
+# 前提:
+#   - Firestore composite index (status ASC, exitAt DESC) on lesson_sessions が必要。
+#     firestore.indexes.json に登録済だが、`firebase deploy --only firestore:indexes -P <alias>`
+#     を手動実行する必要あり（CI/CD には含まれない、rules/firebase.md 参照）。
+#     未デプロイ時は最初の workflow 実行が FAILED_PRECONDITION で失敗する。
+#
 # 安全機構:
 #   - read-only スクリプト（書き込み一切なし）
-#   - tenant_id 入力必須
+#   - tenant_id 入力必須（英数 / _ / - のみ許可）
 #   - userId / email は表示せず、lessonId 別件数のみ表示（PII 制限）
 #
 # セキュリティ: workflow_dispatch 入力はすべて env 経由で受け、run: 内で直接 inputs を

--- a/docs/adr/ADR-027-lesson-session-attendance.md
+++ b/docs/adr/ADR-027-lesson-session-attendance.md
@@ -4,6 +4,7 @@
 承認済み（2026-05-16 改訂: セッション上限を環境変数化）
 
 ## 改訂履歴
+- **2026-05-20**: 現場声「テスト不合格時にいつでも再受験できる方が望ましいのではないか」を起点に再設計を検討。実コード検証で **`maxAttempts=0`（本番設定）配下では既にケース A〜D（動画完了後/セッション内/抱えこみ後/後方互換）で何度でも再受験可能**であり、再受験不可となるのはケース E（動画再生中に `time_limit`、`sessionVideoCompleted=false` で全リセット）と F（受験上限到達）のみと判明。E/F のリセット廃止 / 動画ゲート（ADR-019）撤廃 / 「いつでも再受験」設計変更は **規律装置（強制退室時の全リセット）を破壊する本末転倒** と判断し、いずれも不採用。3h 延長（PR #407）は対症療法として暫定維持、**恒久対応は業務側のコンテンツ設計**（レッスン単位で「動画長 + テスト所要時間 < `SESSION_DURATION_MS`」を満たす分割）で対応する。効果測定として `scripts/audit-session-force-exits.ts` + `.github/workflows/audit-session-force-exits.yml`（read-only）を追加し、ケース E の発生数を継続観察する。
 - **2026-05-16**: セッション上限 `SESSION_DURATION_MS` および一時停止上限 `PAUSE_TIMEOUT_MS` を環境変数で上書き可能化（PR #407）。本番運用で動画 60-80 分のレッスン + テスト解答時間が 2 時間制限内に収まらない事例が複数発生（kanjikai.or.jp テナント、5/3〜5/14 で `time_limit` 強制退室 7 件）。本番は `SESSION_DURATION_MS=10800000`（3 時間）にデプロイ。不正値は `logger.error` 後にデフォルトへフォールバック。受講者向け UI 文言の「2 時間」表記は PR #408 で対応完了（`SessionRulesNotice` は `deadlineAt - entryAt` から動的算出、`ForceExitDialog` / ヘルプ / API 403 message は時間値を明示しない汎用表現に変更）。長期的には動画完了後にテスト専用タイマーに切り替える設計案（"Phase 3" として議論中）も検討。
 - **2026-03-30**: 強制退室発生時にそのレッスンの学習データ（`video_analytics` / `video_events` / `quiz_attempts` / `user_progress` の該当エントリ）を完全リセットする実装を追加（PR #134、Issue #133）。`exitReason` が `pause_timeout` / `time_limit` / `max_attempts_failed` のいずれかで `forceExitSession()` が呼ばれると、`resetLessonDataForUser()` が同期実行される。**ただし `sessionVideoCompleted=true` のセッションはリセットを skip**（HTML5 video の `ended` が pause 状態を伴うため、完了後の自然な pause タイムアウトでデータが全消去されるのを防止）。受講者は強制退室後に白紙状態から再受講可能。
 

--- a/docs/adr/ADR-027-lesson-session-attendance.md
+++ b/docs/adr/ADR-027-lesson-session-attendance.md
@@ -4,7 +4,22 @@
 承認済み（2026-05-16 改訂: セッション上限を環境変数化）
 
 ## 改訂履歴
-- **2026-05-20**: 現場声「テスト不合格時にいつでも再受験できる方が望ましいのではないか」を起点に再設計を検討。実コード検証で **`maxAttempts=0`（本番設定）配下では既にケース A〜D（動画完了後/セッション内/抱えこみ後/後方互換）で何度でも再受験可能**であり、再受験不可となるのはケース E（動画再生中に `time_limit`、`sessionVideoCompleted=false` で全リセット）と F（受験上限到達）のみと判明。E/F のリセット廃止 / 動画ゲート（ADR-019）撤廃 / 「いつでも再受験」設計変更は **規律装置（強制退室時の全リセット）を破壊する本末転倒** と判断し、いずれも不採用。3h 延長（PR #407）は対症療法として暫定維持、**恒久対応は業務側のコンテンツ設計**（レッスン単位で「動画長 + テスト所要時間 < `SESSION_DURATION_MS`」を満たす分割）で対応する。効果測定として `scripts/audit-session-force-exits.ts` + `.github/workflows/audit-session-force-exits.yml`（read-only）を追加し、ケース E の発生数を継続観察する。
+- **2026-05-20**: 現場声「テスト不合格時にいつでも再受験できる方が望ましいのではないか」を起点に再設計を検討。実コード検証で **`maxAttempts=0`（本番テナント `8vexhzpc` の全 quiz 設定。Codex review PR #407 body 参照）配下では既にケース A〜D で何度でも再受験可能** と判明。再受験不可はケース E と F のみ。E/F のリセット廃止 / 動画ゲート（ADR-019）撤廃 / 「いつでも再受験」設計変更は **規律装置（強制退室時の全リセット）を破壊する本末転倒** と判断し、いずれも不採用。3h 延長（PR #407）は対症療法として暫定維持、**恒久対応は業務側のコンテンツ設計**（レッスン単位で「動画長 + テスト所要時間 < `SESSION_DURATION_MS`」を満たす分割）で対応する。効果測定として `scripts/audit-session-force-exits.ts` + `.github/workflows/audit-session-force-exits.yml`（read-only）を追加し、ケース E の発生数を継続観察する。
+
+  ### ケース A〜F 定義（2026-05-20 時点）
+
+  | ID | 条件（reason, sessionVideoCompleted, maxAttempts） | 挙動 | 再受験可否 | コード参照 |
+  |---|---|---|---|---|
+  | A | 不合格 + セッション内（time_limit 未到達）+ maxAttempts 未到達 | セッション継続 | ✅ 即時再受験 | `services/api/src/routes/shared/quiz-attempts.ts:374-397`（合格/上限到達 どちらでもない fall-through） |
+  | B | `reason=time_limit` + `sessionVideoCompleted=true` | `forceExitSession` でリセット skip、in_progress attempt のみ `timed_out` 化 | ✅ 新セッションでテスト再受験 | `services/api/src/services/lesson-session.ts:230-232`（PR #134 + Issue #422） |
+  | C | `reason=browser_close`（abandoned） | リセットせず、in_progress attempt のみ `timed_out` 化 | ✅ 新セッションで再受験 | `services/api/src/services/lesson-session.ts:247-273`（Issue #422） |
+  | D | セッション未作成（後方互換） | `activeSession=null` でセッション制約スキップ | ✅ 受講期間内なら受験可 | `services/api/src/routes/shared/quiz-attempts.ts:292-308`（コメント明示） |
+  | E | `reason=time_limit` + `sessionVideoCompleted=false` | `resetLessonDataForUser` で全リセット（video_analytics / video_events / quiz_attempts / user_progress） | ❌ 動画から見直し | `services/api/src/services/lesson-session.ts:233-237` |
+  | F | `reason=max_attempts_failed`（`maxAttempts > 0 && attemptNumber >= maxAttempts`） | 同上、全リセット | ❌ 動画から見直し（本番 maxAttempts=0 では発火しない） | `services/api/src/routes/shared/quiz-attempts.ts:390-397` |
+
+  ### 規律装置の根拠
+
+  E/F のリセットは罰則ではなく **「1 セッション内で動画視聴→テスト送信まで完了させる」要件**（本 ADR §コンテキスト / `services/api/src/services/lesson-session.ts:201-207`）を担保する装置。E のリセット廃止 = 動画視聴強制の規律装置を撤廃 = 本末転倒。
 - **2026-05-16**: セッション上限 `SESSION_DURATION_MS` および一時停止上限 `PAUSE_TIMEOUT_MS` を環境変数で上書き可能化（PR #407）。本番運用で動画 60-80 分のレッスン + テスト解答時間が 2 時間制限内に収まらない事例が複数発生（kanjikai.or.jp テナント、5/3〜5/14 で `time_limit` 強制退室 7 件）。本番は `SESSION_DURATION_MS=10800000`（3 時間）にデプロイ。不正値は `logger.error` 後にデフォルトへフォールバック。受講者向け UI 文言の「2 時間」表記は PR #408 で対応完了（`SessionRulesNotice` は `deadlineAt - entryAt` から動的算出、`ForceExitDialog` / ヘルプ / API 403 message は時間値を明示しない汎用表現に変更）。長期的には動画完了後にテスト専用タイマーに切り替える設計案（"Phase 3" として議論中）も検討。
 - **2026-03-30**: 強制退室発生時にそのレッスンの学習データ（`video_analytics` / `video_events` / `quiz_attempts` / `user_progress` の該当エントリ）を完全リセットする実装を追加（PR #134、Issue #133）。`exitReason` が `pause_timeout` / `time_limit` / `max_attempts_failed` のいずれかで `forceExitSession()` が呼ばれると、`resetLessonDataForUser()` が同期実行される。**ただし `sessionVideoCompleted=true` のセッションはリセットを skip**（HTML5 video の `ended` が pause 状態を伴うため、完了後の自然な pause タイムアウトでデータが全消去されるのを防止）。受講者は強制退室後に白紙状態から再受講可能。
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -195,6 +195,14 @@
         { "fieldPath": "courseId", "order": "ASCENDING" },
         { "fieldPath": "entryAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "lesson_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "exitAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/scripts/__tests__/audit-session-force-exits.smoke.ts
+++ b/scripts/__tests__/audit-session-force-exits.smoke.ts
@@ -7,13 +7,17 @@
  */
 
 import assert from "node:assert/strict";
-import { aggregateSessions, type RawSession } from "../audit-session-force-exits.ts";
+import {
+  aggregateSessions,
+  type RawSession,
+  type SessionVideoCompletedFlag,
+} from "../audit-session-force-exits.ts";
 
 const ts = "2026-05-19T00:00:00.000Z";
 const ses = (
   lessonId: string | null,
   exitReason: string | null,
-  sessionVideoCompleted: boolean
+  sessionVideoCompleted: SessionVideoCompletedFlag
 ): RawSession => ({
   lessonId,
   exitReason,
@@ -28,6 +32,7 @@ const ses = (
   assert.deepEqual(s.reasonCounts, []);
   assert.equal(s.timeLimitVideoIncomplete, 0);
   assert.equal(s.timeLimitVideoCompleted, 0);
+  assert.equal(s.timeLimitVideoUnknown, 0);
   assert.deepEqual(s.caseELessonCounts, []);
   assert.equal(s.caseELessonTruncated, 0);
   assert.equal(s.caseELessonUniqueCount, 0);
@@ -52,7 +57,7 @@ const ses = (
   ]);
 }
 
-// --- time_limit 内訳（ケース E / B 切り分け） ---
+// --- time_limit 内訳（ケース E / B / 不明 の 3 状態切り分け） ---
 {
   const s = aggregateSessions(
     [
@@ -61,11 +66,13 @@ const ses = (
       ses("L2", "time_limit", true),  // ケース B
       ses("L3", "pause_timeout", false), // 内訳対象外
       ses("L4", "time_limit", true),  // ケース B
+      ses("L5", "time_limit", null),  // 不明（KPI 保留）
     ],
     10
   );
   assert.equal(s.timeLimitVideoIncomplete, 2);
   assert.equal(s.timeLimitVideoCompleted, 2);
+  assert.equal(s.timeLimitVideoUnknown, 1);
 }
 
 // --- ケース E lesson 別降順 + lessonId null は (missing-lessonId) ---
@@ -77,8 +84,9 @@ const ses = (
       ses("L1", "time_limit", false),
       ses("L2", "time_limit", false),
       ses(null, "time_limit", false),
-      // ケース B / 他 reason は caseE に含まれない
+      // ケース B / 不明 / 他 reason は caseE に含まれない
       ses("L1", "time_limit", true),
+      ses("L1", "time_limit", null),
       ses("L1", "pause_timeout", false),
     ],
     10
@@ -96,7 +104,6 @@ const ses = (
 // --- top-lessons で truncate ---
 {
   const sessions: RawSession[] = [];
-  // L0..L4 を各 1 件 + L0 をさらに 2 件、L1 をさらに 1 件
   for (let i = 0; i < 5; i++) sessions.push(ses(`L${i}`, "time_limit", false));
   sessions.push(ses("L0", "time_limit", false));
   sessions.push(ses("L0", "time_limit", false));
@@ -112,26 +119,111 @@ const ses = (
   assert.equal(s.caseELessonTruncated, 3);
 }
 
-// --- ケース E がゼロでもケース B / 他 reason は集計される ---
+// --- top-lessons == unique count: truncated=0 で全件返る ---
+{
+  const s = aggregateSessions(
+    [
+      ses("L1", "time_limit", false),
+      ses("L2", "time_limit", false),
+      ses("L3", "time_limit", false),
+    ],
+    3
+  );
+  assert.equal(s.caseELessonUniqueCount, 3);
+  assert.equal(s.caseELessonCounts.length, 3);
+  assert.equal(s.caseELessonTruncated, 0);
+}
+
+// --- top-lessons > unique count: truncated は負値クランプで 0 ---
+{
+  const s = aggregateSessions(
+    [
+      ses("L1", "time_limit", false),
+      ses("L2", "time_limit", false),
+    ],
+    10
+  );
+  assert.equal(s.caseELessonUniqueCount, 2);
+  assert.equal(s.caseELessonCounts.length, 2);
+  assert.equal(s.caseELessonTruncated, 0); // Math.max(0, -8)
+}
+
+// --- ケース E がゼロでもケース B / 不明 / 他 reason は集計される ---
 {
   const s = aggregateSessions(
     [
       ses("L1", "time_limit", true),
       ses("L2", "pause_timeout", true),
       ses("L3", "max_attempts_failed", false),
+      ses("L4", "time_limit", null),
     ],
     10
   );
-  assert.equal(s.totalForceExits, 3);
+  assert.equal(s.totalForceExits, 4);
   assert.equal(s.timeLimitVideoIncomplete, 0);
   assert.equal(s.timeLimitVideoCompleted, 1);
+  assert.equal(s.timeLimitVideoUnknown, 1);
   assert.deepEqual(s.caseELessonCounts, []);
   assert.equal(s.caseELessonUniqueCount, 0);
   assert.deepEqual(s.reasonCounts, [
-    { reason: "time_limit", count: 1 },
+    { reason: "time_limit", count: 2 },
     { reason: "pause_timeout", count: 1 },
     { reason: "max_attempts_failed", count: 1 },
   ]);
+}
+
+// --- 同件数の lessonId 複数: stable sort で順序を確定（length と内容を確認） ---
+{
+  const s = aggregateSessions(
+    [
+      ses("L1", "time_limit", false),
+      ses("L2", "time_limit", false),
+      ses("L3", "time_limit", false),
+    ],
+    10
+  );
+  assert.equal(s.caseELessonCounts.length, 3);
+  // 件数は全部 1、順序は insertion-order（ECMA-2019 stable sort 仕様）
+  assert.deepEqual(
+    s.caseELessonCounts.map((x) => x.count),
+    [1, 1, 1]
+  );
+  // unique lessonId が全て含まれる（順序非依存）
+  const lessons = s.caseELessonCounts.map((x) => x.lessonId).sort();
+  assert.deepEqual(lessons, ["L1", "L2", "L3"]);
+}
+
+// --- 算術不変量: reasonCounts の合計が totalForceExits と一致 ---
+// --- 算術不変量: timeLimit の 3 バケット合計が reasonCounts["time_limit"] と一致 ---
+// --- 算術不変量: caseELessonCounts.length + caseELessonTruncated == caseELessonUniqueCount ---
+{
+  const sessions: RawSession[] = [
+    ses("L1", "time_limit", false),
+    ses("L1", "time_limit", true),
+    ses("L1", "time_limit", null),
+    ses("L2", "time_limit", false),
+    ses("L3", "pause_timeout", true),
+    ses("L4", "max_attempts_failed", false),
+    ses(null, null, false),
+  ];
+  const s = aggregateSessions(sessions, 1); // top-1 で truncate を起こす
+
+  const sumReasons = s.reasonCounts.reduce((n, x) => n + x.count, 0);
+  assert.equal(sumReasons, s.totalForceExits, "reasonCounts sum != totalForceExits");
+
+  const timeLimitTotal =
+    s.reasonCounts.find((x) => x.reason === "time_limit")?.count ?? 0;
+  assert.equal(
+    s.timeLimitVideoIncomplete + s.timeLimitVideoCompleted + s.timeLimitVideoUnknown,
+    timeLimitTotal,
+    "timeLimit 3 buckets sum != reasonCounts[time_limit]"
+  );
+
+  assert.equal(
+    s.caseELessonCounts.length + s.caseELessonTruncated,
+    s.caseELessonUniqueCount,
+    "caseELessonCounts.length + truncated != uniqueCount"
+  );
 }
 
 console.log("✓ audit-session-force-exits.smoke.ts: all assertions passed");

--- a/scripts/__tests__/audit-session-force-exits.smoke.ts
+++ b/scripts/__tests__/audit-session-force-exits.smoke.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env npx tsx
+/**
+ * `scripts/audit-session-force-exits.ts#aggregateSessions` の smoke test。
+ *
+ * 実行方法:
+ *   npx tsx scripts/__tests__/audit-session-force-exits.smoke.ts
+ */
+
+import assert from "node:assert/strict";
+import { aggregateSessions, type RawSession } from "../audit-session-force-exits.ts";
+
+const ts = "2026-05-19T00:00:00.000Z";
+const ses = (
+  lessonId: string | null,
+  exitReason: string | null,
+  sessionVideoCompleted: boolean
+): RawSession => ({
+  lessonId,
+  exitReason,
+  sessionVideoCompleted,
+  exitAt: ts,
+});
+
+// --- 空入力 ---
+{
+  const s = aggregateSessions([], 10);
+  assert.equal(s.totalForceExits, 0);
+  assert.deepEqual(s.reasonCounts, []);
+  assert.equal(s.timeLimitVideoIncomplete, 0);
+  assert.equal(s.timeLimitVideoCompleted, 0);
+  assert.deepEqual(s.caseELessonCounts, []);
+  assert.equal(s.caseELessonTruncated, 0);
+  assert.equal(s.caseELessonUniqueCount, 0);
+}
+
+// --- reason 別件数（降順） + null は (missing) ---
+{
+  const s = aggregateSessions(
+    [
+      ses("L1", "time_limit", false),
+      ses("L1", "time_limit", false),
+      ses("L2", "pause_timeout", false),
+      ses("L3", null, false),
+    ],
+    10
+  );
+  assert.equal(s.totalForceExits, 4);
+  assert.deepEqual(s.reasonCounts, [
+    { reason: "time_limit", count: 2 },
+    { reason: "pause_timeout", count: 1 },
+    { reason: "(missing)", count: 1 },
+  ]);
+}
+
+// --- time_limit 内訳（ケース E / B 切り分け） ---
+{
+  const s = aggregateSessions(
+    [
+      ses("L1", "time_limit", false), // ケース E
+      ses("L1", "time_limit", false), // ケース E
+      ses("L2", "time_limit", true),  // ケース B
+      ses("L3", "pause_timeout", false), // 内訳対象外
+      ses("L4", "time_limit", true),  // ケース B
+    ],
+    10
+  );
+  assert.equal(s.timeLimitVideoIncomplete, 2);
+  assert.equal(s.timeLimitVideoCompleted, 2);
+}
+
+// --- ケース E lesson 別降順 + lessonId null は (missing-lessonId) ---
+{
+  const s = aggregateSessions(
+    [
+      ses("L1", "time_limit", false),
+      ses("L1", "time_limit", false),
+      ses("L1", "time_limit", false),
+      ses("L2", "time_limit", false),
+      ses(null, "time_limit", false),
+      // ケース B / 他 reason は caseE に含まれない
+      ses("L1", "time_limit", true),
+      ses("L1", "pause_timeout", false),
+    ],
+    10
+  );
+  assert.equal(s.timeLimitVideoIncomplete, 5);
+  assert.deepEqual(s.caseELessonCounts, [
+    { lessonId: "L1", count: 3 },
+    { lessonId: "L2", count: 1 },
+    { lessonId: "(missing-lessonId)", count: 1 },
+  ]);
+  assert.equal(s.caseELessonUniqueCount, 3);
+  assert.equal(s.caseELessonTruncated, 0);
+}
+
+// --- top-lessons で truncate ---
+{
+  const sessions: RawSession[] = [];
+  // L0..L4 を各 1 件 + L0 をさらに 2 件、L1 をさらに 1 件
+  for (let i = 0; i < 5; i++) sessions.push(ses(`L${i}`, "time_limit", false));
+  sessions.push(ses("L0", "time_limit", false));
+  sessions.push(ses("L0", "time_limit", false));
+  sessions.push(ses("L1", "time_limit", false));
+
+  const s = aggregateSessions(sessions, 2);
+  assert.equal(s.timeLimitVideoIncomplete, 8);
+  assert.equal(s.caseELessonUniqueCount, 5);
+  assert.deepEqual(s.caseELessonCounts, [
+    { lessonId: "L0", count: 3 },
+    { lessonId: "L1", count: 2 },
+  ]);
+  assert.equal(s.caseELessonTruncated, 3);
+}
+
+// --- ケース E がゼロでもケース B / 他 reason は集計される ---
+{
+  const s = aggregateSessions(
+    [
+      ses("L1", "time_limit", true),
+      ses("L2", "pause_timeout", true),
+      ses("L3", "max_attempts_failed", false),
+    ],
+    10
+  );
+  assert.equal(s.totalForceExits, 3);
+  assert.equal(s.timeLimitVideoIncomplete, 0);
+  assert.equal(s.timeLimitVideoCompleted, 1);
+  assert.deepEqual(s.caseELessonCounts, []);
+  assert.equal(s.caseELessonUniqueCount, 0);
+  assert.deepEqual(s.reasonCounts, [
+    { reason: "time_limit", count: 1 },
+    { reason: "pause_timeout", count: 1 },
+    { reason: "max_attempts_failed", count: 1 },
+  ]);
+}
+
+console.log("✓ audit-session-force-exits.smoke.ts: all assertions passed");

--- a/scripts/audit-session-force-exits.ts
+++ b/scripts/audit-session-force-exits.ts
@@ -1,0 +1,318 @@
+#!/usr/bin/env npx tsx
+/**
+ * tenant 配下 lesson_sessions の force_exited 強制退室サマリ調査スクリプト（read-only）
+ *
+ * 目的:
+ *   ADR-027 改訂履歴（2026-05-20）の Phase A 効果測定。
+ *   3 時間延長（PR #407、2026-05-16 デプロイ）後にケース E（動画再生中の
+ *   `time_limit` で `sessionVideoCompleted=false`、全リセット）が
+ *   どの程度発生しているかを観察する。
+ *
+ *   reason 別件数と、time_limit については sessionVideoCompleted フラグ別の
+ *   内訳（true=ケース B、false=ケース E）を出力する。
+ *   lessonId 別の上位件数も表示し、長尺レッスンの特定に使う。
+ *
+ * 安全機構:
+ *   - read-only（書き込み一切なし）
+ *   - tenant_id は必須入力
+ *   - userId / lessonId 別件数のみ表示し、userId / email は表示しない（PII 制限）
+ *
+ * 使用方法:
+ *   GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json \
+ *     npx tsx scripts/audit-session-force-exits.ts \
+ *     --tenant-id=8vexhzpc \
+ *     --since-days=30 \
+ *     --top-lessons=20
+ *
+ * 環境変数:
+ *   GOOGLE_APPLICATION_CREDENTIALS  サービスアカウント JSON のパス（WIF 環境では external_account JSON）
+ *   GOOGLE_CLOUD_PROJECT            プロジェクト ID
+ */
+
+import {
+  initializeApp,
+  cert,
+  applicationDefault,
+  type ServiceAccount,
+} from "firebase-admin/app";
+import { getFirestore, type Firestore, Timestamp } from "firebase-admin/firestore";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+// ============================================================
+// 純粋関数（smoke test 対象）
+// ============================================================
+
+export interface RawSession {
+  lessonId: string | null;
+  exitReason: string | null;
+  sessionVideoCompleted: boolean;
+  exitAt: string;
+}
+
+export interface AggregatedSummary {
+  totalForceExits: number;
+  /** reason → 件数（降順）。reason=null は "(missing)" として集計。 */
+  reasonCounts: Array<{ reason: string; count: number }>;
+  /** time_limit のうち sessionVideoCompleted=false（ケース E）= 動画再生中 time_limit で全リセット */
+  timeLimitVideoIncomplete: number;
+  /** time_limit のうち sessionVideoCompleted=true（ケース B）= 動画完了後 time_limit、reset skip */
+  timeLimitVideoCompleted: number;
+  /** ケース E に該当する lessonId → 件数（降順、top N でカット） */
+  caseELessonCounts: Array<{ lessonId: string; count: number }>;
+  /** top N でカットされた残り lesson 件数 */
+  caseELessonTruncated: number;
+  /** ケース E にマッチした unique lesson 数（top で切られても全体数として把握） */
+  caseELessonUniqueCount: number;
+}
+
+/**
+ * 集計（純粋関数）。
+ *
+ * @param sessions 取得済み force_exited セッション
+ * @param topLessons ケース E の lesson 別上位件数。1 以上。
+ */
+export function aggregateSessions(
+  sessions: RawSession[],
+  topLessons: number
+): AggregatedSummary {
+  const reasonMap = new Map<string, number>();
+  let timeLimitVideoIncomplete = 0;
+  let timeLimitVideoCompleted = 0;
+  const caseELessonMap = new Map<string, number>();
+
+  for (const s of sessions) {
+    const reason = s.exitReason ?? "(missing)";
+    reasonMap.set(reason, (reasonMap.get(reason) ?? 0) + 1);
+
+    if (s.exitReason === "time_limit") {
+      if (s.sessionVideoCompleted) {
+        timeLimitVideoCompleted++;
+      } else {
+        timeLimitVideoIncomplete++;
+        const lessonId = s.lessonId ?? "(missing-lessonId)";
+        caseELessonMap.set(lessonId, (caseELessonMap.get(lessonId) ?? 0) + 1);
+      }
+    }
+  }
+
+  const reasonCounts = Array.from(reasonMap.entries())
+    .map(([reason, count]) => ({ reason, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const allCaseELessons = Array.from(caseELessonMap.entries())
+    .map(([lessonId, count]) => ({ lessonId, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const caseELessonCounts = allCaseELessons.slice(0, topLessons);
+  const caseELessonTruncated = Math.max(0, allCaseELessons.length - topLessons);
+
+  return {
+    totalForceExits: sessions.length,
+    reasonCounts,
+    timeLimitVideoIncomplete,
+    timeLimitVideoCompleted,
+    caseELessonCounts,
+    caseELessonTruncated,
+    caseELessonUniqueCount: allCaseELessons.length,
+  };
+}
+
+// ============================================================
+// CLI / メイン
+// ============================================================
+
+const ARG_PREFIXES = [
+  "--tenant-id=",
+  "--since-days=",
+  "--top-lessons=",
+] as const;
+
+const isMainEntry = import.meta.url === `file://${process.argv[1]}`;
+
+if (isMainEntry) {
+  main().catch((err) => {
+    console.error(`[FATAL] 予期しないエラー: ${err instanceof Error ? err.message : err}`);
+    process.exit(1);
+  });
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  for (const a of args) {
+    if (!ARG_PREFIXES.some((p) => a.startsWith(p))) {
+      console.error(
+        `[FATAL] 未知の引数: "${a}" (許容: ${ARG_PREFIXES.join(", ")})`
+      );
+      process.exit(1);
+    }
+  }
+
+  const tenantId = args
+    .find((a) => a.startsWith("--tenant-id="))
+    ?.replace("--tenant-id=", "")
+    .trim();
+  if (!tenantId) {
+    console.error("[FATAL] --tenant-id=<id> は必須");
+    process.exit(1);
+  }
+
+  const sinceDaysRaw = args
+    .find((a) => a.startsWith("--since-days="))
+    ?.replace("--since-days=", "")
+    .trim();
+  const sinceDays = sinceDaysRaw ? Number(sinceDaysRaw) : 30;
+  if (!Number.isFinite(sinceDays) || sinceDays <= 0 || sinceDays > 90) {
+    console.error(
+      `[FATAL] --since-days は 1〜90 の数値: 受け取った値="${sinceDaysRaw}"`
+    );
+    process.exit(1);
+  }
+
+  const topLessonsRaw = args
+    .find((a) => a.startsWith("--top-lessons="))
+    ?.replace("--top-lessons=", "")
+    .trim();
+  const topLessons = topLessonsRaw ? Number(topLessonsRaw) : 20;
+  if (!Number.isFinite(topLessons) || topLessons <= 0 || topLessons > 200) {
+    console.error(
+      `[FATAL] --top-lessons は 1〜200 の数値: 受け取った値="${topLessonsRaw}"`
+    );
+    process.exit(1);
+  }
+
+  // Firebase 初期化（audit-tenant-auth-errors.ts と同じ WIF / SA JSON 兼用ロジック）
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  try {
+    if (credPath) {
+      const jsonPath = resolve(process.cwd(), credPath);
+      const credJson = JSON.parse(readFileSync(jsonPath, "utf8")) as {
+        type?: string;
+      };
+      if (credJson.type === "service_account") {
+        initializeApp({ credential: cert(credJson as ServiceAccount) });
+        console.log(`認証: サービスアカウントJSON (${jsonPath})`);
+      } else {
+        initializeApp({ credential: applicationDefault() });
+        console.log(
+          `認証: Application Default Credentials (cred file type=${credJson.type ?? "unknown"})`
+        );
+      }
+    } else {
+      initializeApp({ credential: applicationDefault() });
+      console.log("認証: Application Default Credentials");
+    }
+  } catch (err) {
+    console.error(
+      `[FATAL] Firebase 初期化失敗: ${err instanceof Error ? err.message : err}`
+    );
+    process.exit(1);
+  }
+
+  const db = getFirestore();
+
+  console.log("=== tenant 配下 lesson_sessions force_exited サマリ調査 ===");
+  console.log(`tenant: ${tenantId}`);
+  console.log(`参照範囲: 直近 ${sinceDays} 日（exitAt 基準）`);
+  console.log(`lesson 別表示上位件数: ${topLessons}`);
+  console.log();
+
+  const tenantRef = db.collection("tenants").doc(tenantId);
+  const tenantDoc = await tenantRef.get();
+  if (!tenantDoc.exists) {
+    console.error(`[FATAL] tenant not found: ${tenantId}`);
+    process.exit(1);
+  }
+  console.log(`tenant 確認: ${tenantId} (name="${tenantDoc.data()?.name ?? ""}")\n`);
+
+  const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
+  const sessions = await fetchForceExitsSince(db, tenantId, since);
+  console.log(`取得件数: ${sessions.length}\n`);
+
+  const summary = aggregateSessions(sessions, topLessons);
+  printSummary(summary);
+}
+
+// ============================================================
+// Firestore 取得（read-only）
+// ============================================================
+
+async function fetchForceExitsSince(
+  db: Firestore,
+  tenantId: string,
+  since: Date
+): Promise<RawSession[]> {
+  // status=force_exited に絞ってから exitAt 範囲で再フィルタ（Firestore composite index 回避）。
+  // 件数は数十〜数百件想定（本番 8vexhzpc で 30 日分 force_exited は <100 件オーダー）。
+  const snap = await db
+    .collection(`tenants/${tenantId}/lesson_sessions`)
+    .where("status", "==", "force_exited")
+    .limit(2000)
+    .get();
+
+  const result: RawSession[] = [];
+  for (const d of snap.docs) {
+    const data = d.data() ?? {};
+    const exitAtRaw = data.exitAt;
+    let exitAtIso: string;
+    if (exitAtRaw instanceof Timestamp) {
+      exitAtIso = exitAtRaw.toDate().toISOString();
+    } else if (typeof exitAtRaw === "string") {
+      exitAtIso = exitAtRaw;
+    } else {
+      continue; // exitAt がない force_exited は集計対象外
+    }
+    const exitAtDate = new Date(exitAtIso);
+    if (Number.isNaN(exitAtDate.getTime()) || exitAtDate < since) continue;
+    result.push({
+      lessonId: (data.lessonId as string | undefined) ?? null,
+      exitReason: (data.exitReason as string | undefined) ?? null,
+      sessionVideoCompleted: Boolean(data.sessionVideoCompleted),
+      exitAt: exitAtIso,
+    });
+  }
+  return result;
+}
+
+// ============================================================
+// 出力
+// ============================================================
+
+function printSummary(summary: AggregatedSummary): void {
+  console.log("=== reason 別件数 ===");
+  if (summary.reasonCounts.length === 0) {
+    console.log("  (該当 force_exited なし)");
+  } else {
+    for (const { reason, count } of summary.reasonCounts) {
+      console.log(`  ${count.toString().padStart(5)}  ${reason}`);
+    }
+  }
+  console.log();
+
+  console.log("=== time_limit 内訳（sessionVideoCompleted 別）===");
+  console.log(
+    `  ${summary.timeLimitVideoIncomplete
+      .toString()
+      .padStart(5)}  false（ケース E: 動画再生中 time_limit → 全リセット = 本末転倒の発生）`
+  );
+  console.log(
+    `  ${summary.timeLimitVideoCompleted
+      .toString()
+      .padStart(5)}  true （ケース B: 動画完了後 time_limit → reset skip = 規律どおり）`
+  );
+  console.log();
+
+  console.log(
+    `=== ケース E lesson 別件数 (unique=${summary.caseELessonUniqueCount}) ===`
+  );
+  if (summary.caseELessonCounts.length === 0) {
+    console.log("  (ケース E の該当なし)");
+  } else {
+    for (const { lessonId, count } of summary.caseELessonCounts) {
+      console.log(`  ${count.toString().padStart(5)}  ${lessonId}`);
+    }
+    if (summary.caseELessonTruncated > 0) {
+      console.log(`  ...他 ${summary.caseELessonTruncated} lesson 省略`);
+    }
+  }
+}

--- a/scripts/audit-session-force-exits.ts
+++ b/scripts/audit-session-force-exits.ts
@@ -43,27 +43,41 @@ import { resolve } from "path";
 // 純粋関数（smoke test 対象）
 // ============================================================
 
+/**
+ * sessionVideoCompleted の tri-state。
+ * - `true`: 動画完了済（ケース B 候補）
+ * - `false`: 動画未完了（ケース E 候補）
+ * - `null`: フィールド欠落 / boolean 以外の型（KPI 不明、E/B どちらにも分類せず別バケット）
+ *
+ * `Boolean()` で false に潰すと「フィールド欠落」が黙ってケース E に算入されて
+ * 「本末転倒の発生数」を誤って膨らませるため、明示的に null と区別する。
+ */
+export type SessionVideoCompletedFlag = boolean | null;
+
+/** 集計対象（"force_exited" 限定、Timestamp は ISO 文字列に正規化済み）。 */
 export interface RawSession {
-  lessonId: string | null;
-  exitReason: string | null;
-  sessionVideoCompleted: boolean;
-  exitAt: string;
+  readonly lessonId: string | null;
+  readonly exitReason: string | null;
+  readonly sessionVideoCompleted: SessionVideoCompletedFlag;
+  readonly exitAt: string;
 }
 
 export interface AggregatedSummary {
-  totalForceExits: number;
+  readonly totalForceExits: number;
   /** reason → 件数（降順）。reason=null は "(missing)" として集計。 */
-  reasonCounts: Array<{ reason: string; count: number }>;
+  readonly reasonCounts: ReadonlyArray<{ readonly reason: string; readonly count: number }>;
   /** time_limit のうち sessionVideoCompleted=false（ケース E）= 動画再生中 time_limit で全リセット */
-  timeLimitVideoIncomplete: number;
+  readonly timeLimitVideoIncomplete: number;
   /** time_limit のうち sessionVideoCompleted=true（ケース B）= 動画完了後 time_limit、reset skip */
-  timeLimitVideoCompleted: number;
+  readonly timeLimitVideoCompleted: number;
+  /** time_limit のうち sessionVideoCompleted=null（不明）= データ不整合 / 欠落、E/B 分類保留 */
+  readonly timeLimitVideoUnknown: number;
   /** ケース E に該当する lessonId → 件数（降順、top N でカット） */
-  caseELessonCounts: Array<{ lessonId: string; count: number }>;
+  readonly caseELessonCounts: ReadonlyArray<{ readonly lessonId: string; readonly count: number }>;
   /** top N でカットされた残り lesson 件数 */
-  caseELessonTruncated: number;
+  readonly caseELessonTruncated: number;
   /** ケース E にマッチした unique lesson 数（top で切られても全体数として把握） */
-  caseELessonUniqueCount: number;
+  readonly caseELessonUniqueCount: number;
 }
 
 /**
@@ -73,12 +87,13 @@ export interface AggregatedSummary {
  * @param topLessons ケース E の lesson 別上位件数。1 以上。
  */
 export function aggregateSessions(
-  sessions: RawSession[],
+  sessions: ReadonlyArray<RawSession>,
   topLessons: number
 ): AggregatedSummary {
   const reasonMap = new Map<string, number>();
   let timeLimitVideoIncomplete = 0;
   let timeLimitVideoCompleted = 0;
+  let timeLimitVideoUnknown = 0;
   const caseELessonMap = new Map<string, number>();
 
   for (const s of sessions) {
@@ -86,12 +101,15 @@ export function aggregateSessions(
     reasonMap.set(reason, (reasonMap.get(reason) ?? 0) + 1);
 
     if (s.exitReason === "time_limit") {
-      if (s.sessionVideoCompleted) {
+      if (s.sessionVideoCompleted === true) {
         timeLimitVideoCompleted++;
-      } else {
+      } else if (s.sessionVideoCompleted === false) {
         timeLimitVideoIncomplete++;
         const lessonId = s.lessonId ?? "(missing-lessonId)";
         caseELessonMap.set(lessonId, (caseELessonMap.get(lessonId) ?? 0) + 1);
+      } else {
+        // null: フィールド欠落 / boolean 以外。E/B どちらにも算入しない。
+        timeLimitVideoUnknown++;
       }
     }
   }
@@ -112,6 +130,7 @@ export function aggregateSessions(
     reasonCounts,
     timeLimitVideoIncomplete,
     timeLimitVideoCompleted,
+    timeLimitVideoUnknown,
     caseELessonCounts,
     caseELessonTruncated,
     caseELessonUniqueCount: allCaseELessons.length,
@@ -162,9 +181,9 @@ async function main(): Promise<void> {
     ?.replace("--since-days=", "")
     .trim();
   const sinceDays = sinceDaysRaw ? Number(sinceDaysRaw) : 30;
-  if (!Number.isFinite(sinceDays) || sinceDays <= 0 || sinceDays > 90) {
+  if (!Number.isInteger(sinceDays) || sinceDays <= 0 || sinceDays > 90) {
     console.error(
-      `[FATAL] --since-days は 1〜90 の数値: 受け取った値="${sinceDaysRaw}"`
+      `[FATAL] --since-days は 1〜90 の整数: 受け取った値="${sinceDaysRaw}"`
     );
     process.exit(1);
   }
@@ -174,9 +193,9 @@ async function main(): Promise<void> {
     ?.replace("--top-lessons=", "")
     .trim();
   const topLessons = topLessonsRaw ? Number(topLessonsRaw) : 20;
-  if (!Number.isFinite(topLessons) || topLessons <= 0 || topLessons > 200) {
+  if (!Number.isInteger(topLessons) || topLessons <= 0 || topLessons > 200) {
     console.error(
-      `[FATAL] --top-lessons は 1〜200 の数値: 受け取った値="${topLessonsRaw}"`
+      `[FATAL] --top-lessons は 1〜200 の整数: 受け取った値="${topLessonsRaw}"`
     );
     process.exit(1);
   }
@@ -223,11 +242,36 @@ async function main(): Promise<void> {
     console.error(`[FATAL] tenant not found: ${tenantId}`);
     process.exit(1);
   }
-  console.log(`tenant 確認: ${tenantId} (name="${tenantDoc.data()?.name ?? ""}")\n`);
+  const tenantName = tenantDoc.data()?.name;
+  if (typeof tenantName !== "string" || tenantName === "") {
+    console.warn(
+      `[WARN] tenant ${tenantId} の name フィールドが空または非 string。tenant ID 自体は exists のため処理続行するが、対象テナントが正しいか再確認してください。`
+    );
+  }
+  console.log(
+    `tenant 確認: ${tenantId} (name="${typeof tenantName === "string" ? tenantName : ""}")\n`
+  );
 
   const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
-  const sessions = await fetchForceExitsSince(db, tenantId, since);
-  console.log(`取得件数: ${sessions.length}\n`);
+  const { sessions, stats } = await fetchForceExitsSince(db, tenantId, since);
+  console.log(
+    `取得件数: ${stats.fetchedCount}（うち集計対象: ${sessions.length} / 期間外: ${stats.outOfRange} / exitAt 欠落: ${stats.exitAtMissing} / exitAt 形式不正: ${stats.exitAtMalformed}）`
+  );
+  if (stats.hitFetchCap) {
+    console.warn(
+      `[WARN] Firestore 取得が上限 ${FETCH_LIMIT} 件に達しました。tenant の累積 force_exited が大きく、古いセッションが欠落している可能性があります。集計値は最大 ${FETCH_LIMIT} 件分のみを反映している点に注意してください。`
+    );
+  }
+  if (
+    stats.lessonIdNonString > 0 ||
+    stats.exitReasonNonString > 0 ||
+    stats.sessionVideoCompletedNonBoolean > 0
+  ) {
+    console.warn(
+      `[WARN] データ品質: lessonId 非 string=${stats.lessonIdNonString}, exitReason 非 string=${stats.exitReasonNonString}, sessionVideoCompleted 非 boolean=${stats.sessionVideoCompletedNonBoolean}`
+    );
+  }
+  console.log();
 
   const summary = aggregateSessions(sessions, topLessons);
   printSummary(summary);
@@ -237,41 +281,129 @@ async function main(): Promise<void> {
 // Firestore 取得（read-only）
 // ============================================================
 
+/** I/O 層で観測したデータ品質の集計（最後に operator に提示する）。 */
+interface IoSkipStats {
+  hitFetchCap: boolean;
+  fetchedCount: number;
+  exitAtMissing: number;
+  exitAtMalformed: number;
+  outOfRange: number;
+  lessonIdNonString: number;
+  exitReasonNonString: number;
+  sessionVideoCompletedNonBoolean: number;
+}
+
+const FETCH_LIMIT = 2000;
+
 async function fetchForceExitsSince(
   db: Firestore,
   tenantId: string,
   since: Date
-): Promise<RawSession[]> {
+): Promise<{ sessions: RawSession[]; stats: IoSkipStats }> {
   // status=force_exited に絞ってから exitAt 範囲で再フィルタ（Firestore composite index 回避）。
-  // 件数は数十〜数百件想定（本番 8vexhzpc で 30 日分 force_exited は <100 件オーダー）。
+  // FETCH_LIMIT 到達時は警告し、operator に再設計（composite index + orderBy）を促す。
   const snap = await db
     .collection(`tenants/${tenantId}/lesson_sessions`)
     .where("status", "==", "force_exited")
-    .limit(2000)
+    .limit(FETCH_LIMIT)
     .get();
 
-  const result: RawSession[] = [];
+  const stats: IoSkipStats = {
+    hitFetchCap: snap.size === FETCH_LIMIT,
+    fetchedCount: snap.size,
+    exitAtMissing: 0,
+    exitAtMalformed: 0,
+    outOfRange: 0,
+    lessonIdNonString: 0,
+    exitReasonNonString: 0,
+    sessionVideoCompletedNonBoolean: 0,
+  };
+
+  const sessions: RawSession[] = [];
   for (const d of snap.docs) {
     const data = d.data() ?? {};
+
+    // exitAt: Timestamp / 有効な ISO 文字列 / null/undefined / その他 の 4 状態に分離
     const exitAtRaw = data.exitAt;
     let exitAtIso: string;
     if (exitAtRaw instanceof Timestamp) {
       exitAtIso = exitAtRaw.toDate().toISOString();
     } else if (typeof exitAtRaw === "string") {
-      exitAtIso = exitAtRaw;
+      const parsed = new Date(exitAtRaw);
+      if (Number.isNaN(parsed.getTime())) {
+        stats.exitAtMalformed++;
+        console.warn(
+          `[WARN] doc ${d.id}: exitAt 文字列がパース不可 ("${exitAtRaw}")。集計から除外`
+        );
+        continue;
+      }
+      exitAtIso = parsed.toISOString();
+    } else if (exitAtRaw == null) {
+      stats.exitAtMissing++;
+      continue;
     } else {
-      continue; // exitAt がない force_exited は集計対象外
+      stats.exitAtMalformed++;
+      const ctor = (exitAtRaw as { constructor?: { name?: string } } | null)?.constructor?.name;
+      console.warn(
+        `[WARN] doc ${d.id}: exitAt が想定外の型 (typeof=${typeof exitAtRaw}, ctor=${ctor ?? "n/a"})。集計から除外`
+      );
+      continue;
     }
+
     const exitAtDate = new Date(exitAtIso);
-    if (Number.isNaN(exitAtDate.getTime()) || exitAtDate < since) continue;
-    result.push({
-      lessonId: (data.lessonId as string | undefined) ?? null,
-      exitReason: (data.exitReason as string | undefined) ?? null,
-      sessionVideoCompleted: Boolean(data.sessionVideoCompleted),
-      exitAt: exitAtIso,
-    });
+    if (exitAtDate < since) {
+      stats.outOfRange++;
+      continue;
+    }
+
+    // lessonId / exitReason は string 以外を null に正規化し、件数を観測
+    let lessonId: string | null;
+    if (typeof data.lessonId === "string") {
+      lessonId = data.lessonId;
+    } else if (data.lessonId == null) {
+      lessonId = null;
+    } else {
+      stats.lessonIdNonString++;
+      console.warn(
+        `[WARN] doc ${d.id}: lessonId が string でない (typeof=${typeof data.lessonId})。null として扱う`
+      );
+      lessonId = null;
+    }
+
+    let exitReason: string | null;
+    if (typeof data.exitReason === "string") {
+      exitReason = data.exitReason;
+    } else if (data.exitReason == null) {
+      exitReason = null;
+    } else {
+      stats.exitReasonNonString++;
+      console.warn(
+        `[WARN] doc ${d.id}: exitReason が string でない (typeof=${typeof data.exitReason})。null として扱う`
+      );
+      exitReason = null;
+    }
+
+    // sessionVideoCompleted: boolean 以外（欠落含む）は null として E/B 分類保留
+    let sessionVideoCompleted: SessionVideoCompletedFlag;
+    if (typeof data.sessionVideoCompleted === "boolean") {
+      sessionVideoCompleted = data.sessionVideoCompleted;
+    } else {
+      sessionVideoCompleted = null;
+      stats.sessionVideoCompletedNonBoolean++;
+      if (data.sessionVideoCompleted != null) {
+        // 欠落（undefined/null）は legacy doc 等で発生し得るため warn まで出さない。
+        // 非 boolean の異常値のみ警告して operator に報告。
+        console.warn(
+          `[WARN] doc ${d.id}: sessionVideoCompleted が boolean でない (typeof=${typeof data.sessionVideoCompleted}, value=${JSON.stringify(
+            data.sessionVideoCompleted
+          )})。ケース判定不能のため別バケットへ`
+        );
+      }
+    }
+
+    sessions.push({ lessonId, exitReason, sessionVideoCompleted, exitAt: exitAtIso });
   }
-  return result;
+  return { sessions, stats };
 }
 
 // ============================================================
@@ -299,6 +431,11 @@ function printSummary(summary: AggregatedSummary): void {
     `  ${summary.timeLimitVideoCompleted
       .toString()
       .padStart(5)}  true （ケース B: 動画完了後 time_limit → reset skip = 規律どおり）`
+  );
+  console.log(
+    `  ${summary.timeLimitVideoUnknown
+      .toString()
+      .padStart(5)}  null （不明: フィールド欠落 / boolean 以外。データ品質要確認、E/B どちらにも算入せず）`
   );
   console.log();
 

--- a/scripts/audit-session-force-exits.ts
+++ b/scripts/audit-session-force-exits.ts
@@ -175,6 +175,14 @@ async function main(): Promise<void> {
     console.error("[FATAL] --tenant-id=<id> は必須");
     process.exit(1);
   }
+  // Firestore document ID safety: 英数 / アンダースコア / ハイフンのみ許可。
+  // path traversal や予期しない collection アクセスを防ぐ。
+  if (!/^[A-Za-z0-9_-]+$/.test(tenantId)) {
+    console.error(
+      `[FATAL] --tenant-id の形式が不正（英数/_/-のみ許可）: "${tenantId}"`
+    );
+    process.exit(1);
+  }
 
   const sinceDaysRaw = args
     .find((a) => a.startsWith("--since-days="))
@@ -259,7 +267,7 @@ async function main(): Promise<void> {
   );
   if (stats.hitFetchCap) {
     console.warn(
-      `[WARN] Firestore 取得が上限 ${FETCH_LIMIT} 件に達しました。tenant の累積 force_exited が大きく、古いセッションが欠落している可能性があります。集計値は最大 ${FETCH_LIMIT} 件分のみを反映している点に注意してください。`
+      `[WARN] Firestore 取得が上限 ${FETCH_LIMIT} 件に達しました。orderBy("exitAt", "desc") により取得済みは「直近 ${FETCH_LIMIT} 件」が保証されますが、これより古い force_exited セッションは集計対象外です。--since-days で指定した期間が ${FETCH_LIMIT} 件目より古い場合、その範囲は不完全になります。`
     );
   }
   if (
@@ -300,11 +308,19 @@ async function fetchForceExitsSince(
   tenantId: string,
   since: Date
 ): Promise<{ sessions: RawSession[]; stats: IoSkipStats }> {
-  // status=force_exited に絞ってから exitAt 範囲で再フィルタ（Firestore composite index 回避）。
-  // FETCH_LIMIT 到達時は警告し、operator に再設計（composite index + orderBy）を促す。
+  // status=force_exited を exitAt 降順で取得（直近 FETCH_LIMIT 件保証）。
+  // orderBy なしで limit すると Firestore は未定義順で返すため、
+  // 累積件数が FETCH_LIMIT 超のテナントで「直近 N 日が拾えず KPI が 0 件」と
+  // 誤って観測されるリスクがあった（Codex review 2026-05-20 指摘）。
+  // since-days フィルタは client 側で続けるが、orderBy("exitAt", "desc") により
+  // 「拾えなかったのは直近 FETCH_LIMIT 件より古い force_exited」と意味が確定する。
+  // 必要な composite index は firestore.indexes.json の
+  // (status ASC, exitAt DESC) として追加済（firebase deploy --only firestore:indexes
+  // を手動実行する必要あり、CI/CD には含まれない）。
   const snap = await db
     .collection(`tenants/${tenantId}/lesson_sessions`)
     .where("status", "==", "force_exited")
+    .orderBy("exitAt", "desc")
     .limit(FETCH_LIMIT)
     .get();
 


### PR DESCRIPTION
## Summary
- ADR-027 改訂履歴に **2026-05-20 エントリ + ケース A〜F 定義表** を追加：「不合格時いつでも再受験」案 / ケース E のリセット廃止案を検討したが、**規律装置を破壊する本末転倒** と判断し不採用、3h 延長は対症療法として暫定維持、恒久対応はコンテンツ側のレッスン分割で対応する方針を記録
- **Phase A 効果測定 workflow** を追加：`force_exited(time_limit)` の `sessionVideoCompleted` 別内訳（ケース E vs B vs 不明）を集計する read-only workflow + smoke test
- 5 並列 review agent + Codex セカンドオピニオンの全 CRITICAL 指摘を反映済み

## レビュー対応サマリ

| Reviewer | CRITICAL 指摘 | 対応 commit |
|---|---|---|
| silent-failure-hunter | `Boolean(data.sessionVideoCompleted)` がケース E カウントを silent 膨らませる | 64d73a7 |
| silent-failure-hunter | exitAt 型ハンドリングの silent skip / 型キャスト無検証 | 64d73a7 |
| comment-analyzer | ADR の「ケース A-F」が定義されていない、semantics 不整合 | 64d73a7 |
| type-design-analyzer | `sessionVideoCompleted: boolean` で legacy doc が case E に化ける | 64d73a7 |
| code-reviewer | `.limit(2000)` 到達時の警告なし | 64d73a7 |
| **Codex** | **`.orderBy` なし limit で「直近 N 日が 0 件」になる KPI 信頼性問題** | **1e2c0ff** |

## 背景
Session 36 セッション内の設計議論で「3 時間延長より、不合格時はいつでも再受験できる方が望ましいのではないか」と提案を受けて再評価。実コード検証の結果、本番 `maxAttempts=0` 配下では既にケース A〜D で再受験可能、リセットされるのはケース E（動画再生中 time_limit）と F のみと判明。E/F のリセットは学習規律装置として正当な挙動、ルールを破ってまでの対応は本末転倒との判断で設計変更は不採用。

## 変更内容

### 1. ADR-027 改訂履歴 + ケース A〜F 定義表（+16 行）
- 2026-05-20 エントリ：判断経緯
- ケース A〜F 構造化定義表（条件 / 挙動 / 再受験可否 / コード参照 file:line）
- 規律装置の根拠（1 セッション内で動画+テスト完了させる要件）を明示

### 2. Phase A 効果測定 workflow（新規 4 ファイル）
- `scripts/audit-session-force-exits.ts`: read-only 集計スクリプト
  - reason 別件数（time_limit / pause_timeout / max_attempts_failed）
  - time_limit の `sessionVideoCompleted` 別 **3 状態** 内訳（true=ケース B / false=ケース E / null=不明）
  - ケース E の lessonId 別上位件数（長尺レッスン特定用）
  - データ品質サマリ（exitAt 欠落 / 形式不正 / 期間外 / 非 string / 非 boolean）
  - `.where(status==force_exited).orderBy(exitAt, desc).limit(2000)` で「直近 2000 件」保証
  - PII 制限: userId / email は表示せず lessonId のみ
- `scripts/__tests__/audit-session-force-exits.smoke.ts`: 純粋関数 smoke test 11 ブロック
  - 不変量 3 種 + 境界 + tri-state + tie-break
- `.github/workflows/audit-session-force-exits.yml`: workflow_dispatch ラッパー
- `firestore.indexes.json`: composite index `(status ASC, exitAt DESC)` 追加

## なぜ /simplify を省略したか
新規スクリプトは既存 audit パターンの horizontal extension で、5 並列レビュー + Codex セカンドオピニオンで品質確認済み。CRITICAL 指摘は全て対応。`/simplify` 単独より深い品質ゲートを既に通過しているため省略。

## Test plan
- [x] `npm run test:scripts`: 新規 11 ブロック + 既存全件 PASS
- [x] `npm run type-check`: 全 workspace PASS
- [x] `npm run lint`: 0 errors（pre-existing warning 1 件のみ、本 PR と無関係）
- [x] `/review-pr` 5 並列レビュー実施、全 CRITICAL 対応済み
- [x] `/codex review` セカンドオピニオン実施、CRITICAL 1 件対応済み
- [ ] CI 全通過（push 後監視中）
- [ ] **merge 後の必須運用手順**:
  1. `firebase deploy --only firestore:indexes -P prod` を手動実行（インデックスは CI/CD に含まれない、rules/firebase.md 参照）
  2. GCP Console > Firestore > インデックス でビルド完了確認（数分）
  3. workflow_dispatch で初回実行：`gh workflow run audit-session-force-exits.yml -f tenant_id=8vexhzpc -f since_days=30`

## 影響範囲
- **本番コード変更なし**（ADR + 新規 read-only workflow + 新規 Firestore index のみ）
- Firestore index 追加はインフラ変更だが additive で既存 query に影響なし
- 他テナント（休眠中の `qos4c4ka` ほか）への影響なし

## 関連
- Session 28 ハンドオフ: `docs/handoff/archive/2026-05-16-session-28.md`
- PR #407（3h 延長本体）
- ADR-027 / ADR-019 / ADR-020

🤖 Generated with [Claude Code](https://claude.com/claude-code)