### PR TITLE
refactor(shared-types): JST_OFFSET_MS を shared-types に中央集約 (Important #8)

### DIFF
--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -11,3 +11,4 @@ export type * from "./tenant.js";
 export type * from "./progress-pdf.js";
 export * from "./filename.js";
 export * from "./dispatch.js";
+export * from "./time.js";

--- a/packages/shared-types/src/time.ts
+++ b/packages/shared-types/src/time.ts
@@ -1,10 +1,11 @@
 /**
  * 時刻関連の共通定数。
  *
- * ADR-029 (タイムゾーン基準) に基づき、JST は固定 UTC+9 (DST なし) として扱う。
- * 過去複数箇所で `9 * 60 * 60 * 1000` を再定義していたため shared-types に集約する
- * (Phase 1 PR #442 review Important #8)。
+ * JST は固定 UTC+9 / DST なし (時刻系の客観的事実)。
+ * 受講期限の JST 表示など、システム内の時刻計算で利用する (ADR-029 参照)。
+ *
+ * 将来マルチテナント TZ 化 (ADR-029 §今後の対応) の際は削除候補。
  */
 
-/** JST と UTC のオフセット (ミリ秒)。ADR-029 により固定 UTC+9 / DST なし。 */
-export const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+/** JST と UTC のオフセット (ミリ秒)。9 時間 × 60 分 × 60 秒 × 1000 ms = 32_400_000。 */
+export const JST_OFFSET_MS = 32_400_000 as const;

--- a/packages/shared-types/src/time.ts
+++ b/packages/shared-types/src/time.ts
@@ -1,0 +1,10 @@
+/**
+ * 時刻関連の共通定数。
+ *
+ * ADR-029 (タイムゾーン基準) に基づき、JST は固定 UTC+9 (DST なし) として扱う。
+ * 過去複数箇所で `9 * 60 * 60 * 1000` を再定義していたため shared-types に集約する
+ * (Phase 1 PR #442 review Important #8)。
+ */
+
+/** JST と UTC のオフセット (ミリ秒)。ADR-029 により固定 UTC+9 / DST なし。 */
+export const JST_OFFSET_MS = 9 * 60 * 60 * 1000;

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -13,7 +13,7 @@
 import { Router, Request, Response } from "express";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { getAuth } from "firebase-admin/auth";
-import type { SuperAttendanceResponse, SuperStudentProgressResponse, TenantEnrollmentSettingResponse } from "@lms-279/shared-types";
+import { JST_OFFSET_MS, type SuperAttendanceResponse, type SuperStudentProgressResponse, type TenantEnrollmentSettingResponse } from "@lms-279/shared-types";
 import {
   superAdminAuthMiddleware,
   getAllSuperAdmins,
@@ -979,8 +979,7 @@ router.get("/tenants/:tenantId/attendance-report", async (req: Request, res: Res
   let sessionsQuery = db.collection(`${basePath}/lesson_sessions`)
     .orderBy("entryAt", "desc") as FirebaseFirestore.Query;
 
-  // 日付フィルタ: JST基準（UTC+9）でUTC境界に変換
-  const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+  // 日付フィルタ: JST基準（UTC+9）でUTC境界に変換 (JST_OFFSET_MS は shared-types から import)
   const fromStr = typeof from === "string" ? from : undefined;
   const toStr = typeof to === "string" ? to : undefined;
   if (fromStr) {

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -979,7 +979,7 @@ router.get("/tenants/:tenantId/attendance-report", async (req: Request, res: Res
   let sessionsQuery = db.collection(`${basePath}/lesson_sessions`)
     .orderBy("entryAt", "desc") as FirebaseFirestore.Query;
 
-  // 日付フィルタ: JST基準（UTC+9）でUTC境界に変換 (JST_OFFSET_MS は shared-types から import)
+  // 日付フィルタ: JST基準（UTC+9）でUTC境界に変換
   const fromStr = typeof from === "string" ? from : undefined;
   const toStr = typeof to === "string" ? to : undefined;
   if (fromStr) {

--- a/services/api/src/services/dispatch/schedule-matcher.ts
+++ b/services/api/src/services/dispatch/schedule-matcher.ts
@@ -15,9 +15,7 @@
  * @returns true なら配信処理を実行、false なら何もしない (200 で即終了)
  */
 
-import type { DispatchSettings } from "@lms-279/shared-types";
-
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+import { JST_OFFSET_MS, type DispatchSettings } from "@lms-279/shared-types";
 
 export function shouldRunNow(settings: DispatchSettings, now: Date): boolean {
   // kill switch (AC-7)

--- a/services/api/src/services/progress-pdf-document.tsx
+++ b/services/api/src/services/progress-pdf-document.tsx
@@ -8,11 +8,12 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Document, Font, Page, StyleSheet, Text, View } from "@react-pdf/renderer";
-import type {
-  Pace,
-  ProgressPdfCourseRecord,
-  ProgressPdfData,
-  ProgressPdfSections,
+import {
+  JST_OFFSET_MS,
+  type Pace,
+  type ProgressPdfCourseRecord,
+  type ProgressPdfData,
+  type ProgressPdfSections,
 } from "@lms-279/shared-types";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -84,7 +85,7 @@ function formatDate(iso: string | null): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
   // JST 日付表示
-  const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000);
+  const jst = new Date(d.getTime() + JST_OFFSET_MS);
   const y = jst.getUTCFullYear();
   const m = String(jst.getUTCMonth() + 1).padStart(2, "0");
   const day = String(jst.getUTCDate()).padStart(2, "0");
@@ -95,7 +96,7 @@ function formatDateTime(iso: string | null): string {
   if (!iso) return "—";
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
-  const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000);
+  const jst = new Date(d.getTime() + JST_OFFSET_MS);
   const y = jst.getUTCFullYear();
   const m = String(jst.getUTCMonth() + 1).padStart(2, "0");
   const day = String(jst.getUTCDate()).padStart(2, "0");

--- a/services/api/src/services/progress-pdf-mail-template.ts
+++ b/services/api/src/services/progress-pdf-mail-template.ts
@@ -7,9 +7,7 @@
  * JST 表示で統一する（ADR-029 タイムゾーン基準）。
  */
 
-import type { Pace, ProgressPdfData } from "@lms-279/shared-types";
-
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+import { JST_OFFSET_MS, type Pace, type ProgressPdfData } from "@lms-279/shared-types";
 
 export interface MailTemplateInput {
   data: ProgressPdfData;

--- a/web/app/super/progress/page.tsx
+++ b/web/app/super/progress/page.tsx
@@ -27,10 +27,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useSuperAdminFetch } from "@/lib/super-api";
-import type {
-  SuperStudentProgressResponse,
-  SuperCourseRecord,
-  SuperLessonRecord,
+import {
+  JST_OFFSET_MS,
+  type SuperStudentProgressResponse,
+  type SuperCourseRecord,
+  type SuperLessonRecord,
 } from "@lms-279/shared-types";
 
 type Tenant = { id: string; name: string };
@@ -140,7 +141,7 @@ export default function StudentProgressPage() {
   const toJstDateAndTime = (iso: string | null): { date: string; time: string } => {
     if (!iso) return { date: "", time: "" };
     const d = new Date(iso);
-    const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000);
+    const jst = new Date(d.getTime() + JST_OFFSET_MS);
     return {
       date: jst.toISOString().slice(0, 10),
       time: jst.toISOString().slice(11, 16),


### PR DESCRIPTION
## Summary
- PR #442 review で指摘された Important #8 (code-simplifier #2) の対応
- `9 * 60 * 60 * 1000` の ms 定数を `packages/shared-types/src/time.ts` に集約
- 6 箇所の重複定義 / 直書きを import に置換 (services 4 + web 1 + shared-types 新規)
- ADR-029 (JST 固定 UTC+9 / DST なし) に紐づく根拠コメント付き
- **挙動変更なし**、純粋リファクタリング

## Background
PR #442 (`94e5dfa`) の 6 エージェント並列レビューで `code-simplifier` が指摘:
> `JST_OFFSET_MS` (= `9 * 60 * 60 * 1000`) が複数箇所で再定義されているため、
> `@lms-279/shared-types` に集約して DRY 違反を解消すべき

## Changes

| ファイル | 変更内容 |
|---|---|
| `packages/shared-types/src/time.ts` (新規) | `export const JST_OFFSET_MS = 9 * 60 * 60 * 1000;` + ADR-029 参照コメント |
| `packages/shared-types/src/index.ts` | `time.js` を re-export 追加 |
| `services/api/src/routes/super-admin.ts:983` | ローカル定義削除 → import |
| `services/api/src/services/progress-pdf-mail-template.ts:12` | ローカル定義削除 → import |
| `services/api/src/services/progress-pdf-document.tsx:88,99` | 2 箇所の直書きを `JST_OFFSET_MS` に置換 |
| `services/api/src/services/dispatch/schedule-matcher.ts:20` | ローカル定義削除 → import |
| `web/app/super/progress/page.tsx:144` | 直書きを `JST_OFFSET_MS` に置換 |

## Test plan
- [x] `npm run build -w @lms-279/shared-types` 成功
- [x] `npm run type-check` 全 workspace 通過 (0 errors)
- [x] `npm run lint` 0 errors (1 warning は既存、本 PR 無関係)
- [x] `npm run test` 71 files / 1048 tests passed
- [ ] CI green (本 PR で確認)
- [ ] Deploy to Cloud Run 成功 (マージ後)

## 関連
- 元 PR: #442 (DXcollege 自動完了通知システム Phase 0/1)
- ADR-029: タイムゾーン基準 (JST は固定 UTC+9 / DST なし)
- Important 残 7 件は Phase 2 PR で吸収予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)