### PR TITLE
refactor(shared-types): dispatch DTO の二重定義削除と PutRequest Pick 化 (Important #2, #3)

### DIFF
--- a/packages/shared-types/src/dispatch.ts
+++ b/packages/shared-types/src/dispatch.ts
@@ -35,16 +35,23 @@ export interface DispatchSettings {
 /** 設定取得レスポンス (senderEmail は env から読み取って併記、編集不可) */
 export type GetDispatchSettingsResponse = DispatchSettings;
 
-/** 設定更新リクエスト (version 不一致で 409) */
-export interface PutDispatchSettingsRequest {
-  enabled: boolean;
-  scheduleDaysOfWeek: number[];
-  scheduleHourJst: number;
-  signatureName: string;
-  completionMessageBody: string;
-  /** 楽観的ロック用、現在の DB version と一致しないと 409 */
-  version: number;
-}
+/**
+ * 設定更新リクエスト (version 不一致で 409)。
+ *
+ * DispatchSettings から派生 (Pick) し、サーバー側で設定する senderEmail /
+ * updatedAt / updatedBy は除外する。version は楽観的ロック用に含める。
+ * DispatchSettings に新規 field を追加した際は、本 Pick にも追加するか
+ * 自動的に PutRequest 対象外として扱うかを意識的に判断する。
+ */
+export type PutDispatchSettingsRequest = Pick<
+  DispatchSettings,
+  | "enabled"
+  | "scheduleDaysOfWeek"
+  | "scheduleHourJst"
+  | "signatureName"
+  | "completionMessageBody"
+  | "version"
+>;
 
 export type DispatchSettingsErrorCode =
   | "invalid_schedule_days"
@@ -82,8 +89,7 @@ export type TenantNotificationCcErrorCode =
   | "unauthorized"
   | "forbidden";
 
-/** notificationCcEmails 上限 */
-export const NOTIFICATION_CC_EMAILS_MAX = 10;
+// notificationCcEmails 上限 / その他の制約値は DISPATCH_CONSTRAINTS に統一 (本ファイル末尾)
 
 // ============================================================
 // 完了通知 (tenants/{tenantId}/completion_notifications/{userId})
@@ -271,8 +277,7 @@ export type TestSendErrorCode =
   | "unauthorized"
   | "forbidden";
 
-/** test-send 1 日あたりレート制限 (スーパー管理者あたり) */
-export const TEST_SEND_DAILY_LIMIT = 50;
+// test-send 1 日あたりレート制限は DISPATCH_CONSTRAINTS.TEST_SEND_DAILY_LIMIT を参照
 
 // ============================================================
 // Reservation transaction の結果 (内部 service 用)


### PR DESCRIPTION
## Summary
- PR #442 review の Important #2 / Important #3 を吸収
- `packages/shared-types/src/dispatch.ts` 1 ファイルの純リファクタ
- **挙動変更なし**、src 側の callsite は Phase 1 着手前のため 0 件

## β (Important #3): 定数二重定義削除
- 個別 export `NOTIFICATION_CC_EMAILS_MAX = 10` を削除
- 個別 export `TEST_SEND_DAILY_LIMIT = 50` を削除
- いずれも `DISPATCH_CONSTRAINTS` (`as const` map) に同値が存在しており、FE/BE 双方で `DISPATCH_CONSTRAINTS.X` 形式に統一
- 二箇所修正のヒューマンエラーリスクを構造的に排除

## γ (Important #2): PutDispatchSettingsRequest を Pick&lt;DispatchSettings&gt; 化
\`\`\`ts
// Before
export interface PutDispatchSettingsRequest {
  enabled: boolean;
  scheduleDaysOfWeek: number[];
  scheduleHourJst: number;
  signatureName: string;
  completionMessageBody: string;
  version: number;
}

// After
export type PutDispatchSettingsRequest = Pick<
  DispatchSettings,
  | "enabled"
  | "scheduleDaysOfWeek"
  | "scheduleHourJst"
  | "signatureName"
  | "completionMessageBody"
  | "version"
>;
\`\`\`
- senderEmail / updatedAt / updatedBy はサーバー側で設定するため Pick から除外
- DispatchSettings 変更が PutRequest に自動波及、手書き重複を解消

## Test plan
- [x] \`npm run build -w @lms-279/shared-types\` 成功
- [x] \`npm run type-check\` 全 workspace 通過 (0 errors)
- [x] \`npm run lint\` 0 errors (1 warning は既存、本 PR 無関係)
- [x] \`npm run test\` 71 files / 1048 tests passed
- [x] grep で src 側 callsite が 0 件であることを確認 (Phase 1 着手前のため定義のみ)
- [ ] CI green (本 PR で確認)
- [ ] Deploy to Cloud Run 成功 (マージ後)

## 関連
- 元 PR: #442 (DXcollege 自動完了通知システム Phase 0/1)
- PR #445 (Important #8) で確立した「Phase 2 着手前に DTO 周辺を整える」流れの 2 件目
- Important 残部: #1 (discriminated union)、#4-#7 (smoke 防御強化系) は Phase 2 PR または smoke 結果次第で吸収

🤖 Generated with [Claude Code](https://claude.com/claude-code)