### PR TITLE
fix(smoke-workflow): shared-types build step を npm ci 後に追加

### DIFF
--- a/.github/workflows/smoke-dwd-gmail-send.yml
+++ b/.github/workflows/smoke-dwd-gmail-send.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build shared-types
+        # scripts/smoke-dwd-gmail-send.ts は services/api/src/services/dispatch/dispatch-error-sanitizer.ts を
+        # 経由して @lms-279/shared-types から DISPATCH_CONSTRAINTS を読む。
+        # shared-types は package.json main が dist/index.js を指すため build 必須。
+        run: npm run build -w @lms-279/shared-types
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:


### PR DESCRIPTION
## Summary

PR #442 マージ後の smoke check dry-run 実行 (run #26163794074) で MODULE_NOT_FOUND エラーが発生:

\`\`\`
Error: Cannot find module '/home/runner/work/lms-279/lms-279/node_modules/@lms-279/shared-types/dist/index.js'
\`\`\`

\`scripts/smoke-dwd-gmail-send.ts\` → \`dispatch-error-sanitizer.ts\` → \`@lms-279/shared-types\` の依存チェーンで shared-types/dist/index.js が未生成だったため。

## 修正

\`.github/workflows/smoke-dwd-gmail-send.yml\` に \`npm run build -w @lms-279/shared-types\` ステップを Install dependencies の直後に追加。

## なぜ既存 audit/cleanup workflow では問題にならなかったか

既存 \`scripts/audit-*.ts\` / \`scripts/cleanup-stuck-quiz-attempts.ts\` は \`services/api/src/datasource/firestore.ts\` 等を経由するが、これらは shared-types を直接 import していない (firebase-admin/firestore 型は使うが \`@lms-279/shared-types\` は使わない)。smoke script が初めて shared-types 依存を持つ scripts/ 配下のスクリプトになったため発覚した。

## Test plan

- [x] yaml 構文確認 (ローカル目視)
- [ ] マージ後 \`gh workflow run smoke-dwd-gmail-send.yml -f mode=dry-run -f to_email=system@279279.net\` で再実行 → MODULE_NOT_FOUND が消えていること確認

## 関連

- PR #442 (本機能の親 PR)
- Failed run: https://github.com/system-279/lms-279/actions/runs/26163794074

🤖 Generated with [Claude Code](https://claude.com/claude-code)