### PR TITLE
feat(dispatch): 自動完了通知 Spec + Phase 1 基礎 + smoke workflow

### DIFF
--- a/.github/workflows/smoke-dwd-gmail-send.yml
+++ b/.github/workflows/smoke-dwd-gmail-send.yml
@@ -1,0 +1,102 @@
+name: Smoke DWD Gmail Send
+
+# Phase 0-A-4 (OQ-2) Group エイリアス DWD smoke check workflow。
+#
+# 目的:
+#   dxcollege@279279.net (Google Group エイリアス) が DWD subject として
+#   gmail.users.messages.send で使えるかを実機検証する。
+#
+# 動作モード:
+#   - dry-run (既定): DWD 認証 + JWT + MIME 組立まで実行、Gmail API は呼ばない
+#   - send: 実送信、宛先に Gmail を届ける (destructive、要明示認可)
+#
+# 安全機構:
+#   - dry-run 既定 (mode=send で実送信)
+#   - to_email 必須 (誤入力防止、smoke 用の test 宛先を明示指定)
+#   - 本文/件名は固定の smoke 文言 (PII を含まない)
+#   - 添付なし
+#   - workflow_dispatch 入力はすべて env 経由で渡し run: 内で直接補間しない
+#     (https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/)
+#
+# 関連:
+#   - 設計仕様書: docs/specs/2026-05-20-completion-notification-design.md OQ-2
+#   - 実装計画: docs/specs/2026-05-20-completion-notification-impl-plan.md Phase 0-A-4
+#   - スクリプト: scripts/smoke-dwd-gmail-send.ts
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: '動作モード (dry-run=Gmail API 呼ばず / send=実送信)'
+        required: true
+        type: choice
+        options:
+          - dry-run
+          - send
+        default: dry-run
+      to_email:
+        description: '送信先 email (必須)。dry-run でも検証用に必要'
+        required: true
+        type: string
+      sender:
+        description: '送信元 email (なりすまし subject、既定 dxcollege@279279.net)'
+        required: false
+        default: 'dxcollege@279279.net'
+        type: string
+      subject:
+        description: 'メール件名 (既定 [smoke] DXcollege 自動完了通知 DWD smoke check)'
+        required: false
+        default: '[smoke] DXcollege 自動完了通知 DWD smoke check'
+        type: string
+
+jobs:
+  smoke:
+    name: Smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      FIREBASE_PROJECT_ID: lms-279
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/1034821634012/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-actions@lms-279.iam.gserviceaccount.com
+
+      - name: Run smoke script
+        env:
+          GOOGLE_CLOUD_PROJECT: lms-279
+          MODE: ${{ inputs.mode }}
+          TO_EMAIL: ${{ inputs.to_email }}
+          SENDER: ${{ inputs.sender }}
+          SUBJECT: ${{ inputs.subject }}
+        run: |
+          set -euo pipefail
+          FLAGS=("--to=$TO_EMAIL")
+          if [ -n "$SENDER" ]; then FLAGS+=("--sender=$SENDER"); fi
+          if [ -n "$SUBJECT" ]; then FLAGS+=("--subject=$SUBJECT"); fi
+          if [ "$MODE" = "send" ]; then
+            FLAGS+=("--send")
+            echo "::warning::Running in SEND mode — an email WILL be delivered to $TO_EMAIL"
+          else
+            FLAGS+=("--dry-run")
+          fi
+          echo "Mode: $MODE"
+          echo "Sender: $SENDER"
+          echo "Recipient: $TO_EMAIL"
+          echo "---"
+          npx tsx scripts/smoke-dwd-gmail-send.ts "${FLAGS[@]}"

--- a/docs/specs/2026-05-20-completion-notification-design.md
+++ b/docs/specs/2026-05-20-completion-notification-design.md
@@ -509,40 +509,88 @@ async function acquireRunLock(): Promise<{ runId: string } | null> {
 }
 ```
 
-### 6.4 403 reason 分類 (Codex Important-4)
+### 6.4 403 reason 分類 (Codex Important-4 + PR #442 review Critical 4+5)
+
+**入力前提**: HTTP 403 専用。429/503/timeout/401 は呼び出し側で別経路に流す。403 以外で呼ぶと例外 throw。
+
+**全体中断対象 reason (`scope_revoked`)** — 設計仕様書管理下の確定リスト:
+- `insufficientPermissions`: DWD scope 未反映 / 認可不足
+- `delegationDenied`: なりすまし送信が拒否された (subject 設定ミス等)
+- `userRateLimitExceeded`: sender 単位の制限超過 (実質 sender disabled)
+
+上記以外 (`recipientRejected` / `forbidden` / `messageRejected` / 未知 reason) は宛先固有 (`user_permanent`)。
+仕様書未記載の reason を独断追加することは AI 駆動開発 4 原則 §1 違反のため、変更時は spec 改訂 → 本田様承認 → 実装の順を厳守する。
 
 ```typescript
 // services/dispatch/dispatch-403-classifier.ts
-function classifyGmail403(err: GaxiosError): "scope_revoked" | "user_permanent" {
-  const reason = err.response?.data?.error?.errors?.[0]?.reason;
-  // run 全体中断 (全 user に影響する全体設定ミス)
-  if (reason === "insufficientPermissions") return "scope_revoked";
-  if (reason === "delegationDenied") return "scope_revoked";
-  if (reason === "userRateLimitExceeded") return "scope_revoked"; // sender disabled 系
-  // 宛先固有 (受講者の Gmail 受信拒否設定等)
-  return "user_permanent";
+const SCOPE_REVOKED_REASONS = new Set<string>([
+  "insufficientPermissions",
+  "delegationDenied",
+  "userRateLimitExceeded",
+]);
+
+function classifyGmail403(err: unknown): "scope_revoked" | "user_permanent" {
+  // PR #442 review Critical 5: HTTP 403 ガード (呼び出し側のバグを早期検知)
+  const status = (err as { response?: { status?: number } })?.response?.status;
+  if (status !== 403) {
+    throw new Error(`classifyGmail403 called for non-403 (status=${status ?? "unknown"})`);
+  }
+  // PR #442 review Critical 4: errors 配列を全件走査 (1 番目だけ見ない)
+  const errors = (err as { response?: { data?: { error?: { errors?: Array<{ reason?: unknown }> } } } })
+    ?.response?.data?.error?.errors ?? [];
+  const hasScopeRevoked = errors.some(
+    (e) => typeof e.reason === "string" && SCOPE_REVOKED_REASONS.has(e.reason),
+  );
+  return hasScopeRevoked ? "scope_revoked" : "user_permanent";
 }
 ```
 
-### 6.5 PII sanitize (NFR-11、Codex Important-7)
+### 6.5 PII sanitize (NFR-11、Codex Important-7 + PR #442 review Critical 2)
+
+対象 PII / トークン (取りこぼし防止のため広めに redaction):
+- email (ASCII 一般形式)
+- access token (`ya29.<...>`)
+- JWT 3-part (`eyJ<...>.<...>.<...>`) — ID token / Bearer 中身
+- refresh token (`1//<...>`)
+- API key (`AIza<35 chars>`)
+- `Authorization: Bearer <token>`
+- MIME headers (`To`/`Cc`/`Bcc`/`From`/`Reply-To`/`Sender`、folded continuation 含む)
+
+UTF-8 マルチバイト境界を割らないよう、置換後に Array.from で grapheme 単位で truncate する。
 
 ```typescript
 // services/dispatch/dispatch-error-sanitizer.ts
 const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
-const ACCESS_TOKEN_RE = /ya29\.[A-Za-z0-9_-]+/g;
+const ACCESS_TOKEN_RE = /ya29\.[A-Za-z0-9_.-]+/g;
+const JWT_RE = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g;
+const REFRESH_TOKEN_RE = /1\/\/[A-Za-z0-9_-]+/g;
+const API_KEY_RE = /AIza[0-9A-Za-z_-]{35}/g;
 const BEARER_RE = /Bearer\s+[A-Za-z0-9_.-]+/g;
-const MIME_HEADER_RE = /(?:To|Cc|Bcc|From):\s*[^\r\n]+/gi;
+const MIME_HEADER_RE =
+  /(?:To|Cc|Bcc|From|Reply-To|Sender):\s*[^\r\n]+(?:\r?\n[ \t][^\r\n]*)*/gi;
+
+function safeTruncate(s: string, maxLength: number): string {
+  if (s.length <= maxLength) return s;
+  return Array.from(s).slice(0, maxLength).join(""); // UTF-8 safe
+}
 
 export function sanitizeErrorForAudit(err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err);
-  return raw
-    .replace(EMAIL_RE, "[EMAIL]")
-    .replace(ACCESS_TOKEN_RE, "[ACCESS_TOKEN]")
-    .replace(BEARER_RE, "[BEARER]")
+  // 置換順序: MIME ヘッダ → Bearer → JWT → access_token → refresh_token → API key → email
+  // (Bearer の中身が JWT / ya29 の場合があるため Bearer を先に処理)
+  const sanitized = raw
     .replace(MIME_HEADER_RE, "[MIME_HEADER]")
-    .slice(0, 1024);  // 上限
+    .replace(BEARER_RE, "[BEARER]")
+    .replace(JWT_RE, "[JWT]")
+    .replace(ACCESS_TOKEN_RE, "[ACCESS_TOKEN]")
+    .replace(REFRESH_TOKEN_RE, "[REFRESH_TOKEN]")
+    .replace(API_KEY_RE, "[API_KEY]")
+    .replace(EMAIL_RE, "[EMAIL]");
+  return safeTruncate(sanitized, 1024);
 }
 ```
+
+**scripts/smoke-dwd-gmail-send.ts も同 sanitizer を経由して error を出力する** (workflow ログから PII を排除、PR #442 review Critical 3)。
 
 ### 6.6 permanent_failed / manual_review_required の手動復旧フロー
 

--- a/docs/specs/2026-05-20-completion-notification-design.md
+++ b/docs/specs/2026-05-20-completion-notification-design.md
@@ -1,0 +1,748 @@
+# DXcollege 自動完了通知システム 設計仕様書
+
+| 項目 | 値 |
+|---|---|
+| 起票日 | 2026-05-20 |
+| 改訂日 | 2026-05-20 (Codex セカンドオピニオン反映) |
+| 起票者 | 本田様 (要件) / system-279 (設計) |
+| 関連 ADR | ADR-026 (DWD) / ADR-029 (JST) / ADR-034 (Phase 2 Gmail 下書き) |
+| 関連 PR | #434 (Phase 2 Gmail 下書き、Manual flow、本機能と独立) |
+| brainstorm 結果 | Phase 1-5 全承認済、Phase 7-8 改訂中 |
+| 処理フロー図 | [docs/specs/2026-05-20-completion-notification-flow.mmd](./2026-05-20-completion-notification-flow.mmd) |
+
+---
+
+## 1. 概要 / 動機
+
+### 1.1 背景
+
+既存 PR #434「受講者進捗 PDF Gmail 下書き作成」は、スーパー管理者が画面でボタン押下し、押した管理者個人の Gmail に**下書き**を作成する**手動フロー**である。
+
+現場 (本田様) より以下 4 つの追加要件:
+
+1. 送信元を `dxcollege@279279.net` (Google Group エイリアス) に固定
+2. 指定曜日・時刻で**自動送信**
+3. テナントごとの担当者 CC を**複数件**指定可能に
+4. **全コース 100% 完了** した受講者のみ、**1 度だけ** 完了通知メールを自動送信
+
+### 1.2 目的
+
+既存の手動 Gmail 下書き機能 (PR #434) と完全に独立した**自動完了通知レーン**を新設する。
+
+### 1.3 既存機能との関係 (重要)
+
+```
+[既存] スーパー管理者が画面でボタン → Gmail 下書き (個人 OAuth, gmail.compose)  ← 維持
+[新規] 自動完了通知 (Cloud Scheduler → DWD なりすまし送信)                      ← 追加
+```
+
+両者は別ファイル・別 routes・別 collection で完全分離する。
+
+---
+
+## 2. 要件
+
+### 2.1 機能要件
+
+| ID | 要件 |
+|---|---|
+| FR-1 | Cloud Scheduler が毎時 00 分 (JST) に起動し、内部 API を呼ぶ |
+| FR-2 | API は `super_dispatch_settings/global` の `enabled` / `scheduleDaysOfWeek` / `scheduleHourJst` と JST 現在時刻を照合し、一致時のみ配信処理を実行 |
+| FR-3 | 全テナントを直列、テナント内 user を並列度 8 で走査 |
+| **FR-4 (改訂)** | **published コース全件**を母集合とし、各 courseId に対して `course_progress.isCompleted=true` かつ `totalLessons` が現行 `lessonOrder.length` と一致することを 100% 完了条件とする。`course_progress` doc が存在しない course は未着手扱い (Codex Critical-2) |
+| FR-5 | DWD なりすまし送信 (`subject=dxcollege@279279.net`, 専用 scope `gmail.send`) で `gmail.users.messages.send` |
+| FR-6 | `To` = 受講者本人、`Cc` = `ownerEmail` + `tenants/{tenantId}.notificationCcEmails` (各 email を個別 validate、重複排除) |
+| **FR-7 (改訂)** | **送信前に Firestore transaction で `completion_notifications/{userId}` を `reserved` 状態で create**。取得できた worker のみ Gmail 送信。送信成功後に `sent` に更新 (Codex Critical-1+3) |
+| FR-8 | スーパー管理者が `/super/dispatch-settings` で設定編集、配信履歴閲覧、ドライラン、テスト送信を実行可能 |
+| FR-9 | テナントごとの `notificationCcEmails` をスーパー管理者が編集可能 (chips UI、上限 10 件) |
+| FR-10 | kill switch (`enabled: false`) は次回 cron 起動時に即時反映 |
+| **FR-11 (新規)** | **run-level lock**: 同一時刻に Cloud Scheduler 重複起動された場合、`super_dispatch_runs/{runId}` を Firestore transaction で create することで二重実行を防止 (Codex Important-3) |
+| **FR-12 (新規)** | **completion_notifications には `courseIdsSnapshot: string[]` / `publishedCourseCount: number` を保存**し、後の問い合わせで「どの時点の全コースか」が追跡可能 (Codex Important-5) |
+
+### 2.2 非機能要件
+
+| ID | 要件 |
+|---|---|
+| NFR-1 | PII 最小化: recipient email は sha256 ハッシュで保存 (ADR-034 踏襲) |
+| NFR-2 | 認証: 内部 API は OIDC ID Token、スーパー管理者 API は既存 super-admin auth (Firebase Bearer Token、CSRF 不要) |
+| **NFR-3 (改訂)** | **二重送信防止: pre-send reservation を transaction で実施。reservation 取得→Gmail 送信→sent 更新の順。reservation 取得後に Gmail 送信失敗した場合は transient なら reservation 維持、permanent なら failed_permanent に更新。lease 期限切れの reserved は manual_review_required に降格** (Codex Critical-1+3) |
+| NFR-4 | audit_logs は Firestore TTL Policy で 1 年自動削除 |
+| NFR-5 | user 1 件あたりの PDF 生成は 30 秒 timeout、超過時は user スキップ |
+| NFR-6 | 設定変更は楽観的ロック (version フィールド)、競合時 409 |
+| NFR-7 | test-send は 1 日 50 件レート制限、**固定ダミーデータ + 添付なし** (本番 PII 複製を防止、Codex Important-8) |
+| NFR-8 | 送信元 email は Cloud Run 環境変数 `DXCOLLEGE_SENDER_EMAIL` で固定 (Secret Manager 不使用、機密性なし) |
+| NFR-9 | DWD SA キーは既存 Secret Manager `dwd-workspace-key` を継承。**`gmail.send` scope は専用 client (`getGmailClientForSender`) に分離し、既存共通 `SCOPES` に追加しない** (Codex Important-1) |
+| NFR-10 | 既存の手動 Gmail 下書き機能 (PR #434) の動作には一切影響を与えない |
+| **NFR-11 (新規)** | **PII sanitize: `sanitizeErrorForAudit()` で email 正規表現・MIME headers・access token 断片を除去してから audit_logs / Error Reporting に渡す** (Codex Important-7) |
+
+---
+
+## 3. アーキテクチャ
+
+### 3.1 システム全体図
+
+```
+┌─────────────────────────────────────────────────────┐
+│          Cloud Scheduler (asia-northeast1)          │
+│  cron: "0 * * * *"                                  │
+│  time-zone: "Asia/Tokyo"                            │
+│  → 毎時 JST 00 分に起動                              │
+│  Service Account: dxcollege-scheduler@lms-279.iam   │
+└─────────────────────────────────────────────────────┘
+                    │ HTTP POST + OIDC ID Token
+                    │ audience = endpoint URL
+                    ▼
+┌─────────────────────────────────────────────────────┐
+│       Cloud Run: services/api (既存 Cloud Run 統合)  │
+│  POST /api/internal/dispatch/run-completion-notifications│
+│                                                     │
+│  ① OIDC verify (audience match)                     │
+│  ② super_dispatch_runs/{runId} create (run lock)    │  ← FR-11 新規
+│  ③ super_dispatch_settings/global 読み取り          │
+│  ④ enabled & スケジュール JST 一致判定              │
+│  ⑤ テナント走査 (直列)                              │
+│  ⑥ users 走査 (並列度 8)                            │
+│  ⑦ published コース全件母集合で 100% 判定           │  ← FR-4 改訂
+│  ⑧ completion_notifications/{userId} reserve        │  ← FR-7 改訂
+│      (Firestore transaction、create-if-not-exists)  │
+│  ⑨ PDF 生成 (既存 ProgressPdfDocument 流用、30 秒) │
+│  ⑩ Gmail 送信 (DWD なりすまし、専用 client)         │  ← NFR-9 改訂
+│  ⑪ completion_notifications を sent に更新          │
+│  ⑫ super_dispatch_audit_logs 書込 (PII sanitize 済) │
+│  ⑬ super_dispatch_runs を completed に更新          │
+└─────────────────────────────────────────────────────┘
+                    │ DWD JWT (subject=dxcollege@279279.net、scope=gmail.send のみ)
+                    ▼
+┌─────────────────────────────────────────────────────┐
+│        Gmail API                                    │
+│  gmail.users.messages.send                          │
+└─────────────────────────────────────────────────────┘
+```
+
+### 3.2 cron スケジュール戦略
+
+Cloud Scheduler は固定で JST 毎時 00 分起動 (`time-zone: Asia/Tokyo`)。配信スケジュールの**柔軟性は DB 設定で実現**:
+
+| 種類 | 値 | 説明 |
+|---|---|---|
+| Cloud Scheduler cron | `0 * * * *` + `time-zone: Asia/Tokyo` | 起動間隔は変更しない |
+| `scheduleDaysOfWeek` | `number[]` (0-6) | DB で曜日を指定 |
+| `scheduleHourJst` | `number` (0-23) | DB で時刻 (時単位、HH:00) を指定 |
+| 一致判定 | API 内で実装 | 起動時刻 (JST) と DB 値を比較 |
+
+これにより Cloud Scheduler を頻繁にいじる必要がなく、UI から柔軟にスケジュール変更可能。
+
+### 3.3 並列度と Cloud Run 制限
+
+| 階層 | 並列度 | 根拠 |
+|---|---|---|
+| テナント間 | 直列 | 現状 2 テナント、ログ可読性優先 |
+| テナント内 user | 8 | 既存 `progress-pdf.ts` `LESSON_FETCH_CONCURRENCY` と同値、Firestore quota 配慮 |
+| user 内 (PDF 生成 + Gmail send) | 順次 | 依存関係あり |
+
+Cloud Run 実行制限は 300 秒。テナント数・user 数増加でこの制限に近づいたら、**Critical-1 race を増幅するため `super_dispatch_runs` の lease + checkpoint** で `runId` 単位の resume 可能設計に拡張する (Phase 1 では非対応、将来課題)。
+
+### 3.4 サービス配置
+
+既存 `services/api` に統合 (新規サービス分離せず)。将来 SLA 分離が必要になれば `services/notification-dispatch` への切り出しを検討。
+
+---
+
+## 4. データモデル
+
+### 4.1 新規 / 拡張 Firestore コレクション
+
+#### 4.1.1 `super_dispatch_settings/global` (新規、固定 doc id)
+
+```typescript
+{
+  enabled: boolean;                            // kill switch
+  scheduleDaysOfWeek: number[];                // 0-6 (日-土)
+  scheduleHourJst: number;                     // 0-23
+  signatureName: string;                       // default: "DXcollege運営スタッフ"
+  completionMessageBody: string;               // default: 「受講お疲れ様でした。…」
+  updatedAt: Timestamp;
+  updatedBy: string;                           // superAdmin email (raw、監査責任明示)
+  version: number;                             // 楽観的ロック
+}
+```
+
+#### 4.1.2 `tenants/{tenantId}` (既存、フィールド追加)
+
+```typescript
+{
+  // ... 既存フィールド (name, ownerEmail, etc.)
+  notificationCcEmails: string[];              // 追加 CC、上限 10 件、空配列なら CC = ownerEmail のみ
+  completionNotificationEnabled: boolean;      // テナント単位の有効化フラグ、default true
+}
+```
+
+#### 4.1.3 `tenants/{tenantId}/completion_notifications/{userId}` (新規 sub-collection、改訂)
+
+```typescript
+{
+  userId: string;
+
+  // === reservation state (Codex Critical-1+3) ===
+  status: "reserved" | "sent" | "failed_permanent" | "manual_review_required";
+  runId: string;                               // 予約した cron 実行 ID
+  reservedAt: Timestamp;                       // reserve 時刻
+  leaseExpiresAt: Timestamp;                   // reservedAt + 10 分。期限切れで manual_review に降格
+
+  // === sent state (status=sent のみ) ===
+  notifiedAt: Timestamp | null;
+  messageId: string | null;                    // Gmail API レスポンス
+
+  // === failed state (status=failed_permanent のみ) ===
+  errorCode: string | null;                    // sanitized
+  errorMessage: string | null;                 // sanitized (Codex Important-7)
+  failedAt: Timestamp | null;
+
+  // === snapshot (Codex Important-5) ===
+  progressSnapshot: {
+    completedLessons: number;
+    totalLessons: number;
+    coursesCompleted: number;
+    coursesTotal: number;
+  };
+  courseIdsSnapshot: string[];                 // 通知時点の published course ID 一覧
+  publishedCourseCount: number;                // courseIdsSnapshot.length と同値、検索高速化用
+
+  // === PII 最小化 (ADR-034 踏襲) ===
+  recipientToHash: string;                     // sha256
+  recipientCcHashes: string[];                 // sha256 配列
+  pdfSizeBytes: number | null;
+}
+```
+
+#### 4.1.4 `super_dispatch_runs/{runId}` (新規、run-level lock)
+
+```typescript
+{
+  runId: string;                               // uuid v4
+  triggeredAt: Timestamp;                      // cron 起動時刻
+  status: "running" | "completed" | "timeout" | "aborted";
+  leaseExpiresAt: Timestamp;                   // triggeredAt + 280 秒 (Cloud Run 300 秒に余裕)
+  processedTenants: number;
+  sent: number;
+  skipped: number;
+  failed: number;
+  abortedReason: string | null;                // 403 全体中断時の理由等
+  ttlExpireAt: Timestamp;                      // triggeredAt + 365 days
+}
+```
+
+#### 4.1.5 `super_dispatch_audit_logs/{auditId}` (新規、グローバル collection)
+
+```typescript
+{
+  runId: string;
+  runStartedAt: Timestamp;
+  eventType: "run_started" | "run_completed" | "run_aborted"
+           | "user_reserved" | "user_notified" | "user_skipped"
+           | "user_failed_transient" | "user_failed_permanent"
+           | "manual_review_required"
+           | "settings_updated" | "test_send" | "dry_run"
+           | "orphan_send";                    // 二重送信リスク発生
+  tenantId: string | null;
+  userId: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;                 // sanitizeErrorForAudit() 済み (NFR-11)
+  durationMs: number | null;
+  createdAt: Timestamp;
+  ttlExpireAt: Timestamp;                      // createdAt + 365 days、Firestore TTL Policy
+}
+```
+
+### 4.2 受講者通知の状態遷移 (改訂)
+
+```
+[None] (completion_notifications/{userId} 不在)
+   │
+   ├─ 100% 未達 → スキップ (状態変化なし)
+   │
+   ├─ 100% 達成 → [Reserved] (status=reserved, runId, leaseExpiresAt セット)
+   │      transaction で create-if-not-exists
+   │      取得失敗 (既に Reserved/Sent) → スキップ
+   │
+   │  [Reserved] からの遷移:
+   │      ├─ Gmail 送信成功 → [Sent] (status=sent, notifiedAt, messageId)
+   │      ├─ Gmail 送信 transient 失敗 → [Reserved] 維持 (次回 cron で再試行可能、leaseExpiresAt まで)
+   │      ├─ Gmail 送信 permanent 失敗 (宛先固有) → [FailedPermanent]
+   │      └─ lease 期限切れ (Cloud Run timeout 等) → [ManualReviewRequired]
+   │            (cron では再送しない、人手介入必要)
+   │
+   ├─ [Sent] は終端、再送しない (idempotency)
+   ├─ [FailedPermanent] は終端、手動 doc 削除で再試行可能
+   └─ [ManualReviewRequired] は終端、scripts/recover-manual-review.ts で個別判断
+```
+
+### 4.3 「後からコース追加」時の振る舞い
+
+brainstorm Phase 3-1 確定 + Codex Important-5: **案 C (全コース完了で 1 回、以降のコース追加は無視) + courseIdsSnapshot 保存**
+
+- マスター講座配信で新規コースが追加されても、`completion_notifications/{userId}` が存在する受講者には再判定しない
+- ただし `courseIdsSnapshot` に通知時点の published course を記録するため、問い合わせ時に「どの時点の全コースか」が説明可能
+- 再送したい場合は script (`scripts/clear-failed-notification.ts` 拡張または別 script) 経由で手動 doc 削除
+
+---
+
+## 5. インターフェース (API・関数境界)
+
+### 5.1 新規 API エンドポイント
+
+#### 5.1.1 内部 API (Cloud Scheduler 専用)
+
+| メソッド | パス | 認証 | 入出力 |
+|---|---|---|---|
+| POST | `/api/internal/dispatch/run-completion-notifications` | OIDC ID Token | 入力なし / 出力 `{ runId, processedTenants, sent, skipped, failed, manualReviewRequired }` |
+
+#### 5.1.2 スーパー管理者 API (既存 super-admin auth、Firebase Bearer Token、CSRF 不要)
+
+| メソッド | パス | 用途 |
+|---|---|---|
+| GET | `/api/v2/super/dispatch/settings` | 設定取得 (senderEmail は env から読み取り) |
+| PUT | `/api/v2/super/dispatch/settings` | 設定更新 (楽観的ロック、version 不一致で 409) |
+| GET | `/api/v2/super/dispatch/audit-logs` | 履歴取得 (フィルタ: tenantId, userId, eventType, from, to) |
+| GET | `/api/v2/super/dispatch/runs` | 過去の run 履歴取得 |
+| GET | `/api/v2/super/tenants/:tenantId/notification-cc-emails` | テナント CC 設定取得 |
+| PUT | `/api/v2/super/tenants/:tenantId/notification-cc-emails` | テナント CC 設定更新 |
+| POST | `/api/v2/super/dispatch/dry-run` | 次回 cron で送信される対象一覧返却 (送信なし) |
+| POST | `/api/v2/super/dispatch/test-send` | スーパー管理者自身宛に**固定ダミーデータ**でテスト送信 (添付なし、1 日 50 件レート制限) |
+
+### 5.2 モジュール構成 (新規ファイル)
+
+```
+services/api/src/
+  routes/
+    internal/
+      dispatch.ts                          # 内部 endpoint
+    super/
+      dispatch-settings.ts                 # GET/PUT settings
+      dispatch-audit-logs.ts               # GET audit_logs
+      dispatch-runs.ts                     # GET runs (NEW)
+      tenant-notification-cc.ts            # GET/PUT tenant の CC 設定
+      dispatch-dry-run.ts                  # POST dry-run
+      dispatch-test-send.ts                # POST test-send (固定ダミー)
+  services/
+    dispatch/
+      run-completion-notifications.ts      # メインロジック (Reservation 方式)
+      schedule-matcher.ts                  # JST 時刻と settings の照合
+      completion-eligibility.ts            # published コース全件母集合判定 (Critical-2)
+      completion-notification-mail.ts      # 完了通知メール本文テンプレート
+      cc-email-validator.ts                # CC 配列の個別 validation + 重複排除 (Important-6)
+      gmail-dwd-send.ts                    # DWD なりすまし送信
+      dispatch-audit.ts                    # audit_logs 書き込み
+      dispatch-error-sanitizer.ts          # sanitizeErrorForAudit (Important-7)
+      dispatch-403-classifier.ts           # 403 reason 分類 (Important-4)
+      reservation.ts                       # pre-send reservation transaction (Critical-1+3)
+      run-lock.ts                          # super_dispatch_runs lock (FR-11)
+    oidc-verify.ts                         # OIDC token middleware
+    gmail-client.ts                        # getGmailClientForSender (Important-1)
+
+packages/shared-types/src/
+  dispatch.ts                              # 設定・履歴・dry-run の DTO 型
+
+web/app/super/dispatch-settings/
+  page.tsx
+  components/
+    ScheduleEditor.tsx
+    TenantCcEditor.tsx                     # chips UI、上限 10 件
+    MessageBodyEditor.tsx                  # プレビュー付き
+    AuditLogTable.tsx
+    RunHistoryTable.tsx                    # run 単位の履歴 (NEW)
+    DryRunPanel.tsx
+    TestSendButton.tsx                     # 固定ダミーで送信
+```
+
+### 5.3 既存ファイルへの変更 (Codex Important-1 反映)
+
+| ファイル | 変更内容 |
+|---|---|
+| `services/api/src/services/google-auth.ts` | **変更なし** (共通 `SCOPES` を汚染しない) |
+| `services/api/src/services/gmail-client.ts` (新規) | `getGmailClientForSender(senderEmail)`: 専用 JWT、scope=`gmail.send` のみ、cache key=`(subject, scope)` |
+| `packages/shared-types/src/index.ts` | dispatch types のエクスポート追加 |
+| (firestore.rules) | (現状未確認、必要に応じて新規 collection の rules 追加) |
+
+### 5.4 既存 PR #434 への影響: **ゼロ**
+
+`services/api/src/routes/super/progress-pdf-draft.ts` および `services/api/src/services/gmail-draft.ts` には**一切変更を加えない**。新機能は完全に別レーンで実装される。
+
+---
+
+## 6. エラー処理
+
+### 6.1 エラー分類と遷移先
+
+| エラー種別 | 遷移先 | 再試行 | 通知レベル |
+|---|---|---|---|
+| OIDC verify NG | 401 即返却 | Cloud Scheduler 自動リトライ | access log |
+| run lock 取得失敗 (重複起動) | 409 即返却 | Cloud Scheduler retry なし | access log |
+| DWD トークン取得失敗 | 全体中断 500、run abort | 次回 cron | Error Reporting (critical) |
+| Firestore 読み取り transient | テナント/user スキップ | 次回 cron | audit_logs (warning) |
+| users.email 無効 | この user スキップ (Reservation せず) | 修正後の次回 cron | audit_logs + Error Reporting (warning) |
+| PDF 生成失敗 / timeout 30s | この user の Reservation を transient_failed として維持 | 次回 cron で再試行可能 (leaseExpiresAt まで) | audit_logs + Error Reporting (warning) |
+| **Gmail 401 (token 失効)** | DWD トークン再取得 → 1 回 retry → ダメなら **run 全体中断** | 次回 cron | Error Reporting (critical) |
+| **Gmail 403 `insufficientPermissions`** | run 全体中断、未処理 user の Reservation も rollback | 次回 cron | **Error Reporting (critical)** (Codex Important-4) |
+| **Gmail 403 `delegation_denied` / sender disabled** | run 全体中断、Reservation rollback | 次回 cron | **Error Reporting (critical)** |
+| Gmail 403 宛先固有 | この user を failed_permanent | 再送しない | audit_logs + Error Reporting (warning) |
+| Gmail 429/503/timeout | Reservation 維持 (transient_failed)、completion_notifications 残置 | 次回 cron で再試行 | audit_logs (transient) |
+| Gmail 400/422 | failed_permanent 記録 | 再送しない | audit_logs + Error Reporting (warning) |
+| Reservation transaction 失敗 (既存予約あり) | この user スキップ | 通常運用、エラーではない | audit_logs (skipped_already_reserved) |
+| Reservation lease 期限切れ | manual_review_required に降格 | cron では再送しない | audit_logs + Error Reporting (warning) |
+| super_dispatch_audit_logs 書き込み失敗 | 警告ログのみ、レスポンスをブロックしない | なし | logger.warn |
+
+### 6.2 二重送信防止の設計 (Reservation 方式、Codex Critical-1+3)
+
+`~/.claude/rules/error-handling.md` §1「状態復旧 > ログ記録 > 通知」に従い、**送信前** に reservation を transaction で書く。これにより複数 worker が同時に「未通知」と判定して並列送信することを防止する。
+
+```typescript
+// 擬似コード (services/dispatch/reservation.ts)
+async function tryReserveOrSkip(
+  tenantId: string,
+  userId: string,
+  runId: string,
+): Promise<{ reserved: boolean; reason?: string }> {
+  const docRef = db.doc(`tenants/${tenantId}/completion_notifications/${userId}`);
+
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(docRef);
+    if (snap.exists) {
+      const data = snap.data();
+      // 既に Sent / FailedPermanent / ManualReview なら通常スキップ
+      if (data.status === "sent") return { reserved: false, reason: "already_sent" };
+      if (data.status === "failed_permanent") return { reserved: false, reason: "failed_permanent" };
+      if (data.status === "manual_review_required") return { reserved: false, reason: "manual_review_required" };
+      // Reserved だが lease 期限切れの場合は manual_review_required に降格
+      if (data.status === "reserved") {
+        const expired = data.leaseExpiresAt.toMillis() < Date.now();
+        if (expired) {
+          tx.update(docRef, { status: "manual_review_required", failedAt: Timestamp.now() });
+          return { reserved: false, reason: "lease_expired_promoted_to_manual_review" };
+        }
+        return { reserved: false, reason: "currently_reserved_by_other_run" };
+      }
+    }
+    // 新規予約
+    tx.set(docRef, {
+      userId,
+      status: "reserved",
+      runId,
+      reservedAt: Timestamp.now(),
+      leaseExpiresAt: Timestamp.fromMillis(Date.now() + 10 * 60 * 1000), // 10 分
+      // ... その他のフィールドは送信成功後にセット
+    });
+    return { reserved: true };
+  });
+}
+```
+
+送信フロー:
+
+```typescript
+const { reserved, reason } = await tryReserveOrSkip(tenantId, userId, runId);
+if (!reserved) {
+  await recordAuditLog({ eventType: "user_skipped", tenantId, userId, errorMessage: reason });
+  return;
+}
+
+try {
+  const messageId = await gmailDwdSend({ ... });
+  await docRef.update({
+    status: "sent",
+    notifiedAt: Timestamp.now(),
+    messageId,
+    courseIdsSnapshot,
+    publishedCourseCount,
+    progressSnapshot,
+    recipientToHash,
+    recipientCcHashes,
+    pdfSizeBytes,
+  });
+  await recordAuditLog({ eventType: "user_notified", ... });
+} catch (err) {
+  const classification = classifyGmailError(err);  // transient | permanent | scope_revoked
+  if (classification === "scope_revoked") {
+    throw new RunAbortError("Gmail scope revoked, aborting run");  // run 全体中断
+  }
+  if (classification === "permanent") {
+    await docRef.update({
+      status: "failed_permanent",
+      errorCode: sanitizeErrorCode(err),
+      errorMessage: sanitizeErrorForAudit(err),
+      failedAt: Timestamp.now(),
+    });
+    await recordAuditLog({ eventType: "user_failed_permanent", ... });
+  } else {
+    // transient: Reservation 維持。次回 cron で再判定 (leaseExpiresAt まで再試行可)
+    await recordAuditLog({ eventType: "user_failed_transient", ... });
+  }
+}
+```
+
+### 6.3 run-level lock (FR-11、Codex Important-3)
+
+`super_dispatch_runs/{runId}` を transaction で create し、同時実行を防ぐ:
+
+```typescript
+async function acquireRunLock(): Promise<{ runId: string } | null> {
+  const runId = crypto.randomUUID();
+  const docRef = db.doc(`super_dispatch_runs/${runId}`);
+
+  // 直近 30 秒以内に他の running があれば実行拒否 (Cloud Scheduler 重複起動対策)
+  const recentRunningSnap = await db.collection("super_dispatch_runs")
+    .where("status", "==", "running")
+    .where("leaseExpiresAt", ">", Timestamp.now())
+    .limit(1).get();
+  if (!recentRunningSnap.empty) return null;
+
+  await docRef.set({
+    runId,
+    triggeredAt: Timestamp.now(),
+    status: "running",
+    leaseExpiresAt: Timestamp.fromMillis(Date.now() + 280 * 1000),
+    processedTenants: 0, sent: 0, skipped: 0, failed: 0,
+    abortedReason: null,
+    ttlExpireAt: Timestamp.fromMillis(Date.now() + 365 * 24 * 60 * 60 * 1000),
+  });
+  return { runId };
+}
+```
+
+### 6.4 403 reason 分類 (Codex Important-4)
+
+```typescript
+// services/dispatch/dispatch-403-classifier.ts
+function classifyGmail403(err: GaxiosError): "scope_revoked" | "user_permanent" {
+  const reason = err.response?.data?.error?.errors?.[0]?.reason;
+  // run 全体中断 (全 user に影響する全体設定ミス)
+  if (reason === "insufficientPermissions") return "scope_revoked";
+  if (reason === "delegationDenied") return "scope_revoked";
+  if (reason === "userRateLimitExceeded") return "scope_revoked"; // sender disabled 系
+  // 宛先固有 (受講者の Gmail 受信拒否設定等)
+  return "user_permanent";
+}
+```
+
+### 6.5 PII sanitize (NFR-11、Codex Important-7)
+
+```typescript
+// services/dispatch/dispatch-error-sanitizer.ts
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+const ACCESS_TOKEN_RE = /ya29\.[A-Za-z0-9_-]+/g;
+const BEARER_RE = /Bearer\s+[A-Za-z0-9_.-]+/g;
+const MIME_HEADER_RE = /(?:To|Cc|Bcc|From):\s*[^\r\n]+/gi;
+
+export function sanitizeErrorForAudit(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  return raw
+    .replace(EMAIL_RE, "[EMAIL]")
+    .replace(ACCESS_TOKEN_RE, "[ACCESS_TOKEN]")
+    .replace(BEARER_RE, "[BEARER]")
+    .replace(MIME_HEADER_RE, "[MIME_HEADER]")
+    .slice(0, 1024);  // 上限
+}
+```
+
+### 6.6 permanent_failed / manual_review_required の手動復旧フロー
+
+permanent_failed / manual_review_required は再送されない終端状態。手動復旧手順:
+
+1. スーパー管理者が UI で対象 user の audit_log と run 履歴を確認
+2. 根本原因 (例: 受講者 email 不正、Cloud Run timeout 等) を修正
+3. `scripts/clear-failed-notification.ts` (新規) を **workflow_dispatch + WIF 認証** 経由で実行
+4. 次回 cron で再評価される (Reservation が削除されるため)
+
+UI からの直接削除ボタンは提供しない (誤操作リスク回避、`feedback_firestore_prod_admin_via_workflow.md` 整合)。
+
+---
+
+## 7. テスト戦略
+
+### 7.1 テスト層別カバレッジ (ADR-028 InMemoryDataSource 中心の統合テスト)
+
+#### Unit Tests (Jest mocks)
+
+- `schedule-matcher.ts`: JST 時刻判定 (曜日・時刻一致 / 不一致 / 月跨ぎ / disabled 時)
+- `completion-eligibility.ts`: published コース全件母集合判定 (course_progress 不在 / 一部完了 / 全完了 / lessonOrder.length と totalLessons の不一致)
+- `completion-notification-mail.ts`: 件名・本文構築 (CC 配列、署名挿入、文言テンプレート、CRLF サニタイズ、空 CC 配列)
+- `cc-email-validator.ts`: CC 配列の個別 validation、重複排除、ownerEmail 重複処理
+- `gmail-dwd-send.ts`: DWD JWT 生成、MIME 組立 (添付込み、CC 配列、`To`/`Cc` ヘッダ)、retry on 429
+- `gmail-client.ts`: 専用 client のキャッシュ key 分離 (subject, scope ベース)
+- `oidc-verify.ts`: OIDC token verify (valid / invalid / wrong audience / expired)
+- `reservation.ts`: transaction 競合シナリオ (新規予約 / 既存 sent / 既存 reserved (lease 内) / 既存 reserved (lease 期限切れ) / 既存 failed_permanent)
+- `run-lock.ts`: 同時起動拒否、lease 期限切れ後の取得成功
+- `dispatch-403-classifier.ts`: insufficientPermissions / delegationDenied / userRateLimitExceeded / その他の分類
+- `dispatch-error-sanitizer.ts`: email / access_token / Bearer / MIME headers の除去
+- `dispatch-audit.ts`: audit_logs 書き込み (event_type 別、TTL field セット、PII ハッシュ化)
+
+#### Integration Tests (InMemoryDataSource)
+
+- `run-completion-notifications` 本体: 100% 完了者のみ送信 / 未通知のみ送信 / transient 失敗で reservation 維持 / permanent 失敗で failed_permanent 記録 / 二重実行で idempotent / kill switch / スケジュール不一致 / run lock 重複起動拒否 / lease 期限切れで manual_review_required
+- 各 super-admin API endpoint: 楽観的ロック (409) / 入力 validation / audit_logs 書き込み / レート制限
+- 内部 API: OIDC 認証必須、Cloud Scheduler SA のみ許可
+- test-send: ダミーデータ固定、添付なし、To = superAdmin.email 強制
+- dry-run: 送信せず対象一覧返却、Reservation も書かない
+
+#### E2E Tests (Playwright)
+
+- スーパー管理者で `/super/dispatch-settings` アクセス
+- 設定変更 → audit_logs 反映
+- dry-run 実行 → 一覧表示
+- test-send 実行 → mock で確認 (Gmail API は完全 mock、O-1)
+
+### 7.2 Acceptance Criteria
+
+> **番号の付け方**: AC は **5 ブロック (機能 / Reservation・Race / Run Lock・403 / エッジケース / セキュリティ)** に区分し、ブロックの境界で番号を切る (AC-1〜9 機能、AC-10〜15 Reservation、AC-16〜18 Run Lock・403、AC-19〜25 エッジケース、AC-30〜34 セキュリティ)。AC-26〜29 は意図的に欠番として将来追加用に確保 (Codex Minor-2 反映)。
+
+#### 機能 AC
+
+- **AC-1**: published コース全件母集合に対して、`course_progress.isCompleted=true` かつ `totalLessons === lessonOrder.length` の全件達成かつ未通知の受講者のみが Gmail に送信される (Critical-2 反映)
+- **AC-2**: 既通知 (Reserved / Sent / FailedPermanent / ManualReviewRequired) の受講者には二度と Gmail 送信されない (idempotency)
+- **AC-3**: 送信元 `From:` ヘッダが `dxcollege@279279.net`
+- **AC-4**: `To:` = 受講者本人、`Cc:` = `ownerEmail` + 個別 validate 済 `notificationCcEmails` 配列 (重複排除)
+- **AC-5**: 完了通知本文に `completionMessageBody` 設定値 + `signatureName` 設定値が含まれる
+- **AC-6**: スケジュール曜日・時刻が現在 JST と一致しない時は何もしない
+- **AC-7**: `enabled: false` で kill switch (cron 起動時に即時何もしない)
+- **AC-8**: dry-run は 100% 完了対象を返すが Gmail 送信も Reservation も実行しない
+- **AC-9**: test-send はスーパー管理者自身宛に**固定ダミーデータ + 添付なし**で送信、1 日 50 件レート制限 (Important-8 反映)
+
+#### Reservation / Race AC (Codex Critical-1+3 反映)
+
+- **AC-10**: Gmail 送信前に `completion_notifications/{userId}` を `reserved` 状態で create する transaction が実行される
+- **AC-11**: 既に Reserved の user に対しては、lease 期限内なら Reservation 取得失敗・スキップ
+- **AC-12**: lease 期限切れ Reserved は `manual_review_required` に降格し、自動再送されない
+- **AC-13**: Gmail 送信成功後、`status: "sent"` に更新、`messageId`/`notifiedAt`/`courseIdsSnapshot`/`publishedCourseCount` がセットされる
+- **AC-14**: Gmail 送信 transient 失敗 (429/503) 時、Reservation は維持されるが status は "reserved" のまま (次回 cron で再試行)
+- **AC-15**: Gmail 送信 permanent 失敗 (400/422 宛先固有) 時、`status: "failed_permanent"` に更新、再送しない
+
+#### Run Lock / 403 AC (Codex Important-3, Important-4 反映)
+
+- **AC-16**: 同一時刻に複数の cron 起動が来た場合、最初の 1 つだけが lock を取得、他は 409 で即終了
+- **AC-17**: Gmail 403 `insufficientPermissions` / `delegationDenied` / sender disabled は run 全体中断、後続 user の Reservation は rollback、Error Reporting critical
+- **AC-18**: Gmail 403 宛先固有は user を failed_permanent、run は継続
+
+#### エッジケース AC
+
+- **AC-19**: users.email 空 / CRLF / format violation → スキップ (Reservation せず) + Error Reporting
+- **AC-20**: ownerEmail null + notificationCcEmails 非空 → CC は notificationCcEmails のみ
+- **AC-21**: notificationCcEmails 空 → CC は ownerEmail のみ
+- **AC-22**: 後からマスター講座配信でコース追加 → 既通知者は通知済みなので再送されない (案 C) + `courseIdsSnapshot` で当時の状態追跡可能
+- **AC-23**: 設定 version 不一致 → 409、UI で警告 + 現在値 reload
+- **AC-24**: notificationCcEmails 11 件以上の入力 → 400 (上限超過)
+- **AC-25**: notificationCcEmails 内に CRLF / カンマ / 制御文字 → 400、個別 validation で拒否
+
+#### セキュリティ AC
+
+- **AC-30**: 内部 endpoint は OIDC ID Token 必須、audience 不一致で 401
+- **AC-31**: スーパー管理者 API は既存 super-admin auth (Firebase Bearer) で保護、CSRF 不要 (cookie 非使用)
+- **AC-32**: recipient email は sha256 で保存、raw は Firestore に保存されない
+- **AC-33**: errorMessage は `sanitizeErrorForAudit()` で email / access_token / Bearer / MIME headers が除去された後に保存
+- **AC-34**: 共通 `SCOPES` (drive/docs/sheets) には `gmail.send` を追加しない、専用 client `getGmailClientForSender` のみが gmail.send scope を使用
+
+---
+
+## 8. インフラ作業 (本田様作業含む)
+
+### 8.1 GCP 側準備 (実装前)
+
+| 作業 | 担当 | 内容 |
+|---|---|---|
+| **DWD scope 拡張** | **本田様** | Google Workspace 管理コンソールで `dwd-workspace-key` SA の DWD 認可に `https://www.googleapis.com/auth/gmail.send` を追加 |
+| **Gmail Group エイリアス送信の smoke check (新規)** | エンジニア | `dxcollege@279279.net` が Google Group の場合、DWD subject として使えるか実機検証。使えない場合は SendAs 設定 or 実ユーザー化 (Codex Important-2) |
+| Gmail API 有効化 | エンジニア | `gcloud services enable gmail.googleapis.com` |
+| Cloud Scheduler API 有効化 | エンジニア | `gcloud services enable cloudscheduler.googleapis.com` |
+| Cloud Scheduler SA 作成 | エンジニア | `dxcollege-scheduler@lms-279.iam.gserviceaccount.com` を作成、Cloud Run invoker 権限付与 |
+| Cloud Run env 設定 | エンジニア | `DXCOLLEGE_SENDER_EMAIL=dxcollege@279279.net` を Cloud Run env に追加 |
+| Cloud Scheduler job 作成 | エンジニア | cron `0 * * * *` + `time-zone Asia/Tokyo` + OIDC token + audience 設定 |
+| Firestore TTL Policy 設定 | エンジニア | `super_dispatch_audit_logs.ttlExpireAt` + `super_dispatch_runs.ttlExpireAt` フィールドに TTL Policy |
+| Firestore index | エンジニア | `super_dispatch_audit_logs` のフィルタ用 composite index、`super_dispatch_runs.status + leaseExpiresAt` の index |
+
+### 8.2 Workspace 側準備 (本田様作業詳細)
+
+DWD scope 拡張手順:
+
+1. Google Workspace 管理コンソール (admin.google.com) にログイン
+2. セキュリティ → アクセスとデータ管理 → API の制御 → ドメイン全体の委任を管理
+3. 既存の `dwd-workspace-key` SA のクライアント ID を選択
+4. スコープ追加: `https://www.googleapis.com/auth/gmail.send`
+5. 保存
+
+→ 反映に最大 24 時間かかる場合がある。実装前に作業完了 → smoke check (§8.1 の Group エイリアス検証) を通過してから実装着手。
+
+---
+
+## 9. スコープ外 / 将来課題
+
+| 項目 | 理由 |
+|---|---|
+| **bounce 検知** | Phase 1 では非対応。受信側 reject の検知は Postmaster Tools or Gmail API polling が必要、運用課題化したら Phase 2 |
+| **テナント管理者向け CC 設定 UI** | スーパー管理者のみ編集、テナント側公開は誤操作リスクのため見送り |
+| **完了通知以外の自動メール** (例: 受講開始通知、期限切れ警告) | 同じ Dispatch 基盤に乗せられるが、Phase 1 では完了通知のみ |
+| **配信スケジュールの「分」単位指定** | 60 分間隔起動のため HH:00 単位のみ |
+| **複数言語対応 (i18n)** | 完了通知本文・UI は日本語固定。テナント単位の locale 未対応を UI 上の運用制約として明示 (Codex Minor) |
+| **メール開封率トラッキング** | プライバシー観点で見送り |
+| **A/B テスト** | 文面 A/B テストは将来課題 |
+| **rate limit 集計の可視化** | test-send レート制限の残数表示は将来課題 |
+| **resumable run (checkpoint)** | Cloud Run timeout 後の resume。Phase 1 では `super_dispatch_runs` lock のみ実装、checkpoint 復帰は将来課題 |
+
+---
+
+## 10. Open Questions (実装着手前にクリアすべき)
+
+| ID | 質問 | 解決手段 |
+|---|---|---|
+| **OQ-1** | Gmail API が `lms-279` プロジェクトで有効化済みか | `gcloud services list --enabled --project=lms-279 \| grep gmail` |
+| **OQ-2 (強化)** | **`dxcollege@279279.net` が Google Group の場合、DWD subject として `gmail.users.messages.send` が成功するか** (Codex Important-2) | **実装着手前に必ず実機 smoke**。失敗時は SendAs 設定 or 実ユーザー mailbox 化を本田様判断 |
+| **OQ-3** | DWD scope 追加 (gmail.send) の Workspace 管理コンソール作業は本田様が実施可能な権限を持つか | 本田様確認 |
+| **OQ-4** | Cloud Run 実行制限 300 秒で全テナント全 user の走査が完了するか | 現状 2 テナント × user 数で実測 |
+| **OQ-5** | 既存 `tenants/{tenantId}` ドキュメントへのフィールド追加は backfill 不要か | Firestore は欠損フィールドを `undefined` 扱い、`sanitizeForUpdate` で対応 |
+| **OQ-6** | Cloud Scheduler の OIDC token audience は Cloud Run service URL でよいか | `services/api` の URL を使用 |
+| **OQ-7 (新規)** | **既存 super-admin auth middleware の認証方式は Firebase Bearer Token か (cookie 不使用か)** (Codex Important-9) | 実装着手前に既存コード確認、Bearer なら CSRF 対策不要を AC-31 で明示済 |
+| **OQ-8 (新規)** | **`super_dispatch_audit_logs` の 1 年 TTL が法務・契約上の保持期間と一致するか** (Codex Minor) | privacy policy / 受講契約と照合、必要に応じて TTL 調整 |
+| **OQ-9 (新規)** | **Reservation の lease 期限 10 分が現実の Gmail send 所要時間と適合するか** | 実装後に実測、必要に応じて調整 |
+
+---
+
+## 11. 関連リソース
+
+- 処理フロー図: [2026-05-20-completion-notification-flow.mmd](./2026-05-20-completion-notification-flow.mmd)
+- ADR-026: Google Workspace 連携 (DWD)
+- ADR-029: タイムゾーン基準 (JST 表示)
+- ADR-034: Phase 2 Gmail 下書き (PII ハッシュ化、CRLF 防御のパターン)
+- PR #434: 受講者進捗 PDF Gmail 下書き作成 (本機能と独立)
+- `~/.claude/rules/error-handling.md`: エラー処理ルール
+- `~/.claude/rules/production-data-safety.md`: 本番データ保護ルール
+- Codex セカンドオピニオン: 2026-05-20 実施、Critical 3 件 / Important 9 件 / Minor 4 件すべて反映
+
+---
+
+## 12. brainstorm Phase 4-5 承認サマリ + Codex 反映状況
+
+| セクション | 確定セット |
+|---|---|
+| 1. アーキテクチャ | 60 分起動 / OIDC / 並列度 8 / 既存 services/api 統合 |
+| 2. データモデル | Firestore TTL Policy / version 楽観ロック / ADR-034 PII ハッシュ化踏襲 + **Reservation 方式追加** |
+| 3. API・関数境界 | settings 競合は警告 reload / CC 入力は chips UI 上限 10 件 / test-send 1 日 50 件 + **dummy data 固定** |
+| 4. エラー処理 | script 復旧 / permanent と orphan_send は critical / PDF 30 秒 timeout + **403 reason 分類 / PII sanitize / run-level lock** |
+| 5. テスト戦略 | Cloud Scheduler 自体はテストせず + Gmail API 完全 mock + PII fixtures + **Reservation race scenario 追加** |
+
+### Codex セカンドオピニオン反映状況
+
+| Codex 指摘 | 反映状況 |
+|---|---|
+| Critical-1+3: Reservation 方式 | ✅ FR-7 / NFR-3 / §4.1.3 / §4.2 / §6.2 / AC-10〜15 |
+| Critical-2: published コース全件母集合 | ✅ FR-4 / `completion-eligibility.ts` / AC-1 |
+| Important-1: DWD scope 分離 | ✅ NFR-9 / `gmail-client.ts` / AC-34 |
+| Important-2: Google Group smoke check | ✅ §8.1 / OQ-2 強化 |
+| Important-3: run-level lock | ✅ FR-11 / §4.1.4 / `run-lock.ts` / §6.3 / AC-16 |
+| Important-4: 403 reason 分類 | ✅ §6.4 / `dispatch-403-classifier.ts` / AC-17, AC-18 |
+| Important-5: courseIdsSnapshot 保存 | ✅ FR-12 / §4.1.3 / §4.3 / AC-22 |
+| Important-6: CC 個別 validation | ✅ FR-6 / `cc-email-validator.ts` / AC-25 |
+| Important-7: PII sanitize | ✅ NFR-11 / `dispatch-error-sanitizer.ts` / §6.5 / AC-33 |
+| Important-8: test-send dummy data | ✅ NFR-7 / AC-9 |
+| Important-9: CSRF 認証方式明記 | ✅ NFR-2 / AC-31 / OQ-7 |
+| Minor-1: API path 表記統一 | ✅ `run-completion-notifications` で統一 |
+| Minor-2: AC 番号欠番 | ✅ AC-1〜AC-34 連番に再整理 |
+| Minor-3: TTL 法務確認 | ✅ OQ-8 |
+| Minor-4: i18n 運用制約明記 | ✅ §9 |

--- a/docs/specs/2026-05-20-completion-notification-flow.mmd
+++ b/docs/specs/2026-05-20-completion-notification-flow.mmd
@@ -1,0 +1,92 @@
+%% DXcollege 自動完了通知システム 処理フロー図
+%% brainstorm Phase 2 視覚補助 (2026-05-20、Codex セカンドオピニオン反映)
+%% 関連 ADR: ADR-026 (DWD), ADR-029 (JST), ADR-034 (PII ハッシュ化)
+%% 既存の手動 Gmail 下書き機能 (PR #434) とは完全に独立した別レーン
+
+flowchart TD
+  Scheduler["Cloud Scheduler<br/>毎時 JST 00 分起動<br/>time-zone: Asia/Tokyo"] -->|HTTP POST + OIDC| InternalAPI["/api/internal/dispatch/<br/>run-completion-notifications"]
+
+  InternalAPI -->|OIDC 認証 NG| Unauth["401 終了"]
+  InternalAPI -->|認証 OK| AcquireLock{"super_dispatch_runs<br/>lock 取得?"}
+
+  AcquireLock -->|失敗 (重複起動)| LockFail["409 終了"]
+  AcquireLock -->|成功| LoadSettings["super_dispatch_settings/global<br/>読込"]
+
+  LoadSettings -->|enabled=false| KillSwitch["何もせず 200<br/>(kill switch)"]
+  LoadSettings -->|enabled=true| ScheduleCheck{"JST 現在時刻が<br/>scheduleDaysOfWeek<br/>+ scheduleHourJst<br/>と一致?"}
+
+  ScheduleCheck -->|不一致| Skip200["何もせず 200"]
+  ScheduleCheck -->|一致| GetDwdToken["DWD トークン取得<br/>(subject=dxcollege@279279.net,<br/>scope=gmail.send 専用 client)"]
+
+  GetDwdToken -->|失敗| RunAbort1["run aborted<br/>Error Reporting critical"]
+  GetDwdToken -->|成功| LoadCourses["published コース全件取得<br/>(母集合構築)"]
+
+  LoadCourses --> TenantLoop["全テナント走査 (直列)"]
+
+  TenantLoop --> UserLoop["テナント内 users 走査<br/>(並列度 8)"]
+
+  UserLoop --> CheckEmail{"users/{userId}.email<br/>有効?"}
+  CheckEmail -->|空 / 不正| SkipUser["スキップ + Error Reporting"]
+  CheckEmail -->|有効| Check100{"全 published コースが<br/>course_progress.isCompleted=true<br/>かつ totalLessons一致?"}
+
+  Check100 -->|未達| SkipUser
+  Check100 -->|100% 達成| TryReserve["Reservation transaction<br/>(create-if-not-exists)"]
+
+  TryReserve -->|既存 sent / failed_permanent / manual_review| SkipUser
+  TryReserve -->|既存 reserved lease 内| SkipReserved["スキップ<br/>(他 run が処理中)"]
+  TryReserve -->|既存 reserved lease 期限切れ| PromoteManual["status=manual_review_required<br/>に降格 + Error Reporting"]
+  TryReserve -->|新規予約成功| BuildPdf["PDF 生成<br/>(30 秒 timeout)"]
+
+  BuildPdf -->|タイムアウト/失敗| TransientUser["Reservation 維持<br/>(次回 cron で再試行)"]
+  BuildPdf -->|成功| BuildMail["メール本文構築<br/>+ CC 個別 validate<br/>+ ownerEmail 結合"]
+
+  BuildMail --> SendGmail["gmail.users.messages.send<br/>(DWD なりすまし)"]
+
+  SendGmail -->|成功 200| MarkSent["completion_notifications<br/>status=sent + messageId<br/>+ courseIdsSnapshot<br/>+ progressSnapshot"]
+  SendGmail -->|transient 429/503/timeout| TransientUser
+  SendGmail -->|permanent 400/422<br/>宛先固有| MarkFailedPermanent["status=failed_permanent<br/>+ sanitized errorMessage"]
+  SendGmail -->|403 insufficientPermissions<br/>delegationDenied<br/>sender disabled| RunAbort2["run 全体中断<br/>後続 reservation rollback<br/>Error Reporting critical"]
+  SendGmail -->|403 宛先固有| MarkFailedPermanent
+  SendGmail -->|401 token 失効| RetryToken["DWD token 再取得<br/>1 回 retry"]
+
+  RetryToken -->|成功| SendGmail
+  RetryToken -->|再失敗| RunAbort2
+
+  MarkSent --> AuditSuccess["audit_logs user_notified"]
+  MarkFailedPermanent --> AuditPermanent["audit_logs user_failed_permanent<br/>+ Error Reporting warning"]
+  TransientUser --> AuditTransient["audit_logs user_failed_transient"]
+  PromoteManual --> AuditManual["audit_logs manual_review_required<br/>+ Error Reporting warning"]
+  SkipReserved --> AuditSkipped["audit_logs user_skipped"]
+
+  AuditSuccess --> NextUser["次の user"]
+  AuditPermanent --> NextUser
+  AuditTransient --> NextUser
+  AuditManual --> NextUser
+  AuditSkipped --> NextUser
+  SkipUser --> NextUser
+
+  NextUser --> UserLoopEnd{"残 user 有?"}
+  UserLoopEnd -->|有| UserLoop
+  UserLoopEnd -->|無| TenantLoopEnd{"残テナント有?"}
+  TenantLoopEnd -->|有| TenantLoop
+  TenantLoopEnd -->|無| FinalizeRun["super_dispatch_runs<br/>status=completed<br/>カウンタ更新"]
+
+  FinalizeRun --> Done200["全件処理完了 200"]
+
+  RunAbort1 --> AbortRun["super_dispatch_runs<br/>status=aborted"]
+  RunAbort2 --> AbortRun
+  AbortRun --> Done500["500 終了"]
+
+  classDef external fill:#e1f5fe,stroke:#01579b,stroke-width:2px
+  classDef terminal fill:#c8e6c9,stroke:#1b5e20,stroke-width:2px
+  classDef error fill:#ffcdd2,stroke:#b71c1c,stroke-width:2px
+  classDef decision fill:#fff9c4,stroke:#f57f17,stroke-width:2px
+  classDef write fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
+  classDef critical fill:#ff8a80,stroke:#b71c1c,stroke-width:3px
+
+  class Scheduler,SendGmail,GetDwdToken,RetryToken external
+  class Done200,Skip200,KillSwitch,Unauth,LockFail terminal
+  class RunAbort1,RunAbort2,MarkFailedPermanent,AuditPermanent,AuditTransient,AuditManual,Done500 error
+  class AcquireLock,ScheduleCheck,CheckEmail,Check100,UserLoopEnd,TenantLoopEnd decision
+  class MarkSent,AuditSuccess,FinalizeRun write
+  class TryReserve,PromoteManual,AbortRun critical

--- a/docs/specs/2026-05-20-completion-notification-impl-plan.md
+++ b/docs/specs/2026-05-20-completion-notification-impl-plan.md
@@ -1,0 +1,503 @@
+# DXcollege 自動完了通知システム 実装計画
+
+| 項目 | 値 |
+|---|---|
+| 策定日 | 2026-05-20 |
+| 設計仕様書 | [2026-05-20-completion-notification-design.md](./2026-05-20-completion-notification-design.md) |
+| 処理フロー図 | [2026-05-20-completion-notification-flow.mmd](./2026-05-20-completion-notification-flow.mmd) |
+| ブランチ | `feat/completion-notification-system-design` (設計) + Phase 別 feature ブランチ (実装) |
+| 推定総工数 | エンジニア作業 5-7 日 + 本田様作業 0.5-1 日 + DWD 反映待ち最大 24 時間 |
+
+---
+
+## 1. 計画サマリ
+
+### 1.1 ゴール
+
+設計仕様書 AC 30 件 (機能 9 / Reservation 6 / Run Lock・403 3 / エッジケース 7 / セキュリティ 5) を全て満たす自動完了通知システムを、本番受講者への誤送信ゼロで段階的にデプロイする。
+
+### 1.2 スコープ
+
+| In Scope | Out of Scope (将来課題) |
+|---|---|
+| 設計仕様書の全機能要件 (FR-1〜FR-12) | bounce 検知 |
+| 全非機能要件 (NFR-1〜NFR-11) | テナント管理者向け CC 設定 UI |
+| 全 AC 30 件の自動テスト | 完了通知以外の自動メール (受講開始通知等) |
+| ADR-035 として設計判断を ADR 登録 | 配信スケジュールの「分」単位指定 |
+| Cutover 手順書 (Phase 8) | 多言語対応 (i18n) |
+
+### 1.3 制約事項
+
+- **誤送信時ロールバック不可**: 本番デプロイ前に必ず dev or staging で実機検証
+- **CLAUDE.md CRITICAL 全項目遵守**: main 直 push 禁止、Definition of Done、Quality Gate (Evaluator 分離プロトコル発動条件 5+ ファイル変更を満たす)
+- **既存 PR #434 機能には一切影響を与えない**: `gmail-draft.ts` / `progress-pdf-draft.ts` を変更しない
+- **DWD scope 共通化禁止**: `gmail.send` 専用 client、既存 `SCOPES` を汚染しない (Codex Important-1)
+
+---
+
+## 2. Phase 分割と依存関係
+
+### 2.1 Phase 一覧
+
+| Phase | 内容 | 規模 | 推定工数 | 依存 |
+|---|---|---|---|---|
+| **Phase 0** | 前提作業 (本田様 Workspace 作業 + Infra 確認) | 中 | 0.5-1 日 + DWD 反映 24h | なし |
+| **Phase 1** | 基礎 services (Unit Test 中心) | 大 | 1 日 | Phase 0 |
+| **Phase 2** | Reservation / Run Lock layer | 中 | 0.5 日 | Phase 1 |
+| **Phase 3** | Mail template + Gmail DWD send | 中 | 0.5 日 | Phase 1 |
+| **Phase 4** | Internal API + メインロジック (race / lock / 403 シナリオ全網羅) | 大 | 1 日 | Phase 1, 2, 3 |
+| **Phase 5** | Super admin API (6 endpoints) | 大 | 1 日 | Phase 1, 2 (Phase 3, 4 と並列実装可) |
+| **Phase 6** | Frontend UI (1 page + 7 components + Playwright E2E) | 大 | 1.5 日 | Phase 5 (DTO 確定後) |
+| **Phase 7** | Infrastructure + ADR-035 登録 | 中 | 0.5 日 | Phase 4, 5, 6 完了後 |
+| **Phase 8** | Smoke check + Cutover | 中 | 0.5 日 + 本田様承認 | Phase 7 |
+
+### 2.2 依存関係グラフ
+
+```
+Phase 0 (前提作業、人手)
+   │ DWD scope 反映、Group smoke、auth 方式確認、infra 準備
+   ▼
+Phase 1 (基礎 services、並列実装可能 7 ファイル)
+   │ sanitizer / 403-classifier / schedule-matcher /
+   │ completion-eligibility / cc-validator / gmail-client / shared-types
+   ▼
+   ├──→ Phase 2 (Reservation/Lock、3 ファイル)
+   │      │ reservation / run-lock / dispatch-audit
+   │      │
+   │      ▼
+   │   Phase 4 (Internal API、メインロジック)
+   │      │
+   │      ├──→ Phase 7 (Infra + ADR)
+   │      │
+   ├──→ Phase 3 (Mail + Gmail send、2 ファイル) ──┐
+   │                                              │
+   └──→ Phase 5 (Super admin API、6 routes) ────┐ ▼
+                                                │ Phase 4 統合点
+              ┌─────────────────────────────────┘
+              ▼
+        Phase 6 (Frontend UI、API DTO 確定後)
+              │
+              ▼
+        Phase 7 (Infrastructure + Deploy)
+              │
+              ▼
+        Phase 8 (Smoke check + Cutover)
+```
+
+### 2.3 並列化機会
+
+- **Phase 1 内 7 ファイル**: 完全独立、並列実装可能 (Agent Teams or 直列 TDD どちらでも可)
+- **Phase 3 と Phase 5**: 互いに独立 (Phase 5 は Phase 4 結合より先に着手可)
+- **Phase 6 内 7 components**: API DTO 確定後は並列実装可能
+
+### 2.4 Phase 別 PR 戦略
+
+各 Phase で個別 PR を切る (推奨)。理由:
+- レビュー粒度の制御
+- 部分 rollback の容易性
+- Quality Gate (Evaluator 分離) の Phase 単位発動
+
+| PR | 含めるもの |
+|---|---|
+| PR-A (Phase 1) | 基礎 services + Unit Test |
+| PR-B (Phase 2) | Reservation/Lock + Integration Test |
+| PR-C (Phase 3) | Mail template + Gmail send + Unit Test |
+| PR-D (Phase 4) | Internal API + メインロジック + Integration Test (race scenario 全網羅) |
+| PR-E (Phase 5) | Super admin API 6 endpoints |
+| PR-F (Phase 6) | Frontend UI + Playwright E2E |
+| PR-G (Phase 7) | Infra (Cloud Scheduler / TTL / env) + ADR-035 |
+
+---
+
+## 3. Phase 詳細
+
+### Phase 0: 前提作業 (Open Questions 解決)
+
+| Task | 担当 | 依存 |
+|---|---|---|
+| OQ-3 解決: 本田様が Workspace 管理コンソール権限を持つか確認 | エンジニア + 本田様 | なし |
+| OQ-3 実施: `dwd-workspace-key` SA に `gmail.send` scope 追加 | **本田様** | OQ-3 解決 |
+| DWD 反映待ち (最大 24h) | - | OQ-3 実施 |
+| **OQ-2 解決**: `dxcollege@279279.net` で実機 smoke (`gmail.users.messages.send` を `subject=dxcollege@279279.net`、`To=エンジニア自身`、`scope=gmail.send` のみで実行) | エンジニア | DWD 反映完了 |
+| smoke 失敗時の判断: SendAs 設定 or 実ユーザー mailbox 化 | 本田様 | smoke 結果 |
+| OQ-7 解決: 既存 super-admin auth が Firebase Bearer か確認 (`services/api/src/middleware/super-admin.ts` 等を grep) | エンジニア | なし |
+| OQ-8 解決: `super_dispatch_audit_logs` 1 年 TTL の法務確認 | 本田様 | なし |
+| Gmail API / Cloud Scheduler API 有効化確認 | エンジニア | なし |
+
+**Phase 0 完了条件**:
+- OQ-2/3/7/8 全て解決
+- Group エイリアス smoke 成功 (or 代替判断完了)
+- DWD scope 反映確認
+
+### Phase 1: 基礎 services
+
+| File | 機能 | 関連 AC | テスト |
+|---|---|---|---|
+| `services/api/src/services/dispatch/dispatch-error-sanitizer.ts` | `sanitizeErrorForAudit()` | AC-33 | Unit |
+| `services/api/src/services/dispatch/dispatch-403-classifier.ts` | 403 reason 分類 | AC-17, AC-18 | Unit |
+| `services/api/src/services/dispatch/schedule-matcher.ts` | JST 時刻判定 | AC-6 | Unit |
+| `services/api/src/services/dispatch/completion-eligibility.ts` | published コース全件母集合判定 | AC-1 | Unit |
+| `services/api/src/services/dispatch/cc-email-validator.ts` | CC 配列 individual validation | AC-4, AC-25 | Unit |
+| `services/api/src/services/gmail-client.ts` | `getGmailClientForSender(senderEmail)` 専用 client | AC-34 | Unit |
+| `packages/shared-types/src/dispatch.ts` | DTO 型 | - | (型のみ) |
+
+**Phase 1 完了条件**:
+- 各 service の Unit Test カバレッジ ≥ 90%
+- `npm run lint && npm run type-check && npm test -w @lms-279/api` 全 PASS
+- 既存 `progress-pdf-draft.ts` の `validateRecipientEmail` を `cc-email-validator.ts` で再利用 (DRY)
+
+### Phase 2: Reservation / Run Lock layer
+
+| File | 機能 | 関連 AC | テスト |
+|---|---|---|---|
+| `services/api/src/services/dispatch/reservation.ts` | pre-send transaction (`tryReserveOrSkip`) | AC-10, AC-11, AC-12 | Integration |
+| `services/api/src/services/dispatch/run-lock.ts` | `super_dispatch_runs` lock | AC-16 | Integration |
+| `services/api/src/services/dispatch/dispatch-audit.ts` | audit_logs 書き込み | AC-33 | Integration |
+
+**Phase 2 完了条件**:
+- Integration Test で transaction 競合 6 シナリオ網羅 (新規 / sent / failed_permanent / reserved-in-lease / reserved-expired / manual_review)
+- run lock 同時起動 2 件で 1 つだけ成功するシナリオ確認
+- audit_logs に PII 漏洩がないことを assertion
+
+### Phase 3: Mail template + Gmail DWD send
+
+| File | 機能 | 関連 AC | テスト |
+|---|---|---|---|
+| `services/api/src/services/dispatch/completion-notification-mail.ts` | 完了通知テンプレート | AC-3, AC-5 | Unit |
+| `services/api/src/services/dispatch/gmail-dwd-send.ts` | DWD send + MIME 組立 + retry | AC-32 | Unit (Gmail API mock) |
+
+**Phase 3 完了条件**:
+- 完了通知本文が `completionMessageBody` + `signatureName` を含む
+- CC validation 失敗時に MIME に Cc: ヘッダが出ない
+- Gmail API 429 retry が exponential backoff で 3 回まで
+
+### Phase 4: Internal API + メインロジック
+
+| File | 機能 | 関連 AC | テスト |
+|---|---|---|---|
+| `services/api/src/services/oidc-verify.ts` | OIDC token middleware | AC-30 | Unit + Integration |
+| `services/api/src/services/dispatch/run-completion-notifications.ts` | メインロジック | 全 AC | Integration |
+| `services/api/src/routes/internal/dispatch.ts` | POST endpoint | AC-30 | Integration |
+
+**Phase 4 完了条件**:
+- Integration Test で AC-1〜18 全シナリオ網羅 (race / lock / 403 / 100% 判定 / kill switch 全て)
+- **Evaluator 分離プロトコル発動** (Phase 完了時に `evaluator` agent で AC 検証 + 独立評価)
+- `~/.claude/rules/error-handling.md` 状態復旧 > ログ記録 > 通知 の原則準拠を確認
+
+### Phase 5: Super admin API
+
+| File | endpoint | 関連 AC |
+|---|---|---|
+| `routes/super/dispatch-settings.ts` | GET/PUT `/api/v2/super/dispatch/settings` | AC-23 |
+| `routes/super/dispatch-audit-logs.ts` | GET `/api/v2/super/dispatch/audit-logs` | - |
+| `routes/super/dispatch-runs.ts` | GET `/api/v2/super/dispatch/runs` | - |
+| `routes/super/tenant-notification-cc.ts` | GET/PUT `/api/v2/super/tenants/:tenantId/notification-cc-emails` | AC-24, AC-25 |
+| `routes/super/dispatch-dry-run.ts` | POST `/api/v2/super/dispatch/dry-run` | AC-8 |
+| `routes/super/dispatch-test-send.ts` | POST `/api/v2/super/dispatch/test-send` | AC-9 |
+
+**Phase 5 完了条件**:
+- 各 endpoint で既存 super-admin auth middleware 適用 (AC-31)
+- test-send は固定ダミーデータ + 添付なし + To=superAdmin.email 強制
+- 楽観的ロック (version) で 409 を返す確認
+- レート制限 (test-send 1 日 50 件) の確認
+
+### Phase 6: Frontend UI
+
+| File | 機能 | テスト |
+|---|---|---|
+| `web/app/super/dispatch-settings/page.tsx` | ページ本体 | Playwright |
+| `web/app/super/dispatch-settings/components/ScheduleEditor.tsx` | 曜日 + 時刻入力 | Jest |
+| `web/app/super/dispatch-settings/components/TenantCcEditor.tsx` | chips UI (上限 10 件) | Jest |
+| `web/app/super/dispatch-settings/components/MessageBodyEditor.tsx` | プレビュー付き textarea | Jest |
+| `web/app/super/dispatch-settings/components/AuditLogTable.tsx` | 履歴一覧 (フィルタ) | Jest |
+| `web/app/super/dispatch-settings/components/RunHistoryTable.tsx` | run 履歴 | Jest |
+| `web/app/super/dispatch-settings/components/DryRunPanel.tsx` | ドライラン結果 | Jest |
+| `web/app/super/dispatch-settings/components/TestSendButton.tsx` | テスト送信 | Jest |
+
+**Phase 6 完了条件**:
+- Playwright E2E で「設定変更 → DB 反映 → audit_logs 記録」を確認
+- chips UI で CRLF / カンマ / 重複が拒否される
+- スーパー管理者以外は 401/403 が返る
+
+### Phase 7: Infrastructure + ADR
+
+| Task | 内容 |
+|---|---|
+| Cloud Scheduler job 作成 | `gcloud scheduler jobs create http` で `0 * * * *` + `time-zone=Asia/Tokyo` + OIDC token |
+| Cloud Run env 追加 | `DXCOLLEGE_SENDER_EMAIL=dxcollege@279279.net` |
+| Firestore TTL Policy | `super_dispatch_audit_logs.ttlExpireAt` + `super_dispatch_runs.ttlExpireAt` |
+| Firestore composite index | `super_dispatch_audit_logs` のフィルタ用、`super_dispatch_runs.status + leaseExpiresAt` |
+| Cloud Scheduler SA 作成 + 権限付与 | `dxcollege-scheduler@lms-279.iam.gserviceaccount.com` に Cloud Run invoker |
+| ADR-035 起票 | `docs/adr/ADR-035-auto-completion-notification.md` |
+| deploy.yml 更新 | 必要に応じて (env 追加分) |
+
+### Phase 8: Smoke check + Cutover
+
+| Step | 内容 | 担当 |
+|---|---|---|
+| 1 | 本番デプロイ前、`super_dispatch_settings/global.enabled = false` で初期化 | エンジニア |
+| 2 | 本番デプロイ実行 (deploy.yml workflow) | エンジニア |
+| 3 | Cloud Run 起動確認、Cloud Scheduler 1 回起動を待つ (kill switch なので何もしない) | エンジニア |
+| 4 | test-send 実行 → スーパー管理者自身宛にダミーメール受信確認 | エンジニア |
+| 5 | dry-run 実行 → 次回 cron で送信される対象一覧確認 | エンジニア |
+| 6 | 一覧を本田様にレビュー、対象が期待通りか確認 | 本田様 |
+| 7 | 本田様の明示承認 (番号単位の認可、CLAUDE.md 4 原則 §3) | 本田様 |
+| 8 | `enabled = true` に切替 (UI から実施) | エンジニア |
+| 9 | 次の cron 起動 (最大 60 分以内) で初回本番送信 | (自動) |
+| 10 | 初回送信件数を audit_logs / run_history で確認 | エンジニア |
+| 11 | 受信受講者・テナント担当者からの問い合わせ受付 | 本田様 |
+| 12 | 問題発生時は即時 `enabled = false` で kill switch | エンジニア |
+
+---
+
+## 4. 統合影響分析
+
+### 4.1 関連する既存機能
+
+| 既存機能 | 依存方向 | 整合性 |
+|---|---|---|
+| `services/api/src/services/google-auth.ts` (DWD) | この機能が依存 (gmail-client.ts で新規 JWT) | ✅ 既存共通 SCOPES 非変更で互換性確保 (Codex Important-1) |
+| `services/api/src/services/progress-pdf.ts` (PDF 生成) | この機能が依存 (ProgressPdfDocument を import) | ✅ 既存 export 流用 |
+| `services/api/src/services/progress-pdf-mail-template.ts` (mail template) | 参照 (構造を踏襲しつつ別ファイル) | ✅ 直接依存なし |
+| `services/api/src/routes/super/progress-pdf-draft.ts` (PR #434) | **完全独立、変更なし** | ✅ |
+| `services/api/src/services/gmail-draft.ts` (PR #434) | **完全独立、変更なし** | ✅ |
+| `course_progress` collection (既存) | この機能が読み取り | ✅ 既存 schema 変更なし |
+| `tenants/{tenantId}` (既存) | この機能が write (`notificationCcEmails` / `completionNotificationEnabled` 追加) | ⚠️ Firestore は欠損フィールド `undefined` 扱いなので backfill 不要、`sanitizeForUpdate` パターンで対応 (OQ-5) |
+| Super-admin auth middleware | この機能が依存 | ✅ 既存 middleware 流用 (OQ-7 で Bearer 確認) |
+
+### 4.2 既存ファイル変更箇所
+
+| ファイル | 変更内容 | 影響 |
+|---|---|---|
+| `services/api/src/index.ts` (or 同等の router 登録) | 新規 routes (`/api/internal/dispatch`, `/api/v2/super/dispatch/*`) 登録 | minor、import 追加のみ |
+| `packages/shared-types/src/index.ts` | dispatch types export 追加 | minor、export 追加のみ |
+| `services/api/firestore.rules` (存在すれば) | 新規 collection の rules 追加 | minor |
+| `services/api/src/services/google-auth.ts` | **変更なし** | ゼロ (Codex Important-1) |
+
+### 4.3 E2E フロー (本機能を含む完全フロー)
+
+#### メインフロー (100% 完了 → 通知)
+
+```
+1. 受講者がコース全レッスン受講 → quiz 受験 → 全 quiz 合格
+2. course_progress.isCompleted = true (既存ロジックで書き換え)
+3. 受講者が enroll している全 published コースで step 2 が完了
+4. 次の Cloud Scheduler 起動 (最大 60 分以内)
+5. BE が super_dispatch_settings/global を読み、スケジュール一致確認
+6. BE が published コース全件 + course_progress で 100% 完了判定
+7. BE が completion_notifications/{userId} を transaction で reserve
+8. PDF 生成 → DWD なりすまし送信 (To=受講者、CC=ownerEmail + notificationCcEmails)
+9. completion_notifications.status = sent に更新
+10. 受講者と CC 担当者に Gmail 受信
+11. audit_logs に user_notified 記録
+```
+
+#### 設定フロー (本田様)
+
+```
+1. 本田様が /super/dispatch-settings にアクセス
+2. ScheduleEditor で曜日・時刻設定
+3. TenantCcEditor で各テナントの CC 追加担当者を chips で入力
+4. MessageBodyEditor で完了通知本文プレビュー確認
+5. 保存 → version 楽観的ロック → audit_logs 記録
+6. 次回 cron 起動で新設定が適用される
+```
+
+#### エラー復旧フロー
+
+```
+1. permanent_failed / manual_review_required ユーザー発生
+2. 本田様が UI で AuditLogTable / RunHistoryTable から該当 user を特定
+3. 根本原因 (例: 受講者 email 不正) を本田様判断で修正
+4. エンジニアが scripts/clear-failed-notification.ts を workflow_dispatch 経由で実行
+5. 次回 cron で再評価 → 通知される
+```
+
+---
+
+## 5. テスト戦略
+
+### 5.1 Phase 別カバレッジ
+
+| Phase | Unit Test | Integration Test | E2E Test | 実機 smoke |
+|---|---|---|---|---|
+| Phase 1 | ✅ 全 service | - | - | - |
+| Phase 2 | ✅ 純粋関数部分 | ✅ transaction シナリオ 6 件 | - | - |
+| Phase 3 | ✅ template + MIME | ✅ Gmail mock | - | - |
+| Phase 4 | ✅ middleware | **✅ AC-1〜18 全網羅** | - | - |
+| Phase 5 | ✅ validation | ✅ 各 endpoint Auth + レート制限 | - | - |
+| Phase 6 | ✅ component | - | ✅ Playwright | - |
+| Phase 7 | - | - | - | dev で Cloud Scheduler 起動確認 |
+| Phase 8 | - | - | - | **本番 smoke (test-send + dry-run)** |
+
+### 5.2 重点テストシナリオ
+
+#### Phase 2 / Phase 4 で必須の Reservation シナリオ
+
+1. **新規予約**: completion_notifications 不在 → reserved 状態で create 成功
+2. **既存 sent**: 既に sent → スキップ
+3. **既存 failed_permanent**: 既に failed_permanent → スキップ
+4. **既存 reserved (lease 内)**: 他 run が処理中 → スキップ
+5. **既存 reserved (lease 期限切れ)**: manual_review_required に降格、再送しない
+6. **既存 manual_review_required**: スキップ
+7. **transaction 競合**: 2 並列 worker が同時 reserve → 1 つのみ成功
+8. **送信成功**: reserved → sent
+9. **送信 transient 失敗**: reserved 維持、次回 cron で再試行
+10. **送信 permanent 失敗 (宛先固有)**: failed_permanent に更新
+11. **送信 403 insufficientPermissions**: run 全体中断、後続 reservation rollback
+
+#### Phase 6 Playwright シナリオ
+
+1. スーパー管理者で `/super/dispatch-settings` アクセス → ページ表示
+2. ScheduleEditor で「月木の 09:00」設定 → 保存 → DB 反映確認
+3. TenantCcEditor で `a@example.com` 追加 → chip 表示 → 保存
+4. TenantCcEditor で CRLF 含む文字列を入力 → エラー表示
+5. test-send ボタン押下 → スーパー管理者自身に Gmail 届く (mock 検証)
+6. dry-run ボタン押下 → 一覧表示
+7. スーパー管理者以外でアクセス → 401/403
+
+### 5.3 Quality Gate
+
+| 規模 | Phase | 完了条件 |
+|---|---|---|
+| 大 | Phase 1, 4, 5, 6 | Lint + Test + Build + `/simplify` + `/safe-refactor` + **Evaluator 分離プロトコル** |
+| 中 | Phase 2, 3, 7, 8 | Lint + Test + Build + `/simplify` |
+
+---
+
+## 6. デプロイ戦略
+
+### 6.1 デプロイフロー
+
+```
+Phase 7 デプロイ時点
+  ↓ super_dispatch_settings/global.enabled = false で初期化
+本番 Cloud Run / Cloud Scheduler 起動
+  ↓ cron 起動するが kill switch で何もしない (audit_logs だけ run_started/completed 記録)
+test-send で実機検証 (エンジニア自身宛)
+  ↓ メール受信 + Gmail UI 確認
+dry-run で本番データ確認
+  ↓ 送信予定者リストを本田様レビュー
+本田様の番号単位明示認可
+  ↓ "PR #N — タイトル の cutover を進めて良い" 形式
+enabled = true に切替 (UI から)
+  ↓ 次の cron 起動で本番送信開始
+初回送信件数監視 + 問い合わせ受付
+```
+
+### 6.2 Cutover 安全装置
+
+| 装置 | 効果 |
+|---|---|
+| `enabled = false` 初期化 | 本番デプロイ後も即時送信されない |
+| test-send | 実機 Gmail 受信を事前確認 |
+| dry-run | 送信対象を事前に本田様レビュー |
+| 番号単位明示認可 | AI が勝手に enable しない (CLAUDE.md 4 原則 §3) |
+| kill switch | 問題発生時に即時停止 |
+| Reservation 方式 | 同一 user への二重送信を構造的に防止 |
+| 403 reason 分類 | scope 撤回時に全 user 終端化を防ぐ |
+
+---
+
+## 7. ロールバック戦略
+
+| 状況 | 対応 | 復旧時間 |
+|---|---|---|
+| 設定誤入力 (誤った時刻設定) | UI から再設定、次回 cron に反映 | 即時 (最大 60 分後の cron 起動で適用) |
+| 一部 user のみ誤送信 | `scripts/clear-failed-notification.ts` で個別 doc 削除、本田様が受信者対応 | 数時間 |
+| 大量誤送信中 | UI から `enabled = false` → 即時 kill switch | 即時 (次の cron で停止) |
+| 致命的バグ (例: 全 user に永久 transient_failed) | Cloud Scheduler job pause → Cloud Run rollback (前 commit に revert) → 設計再検討 | 30 分 |
+| Firestore データ破壊 | PITR で復元 (CLAUDE.md production-data-safety.md §2) | 1-2 時間 |
+| 全体設定ミス (DWD scope 撤回等) | 403 reason 分類で自動 run abort、Error Reporting critical 通知、本田様対応 | 即時検知 + 対応は scope 依存 |
+
+---
+
+## 8. Open Questions の解決順序
+
+| 順序 | OQ | Phase | 解決手段 |
+|---|---|---|---|
+| 1 | OQ-3 (Workspace 権限) | Phase 0 | 本田様確認、無ければエンジニアが代行不可 |
+| 2 | OQ-3 実施 (gmail.send scope 追加) | Phase 0 | 本田様作業、24h 反映待ち |
+| 3 | OQ-2 (Group エイリアス DWD smoke) | Phase 0 | エンジニアが実機 smoke、失敗時は本田様判断 |
+| 4 | OQ-7 (super-admin auth 方式) | Phase 0 | 既存コード grep、5 分 |
+| 5 | OQ-8 (TTL 法務) | Phase 0 | 本田様 + 法務確認 |
+| 6 | OQ-1, OQ-6 (Gmail API / OIDC audience) | Phase 7 | gcloud / Cloud Run 確認 |
+| 7 | OQ-4 (Cloud Run 300 秒) | Phase 4 | Integration Test で実測 |
+| 8 | OQ-5 (tenant フィールド追加 backfill) | Phase 5 | `sanitizeForUpdate` で対応 |
+| 9 | OQ-9 (lease 期限実測) | Phase 4 / 8 | Integration Test + 本番 smoke で確定 |
+
+---
+
+## 9. AC ↔ Phase マッピング
+
+設計仕様書 AC 30 件を Phase に紐付け。実装完了時に全 AC を Phase 完了条件として検証する。
+
+| Phase | カバー AC |
+|---|---|
+| Phase 1 | AC-4 (CC validation), AC-25 (CRLF/カンマ拒否), AC-33 (sanitize), AC-34 (scope 分離) |
+| Phase 2 | AC-10 (reserve transaction), AC-11 (reserved lease 内), AC-12 (lease 期限切れ降格), AC-16 (run lock) |
+| Phase 3 | AC-3 (sender), AC-5 (テンプレート), AC-32 (PII hash) |
+| Phase 4 | AC-1 (100% 判定母集合), AC-2 (idempotency), AC-6 (スケジュール), AC-7 (kill switch), AC-13 (sent 更新), AC-14 (transient 維持), AC-15 (permanent 記録), AC-17 (403 全体中断), AC-18 (403 宛先固有), AC-19 (email 無効), AC-22 (案 C), AC-30 (OIDC) |
+| Phase 5 | AC-8 (dry-run), AC-9 (test-send dummy), AC-20 (ownerEmail null), AC-21 (CcEmails 空), AC-23 (version 楽観ロック), AC-24 (CC 上限 10), AC-31 (Bearer auth) |
+| Phase 6 | UI 統合 (AC-23 警告 reload, AC-25 chips validation) |
+| Phase 8 | 全 AC 本番検証 |
+
+---
+
+## 10. CLAUDE.md ルール準拠チェックリスト
+
+| ルール | 準拠状況 |
+|---|---|
+| CRITICAL: 3 ステップ以上 → `/impl-plan` | ✅ 本ドキュメント |
+| CRITICAL: 3 ファイル以上 → `/simplify` + `/safe-refactor` | ✅ Phase 1/4/5/6 完了時 |
+| CRITICAL: 同じエラー 3 回失敗 → `/codex` | ✅ 既に Phase 7 セルフレビュー後に実施済 |
+| CRITICAL: API 境界変更 → FE/BE 確認 | ✅ Phase 5 で `check-api-impact` skill |
+| CRITICAL: statusフィールド管理 → 状態遷移図先行 | ✅ 設計仕様書 §4.2 |
+| CRITICAL: DB Partial Update → 更新対象外保護 | ✅ `sanitizeForUpdate` パターン (OQ-5) |
+| CRITICAL: 未実装確認 → ソース実在確認 + git log | ✅ Phase 0 実施 |
+| CRITICAL: main 直 push 禁止 | ✅ `feat/completion-notification-system-design` 作業中 |
+| CRITICAL: destructive 操作 → 1 行詰めコマンド + 件数 assert | N/A (本機能は destructive 操作なし、新規追加のみ) |
+| CRITICAL: グローバル memory 追加前に既存 grep + スコープ判定 | N/A |
+| Test First: 実装 → `/tdd` で RED→GREEN→REFACTOR | ✅ Phase 1-5 で適用 |
+| Test First: 境界値・異常系を必ず含める | ✅ AC-10〜18 / AC-19〜25 |
+| Test First: 新データパス → 全出力フィールド期待値列挙 | ✅ progressSnapshot / courseIdsSnapshot |
+| Test First: 関数戻り値変更 → 全呼び出し元整合性確認 | ✅ Phase 5 で `check-api-impact` |
+| Test First: データフロー実装後 → `/trace-dataflow` | ✅ Phase 6 で適用 |
+| Definition of Done: テスト・lint・型 PASS + 件数提示 | ✅ 各 Phase 完了時 |
+| Definition of Done: コードパス最低 1 回実行 | ✅ Phase 8 cutover |
+| Definition of Done: Test plan 全項目実行 | ✅ 各 PR で明記 |
+| Definition of Done: 公式に存在しないメカニズム禁止 | ✅ Codex セカンドオピニオンで確認済 |
+| Quality Gate: 実装完了後 `/simplify` | ✅ 各 Phase |
+| Quality Gate: 3+ ファイル → `/safe-refactor` | ✅ 各 Phase |
+| Quality Gate: 5+ ファイル → Evaluator 分離プロトコル | ✅ Phase 1, 4, 5, 6 |
+| Quality Gate: PR レビュー → `/review-pr` | ✅ 各 PR |
+| Debug Protocol: データ検証優先 | ✅ Phase 8 cutover 手順 |
+| Task Delegation: 30 秒以上 → バックグラウンド | ✅ Codex セカンドオピニオン |
+
+---
+
+## 11. 想定リスクと対策
+
+| リスク | 確率 | 影響 | 対策 |
+|---|---|---|---|
+| Google Group エイリアスが DWD subject として使えない | 中 | 高 | Phase 0 で smoke 必須、失敗時は SendAs/実ユーザー化を判断 |
+| Cloud Run 300 秒で全 user 処理が完了しない (将来テナント増) | 低 (現状 2 テナント) | 中 | Phase 4 Integration Test で実測、超過時は resumable run を将来課題に |
+| Reservation transaction が高頻度競合する | 低 | 低 | 並列度 8 + 単一 worker 想定なら問題なし、超過時は lease 短縮 |
+| 受講者の Gmail が受信拒否設定 | 低 | 低 | Gmail API 403 宛先固有として failed_permanent 記録、本田様判断 |
+| 本田様の Workspace 管理コンソール権限が不足 | 低 | 高 (Phase 0 ブロック) | Phase 0 開始時に最優先で確認 |
+| 法務確認 (TTL 1 年) で延長要請 | 低 | 低 | TTL を 2-7 年等に調整、Firestore TTL Policy で対応可能 |
+| Cloud Scheduler の barometer 起動誤差 | 低 | 低 | DB 設定との一致判定で吸収、5 分以内のずれは許容 |
+
+---
+
+## 12. 完了の定義 (Phase 全体)
+
+以下を全て満たした時点で本機能の実装完了とする:
+
+1. ✅ AC 30 件全て満たす自動テストが PASS
+2. ✅ Phase 1-7 の全 PR が main にマージ済み
+3. ✅ Phase 8 cutover で本番初回送信に成功
+4. ✅ 受講者 1 名以上から実際に Gmail 受信確認
+5. ✅ ADR-035 が main に登録済み
+6. ✅ 本田様の運用引き継ぎ完了 (UI 操作・kill switch・script 復旧フロー説明)
+7. ✅ `~/.claude/memory/` に運用上の教訓を追記 (該当があれば)

--- a/packages/shared-types/src/dispatch.ts
+++ b/packages/shared-types/src/dispatch.ts
@@ -1,0 +1,320 @@
+/**
+ * DXcollege 自動完了通知システム DTO
+ * 設計仕様書: docs/specs/2026-05-20-completion-notification-design.md
+ *
+ * 既存の手動 Gmail 下書き機能 (progress-pdf.ts、PR #434) と完全独立した別レーン。
+ *
+ * 関連 ADR: ADR-026 (DWD), ADR-029 (JST), ADR-034 (Phase 2 Gmail draft, PII hash)
+ */
+
+// ============================================================
+// 配信設定 (super_dispatch_settings/global)
+// ============================================================
+
+export interface DispatchSettings {
+  /** kill switch: false で次回 cron 起動時に即時停止 */
+  enabled: boolean;
+  /** 0-6 (日-土) の配信曜日。空配列なら常に skip */
+  scheduleDaysOfWeek: number[];
+  /** 0-23 の配信時刻 (JST、HH:00 単位) */
+  scheduleHourJst: number;
+  /** メール末尾の署名文字列 (例: "DXcollege運営スタッフ") */
+  signatureName: string;
+  /** 完了通知本文 (CRLF/カンマ/制御文字を含まない、上限 4000 文字) */
+  completionMessageBody: string;
+  /** 送信元 email (Cloud Run env DXCOLLEGE_SENDER_EMAIL から読み取り、編集不可) */
+  senderEmail: string;
+  /** 最終更新時刻 (ISO 8601) */
+  updatedAt: string;
+  /** 最終更新者の email (raw、監査責任明示のため hash 化しない) */
+  updatedBy: string;
+  /** 楽観的ロック用バージョン */
+  version: number;
+}
+
+/** 設定取得レスポンス (senderEmail は env から読み取って併記、編集不可) */
+export type GetDispatchSettingsResponse = DispatchSettings;
+
+/** 設定更新リクエスト (version 不一致で 409) */
+export interface PutDispatchSettingsRequest {
+  enabled: boolean;
+  scheduleDaysOfWeek: number[];
+  scheduleHourJst: number;
+  signatureName: string;
+  completionMessageBody: string;
+  /** 楽観的ロック用、現在の DB version と一致しないと 409 */
+  version: number;
+}
+
+export type DispatchSettingsErrorCode =
+  | "invalid_schedule_days"
+  | "invalid_schedule_hour"
+  | "invalid_signature_name"
+  | "invalid_completion_message_body"
+  | "version_conflict"
+  | "unauthorized"
+  | "forbidden";
+
+// ============================================================
+// テナント別 CC 設定 (tenants/{tenantId} 拡張フィールド)
+// ============================================================
+
+export interface TenantNotificationCcConfig {
+  /** 既存 tenants.ownerEmail (read-only、参考表示) */
+  ownerEmail: string | null;
+  /** 追加 CC email 配列 (上限 10 件、各 email は CRLF/カンマ/制御文字を含まない) */
+  notificationCcEmails: string[];
+  /** テナント単位の有効化フラグ、false で当テナントは配信対象外 */
+  completionNotificationEnabled: boolean;
+}
+
+export type GetTenantNotificationCcResponse = TenantNotificationCcConfig;
+
+export interface PutTenantNotificationCcRequest {
+  notificationCcEmails: string[];
+  completionNotificationEnabled: boolean;
+}
+
+export type TenantNotificationCcErrorCode =
+  | "invalid_cc_emails"
+  | "cc_emails_too_many"
+  | "tenant_not_found"
+  | "unauthorized"
+  | "forbidden";
+
+/** notificationCcEmails 上限 */
+export const NOTIFICATION_CC_EMAILS_MAX = 10;
+
+// ============================================================
+// 完了通知 (tenants/{tenantId}/completion_notifications/{userId})
+// ============================================================
+
+/**
+ * 完了通知の状態遷移 (設計仕様書 §4.2):
+ * - reserved: pre-send transaction で確保、Gmail 送信中
+ * - sent: Gmail 送信成功、終端 (idempotency キー)
+ * - failed_permanent: 宛先固有の permanent 失敗、終端
+ * - manual_review_required: lease 期限切れ、人手介入待ち、終端
+ */
+export type CompletionNotificationStatus =
+  | "reserved"
+  | "sent"
+  | "failed_permanent"
+  | "manual_review_required";
+
+export interface CompletionNotificationProgressSnapshot {
+  completedLessons: number;
+  totalLessons: number;
+  coursesCompleted: number;
+  coursesTotal: number;
+}
+
+export interface CompletionNotification {
+  userId: string;
+  status: CompletionNotificationStatus;
+  /** 予約した cron 実行 ID */
+  runId: string;
+  /** 予約時刻 (ISO 8601) */
+  reservedAt: string;
+  /** Lease 期限 (ISO 8601)。Date.now() > leaseExpiresAt で manual_review に降格 */
+  leaseExpiresAt: string;
+  /** 送信成功時刻 (status=sent のみ) */
+  notifiedAt: string | null;
+  /** Gmail API messageId (status=sent のみ) */
+  messageId: string | null;
+  /** sanitized error code (status=failed_permanent のみ) */
+  errorCode: string | null;
+  /** sanitized error message (status=failed_permanent のみ) */
+  errorMessage: string | null;
+  /** 失敗時刻 (status=failed_permanent のみ) */
+  failedAt: string | null;
+  /** 通知時点の進捗スナップショット */
+  progressSnapshot: CompletionNotificationProgressSnapshot;
+  /** 通知時点の published course ID 一覧 (案 C: 後からコース追加されても再送しない) */
+  courseIdsSnapshot: string[];
+  /** courseIdsSnapshot.length と同値、検索高速化用 */
+  publishedCourseCount: number;
+  /** sha256 ハッシュ (ADR-034 PII 最小化) */
+  recipientToHash: string;
+  /** sha256 配列 (CC) */
+  recipientCcHashes: string[];
+  pdfSizeBytes: number | null;
+}
+
+// ============================================================
+// Run lock (super_dispatch_runs/{runId})
+// ============================================================
+
+export type DispatchRunStatus = "running" | "completed" | "timeout" | "aborted";
+
+export interface DispatchRun {
+  runId: string;
+  /** cron 起動時刻 (ISO 8601) */
+  triggeredAt: string;
+  status: DispatchRunStatus;
+  /** Lease 期限 (ISO 8601)。triggeredAt + 280 秒 (Cloud Run 300 秒に余裕) */
+  leaseExpiresAt: string;
+  processedTenants: number;
+  sent: number;
+  skipped: number;
+  failed: number;
+  /** abort 理由 (403 全体中断等、status=aborted のみ) */
+  abortedReason: string | null;
+  /** TTL 期限 (ISO 8601)、triggeredAt + 365 days */
+  ttlExpireAt: string;
+}
+
+// ============================================================
+// 内部 API レスポンス (Cloud Scheduler → Cloud Run)
+// ============================================================
+
+export interface RunCompletionNotificationsResponse {
+  runId: string;
+  processedTenants: number;
+  sent: number;
+  skipped: number;
+  failed: number;
+  manualReviewRequired: number;
+}
+
+// ============================================================
+// Audit log (super_dispatch_audit_logs)
+// ============================================================
+
+export type DispatchAuditEventType =
+  | "run_started"
+  | "run_completed"
+  | "run_aborted"
+  | "user_reserved"
+  | "user_notified"
+  | "user_skipped"
+  | "user_failed_transient"
+  | "user_failed_permanent"
+  | "manual_review_required"
+  | "settings_updated"
+  | "test_send"
+  | "dry_run"
+  | "orphan_send";
+
+export interface DispatchAuditLog {
+  auditId: string;
+  runId: string;
+  runStartedAt: string;
+  eventType: DispatchAuditEventType;
+  tenantId: string | null;
+  userId: string | null;
+  errorCode: string | null;
+  /** sanitizeErrorForAudit() 済み (PII 除去後) */
+  errorMessage: string | null;
+  durationMs: number | null;
+  createdAt: string;
+  /** TTL 期限 (Firestore TTL Policy で 1 年自動削除) */
+  ttlExpireAt: string;
+}
+
+export interface GetAuditLogsQuery {
+  tenantId?: string;
+  userId?: string;
+  eventType?: DispatchAuditEventType;
+  /** ISO 8601 */
+  from?: string;
+  /** ISO 8601 */
+  to?: string;
+  /** ページサイズ、default 50、max 200 */
+  limit?: number;
+  /** ページネーション用 */
+  cursor?: string;
+}
+
+export interface GetAuditLogsResponse {
+  logs: DispatchAuditLog[];
+  nextCursor: string | null;
+}
+
+// ============================================================
+// Dry-run
+// ============================================================
+
+export interface DryRunTarget {
+  tenantId: string;
+  userId: string;
+  /** 受講者 email (UI 表示用、PII 含むためログには出さない) */
+  userEmail: string;
+  userName: string;
+  progressSnapshot: CompletionNotificationProgressSnapshot;
+}
+
+export interface DryRunResponse {
+  /** 次回 cron で送信される対象一覧 (Gmail 送信も Reservation も実行されない) */
+  wouldNotify: DryRunTarget[];
+  /** 評価時刻 (ISO 8601) */
+  evaluatedAt: string;
+}
+
+// ============================================================
+// Test-send (固定ダミーデータ + 添付なし、スーパー管理者自身宛)
+// ============================================================
+
+export interface TestSendResponse {
+  /** Gmail API messageId */
+  messageId: string;
+  /** 送信先 (スーパー管理者自身の email) */
+  sentTo: string;
+  sentAt: string;
+}
+
+export type TestSendErrorCode =
+  | "rate_limit_exceeded"
+  | "gmail_api_error"
+  | "gmail_api_transient"
+  | "dwd_token_failed"
+  | "unauthorized"
+  | "forbidden";
+
+/** test-send 1 日あたりレート制限 (スーパー管理者あたり) */
+export const TEST_SEND_DAILY_LIMIT = 50;
+
+// ============================================================
+// Reservation transaction の結果 (内部 service 用)
+// ============================================================
+
+export type ReservationOutcome =
+  | { reserved: true }
+  | {
+      reserved: false;
+      reason:
+        | "already_sent"
+        | "failed_permanent"
+        | "manual_review_required"
+        | "currently_reserved_by_other_run"
+        | "lease_expired_promoted_to_manual_review";
+    };
+
+// ============================================================
+// Gmail 403 reason 分類 (内部 service 用)
+// ============================================================
+
+export type Gmail403Classification = "scope_revoked" | "user_permanent";
+
+// ============================================================
+// 制約値 (export して FE/BE で共有)
+// ============================================================
+
+export const DISPATCH_CONSTRAINTS = {
+  /** notificationCcEmails 上限 */
+  NOTIFICATION_CC_EMAILS_MAX: 10,
+  /** signatureName 文字数上限 */
+  SIGNATURE_NAME_MAX_LENGTH: 100,
+  /** completionMessageBody 文字数上限 */
+  COMPLETION_MESSAGE_BODY_MAX_LENGTH: 4000,
+  /** test-send 1 日あたり上限 */
+  TEST_SEND_DAILY_LIMIT: 50,
+  /** Reservation lease 期限 (ミリ秒) */
+  RESERVATION_LEASE_MS: 10 * 60 * 1000,
+  /** Dispatch run lease 期限 (ミリ秒、Cloud Run 300 秒に余裕) */
+  DISPATCH_RUN_LEASE_MS: 280 * 1000,
+  /** Audit logs TTL (日) */
+  AUDIT_LOGS_TTL_DAYS: 365,
+  /** sanitized error message 上限 */
+  SANITIZED_ERROR_MESSAGE_MAX_LENGTH: 1024,
+} as const;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -10,3 +10,4 @@ export type * from "./quiz.js";
 export type * from "./tenant.js";
 export type * from "./progress-pdf.js";
 export * from "./filename.js";
+export * from "./dispatch.js";

--- a/scripts/smoke-dwd-gmail-send.ts
+++ b/scripts/smoke-dwd-gmail-send.ts
@@ -36,6 +36,7 @@
 
 import { google } from "googleapis";
 import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+import { sanitizeErrorForAudit } from "../services/api/src/services/dispatch/dispatch-error-sanitizer.js";
 
 const GCP_PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT ?? "lms-279";
 const DWD_SECRET_NAME = `projects/${GCP_PROJECT_ID}/secrets/dwd-workspace-key/versions/latest`;
@@ -204,27 +205,48 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error("");
-  console.error("=== smoke check FAILED ===");
-  if (err instanceof Error) {
-    console.error(`Error: ${err.message}`);
-    // GaxiosError 形式から reason を取り出して原因の手がかりを出す
-    const gax = err as Error & {
-      response?: { status?: number; data?: unknown };
+  // PR #442 review Critical 3 対応:
+  //   workflow log は organization 内で閲覧可能なため、raw response.data を吐くと
+  //   PII (受講者 email / access token / API key 等) が漏れる。
+  //   sanitizeErrorForAudit を通してから出力する。
+  process.exitCode = 1;
+  process.stderr.write("\n=== smoke check FAILED ===\n");
+
+  const sanitizedMessage = sanitizeErrorForAudit(err);
+  process.stderr.write(`Error: ${sanitizedMessage}\n`);
+
+  // 安全部分のみ個別に抽出 (status / code / reason)。
+  // response.data 全体は dump しない (PII 漏洩リスク、Critical 3)。
+  const gax = err as Error & {
+    code?: unknown;
+    response?: {
+      status?: number;
+      data?: { error?: { errors?: Array<{ reason?: unknown }> } };
     };
-    if (gax.response) {
-      console.error(`HTTP status: ${gax.response.status}`);
-      console.error(`Response data: ${JSON.stringify(gax.response.data, null, 2)}`);
-    }
-  } else {
-    console.error(String(err));
+  };
+  if (typeof gax.code === "string") {
+    process.stderr.write(`Error code: ${gax.code}\n`);
   }
-  console.error("");
-  console.error("対処:");
-  console.error("  - 403 insufficientPermissions: DWD scope 反映待ち (最大 24h)");
-  console.error("  - 403 delegationDenied: dxcollege@279279.net への DWD なりすまし不可");
-  console.error("                          → SendAs 設定 or 実ユーザー mailbox 化を判断");
-  console.error("  - 401: SA キー無効 / Secret Manager 読取り失敗");
-  console.error("");
-  process.exit(1);
+  if (gax.response?.status !== undefined) {
+    process.stderr.write(`HTTP status: ${gax.response.status}\n`);
+  }
+  const reasons = gax.response?.data?.error?.errors;
+  if (Array.isArray(reasons)) {
+    const reasonList = reasons
+      .map((entry) => (typeof entry.reason === "string" ? entry.reason : null))
+      .filter((r): r is string => r !== null);
+    if (reasonList.length > 0) {
+      process.stderr.write(`Reasons: ${reasonList.join(", ")}\n`);
+    }
+  }
+
+  process.stderr.write("\n対処:\n");
+  process.stderr.write("  - 403 insufficientPermissions: DWD scope 反映待ち (最大 24h)\n");
+  process.stderr.write(
+    "  - 403 delegationDenied: dxcollege@279279.net への DWD なりすまし不可\n",
+  );
+  process.stderr.write(
+    "                          → SendAs 設定 or 実ユーザー mailbox 化を判断\n",
+  );
+  process.stderr.write("  - 401: SA キー無効 / Secret Manager 読取り失敗\n\n");
 });

--- a/scripts/smoke-dwd-gmail-send.ts
+++ b/scripts/smoke-dwd-gmail-send.ts
@@ -1,0 +1,230 @@
+#!/usr/bin/env npx tsx
+/**
+ * Phase 0-A-4 (OQ-2) Group エイリアス DWD smoke check スクリプト。
+ *
+ * 目的:
+ *   `dxcollege@279279.net` が Google Group エイリアスでも、DWD subject として
+ *   `gmail.users.messages.send` が成功するかを実機検証する。
+ *   失敗した場合は設計仕様書 OQ-2 の代替案 (SendAs 設定 or 実ユーザー mailbox 化) を
+ *   本田様判断で検討する必要がある。
+ *
+ * 動作モード:
+ *   --dry-run (既定): DWD 認証 + JWT 生成 + MIME 組立まで実行、Gmail API 呼出しは行わない
+ *   --send: 上記に加え、実際に Gmail API で送信する
+ *
+ * 安全機構:
+ *   - --dry-run 既定 (--send で実送信)
+ *   - --to (必須): 送信先 email、明示指定。誤入力防止。
+ *   - --subject (任意): 件名、既定 "[smoke] DXcollege 自動完了通知 DWD smoke check"
+ *   - 本文は固定 (PII を含まないダミー文)
+ *   - 添付なし (本番 PDF 生成パスは別 phase で検証)
+ *   - 実行ログには messageId のみ出力、本文/宛先 raw は出さない
+ *
+ * 使用方法:
+ *   # ローカル (ADC 経由、要 GOOGLE_APPLICATION_CREDENTIALS or gcloud auth):
+ *   GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json npx tsx scripts/smoke-dwd-gmail-send.ts \
+ *     --to=engineer@example.com --dry-run
+ *
+ *   # workflow_dispatch (WIF 認証):
+ *   GitHub Actions UI > Smoke DWD Gmail Send > Run workflow
+ *
+ * 関連:
+ *   - 設計仕様書: docs/specs/2026-05-20-completion-notification-design.md OQ-2
+ *   - 実装計画: docs/specs/2026-05-20-completion-notification-impl-plan.md Phase 0-A-4
+ *   - 既存 DWD 基盤: services/api/src/services/google-auth.ts
+ */
+
+import { google } from "googleapis";
+import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+
+const GCP_PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT ?? "lms-279";
+const DWD_SECRET_NAME = `projects/${GCP_PROJECT_ID}/secrets/dwd-workspace-key/versions/latest`;
+// 設計仕様書 NFR-8 / Phase 7 で Cloud Run env に追加予定。ローカル smoke では引数で上書き可能。
+const DEFAULT_SENDER = process.env.DXCOLLEGE_SENDER_EMAIL ?? "dxcollege@279279.net";
+
+// ============================================================
+// CLI 引数パース
+// ============================================================
+
+interface CliOptions {
+  to: string;
+  subject: string;
+  sender: string;
+  send: boolean; // true なら実送信、false (既定) なら dry-run
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  let to: string | null = null;
+  let subject = "[smoke] DXcollege 自動完了通知 DWD smoke check";
+  let sender = DEFAULT_SENDER;
+  let send = false;
+
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith("--to=")) {
+      to = arg.slice("--to=".length).trim();
+    } else if (arg.startsWith("--subject=")) {
+      subject = arg.slice("--subject=".length).trim();
+    } else if (arg.startsWith("--sender=")) {
+      sender = arg.slice("--sender=".length).trim();
+    } else if (arg === "--send") {
+      send = true;
+    } else if (arg === "--dry-run") {
+      send = false;
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(
+        "Usage: smoke-dwd-gmail-send.ts --to=<email> [--subject=...] [--sender=...] [--send|--dry-run]",
+      );
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      process.exit(2);
+    }
+  }
+
+  if (!to) {
+    console.error("FATAL: --to=<email> is required (送信先指定なしでは smoke 不可)");
+    process.exit(2);
+  }
+
+  // 簡易バリデーション (smoke なので最小限)
+  if (!/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/.test(to)) {
+    console.error(`FATAL: --to does not look like a valid email: ${to}`);
+    process.exit(2);
+  }
+  if (!/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/.test(sender)) {
+    console.error(`FATAL: --sender does not look like a valid email: ${sender}`);
+    process.exit(2);
+  }
+
+  return { to, subject, sender, send };
+}
+
+// ============================================================
+// Secret Manager から DWD SA キー取得
+// ============================================================
+
+async function getDwdKey(): Promise<{ client_email: string; private_key: string }> {
+  const client = new SecretManagerServiceClient();
+  const [version] = await client.accessSecretVersion({ name: DWD_SECRET_NAME });
+  const payload = version.payload?.data;
+  if (!payload) {
+    throw new Error(`DWD service account key not found at ${DWD_SECRET_NAME}`);
+  }
+  const keyData = typeof payload === "string" ? payload : payload.toString();
+  return JSON.parse(keyData);
+}
+
+// ============================================================
+// MIME 組立 (ダミー本文、添付なし)
+// ============================================================
+
+function buildRawMime(opts: {
+  to: string;
+  sender: string;
+  subject: string;
+}): string {
+  // Gmail API messages.send は base64url エンコード済の MIME を期待
+  const body = [
+    `From: ${opts.sender}`,
+    `To: ${opts.to}`,
+    `Subject: =?UTF-8?B?${Buffer.from(opts.subject, "utf-8").toString("base64")}?=`,
+    "MIME-Version: 1.0",
+    'Content-Type: text/plain; charset="UTF-8"',
+    "Content-Transfer-Encoding: 7bit",
+    "",
+    "This is a DWD smoke test message for DXcollege completion notification system.",
+    "If you received this, the DWD subject = dxcollege@279279.net is working.",
+    "",
+    "Phase 0-A-4 (OQ-2) smoke check",
+    "Related: docs/specs/2026-05-20-completion-notification-design.md",
+  ].join("\r\n");
+
+  return Buffer.from(body, "utf-8").toString("base64url");
+}
+
+// ============================================================
+// メイン
+// ============================================================
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv);
+
+  console.log(`Mode: ${opts.send ? "SEND (実送信)" : "DRY-RUN (Gmail API 呼出しなし)"}`);
+  console.log(`Sender (DWD subject): ${opts.sender}`);
+  console.log(`Recipient: ${opts.to}`);
+  console.log(`Subject: ${opts.subject}`);
+  console.log("---");
+
+  console.log("Step 1: Secret Manager から DWD SA キーを取得...");
+  const keyData = await getDwdKey();
+  console.log(`  ✓ SA client_email: ${keyData.client_email}`);
+
+  console.log("Step 2: gmail.send 専用 JWT 生成 (scope を共通 client と分離)...");
+  const auth = new google.auth.JWT({
+    email: keyData.client_email,
+    key: keyData.private_key,
+    scopes: ["https://www.googleapis.com/auth/gmail.send"],
+    subject: opts.sender, // ← なりすまし対象
+  });
+  await auth.authorize();
+  console.log("  ✓ JWT 認可成功 (DWD scope 反映済み)");
+
+  console.log("Step 3: MIME 組立...");
+  const raw = buildRawMime({
+    to: opts.to,
+    sender: opts.sender,
+    subject: opts.subject,
+  });
+  console.log(`  ✓ MIME size: ${raw.length} bytes (base64url)`);
+
+  if (!opts.send) {
+    console.log("---");
+    console.log("DRY-RUN: Gmail API messages.send 呼出しはスキップしました。");
+    console.log("実送信するには --send を付けて再実行してください。");
+    return;
+  }
+
+  console.log("Step 4: Gmail API messages.send 実行...");
+  const gmail = google.gmail({ version: "v1", auth });
+  const response = await gmail.users.messages.send({
+    userId: "me", // subject に設定された Group/User として送信
+    requestBody: { raw },
+  });
+
+  const messageId = response.data.id;
+  const threadId = response.data.threadId;
+
+  console.log("---");
+  console.log(`✓ 送信成功`);
+  console.log(`  messageId: ${messageId}`);
+  console.log(`  threadId:  ${threadId}`);
+  console.log("");
+  console.log("OQ-2 smoke check 結果: PASS");
+  console.log("→ Group エイリアスでも DWD subject として gmail.send が機能することを確認");
+}
+
+main().catch((err) => {
+  console.error("");
+  console.error("=== smoke check FAILED ===");
+  if (err instanceof Error) {
+    console.error(`Error: ${err.message}`);
+    // GaxiosError 形式から reason を取り出して原因の手がかりを出す
+    const gax = err as Error & {
+      response?: { status?: number; data?: unknown };
+    };
+    if (gax.response) {
+      console.error(`HTTP status: ${gax.response.status}`);
+      console.error(`Response data: ${JSON.stringify(gax.response.data, null, 2)}`);
+    }
+  } else {
+    console.error(String(err));
+  }
+  console.error("");
+  console.error("対処:");
+  console.error("  - 403 insufficientPermissions: DWD scope 反映待ち (最大 24h)");
+  console.error("  - 403 delegationDenied: dxcollege@279279.net への DWD なりすまし不可");
+  console.error("                          → SendAs 設定 or 実ユーザー mailbox 化を判断");
+  console.error("  - 401: SA キー無効 / Secret Manager 読取り失敗");
+  console.error("");
+  process.exit(1);
+});

--- a/services/api/src/services/dispatch/__tests__/dispatch-403-classifier.test.ts
+++ b/services/api/src/services/dispatch/__tests__/dispatch-403-classifier.test.ts
@@ -1,0 +1,96 @@
+/**
+ * dispatch-403-classifier の単体テスト (TDD RED)。
+ *
+ * 設計仕様書 §6.4、Codex Important-4 (403 reason 分類) に対応。
+ *
+ * Gmail API 403 を 2 つに分類:
+ * - scope_revoked (全体中断): insufficientPermissions / delegationDenied / sender disabled 系
+ * - user_permanent (宛先固有): その他 (受講者の Gmail 受信拒否設定等)
+ *
+ * 観点:
+ * - GaxiosError 形式の data.error.errors[0].reason を読み取る
+ * - 既知の scope_revoked reasons: insufficientPermissions / delegationDenied / userRateLimitExceeded
+ * - reason が未定義 / errors 配列空 / data 不在 → user_permanent (デフォルト宛先固有)
+ * - 非 403 / 非 Error 入力 → user_permanent (安全側、宛先固有として扱う)
+ */
+
+import { describe, it, expect } from "vitest";
+import { classifyGmail403 } from "../dispatch-403-classifier.js";
+
+function makeGaxios403(reason: string | undefined) {
+  const err = new Error("403 Forbidden") as Error & {
+    response?: { data?: unknown; status?: number };
+  };
+  err.response = {
+    status: 403,
+    data: {
+      error: {
+        errors: reason ? [{ reason }] : [],
+      },
+    },
+  };
+  return err;
+}
+
+describe("classifyGmail403", () => {
+  describe("scope_revoked (run 全体中断)", () => {
+    it("insufficientPermissions → scope_revoked", () => {
+      expect(classifyGmail403(makeGaxios403("insufficientPermissions"))).toBe(
+        "scope_revoked",
+      );
+    });
+
+    it("delegationDenied → scope_revoked", () => {
+      expect(classifyGmail403(makeGaxios403("delegationDenied"))).toBe(
+        "scope_revoked",
+      );
+    });
+
+    it("userRateLimitExceeded → scope_revoked (sender disabled 系)", () => {
+      expect(classifyGmail403(makeGaxios403("userRateLimitExceeded"))).toBe(
+        "scope_revoked",
+      );
+    });
+
+    it("forbidden → scope_revoked (DWD 認可未反映の典型)", () => {
+      expect(classifyGmail403(makeGaxios403("forbidden"))).toBe("scope_revoked");
+    });
+  });
+
+  describe("user_permanent (宛先固有)", () => {
+    it("既知の宛先固有 reason → user_permanent", () => {
+      expect(classifyGmail403(makeGaxios403("recipientRejected"))).toBe(
+        "user_permanent",
+      );
+    });
+
+    it("未知の reason → user_permanent (デフォルト安全側)", () => {
+      expect(classifyGmail403(makeGaxios403("someUnknownReason"))).toBe(
+        "user_permanent",
+      );
+    });
+
+    it("reason undefined → user_permanent", () => {
+      expect(classifyGmail403(makeGaxios403(undefined))).toBe("user_permanent");
+    });
+  });
+
+  describe("不正形式の入力 (defense in depth)", () => {
+    it("response 不在 → user_permanent", () => {
+      const err = new Error("plain error");
+      expect(classifyGmail403(err)).toBe("user_permanent");
+    });
+
+    it("response.data 不在 → user_permanent", () => {
+      const err = new Error("err") as Error & { response?: { status?: number } };
+      err.response = { status: 403 };
+      expect(classifyGmail403(err)).toBe("user_permanent");
+    });
+
+    it("non-Error 入力 → user_permanent", () => {
+      expect(classifyGmail403("string error")).toBe("user_permanent");
+      expect(classifyGmail403(null)).toBe("user_permanent");
+      expect(classifyGmail403(undefined)).toBe("user_permanent");
+    });
+  });
+});

--- a/services/api/src/services/dispatch/__tests__/dispatch-403-classifier.test.ts
+++ b/services/api/src/services/dispatch/__tests__/dispatch-403-classifier.test.ts
@@ -1,31 +1,39 @@
 /**
- * dispatch-403-classifier の単体テスト (TDD RED)。
+ * dispatch-403-classifier の単体テスト。
  *
  * 設計仕様書 §6.4、Codex Important-4 (403 reason 分類) に対応。
+ * PR #442 review 後の改修反映:
+ *   - Critical 1 (forbidden 独断追加除去)
+ *   - Critical 4 (errors.some() で複数 reason 取りこぼし防止)
+ *   - Critical 5 (HTTP 403 ガード、非 403 で throw)
  *
  * Gmail API 403 を 2 つに分類:
- * - scope_revoked (全体中断): insufficientPermissions / delegationDenied / sender disabled 系
- * - user_permanent (宛先固有): その他 (受講者の Gmail 受信拒否設定等)
+ * - scope_revoked (全体中断): insufficientPermissions / delegationDenied / userRateLimitExceeded
+ * - user_permanent (宛先固有): その他 (受講者の Gmail 受信拒否設定 / recipientRejected / forbidden 等)
  *
  * 観点:
- * - GaxiosError 形式の data.error.errors[0].reason を読み取る
- * - 既知の scope_revoked reasons: insufficientPermissions / delegationDenied / userRateLimitExceeded
+ * - HTTP 403 専用、403 以外は throw (呼び出し側のバグ検知)
+ * - GaxiosError 形式の data.error.errors[] を全件走査 (errors.some())
+ * - 既知の scope_revoked reasons 3 つ
  * - reason が未定義 / errors 配列空 / data 不在 → user_permanent (デフォルト宛先固有)
- * - 非 403 / 非 Error 入力 → user_permanent (安全側、宛先固有として扱う)
+ * - 複数 reason のうち 1 つでも scope_revoked にマッチすれば scope_revoked
  */
 
 import { describe, it, expect } from "vitest";
 import { classifyGmail403 } from "../dispatch-403-classifier.js";
 
-function makeGaxios403(reason: string | undefined) {
-  const err = new Error("403 Forbidden") as Error & {
-    response?: { data?: unknown; status?: number };
+function makeGaxios(
+  status: number,
+  reasons: Array<string | undefined> = [],
+): Error {
+  const err = new Error(`${status} error`) as Error & {
+    response?: { status?: number; data?: unknown };
   };
   err.response = {
-    status: 403,
+    status,
     data: {
       error: {
-        errors: reason ? [{ reason }] : [],
+        errors: reasons.map((reason) => (reason ? { reason } : {})),
       },
     },
   };
@@ -33,64 +41,127 @@ function makeGaxios403(reason: string | undefined) {
 }
 
 describe("classifyGmail403", () => {
-  describe("scope_revoked (run 全体中断)", () => {
+  describe("scope_revoked (run 全体中断、設計仕様書 §6.4 記載 3 reason のみ)", () => {
     it("insufficientPermissions → scope_revoked", () => {
-      expect(classifyGmail403(makeGaxios403("insufficientPermissions"))).toBe(
+      expect(classifyGmail403(makeGaxios(403, ["insufficientPermissions"]))).toBe(
         "scope_revoked",
       );
     });
 
     it("delegationDenied → scope_revoked", () => {
-      expect(classifyGmail403(makeGaxios403("delegationDenied"))).toBe(
+      expect(classifyGmail403(makeGaxios(403, ["delegationDenied"]))).toBe(
         "scope_revoked",
       );
     });
 
     it("userRateLimitExceeded → scope_revoked (sender disabled 系)", () => {
-      expect(classifyGmail403(makeGaxios403("userRateLimitExceeded"))).toBe(
-        "scope_revoked",
-      );
-    });
-
-    it("forbidden → scope_revoked (DWD 認可未反映の典型)", () => {
-      expect(classifyGmail403(makeGaxios403("forbidden"))).toBe("scope_revoked");
+      expect(
+        classifyGmail403(makeGaxios(403, ["userRateLimitExceeded"])),
+      ).toBe("scope_revoked");
     });
   });
 
   describe("user_permanent (宛先固有)", () => {
-    it("既知の宛先固有 reason → user_permanent", () => {
-      expect(classifyGmail403(makeGaxios403("recipientRejected"))).toBe(
+    it("forbidden → user_permanent (仕様書未記載のため scope_revoked にしない)", () => {
+      // Codex Critical-1 対応: AI 越権で SCOPE_REVOKED_REASONS に追加していた forbidden を除去。
+      // 仕様書 §6.4 は 3 reason のみで、forbidden は組織側拒否ポリシー等でも返るため宛先固有扱い。
+      expect(classifyGmail403(makeGaxios(403, ["forbidden"]))).toBe("user_permanent");
+    });
+
+    it("recipientRejected → user_permanent", () => {
+      expect(classifyGmail403(makeGaxios(403, ["recipientRejected"]))).toBe(
         "user_permanent",
       );
     });
 
     it("未知の reason → user_permanent (デフォルト安全側)", () => {
-      expect(classifyGmail403(makeGaxios403("someUnknownReason"))).toBe(
+      expect(classifyGmail403(makeGaxios(403, ["someUnknownReason"]))).toBe(
         "user_permanent",
       );
     });
 
     it("reason undefined → user_permanent", () => {
-      expect(classifyGmail403(makeGaxios403(undefined))).toBe("user_permanent");
+      expect(classifyGmail403(makeGaxios(403, [undefined]))).toBe("user_permanent");
+    });
+
+    it("errors 配列空 → user_permanent", () => {
+      expect(classifyGmail403(makeGaxios(403, []))).toBe("user_permanent");
+    });
+  });
+
+  describe("複数 reason の OR 評価 (Codex Critical-4)", () => {
+    it("1 件目 user 系、2 件目 scope_revoked → scope_revoked", () => {
+      // errors[0] のみ参照すると見落とすため .some() で全件走査
+      expect(
+        classifyGmail403(
+          makeGaxios(403, ["recipientRejected", "insufficientPermissions"]),
+        ),
+      ).toBe("scope_revoked");
+    });
+
+    it("2 件とも scope_revoked → scope_revoked", () => {
+      expect(
+        classifyGmail403(
+          makeGaxios(403, ["delegationDenied", "userRateLimitExceeded"]),
+        ),
+      ).toBe("scope_revoked");
+    });
+
+    it("2 件とも user 系 → user_permanent", () => {
+      expect(
+        classifyGmail403(makeGaxios(403, ["recipientRejected", "forbidden"])),
+      ).toBe("user_permanent");
+    });
+  });
+
+  describe("HTTP 403 ガード (Codex Critical-5)", () => {
+    it("status=429 → throw (transient と分類するのは呼び出し側の責務)", () => {
+      expect(() =>
+        classifyGmail403(makeGaxios(429, ["rateLimitExceeded"])),
+      ).toThrow(/non-403/);
+    });
+
+    it("status=503 → throw", () => {
+      expect(() => classifyGmail403(makeGaxios(503))).toThrow(/non-403/);
+    });
+
+    it("status=401 → throw (token 失効は別経路)", () => {
+      expect(() => classifyGmail403(makeGaxios(401))).toThrow(/non-403/);
+    });
+
+    it("status=200 → throw (誤呼び出し検知)", () => {
+      expect(() => classifyGmail403(makeGaxios(200))).toThrow(/non-403/);
+    });
+
+    it("response 不在 → throw (status=unknown)", () => {
+      const err = new Error("plain error");
+      expect(() => classifyGmail403(err)).toThrow(/non-403/);
+    });
+
+    it("response.status 不在 → throw", () => {
+      const err = new Error("err") as Error & { response?: unknown };
+      err.response = {};
+      expect(() => classifyGmail403(err)).toThrow(/non-403/);
     });
   });
 
   describe("不正形式の入力 (defense in depth)", () => {
-    it("response 不在 → user_permanent", () => {
-      const err = new Error("plain error");
-      expect(classifyGmail403(err)).toBe("user_permanent");
+    it("non-Error 入力 (string) → throw", () => {
+      expect(() => classifyGmail403("string error")).toThrow(/non-object/);
     });
 
-    it("response.data 不在 → user_permanent", () => {
+    it("null → throw", () => {
+      expect(() => classifyGmail403(null)).toThrow(/non-object/);
+    });
+
+    it("undefined → throw", () => {
+      expect(() => classifyGmail403(undefined)).toThrow(/non-object/);
+    });
+
+    it("status=403 だが data 不在 → user_permanent (空 errors 扱い)", () => {
       const err = new Error("err") as Error & { response?: { status?: number } };
       err.response = { status: 403 };
       expect(classifyGmail403(err)).toBe("user_permanent");
-    });
-
-    it("non-Error 入力 → user_permanent", () => {
-      expect(classifyGmail403("string error")).toBe("user_permanent");
-      expect(classifyGmail403(null)).toBe("user_permanent");
-      expect(classifyGmail403(undefined)).toBe("user_permanent");
     });
   });
 });

--- a/services/api/src/services/dispatch/__tests__/dispatch-error-sanitizer.test.ts
+++ b/services/api/src/services/dispatch/__tests__/dispatch-error-sanitizer.test.ts
@@ -1,18 +1,12 @@
 /**
- * dispatch-error-sanitizer の単体テスト (TDD RED)。
+ * dispatch-error-sanitizer の単体テスト。
  *
  * 設計仕様書 §6.5、AC-33 に対応。
- * PII (email / access_token / Bearer / MIME headers) を [REDACTED] に置換し、
- * 1024 文字上限で truncate する純粋ロジック。
+ * PR #442 review Critical 2 対応 (JWT / refresh token / API key / folded MIME / UTF-8 safe truncate)
+ * + pr-test-analyzer 指摘 (#5 複数行 MIME、#1 境界 truncate、#2 ya29 境界) を反映。
  *
- * 観点:
- * - email 正規表現マッチ (1 件 / 複数件 / 国際化 TLD は対象外)
- * - access token (ya29.* 形式) マッチ
- * - Bearer token マッチ
- * - MIME headers (To/Cc/Bcc/From) 1 行除去
- * - 上限 1024 文字での truncate
- * - 非 Error 入力 (string / null / undefined / 数値) の挙動
- * - 既に sanitize 済みの文字列は冪等
+ * PII (email / access_token / Bearer / JWT / refresh_token / API_key / MIME headers) を
+ * [REDACTED] に置換し、UTF-8 safe で 1024 文字に truncate する純粋ロジック。
  */
 
 import { describe, it, expect } from "vitest";
@@ -21,83 +15,162 @@ import { sanitizeErrorForAudit } from "../dispatch-error-sanitizer.js";
 describe("sanitizeErrorForAudit", () => {
   describe("email 除去", () => {
     it("単一の email を [EMAIL] に置換する", () => {
-      const input = new Error("Send failed to alice@example.com");
-      expect(sanitizeErrorForAudit(input)).toBe("Send failed to [EMAIL]");
+      expect(sanitizeErrorForAudit(new Error("Send failed to alice@example.com"))).toBe(
+        "Send failed to [EMAIL]",
+      );
     });
 
     it("複数の email を全て [EMAIL] に置換する", () => {
-      const input = new Error("Both alice@x.com and bob@y.co.jp rejected");
-      expect(sanitizeErrorForAudit(input)).toBe("Both [EMAIL] and [EMAIL] rejected");
+      expect(
+        sanitizeErrorForAudit(new Error("Both alice@x.com and bob@y.co.jp rejected")),
+      ).toBe("Both [EMAIL] and [EMAIL] rejected");
     });
 
-    it("email 内のドット・ハイフン・サブドメインを含む形式も置換する", () => {
-      const input = new Error("user.name+tag@sub-domain.co.jp");
-      expect(sanitizeErrorForAudit(input)).toBe("[EMAIL]");
+    it("ドット・ハイフン・サブドメインを含む email も置換する", () => {
+      expect(sanitizeErrorForAudit(new Error("user.name+tag@sub-domain.co.jp"))).toBe(
+        "[EMAIL]",
+      );
     });
   });
 
-  describe("access token 除去", () => {
+  describe("access token (ya29) 除去", () => {
     it("Google ya29 形式 access token を [ACCESS_TOKEN] に置換する", () => {
-      const input = new Error("Invalid token: ya29.abc-DEF_123xyz");
-      expect(sanitizeErrorForAudit(input)).toBe("Invalid token: [ACCESS_TOKEN]");
+      expect(
+        sanitizeErrorForAudit(new Error("Invalid token: ya29.abc-DEF_123xyz")),
+      ).toBe("Invalid token: [ACCESS_TOKEN]");
+    });
+
+    it("ya29. の後ろに本体がない単独 ya29 は誤マッチしない (regex は + で最低 1 文字要求)", () => {
+      expect(sanitizeErrorForAudit(new Error("partial ya29"))).toBe("partial ya29");
+    });
+  });
+
+  describe("JWT (eyJ...) 除去 (Critical 2 拡張)", () => {
+    it("3-part JWT を [JWT] に置換する", () => {
+      const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abc-def_ghi";
+      expect(sanitizeErrorForAudit(new Error(`token: ${jwt}`))).toBe("token: [JWT]");
+    });
+
+    it("Bearer プレフィックス付き JWT は Bearer 側で先に redaction される", () => {
+      const jwt = "eyJabc.eyJdef.xyz123";
+      const result = sanitizeErrorForAudit(new Error(`Authorization: Bearer ${jwt}`));
+      // Bearer 側のマッチは [A-Za-z0-9_.-]+ で JWT 本体も食う
+      expect(result).not.toContain("eyJ");
+      expect(result).toContain("[BEARER]");
+    });
+  });
+
+  describe("refresh token (1//) 除去 (Critical 2 拡張)", () => {
+    it("1// 形式 refresh token を [REFRESH_TOKEN] に置換する", () => {
+      expect(
+        sanitizeErrorForAudit(new Error("rt: 1//0gabc_DEF-123xyz_ABCDEF")),
+      ).toBe("rt: [REFRESH_TOKEN]");
+    });
+  });
+
+  describe("Google API key (AIza...) 除去 (Critical 2 拡張)", () => {
+    it("AIza + 35 chars 形式の API key を [API_KEY] に置換する", () => {
+      // AIza + 35 文字 (合計 39 文字)
+      const apiKey = "AIza" + "a".repeat(35);
+      expect(sanitizeErrorForAudit(new Error(`key=${apiKey}`))).toBe("key=[API_KEY]");
+    });
+
+    it("AIza 短すぎる場合は誤マッチしない", () => {
+      expect(sanitizeErrorForAudit(new Error("AIza_short"))).toBe("AIza_short");
     });
   });
 
   describe("Bearer token 除去", () => {
     it("Bearer プレフィックス付き token を [BEARER] に置換する", () => {
-      const input = new Error("Authorization header: Bearer abc.def-ghi_123");
-      expect(sanitizeErrorForAudit(input)).toBe("Authorization header: [BEARER]");
+      expect(
+        sanitizeErrorForAudit(new Error("Authorization header: Bearer abc.def-ghi_123")),
+      ).toBe("Authorization header: [BEARER]");
     });
   });
 
-  describe("MIME headers 除去", () => {
-    it("To: ヘッダ行を [MIME_HEADER] に置換する", () => {
-      const input = new Error("Failed: To: recipient@example.com");
-      // To: 行 + その後の email も sanitize される (順序は実装依存だが PII は残らない)
-      const result = sanitizeErrorForAudit(input);
+  describe("MIME headers 除去 (pr-test-analyzer #5 反映)", () => {
+    it("To: ヘッダ行は [MIME_HEADER] に厳密置換される (順序固定 assertion)", () => {
+      const result = sanitizeErrorForAudit(new Error("Failed: To: recipient@example.com"));
+      // 順序が MIME → ... → email なので、To: 行は [MIME_HEADER] で吸収される
+      expect(result).toContain("[MIME_HEADER]");
+      expect(result).not.toContain("To:");
       expect(result).not.toContain("recipient@example.com");
-      expect(result).toMatch(/\[MIME_HEADER\]|\[EMAIL\]/);
     });
 
-    it("Cc/Bcc/From も同様に置換する", () => {
-      expect(sanitizeErrorForAudit(new Error("Cc: a@b.com"))).not.toContain("a@b.com");
-      expect(sanitizeErrorForAudit(new Error("Bcc: c@d.com"))).not.toContain("c@d.com");
-      expect(sanitizeErrorForAudit(new Error("From: e@f.com"))).not.toContain("e@f.com");
+    it("Cc/Bcc/From/Reply-To/Sender も同様に置換する", () => {
+      expect(sanitizeErrorForAudit(new Error("Cc: a@b.com"))).toBe("[MIME_HEADER]");
+      expect(sanitizeErrorForAudit(new Error("Bcc: c@d.com"))).toBe("[MIME_HEADER]");
+      expect(sanitizeErrorForAudit(new Error("From: e@f.com"))).toBe("[MIME_HEADER]");
+      expect(sanitizeErrorForAudit(new Error("Reply-To: g@h.com"))).toBe("[MIME_HEADER]");
+      expect(sanitizeErrorForAudit(new Error("Sender: i@j.com"))).toBe("[MIME_HEADER]");
+    });
+
+    it("小文字 (to:) もケースインセンシティブで置換される", () => {
+      const result = sanitizeErrorForAudit(new Error("to: lower@example.com"));
+      expect(result).toContain("[MIME_HEADER]");
+      expect(result).not.toContain("lower@example.com");
+    });
+
+    it("複数行の MIME ヘッダも全行置換される", () => {
+      const input = new Error("To: a@x.com\r\nCc: b@y.com\r\nFrom: c@z.com");
+      const result = sanitizeErrorForAudit(input);
+      expect(result).not.toContain("a@x.com");
+      expect(result).not.toContain("b@y.com");
+      expect(result).not.toContain("c@z.com");
+    });
+
+    it("folded MIME ヘッダ (次行が空白で継続) も置換される", () => {
+      // RFC 5322 §2.2.3 folded header
+      const input = new Error("To: very.long.address@example.com,\r\n  another@example.com");
+      const result = sanitizeErrorForAudit(input);
+      expect(result).not.toContain("very.long.address@example.com");
+      expect(result).not.toContain("another@example.com");
     });
   });
 
-  describe("文字数上限", () => {
+  describe("文字数上限 + UTF-8 safe truncate", () => {
     it("1024 文字を超える入力は 1024 文字に truncate する", () => {
-      const longInput = new Error("x".repeat(2000));
-      expect(sanitizeErrorForAudit(longInput).length).toBeLessThanOrEqual(1024);
+      expect(
+        sanitizeErrorForAudit(new Error("x".repeat(2000))).length,
+      ).toBeLessThanOrEqual(1024);
     });
 
-    it("1024 文字以下の入力はそのまま返す (PII 置換のみ)", () => {
-      const input = new Error("normal short message");
-      expect(sanitizeErrorForAudit(input)).toBe("normal short message");
+    it("1024 文字以下の入力はそのまま返す", () => {
+      expect(sanitizeErrorForAudit(new Error("normal short message"))).toBe(
+        "normal short message",
+      );
+    });
+
+    it("UTF-8 マルチバイト文字 (日本語) を含む入力でも境界を割らない", () => {
+      // 1024 code point ちょうど + 余り
+      const input = new Error("あ".repeat(2000));
+      const result = sanitizeErrorForAudit(input);
+      // 結果は valid UTF-8 string (壊れた byte 列を含まない)
+      expect(result.length).toBeLessThanOrEqual(1024);
+      expect(() => Buffer.from(result, "utf-8").toString("utf-8")).not.toThrow();
     });
   });
 
   describe("非 Error 入力", () => {
-    it("string 入力は そのまま PII 除去対象になる", () => {
+    it("string 入力でも PII 除去対象になる", () => {
       expect(sanitizeErrorForAudit("Failed for user@example.com")).toBe(
         "Failed for [EMAIL]",
       );
     });
 
-    it("null 入力は 'null' 文字列として処理される", () => {
+    it("null → 'null' 文字列として処理される", () => {
       expect(sanitizeErrorForAudit(null)).toBe("null");
     });
 
-    it("undefined 入力は 'undefined' 文字列として処理される", () => {
+    it("undefined → 'undefined' 文字列として処理される", () => {
       expect(sanitizeErrorForAudit(undefined)).toBe("undefined");
     });
 
-    it("数値入力は String() 化される", () => {
+    it("数値入力 → String() 化される", () => {
       expect(sanitizeErrorForAudit(42)).toBe("42");
     });
 
-    it("オブジェクト入力は String() で表現される", () => {
+    it("オブジェクト入力 → '[object Object]' になる", () => {
       expect(sanitizeErrorForAudit({ foo: "bar" })).toBe("[object Object]");
     });
   });
@@ -105,6 +178,11 @@ describe("sanitizeErrorForAudit", () => {
   describe("冪等性", () => {
     it("既に sanitize 済みの文字列は変化しない", () => {
       const sanitized = "Send failed to [EMAIL] with [ACCESS_TOKEN]";
+      expect(sanitizeErrorForAudit(sanitized)).toBe(sanitized);
+    });
+
+    it("[BEARER] / [JWT] / [API_KEY] を含む sanitize 済みも変化しない", () => {
+      const sanitized = "Auth [BEARER] failed, [JWT] expired, [API_KEY] revoked";
       expect(sanitizeErrorForAudit(sanitized)).toBe(sanitized);
     });
   });
@@ -119,6 +197,17 @@ describe("sanitizeErrorForAudit", () => {
       expect(result).not.toContain("bob@y.com");
       expect(result).not.toContain("ya29.tok-1");
       expect(result).not.toContain("Bearer ya29");
+    });
+
+    it("JWT + refresh_token + API key が混在する Gaxios 風エラーメッセージ", () => {
+      const input = new Error(
+        "id_token=eyJabc.eyJdef.xyz refresh_token=1//tok-abc api_key=AIza" +
+          "0123456789012345678901234567890abcde",
+      );
+      const result = sanitizeErrorForAudit(input);
+      expect(result).not.toContain("eyJ");
+      expect(result).not.toContain("1//tok-abc");
+      expect(result).toContain("[API_KEY]");
     });
   });
 });

--- a/services/api/src/services/dispatch/__tests__/dispatch-error-sanitizer.test.ts
+++ b/services/api/src/services/dispatch/__tests__/dispatch-error-sanitizer.test.ts
@@ -1,0 +1,124 @@
+/**
+ * dispatch-error-sanitizer の単体テスト (TDD RED)。
+ *
+ * 設計仕様書 §6.5、AC-33 に対応。
+ * PII (email / access_token / Bearer / MIME headers) を [REDACTED] に置換し、
+ * 1024 文字上限で truncate する純粋ロジック。
+ *
+ * 観点:
+ * - email 正規表現マッチ (1 件 / 複数件 / 国際化 TLD は対象外)
+ * - access token (ya29.* 形式) マッチ
+ * - Bearer token マッチ
+ * - MIME headers (To/Cc/Bcc/From) 1 行除去
+ * - 上限 1024 文字での truncate
+ * - 非 Error 入力 (string / null / undefined / 数値) の挙動
+ * - 既に sanitize 済みの文字列は冪等
+ */
+
+import { describe, it, expect } from "vitest";
+import { sanitizeErrorForAudit } from "../dispatch-error-sanitizer.js";
+
+describe("sanitizeErrorForAudit", () => {
+  describe("email 除去", () => {
+    it("単一の email を [EMAIL] に置換する", () => {
+      const input = new Error("Send failed to alice@example.com");
+      expect(sanitizeErrorForAudit(input)).toBe("Send failed to [EMAIL]");
+    });
+
+    it("複数の email を全て [EMAIL] に置換する", () => {
+      const input = new Error("Both alice@x.com and bob@y.co.jp rejected");
+      expect(sanitizeErrorForAudit(input)).toBe("Both [EMAIL] and [EMAIL] rejected");
+    });
+
+    it("email 内のドット・ハイフン・サブドメインを含む形式も置換する", () => {
+      const input = new Error("user.name+tag@sub-domain.co.jp");
+      expect(sanitizeErrorForAudit(input)).toBe("[EMAIL]");
+    });
+  });
+
+  describe("access token 除去", () => {
+    it("Google ya29 形式 access token を [ACCESS_TOKEN] に置換する", () => {
+      const input = new Error("Invalid token: ya29.abc-DEF_123xyz");
+      expect(sanitizeErrorForAudit(input)).toBe("Invalid token: [ACCESS_TOKEN]");
+    });
+  });
+
+  describe("Bearer token 除去", () => {
+    it("Bearer プレフィックス付き token を [BEARER] に置換する", () => {
+      const input = new Error("Authorization header: Bearer abc.def-ghi_123");
+      expect(sanitizeErrorForAudit(input)).toBe("Authorization header: [BEARER]");
+    });
+  });
+
+  describe("MIME headers 除去", () => {
+    it("To: ヘッダ行を [MIME_HEADER] に置換する", () => {
+      const input = new Error("Failed: To: recipient@example.com");
+      // To: 行 + その後の email も sanitize される (順序は実装依存だが PII は残らない)
+      const result = sanitizeErrorForAudit(input);
+      expect(result).not.toContain("recipient@example.com");
+      expect(result).toMatch(/\[MIME_HEADER\]|\[EMAIL\]/);
+    });
+
+    it("Cc/Bcc/From も同様に置換する", () => {
+      expect(sanitizeErrorForAudit(new Error("Cc: a@b.com"))).not.toContain("a@b.com");
+      expect(sanitizeErrorForAudit(new Error("Bcc: c@d.com"))).not.toContain("c@d.com");
+      expect(sanitizeErrorForAudit(new Error("From: e@f.com"))).not.toContain("e@f.com");
+    });
+  });
+
+  describe("文字数上限", () => {
+    it("1024 文字を超える入力は 1024 文字に truncate する", () => {
+      const longInput = new Error("x".repeat(2000));
+      expect(sanitizeErrorForAudit(longInput).length).toBeLessThanOrEqual(1024);
+    });
+
+    it("1024 文字以下の入力はそのまま返す (PII 置換のみ)", () => {
+      const input = new Error("normal short message");
+      expect(sanitizeErrorForAudit(input)).toBe("normal short message");
+    });
+  });
+
+  describe("非 Error 入力", () => {
+    it("string 入力は そのまま PII 除去対象になる", () => {
+      expect(sanitizeErrorForAudit("Failed for user@example.com")).toBe(
+        "Failed for [EMAIL]",
+      );
+    });
+
+    it("null 入力は 'null' 文字列として処理される", () => {
+      expect(sanitizeErrorForAudit(null)).toBe("null");
+    });
+
+    it("undefined 入力は 'undefined' 文字列として処理される", () => {
+      expect(sanitizeErrorForAudit(undefined)).toBe("undefined");
+    });
+
+    it("数値入力は String() 化される", () => {
+      expect(sanitizeErrorForAudit(42)).toBe("42");
+    });
+
+    it("オブジェクト入力は String() で表現される", () => {
+      expect(sanitizeErrorForAudit({ foo: "bar" })).toBe("[object Object]");
+    });
+  });
+
+  describe("冪等性", () => {
+    it("既に sanitize 済みの文字列は変化しない", () => {
+      const sanitized = "Send failed to [EMAIL] with [ACCESS_TOKEN]";
+      expect(sanitizeErrorForAudit(sanitized)).toBe(sanitized);
+    });
+  });
+
+  describe("複合シナリオ", () => {
+    it("email + access_token + Bearer が混在した文字列を全て除去する", () => {
+      const input = new Error(
+        "Auth Bearer ya29.tok-1 failed for alice@x.com (To: bob@y.com)",
+      );
+      const result = sanitizeErrorForAudit(input);
+      expect(result).not.toContain("alice@x.com");
+      expect(result).not.toContain("bob@y.com");
+      expect(result).not.toContain("ya29.tok-1");
+      expect(result).not.toContain("Bearer ya29");
+    });
+  });
+});

--- a/services/api/src/services/dispatch/__tests__/schedule-matcher.test.ts
+++ b/services/api/src/services/dispatch/__tests__/schedule-matcher.test.ts
@@ -1,0 +1,165 @@
+/**
+ * schedule-matcher の単体テスト (TDD RED)。
+ *
+ * 設計仕様書 §3.2、FR-2、AC-6 / AC-7 に対応。
+ *
+ * Cloud Scheduler は固定で毎時 JST 00 分起動。BE 側で
+ * super_dispatch_settings の scheduleDaysOfWeek / scheduleHourJst と
+ * 現在 JST 時刻を照合し、一致時のみ配信処理を実行する。
+ *
+ * 観点:
+ * - JST 時刻一致判定 (曜日 + 時刻)
+ * - enabled=false で常に false (kill switch)
+ * - scheduleDaysOfWeek 空配列で常に false
+ * - 月跨ぎ (UTC 月末 23:00 → JST 翌月 1 日 08:00 等)
+ * - DST なし (JST は固定 UTC+9)
+ * - 0 時 (深夜) / 23 時の境界
+ */
+
+import { describe, it, expect } from "vitest";
+import { shouldRunNow } from "../schedule-matcher.js";
+import type { DispatchSettings } from "@lms-279/shared-types";
+
+function makeSettings(
+  partial: Partial<DispatchSettings> = {},
+): DispatchSettings {
+  return {
+    enabled: true,
+    scheduleDaysOfWeek: [1, 4], // 月木
+    scheduleHourJst: 9,
+    signatureName: "DXcollege運営スタッフ",
+    completionMessageBody: "test",
+    senderEmail: "dxcollege@279279.net",
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    updatedBy: "test@example.com",
+    version: 1,
+    ...partial,
+  };
+}
+
+describe("shouldRunNow", () => {
+  describe("kill switch", () => {
+    it("enabled=false なら常に false", () => {
+      // 月曜 09:00 JST (一致するはずの曜日・時刻)
+      const now = new Date("2026-05-18T00:00:00.000Z"); // UTC 0:00 = JST 9:00
+      expect(shouldRunNow(makeSettings({ enabled: false }), now)).toBe(false);
+    });
+  });
+
+  describe("scheduleDaysOfWeek", () => {
+    it("月曜 09:00 JST、settings 月木 09:00 → true", () => {
+      const now = new Date("2026-05-18T00:00:00.000Z"); // 月曜 UTC 0:00 = JST 9:00
+      expect(shouldRunNow(makeSettings(), now)).toBe(true);
+    });
+
+    it("木曜 09:00 JST、settings 月木 09:00 → true", () => {
+      const now = new Date("2026-05-21T00:00:00.000Z"); // 木曜 UTC 0:00 = JST 9:00
+      expect(shouldRunNow(makeSettings(), now)).toBe(true);
+    });
+
+    it("火曜 09:00 JST、settings 月木 09:00 → false (曜日不一致)", () => {
+      const now = new Date("2026-05-19T00:00:00.000Z"); // 火曜
+      expect(shouldRunNow(makeSettings(), now)).toBe(false);
+    });
+
+    it("scheduleDaysOfWeek 空配列 → 常に false", () => {
+      const now = new Date("2026-05-18T00:00:00.000Z");
+      expect(
+        shouldRunNow(makeSettings({ scheduleDaysOfWeek: [] }), now),
+      ).toBe(false);
+    });
+
+    it("scheduleDaysOfWeek 全曜日指定 → 全曜日で true", () => {
+      const settings = makeSettings({
+        scheduleDaysOfWeek: [0, 1, 2, 3, 4, 5, 6],
+      });
+      // 日曜 09:00 JST
+      expect(
+        shouldRunNow(settings, new Date("2026-05-17T00:00:00.000Z")),
+      ).toBe(true);
+      // 土曜 09:00 JST
+      expect(
+        shouldRunNow(settings, new Date("2026-05-23T00:00:00.000Z")),
+      ).toBe(true);
+    });
+  });
+
+  describe("scheduleHourJst", () => {
+    it("月曜 09:00 JST、settings 月 09:00 → true", () => {
+      const now = new Date("2026-05-18T00:00:00.000Z"); // 月曜 JST 9:00
+      expect(
+        shouldRunNow(makeSettings({ scheduleHourJst: 9 }), now),
+      ).toBe(true);
+    });
+
+    it("月曜 10:00 JST、settings 月 09:00 → false (時刻不一致)", () => {
+      const now = new Date("2026-05-18T01:00:00.000Z"); // 月曜 JST 10:00
+      expect(
+        shouldRunNow(makeSettings({ scheduleHourJst: 9 }), now),
+      ).toBe(false);
+    });
+
+    it("0 時 (深夜) JST 一致 → true", () => {
+      // 月曜 JST 00:00 = 日曜 UTC 15:00
+      const now = new Date("2026-05-17T15:00:00.000Z");
+      expect(
+        shouldRunNow(
+          makeSettings({ scheduleDaysOfWeek: [1], scheduleHourJst: 0 }),
+          now,
+        ),
+      ).toBe(true);
+    });
+
+    it("23 時 JST 一致 → true", () => {
+      // 月曜 JST 23:00 = 月曜 UTC 14:00
+      const now = new Date("2026-05-18T14:00:00.000Z");
+      expect(
+        shouldRunNow(
+          makeSettings({ scheduleDaysOfWeek: [1], scheduleHourJst: 23 }),
+          now,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("月跨ぎ・年跨ぎ", () => {
+    it("UTC 月末 23:00 → JST 翌月 1 日 08:00 (曜日変わる)", () => {
+      // 2026-04-30 23:00 UTC = 2026-05-01 08:00 JST (金曜)
+      const now = new Date("2026-04-30T23:00:00.000Z");
+      expect(
+        shouldRunNow(
+          makeSettings({ scheduleDaysOfWeek: [5], scheduleHourJst: 8 }),
+          now,
+        ),
+      ).toBe(true);
+    });
+
+    it("UTC 年末 23:00 → JST 翌年 1 日 08:00", () => {
+      // 2026-12-31 23:00 UTC = 2027-01-01 08:00 JST (金曜)
+      const now = new Date("2026-12-31T23:00:00.000Z");
+      expect(
+        shouldRunNow(
+          makeSettings({ scheduleDaysOfWeek: [5], scheduleHourJst: 8 }),
+          now,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("複数曜日 + 複数日にわたるテスト", () => {
+    it("月木の 09:00 JST に水曜 09:00 で false", () => {
+      const now = new Date("2026-05-20T00:00:00.000Z"); // 水曜 JST 09:00
+      expect(shouldRunNow(makeSettings(), now)).toBe(false);
+    });
+
+    it("月木の 09:00 JST に月曜 08:59 で false (時刻不一致)", () => {
+      const now = new Date("2026-05-17T23:59:00.000Z"); // 月曜 JST 08:59
+      expect(shouldRunNow(makeSettings(), now)).toBe(false);
+    });
+
+    it("月木の 09:00 JST に月曜 09:59 で true (時単位一致、分は無視)", () => {
+      const now = new Date("2026-05-18T00:59:00.000Z"); // 月曜 JST 09:59
+      expect(shouldRunNow(makeSettings(), now)).toBe(true);
+    });
+  });
+});

--- a/services/api/src/services/dispatch/dispatch-403-classifier.ts
+++ b/services/api/src/services/dispatch/dispatch-403-classifier.ts
@@ -2,11 +2,18 @@
  * Gmail API 403 エラーを「全体中断」と「宛先固有」に分類する純粋関数。
  *
  * 設計仕様書 §6.4、Codex セカンドオピニオン Important-4 (403 reason 分類) に対応。
+ * PR #442 review で指摘された Critical 1 (forbidden 独断追加除去) / Critical 4 (errors.some) /
+ * Critical 5 (HTTP 403 ガード) を反映済み。
  *
  * 背景:
  *   全体設定ミス (DWD scope 未反映 / 管理者同意撤回 / 送信元 disabled) で 403 が返ると、
  *   それを user 固有の permanent 失敗として全 user を failed_permanent に終端化してしまう。
  *   これを防ぐため、reason 別に分類して全体中断 (run abort) と user permanent を分ける。
+ *
+ * 入力前提:
+ *   - 本関数は HTTP 403 専用。403 以外で呼ぶと呼び出し側のバグなので例外を throw する。
+ *   - 呼び出し側で予め status を確認し、429/503 等の transient と 401 (token 失効) は
+ *     別の分岐に流すこと。
  *
  * 戻り値:
  *   - "scope_revoked": run 全体中断、後続 user の Reservation も rollback
@@ -18,31 +25,53 @@ import type { Gmail403Classification } from "@lms-279/shared-types";
 /**
  * Gmail API 403 で「全体設定ミス」を示す reason 一覧。
  *
+ * 設計仕様書 §6.4 に明示された 3 つの reason のみを採用する。
+ * 仕様書未記載の reason を実装段階で独断追加することは AI 駆動開発 4 原則 §1
+ * (decision-maker 領分越え) に該当するため、追加要望は spec 改訂 → 本田様承認 →
+ * 本ファイル更新の順で行う。
+ *
  * Google Gmail API ドキュメントで定義されている代表的な reason:
  * - insufficientPermissions: DWD scope 未反映 / 認可不足
  * - delegationDenied: なりすまし送信が拒否された (subject 設定ミス等)
  * - userRateLimitExceeded: sender 単位の制限超過 (実質 sender disabled)
- * - forbidden: 一般的な認可エラー、DWD 未反映の典型
  *
- * これら以外 (recipientRejected 等) は宛先固有として user_permanent に分類する。
+ * これら以外 (recipientRejected / forbidden / その他) は宛先固有として
+ * user_permanent に分類する。
  */
 const SCOPE_REVOKED_REASONS = new Set<string>([
   "insufficientPermissions",
   "delegationDenied",
   "userRateLimitExceeded",
-  "forbidden",
 ]);
 
+/**
+ * Gmail API 403 を分類する。HTTP 403 以外で呼ぶと例外を throw する。
+ *
+ * Codex Critical-4: errors 配列を全件走査し、いずれかが SCOPE_REVOKED_REASONS にマッチすれば
+ *   scope_revoked を返す (1 番目だけ見ない、全体設定ミスの取りこぼし防止)。
+ * Codex Critical-5: 関数冒頭で response.status===403 をガードし、それ以外は throw。
+ *   呼び出し側で 429/503/401 を別経路に流す責務を明確化する。
+ */
 export function classifyGmail403(err: unknown): Gmail403Classification {
   if (!err || typeof err !== "object") {
-    return "user_permanent";
+    throw new Error("classifyGmail403 received a non-object error");
   }
   const e = err as {
-    response?: { data?: { error?: { errors?: Array<{ reason?: string }> } } };
+    response?: {
+      status?: number;
+      data?: { error?: { errors?: Array<{ reason?: unknown }> } };
+    };
   };
-  const reason = e.response?.data?.error?.errors?.[0]?.reason;
-  if (typeof reason === "string" && SCOPE_REVOKED_REASONS.has(reason)) {
-    return "scope_revoked";
+  const status = e.response?.status;
+  if (status !== 403) {
+    throw new Error(
+      `classifyGmail403 called for non-403 error (status=${status ?? "unknown"})`,
+    );
   }
-  return "user_permanent";
+  const errors = e.response?.data?.error?.errors ?? [];
+  const hasScopeRevoked = errors.some(
+    (entry) =>
+      typeof entry.reason === "string" && SCOPE_REVOKED_REASONS.has(entry.reason),
+  );
+  return hasScopeRevoked ? "scope_revoked" : "user_permanent";
 }

--- a/services/api/src/services/dispatch/dispatch-403-classifier.ts
+++ b/services/api/src/services/dispatch/dispatch-403-classifier.ts
@@ -1,0 +1,48 @@
+/**
+ * Gmail API 403 エラーを「全体中断」と「宛先固有」に分類する純粋関数。
+ *
+ * 設計仕様書 §6.4、Codex セカンドオピニオン Important-4 (403 reason 分類) に対応。
+ *
+ * 背景:
+ *   全体設定ミス (DWD scope 未反映 / 管理者同意撤回 / 送信元 disabled) で 403 が返ると、
+ *   それを user 固有の permanent 失敗として全 user を failed_permanent に終端化してしまう。
+ *   これを防ぐため、reason 別に分類して全体中断 (run abort) と user permanent を分ける。
+ *
+ * 戻り値:
+ *   - "scope_revoked": run 全体中断、後続 user の Reservation も rollback
+ *   - "user_permanent": この user だけ failed_permanent、run は継続
+ */
+
+import type { Gmail403Classification } from "@lms-279/shared-types";
+
+/**
+ * Gmail API 403 で「全体設定ミス」を示す reason 一覧。
+ *
+ * Google Gmail API ドキュメントで定義されている代表的な reason:
+ * - insufficientPermissions: DWD scope 未反映 / 認可不足
+ * - delegationDenied: なりすまし送信が拒否された (subject 設定ミス等)
+ * - userRateLimitExceeded: sender 単位の制限超過 (実質 sender disabled)
+ * - forbidden: 一般的な認可エラー、DWD 未反映の典型
+ *
+ * これら以外 (recipientRejected 等) は宛先固有として user_permanent に分類する。
+ */
+const SCOPE_REVOKED_REASONS = new Set<string>([
+  "insufficientPermissions",
+  "delegationDenied",
+  "userRateLimitExceeded",
+  "forbidden",
+]);
+
+export function classifyGmail403(err: unknown): Gmail403Classification {
+  if (!err || typeof err !== "object") {
+    return "user_permanent";
+  }
+  const e = err as {
+    response?: { data?: { error?: { errors?: Array<{ reason?: string }> } } };
+  };
+  const reason = e.response?.data?.error?.errors?.[0]?.reason;
+  if (typeof reason === "string" && SCOPE_REVOKED_REASONS.has(reason)) {
+    return "scope_revoked";
+  }
+  return "user_permanent";
+}

--- a/services/api/src/services/dispatch/dispatch-error-sanitizer.ts
+++ b/services/api/src/services/dispatch/dispatch-error-sanitizer.ts
@@ -2,35 +2,78 @@
  * Audit log / Error Reporting に出力する前にエラーメッセージから PII を除去するユーティリティ。
  *
  * 設計仕様書 §6.5 / NFR-11 / AC-33 (PII sanitize) に対応。
- * Codex セカンドオピニオン Important-7 (PII ログ漏洩) を踏まえ、Gmail / Gaxios の
- * raw エラーメッセージに含まれる可能性がある email / access_token / Bearer / MIME headers を
- * [REDACTED] プレースホルダーに置換し、上限 1024 文字で truncate する。
+ * Codex セカンドオピニオン Important-7 (PII ログ漏洩) + PR #442 review Critical 2 (取りこぼし拡張)
+ * を反映済み。
  *
- * 順序は重要: MIME_HEADER → Bearer → access_token → email の順で置換すると、
- * "To: alice@x.com" のような複合ケースで MIME ヘッダ行全体が先に消える。
+ * 対象 PII / トークン:
+ *   - email アドレス (一般形式)
+ *   - Google OAuth2 access token (ya29.<...>)
+ *   - JWT 3-part (eyJ<...>.<...>.<...>) — ID token / Bearer token 本体
+ *   - Refresh token (1//<...>)
+ *   - Google API key (AIza<35 chars>)
+ *   - Authorization: Bearer <token>
+ *   - MIME ヘッダ行 (To/Cc/Bcc/From/Reply-To/Sender、folded continuation 含む)
+ *
+ * 置換順序:
+ *   MIME ヘッダ全体 → Bearer (token 切り出し前) → JWT → access_token → refresh_token →
+ *   API key → email の順。順序を変更すると "To: alice@x.com" のような複合ケースで
+ *   ヘッダ全体ではなく email だけ消えて "To:" 残骸が出る等の中途半端 redaction になる。
+ *
+ * 文字数上限: DISPATCH_CONSTRAINTS.SANITIZED_ERROR_MESSAGE_MAX_LENGTH (現在 1024)
+ *   UTF-8 マルチバイト境界を割らないよう、置換後に Array.from で grapheme 単位で
+ *   slice する。
  */
 
 import { DISPATCH_CONSTRAINTS } from "@lms-279/shared-types";
 
-// email: RFC 5322 完全対応はしない、Gmail API エラーで観測される一般形式に絞る
+// === 正規表現 ===
+// email: RFC 5322 完全対応はしない、Gmail API エラーで観測される一般形式に絞る。
+// IDN (国際化ドメイン) / quoted-string local-part 等の特殊形式は対象外
+// (それらが PII として漏れた場合は別途検知層を設ける想定)。
 const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+
 // Google OAuth2 access token (ya29 プレフィックス)
 const ACCESS_TOKEN_RE = /ya29\.[A-Za-z0-9_.-]+/g;
-// Authorization: Bearer <token>
+
+// JWT 3-part (eyJ で始まる base64url の 3 セクション)。
+// ID token / OIDC ID token / Bearer の中身 を broadly キャッチ。
+const JWT_RE = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g;
+
+// Google OAuth2 refresh token (1// プレフィックス)
+const REFRESH_TOKEN_RE = /1\/\/[A-Za-z0-9_-]+/g;
+
+// Google API key (AIza + 35 chars の固定形式)
+const API_KEY_RE = /AIza[0-9A-Za-z_-]{35}/g;
+
+// Authorization: Bearer <token>。token 部分には ya29 / JWT 等が入りうるため、
+// access_token / JWT より先に処理して "Bearer ya29..." → "[BEARER]" にする。
 const BEARER_RE = /Bearer\s+[A-Za-z0-9_.-]+/g;
-// MIME ヘッダ行 (1 行単位、改行で終わるかメッセージ末尾まで)
-const MIME_HEADER_RE = /(?:To|Cc|Bcc|From):\s*[^\r\n]+/gi;
+
+// MIME ヘッダ行 (To/Cc/Bcc/From/Reply-To/Sender)、
+// folded header (次行頭が空白文字で継続するパターン RFC 5322 §2.2.3) を含む。
+const MIME_HEADER_RE =
+  /(?:To|Cc|Bcc|From|Reply-To|Sender):\s*[^\r\n]+(?:\r?\n[ \t][^\r\n]*)*/gi;
 
 const MAX_LENGTH = DISPATCH_CONSTRAINTS.SANITIZED_ERROR_MESSAGE_MAX_LENGTH;
 
+/**
+ * UTF-8 マルチバイト境界を割らない truncate。
+ * Array.from は code point 単位でイテレートするためサロゲートペア / 結合文字も安全。
+ */
+function safeTruncate(s: string, maxLength: number): string {
+  if (s.length <= maxLength) return s;
+  return Array.from(s).slice(0, maxLength).join("");
+}
+
 export function sanitizeErrorForAudit(err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err);
-  // 順序: MIME ヘッダ全体 → Bearer → access token → email
-  // (Bearer の token 部分が ya29 形式の場合があるため Bearer を先に処理)
-  return raw
+  const sanitized = raw
     .replace(MIME_HEADER_RE, "[MIME_HEADER]")
     .replace(BEARER_RE, "[BEARER]")
+    .replace(JWT_RE, "[JWT]")
     .replace(ACCESS_TOKEN_RE, "[ACCESS_TOKEN]")
-    .replace(EMAIL_RE, "[EMAIL]")
-    .slice(0, MAX_LENGTH);
+    .replace(REFRESH_TOKEN_RE, "[REFRESH_TOKEN]")
+    .replace(API_KEY_RE, "[API_KEY]")
+    .replace(EMAIL_RE, "[EMAIL]");
+  return safeTruncate(sanitized, MAX_LENGTH);
 }

--- a/services/api/src/services/dispatch/dispatch-error-sanitizer.ts
+++ b/services/api/src/services/dispatch/dispatch-error-sanitizer.ts
@@ -1,0 +1,36 @@
+/**
+ * Audit log / Error Reporting に出力する前にエラーメッセージから PII を除去するユーティリティ。
+ *
+ * 設計仕様書 §6.5 / NFR-11 / AC-33 (PII sanitize) に対応。
+ * Codex セカンドオピニオン Important-7 (PII ログ漏洩) を踏まえ、Gmail / Gaxios の
+ * raw エラーメッセージに含まれる可能性がある email / access_token / Bearer / MIME headers を
+ * [REDACTED] プレースホルダーに置換し、上限 1024 文字で truncate する。
+ *
+ * 順序は重要: MIME_HEADER → Bearer → access_token → email の順で置換すると、
+ * "To: alice@x.com" のような複合ケースで MIME ヘッダ行全体が先に消える。
+ */
+
+import { DISPATCH_CONSTRAINTS } from "@lms-279/shared-types";
+
+// email: RFC 5322 完全対応はしない、Gmail API エラーで観測される一般形式に絞る
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+// Google OAuth2 access token (ya29 プレフィックス)
+const ACCESS_TOKEN_RE = /ya29\.[A-Za-z0-9_.-]+/g;
+// Authorization: Bearer <token>
+const BEARER_RE = /Bearer\s+[A-Za-z0-9_.-]+/g;
+// MIME ヘッダ行 (1 行単位、改行で終わるかメッセージ末尾まで)
+const MIME_HEADER_RE = /(?:To|Cc|Bcc|From):\s*[^\r\n]+/gi;
+
+const MAX_LENGTH = DISPATCH_CONSTRAINTS.SANITIZED_ERROR_MESSAGE_MAX_LENGTH;
+
+export function sanitizeErrorForAudit(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  // 順序: MIME ヘッダ全体 → Bearer → access token → email
+  // (Bearer の token 部分が ya29 形式の場合があるため Bearer を先に処理)
+  return raw
+    .replace(MIME_HEADER_RE, "[MIME_HEADER]")
+    .replace(BEARER_RE, "[BEARER]")
+    .replace(ACCESS_TOKEN_RE, "[ACCESS_TOKEN]")
+    .replace(EMAIL_RE, "[EMAIL]")
+    .slice(0, MAX_LENGTH);
+}

--- a/services/api/src/services/dispatch/schedule-matcher.ts
+++ b/services/api/src/services/dispatch/schedule-matcher.ts
@@ -1,0 +1,41 @@
+/**
+ * 配信スケジュール (settings.scheduleDaysOfWeek + scheduleHourJst) と
+ * 現在 JST 時刻を照合する純粋関数。
+ *
+ * 設計仕様書 §3.2、FR-2、AC-6 / AC-7 に対応。
+ *
+ * Cloud Scheduler は毎時 JST 00 分起動 (`time-zone: Asia/Tokyo`) で固定だが、
+ * 配信スケジュールの柔軟性 (曜日 + 時刻) は DB 設定値で実現する。
+ * 本関数は cron 起動時に「今が配信時刻か」を判定するためだけに使う純粋関数。
+ *
+ * JST は固定 UTC+9 (DST なし、ADR-029)。
+ *
+ * @param settings 配信設定
+ * @param now 現在時刻 (UTC、Date 型)。テストで固定できるよう注入可能
+ * @returns true なら配信処理を実行、false なら何もしない (200 で即終了)
+ */
+
+import type { DispatchSettings } from "@lms-279/shared-types";
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+export function shouldRunNow(settings: DispatchSettings, now: Date): boolean {
+  // kill switch (AC-7)
+  if (!settings.enabled) return false;
+
+  // 空配列なら常に false (誤発火防止)
+  if (settings.scheduleDaysOfWeek.length === 0) return false;
+
+  // JST 換算 (UTC + 9 時間)
+  const jst = new Date(now.getTime() + JST_OFFSET_MS);
+  const jstDayOfWeek = jst.getUTCDay(); // JST 換算後の値を getUTCDay で取り出す
+  const jstHour = jst.getUTCHours();
+
+  // 曜日一致 (AC-6)
+  if (!settings.scheduleDaysOfWeek.includes(jstDayOfWeek)) return false;
+
+  // 時刻一致 (時単位、分は無視)
+  if (jstHour !== settings.scheduleHourJst) return false;
+
+  return true;
+}


### PR DESCRIPTION
## Summary

DXcollege 自動完了通知システムの **設計仕様書 + 実装計画 + Phase 1 基礎 services + smoke check workflow** を一括で main に取り込む PR。

- 既存 PR #434 (手動 Gmail 下書き作成) と**完全独立した別レーン**として実装
- Cloud Scheduler で毎時 JST 00 分起動 → BE が DB 設定で配信時刻判定 → 100% 完了者にだけ自動送信
- brainstorm Phase 1-9 完了 + Codex セカンドオピニオン (Critical 3 / Important 9 / Minor 4) 全反映

## 含まれる commit

| Commit | 内容 | 行数 |
|---|---|---|
| `18169af` | 設計仕様書 + 処理フロー図 | +840 |
| `aa3110d` | 実装計画 (Phase 0-8) | +503 |
| `c804ab2` | Phase 1 基礎 services (sanitizer / 403-classifier / schedule-matcher / DTO) | +831 |
| `1f437e2` | smoke check workflow + script (OQ-2 検証用) | +332 |

合計: **+2,506 行 / 13 ファイル新規**

## 変更点

### Documentation
- `docs/specs/2026-05-20-completion-notification-design.md` (748 行): 設計仕様書 v2 (Codex 反映済、AC 30 件)
- `docs/specs/2026-05-20-completion-notification-flow.mmd` (92 行): 処理フロー図 (Mermaid、Reservation 方式)
- `docs/specs/2026-05-20-completion-notification-impl-plan.md` (503 行): Phase 0-8 実装計画

### Phase 1 基礎 services (TDD で実装)
- `packages/shared-types/src/dispatch.ts` (320 行): DTO 型 (Settings / Tenant CC / Notification / Run / Audit / Dry-run / Test-send 等)
- `services/api/src/services/dispatch/dispatch-error-sanitizer.ts`: PII sanitize (email / access_token / Bearer / MIME headers → [REDACTED])
- `services/api/src/services/dispatch/dispatch-403-classifier.ts`: Gmail 403 reason 分類 (scope_revoked / user_permanent)
- `services/api/src/services/dispatch/schedule-matcher.ts`: JST 時刻照合

### smoke check (OQ-2 検証用)
- `scripts/smoke-dwd-gmail-send.ts`: DWD JWT + gmail.send で `dxcollege@279279.net` を subject にした送信検証
- `.github/workflows/smoke-dwd-gmail-send.yml`: workflow_dispatch (dry-run / send mode 分離)

## 主要設計判断 (詳細は仕様書参照)

1. **Reservation 方式** (Codex Critical-1+3): Gmail 送信前に Firestore transaction で `completion_notifications/{userId}` を `reserved` 状態で create → 二重送信を構造的に防止
2. **published コース全件母集合** (Codex Critical-2): `course_progress` 不在 = 未着手扱い (新規コース未着手者を誤通知しない)
3. **DWD scope 分離** (Codex Important-1): 既存共通 `SCOPES` を汚染せず、`gmail.send` 専用 client (`getGmailClientForSender`) を新設
4. **403 reason 分類** (Codex Important-4): `insufficientPermissions` 等は run 全体中断、宛先固有のみ user permanent
5. **PII sanitize** (Codex Important-7): `sanitizeErrorForAudit()` で raw email / token を除去してから audit_logs / Error Reporting に渡す
6. **run-level lock** (Codex Important-3): `super_dispatch_runs` で同時起動を transaction で拒否
7. **courseIdsSnapshot 保存** (Codex Important-5): 案 C (再送しない) + 通知時点の published course を記録

## Test plan

### 自動テスト (実行済)
- [x] `npm test -w @lms-279/api`: **1025 件全 PASS** (新規 41 + 既存 984、回帰なし)
  - dispatch-error-sanitizer: 16 件
  - dispatch-403-classifier: 10 件
  - schedule-matcher: 15 件
- [x] `npm run type-check`: PASS (@lms-279/api、@lms-279/shared-types)
- [x] `npm run lint`: 0 errors

### 手動 smoke check (マージ後実施予定)
- [ ] `gh workflow run smoke-dwd-gmail-send.yml -f mode=dry-run -f to_email=system@279279.net` で dry-run 成功確認 (Secret Manager 読取り + JWT 生成 + MIME 組立)
- [ ] DWD 反映完了確認後、`-f mode=send` で実送信検証 → `system@279279.net` に smoke メール受信
- [ ] OQ-2 PASS = `dxcollege@279279.net` (Google Group) が DWD subject として動作することを確認

## カバー AC (Phase 1 分)

- **AC-6** (スケジュール一致判定)
- **AC-7** (kill switch)
- **AC-17** (403 全体中断分類)
- **AC-18** (403 宛先固有分類)
- **AC-33** (PII sanitize)

Phase 2 以降で残り AC を順次カバー。

## 関連 OQ 解決状況

- **OQ-3** (Workspace 管理コンソール権限): ✅ 本田様確認済 (gmail.send scope 追加完了、本 PR 発出時点で DWD 反映待ち)
- **OQ-7** (super-admin auth 方式): ✅ Firebase Bearer Token 確認済、CSRF 不要
- **OQ-2** (Group エイリアス DWD smoke): 🕐 マージ後に smoke workflow で検証
- **OQ-8** (TTL 法務確認): 🔄 本田様確認中

## マージ後の即時アクション

1. `gh workflow run smoke-dwd-gmail-send.yml -f mode=dry-run -f to_email=system@279279.net` で dry-run 確認
2. dry-run 成功 → DWD 反映完了待ち → send mode で実送信検証
3. send 成功 = OQ-2 PASS → Phase 1 残部 (`completion-eligibility` / `cc-email-validator` / `gmail-client`) + Phase 2 着手可能

## 注意事項

- 本 PR は**自動配信機能本体を含まない** (Cloud Scheduler 設定、Cloud Run env、Firestore TTL Policy 等は Phase 7 で実施)
- 既存 PR #434 機能には**一切影響なし** (`gmail-draft.ts` / `progress-pdf-draft.ts` 等を変更していない)
- main にマージしても `enabled=false` 等の初期化が走るのは Phase 7 デプロイ時、本 PR では何も自動起動しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)