### PR TITLE
feat(security): Gmail API エラーメッセージの PII フィルタ (#437)

### DIFF
--- a/docs/adr/ADR-034-phase2-gmail-draft.md
+++ b/docs/adr/ADR-034-phase2-gmail-draft.md
@@ -7,6 +7,10 @@
 
 ## 改訂履歴
 
+- **2026-05-21 (Issue #437)**: Gmail API エラー message の PII フィルタ。
+  - §8 エラー分類: `GmailDraftError` に **`publicMessage` getter** (errorCode → 固定文言マップ `GMAIL_ERROR_PUBLIC_MESSAGES`) を追加。`message` (Error 標準フィールド) は内部診断用 (raw Gmail API error 含む可能性、logger / HTTP レスポンスへ出さない)、`publicMessage` は外部公開用 (PII フリーの固定文言)。
+  - route 層 (`progress-pdf-draft.ts`): logger.error / HTTP レスポンスの `message` フィールドを `gmailErr.publicMessage` に統一。logger からは raw `errorMessage` を撤去 (errorCode + httpStatus のみで運用追跡、Cloud Logging req/res telemetry で詳細は別途参照)。
+  - 効果: Gmail API が `response.data.error.message` に raw email / MIME 断片 / アカウント情報を含めて返してきた場合でも、Cloud Logging / HTTP レスポンスに PII が漏洩しない (ismap 準拠の観点でも改善)。
 - **2026-05-21 (Issue #435)**: idempotency アトミック化 + 状態遷移ログ。Codex review High 1 / 3 を反映 (High 90: `recordPdfDraftLog().set()` 混在 / Medium 86: orphan pending 復旧 / Low 82: failed mock test は本 PR scope 外、follow-up Issue 化)。
   - §7 監査ログスキーマ: `status` を `"pending" | "success" | "failed"` に拡張。`finalizedAt` (状態遷移時刻) を追加。
   - §3 idempotency 構造を全面再設計 (transaction ベース):

--- a/services/api/src/__tests__/integration/progress-pdf-draft.test.ts
+++ b/services/api/src/__tests__/integration/progress-pdf-draft.test.ts
@@ -107,6 +107,7 @@ vi.mock("../../datasource/factory.js", () => ({
 import { InMemoryDataSource } from "../../datasource/in-memory.js";
 import { progressPdfDraftRouter } from "../../routes/super/progress-pdf-draft.js";
 import { GmailDraftError } from "../../services/gmail-draft.js";
+import { logger } from "../../utils/logger.js";
 
 const ALL_ON = { profile: true, deadline: true, summary: true, lessons: true, quiz: true, pace: true, video: true };
 const FAKE_PDF = Buffer.concat([Buffer.from("%PDF-1.4\n"), Buffer.alloc(1024, 0x20)]);
@@ -519,6 +520,82 @@ describe("POST /api/v2/super/tenants/:tenantId/users/:userId/progress-pdf-draft"
       expect(res.status).toBe(401);
       expect(res.body.message).not.toContain("secret@victim.com");
       expect(res.body.message).toBe("Access token is invalid or expired");
+    });
+
+    // Codex review (Issue #437 follow-up Low 82): logger payload にも raw message が
+    // 入らないことを直接 assert する。回帰防止 (将来 route の catch を触った際に
+    // `errorMessage: gmailErr.message` が戻っても検出可能にする)。
+    it("AC-2 (Issue #437): logger.error payload に Gmail API raw message (PII) が含まれない", async () => {
+      const { user } = await seedTenant(ds);
+      const piiEmail = "leak-target@example.com";
+      mocks.createGmailDraftMock.mockRejectedValueOnce(
+        new GmailDraftError(
+          `Cannot send to ${piiEmail}: MIME header rejected`,
+          "gmail_api_error",
+          502,
+        ),
+      );
+      const loggerErrorSpy = vi.spyOn(logger, "error").mockImplementation(() => undefined);
+
+      try {
+        await request
+          .post(`/api/v2/super/tenants/tenant-1/users/${user.id}/progress-pdf-draft`)
+          .send({ requestId: "req-logger-pii", sections: ALL_ON, accessToken: "t" });
+
+        // Gmail draft creation failed の logger.error 呼び出しがあること
+        expect(loggerErrorSpy).toHaveBeenCalled();
+        // すべての logger.error 呼び出しの payload を文字列化して PII を検査
+        for (const call of loggerErrorSpy.mock.calls) {
+          const payloadStr = JSON.stringify(call);
+          expect(payloadStr).not.toContain(piiEmail);
+          expect(payloadStr).not.toContain("leak-target");
+        }
+        // 一方で errorCode + httpStatus は記録されている (運用追跡が機能している)
+        const gmailDraftFailedCall = loggerErrorSpy.mock.calls.find(
+          (c) => typeof c[0] === "string" && c[0].includes("Gmail draft creation failed"),
+        );
+        expect(gmailDraftFailedCall).toBeDefined();
+        if (gmailDraftFailedCall) {
+          const payload = gmailDraftFailedCall[1] as Record<string, unknown>;
+          expect(payload.errorCode).toBe("gmail_api_error");
+          expect(payload.httpStatus).toBe(502);
+        }
+      } finally {
+        loggerErrorSpy.mockRestore();
+      }
+    });
+
+    it("AC-2 (Issue #437): logger.warn payload (tokeninfo failure 経路) にも raw message が含まれない", async () => {
+      const { user } = await seedTenant(ds);
+      const piiEmail = "tokeninfo-leak@example.com";
+      mocks.verifyAccessTokenOwnerMock.mockRejectedValueOnce(
+        new GmailDraftError(
+          `Token bound to ${piiEmail} has been revoked`,
+          "invalid_access_token",
+          401,
+        ),
+      );
+      const loggerWarnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+
+      try {
+        await request
+          .post(`/api/v2/super/tenants/tenant-1/users/${user.id}/progress-pdf-draft`)
+          .send({ requestId: "req-tokeninfo-logger-pii", sections: ALL_ON, accessToken: "t" });
+
+        // tokeninfo failure 経路の logger.warn 呼び出しがあること
+        const tokeninfoCall = loggerWarnSpy.mock.calls.find(
+          (c) => typeof c[0] === "string" && c[0].includes("verify access token"),
+        );
+        expect(tokeninfoCall).toBeDefined();
+        // 全 logger.warn 呼び出しに PII が含まれないこと
+        for (const call of loggerWarnSpy.mock.calls) {
+          const payloadStr = JSON.stringify(call);
+          expect(payloadStr).not.toContain(piiEmail);
+          expect(payloadStr).not.toContain("tokeninfo-leak");
+        }
+      } finally {
+        loggerWarnSpy.mockRestore();
+      }
     });
   });
 

--- a/services/api/src/__tests__/integration/progress-pdf-draft.test.ts
+++ b/services/api/src/__tests__/integration/progress-pdf-draft.test.ts
@@ -455,6 +455,71 @@ describe("POST /api/v2/super/tenants/:tenantId/users/:userId/progress-pdf-draft"
       expect(res.status).toBe(502);
       expect(res.body.error).toBe("gmail_api_error");
     });
+
+    // Issue #437: Gmail API raw error message (受講者 email や MIME 断片を含む可能性) を
+    // HTTP レスポンスに露出させない。res.body.message は固定文言。
+    it("AC-3 (Issue #437): Gmail API failure 時 res.body.message に raw PII が含まれず、publicMessage (固定文言) が返る", async () => {
+      const { user } = await seedTenant(ds);
+      const piiEmail = "victim@private.example.com";
+      // Gmail API が raw error message に PII を含んで返してきたケースを mock
+      mocks.createGmailDraftMock.mockRejectedValueOnce(
+        new GmailDraftError(
+          `Cannot send to ${piiEmail}: invalid recipient`,
+          "gmail_api_error",
+          502,
+        ),
+      );
+
+      const res = await request
+        .post(`/api/v2/super/tenants/tenant-1/users/${user.id}/progress-pdf-draft`)
+        .send({ requestId: "req-pii", sections: ALL_ON, accessToken: "t" });
+
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBe("gmail_api_error");
+      // PII が含まれないこと
+      expect(res.body.message).not.toContain(piiEmail);
+      expect(res.body.message).not.toContain("victim");
+      // 固定文言 (GMAIL_ERROR_PUBLIC_MESSAGES.gmail_api_error) が返ること
+      expect(res.body.message).toBe("Gmail API error");
+    });
+
+    it("AC-3 (Issue #437): scope 不足時も res.body.message は固定文言 (reauthenticateWithPopup ガイダンス)", async () => {
+      const { user } = await seedTenant(ds);
+      mocks.createGmailDraftMock.mockRejectedValueOnce(
+        new GmailDraftError(
+          "insufficientPermissions for account leak@example.com",
+          "gmail_scope_required",
+          403,
+        ),
+      );
+
+      const res = await request
+        .post(`/api/v2/super/tenants/tenant-1/users/${user.id}/progress-pdf-draft`)
+        .send({ requestId: "req-scope-pii", sections: ALL_ON, accessToken: "t" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.message).not.toContain("leak@example.com");
+      expect(res.body.message).toBe("Gmail compose scope is required (please re-authenticate)");
+    });
+
+    it("AC-2 (Issue #437): tokeninfo failure 時も res.body.message は固定文言", async () => {
+      const { user } = await seedTenant(ds);
+      mocks.verifyAccessTokenOwnerMock.mockRejectedValueOnce(
+        new GmailDraftError(
+          "token bound to user secret@victim.com revoked",
+          "invalid_access_token",
+          401,
+        ),
+      );
+
+      const res = await request
+        .post(`/api/v2/super/tenants/tenant-1/users/${user.id}/progress-pdf-draft`)
+        .send({ requestId: "req-tokeninfo-pii", sections: ALL_ON, accessToken: "t" });
+
+      expect(res.status).toBe(401);
+      expect(res.body.message).not.toContain("secret@victim.com");
+      expect(res.body.message).toBe("Access token is invalid or expired");
+    });
   });
 
   describe("PDF サイズ上限", () => {

--- a/services/api/src/routes/super/progress-pdf-draft.ts
+++ b/services/api/src/routes/super/progress-pdf-draft.ts
@@ -314,13 +314,15 @@ router.post(
       const gmailErr = err instanceof GmailDraftError ? err : null;
       const errorCode: ProgressPdfDraftErrorCode = gmailErr?.errorCode ?? "gmail_api_error";
       const httpStatus = gmailErr?.httpStatus ?? 502;
+      // Issue #437 (PII フィルタ): logger に raw Gmail API error message を出さない。
+      // errorCode + httpStatus のみで運用追跡し、内容の詳細は GCP Logs Explorer で
+      // Cloud Run の stderr (req/res の telemetry) を別途参照する。
       logger.warn("Failed to verify access token owner (Gmail API call skipped)", {
         tenantId,
         userId,
         requestId: parsed.requestId,
         errorCode,
         httpStatus,
-        errorMessage: gmailErr?.message ?? (err instanceof Error ? err.message : "unknown error"),
       });
       await recordPdfDraftLog(db, {
         requestId: parsed.requestId,
@@ -346,9 +348,10 @@ router.post(
           errorMessage: auditErr instanceof Error ? auditErr.message : String(auditErr),
         });
       });
+      // Issue #437: 外部レスポンスには publicMessage (固定文言) のみ返す
       res.status(httpStatus).json({
         error: errorCode,
-        message: gmailErr?.message ?? "Failed to verify access token",
+        message: gmailErr?.publicMessage ?? "Failed to verify access token",
       });
       return;
     }
@@ -677,9 +680,9 @@ router.post(
         });
       }
 
-      // SECURITY (I2 / ADR-034): GmailDraftError は raw GaxiosError 参照を持たない
-      // 設計 (gmail-draft.ts §GmailDraftError) のため、ここでは分類済みの
-      // errorCode / httpStatus / message のみを記録する。
+      // SECURITY (I2 / ADR-034 / Issue #437): GmailDraftError の `message` は Gmail API の
+      // raw error を含む可能性があるため、logger.error にも HTTP レスポンスにも出さない。
+      // 運用追跡には errorCode + httpStatus のみで十分 (Cloud Logging で req/res telemetry を参照)。
       logger.error("Gmail draft creation failed", {
         errorType: "gmail_draft_failed",
         tenantId,
@@ -687,11 +690,11 @@ router.post(
         requestId: parsed.requestId,
         errorCode,
         httpStatus,
-        errorMessage: gmailErr?.message ?? (err instanceof Error ? err.message : "unknown error"),
       });
+      // Issue #437: 外部レスポンスには publicMessage (固定文言) のみ返す
       res.status(httpStatus).json({
         error: errorCode,
-        message: gmailErr?.message ?? "Gmail draft creation failed",
+        message: gmailErr?.publicMessage ?? "Gmail draft creation failed",
       });
     }
   },

--- a/services/api/src/services/__tests__/gmail-draft.test.ts
+++ b/services/api/src/services/__tests__/gmail-draft.test.ts
@@ -43,6 +43,7 @@ const {
   createGmailDraft,
   verifyAccessTokenOwner,
   GmailDraftError,
+  GMAIL_ERROR_PUBLIC_MESSAGES,
   TRANSIENT_NETWORK_CODES,
   __internal,
 } = await import("../gmail-draft.js");
@@ -821,5 +822,76 @@ describe("verifyAccessTokenOwner (Issue #436)", () => {
       errorCode: "gmail_api_error",
       httpStatus: 502,
     });
+  });
+});
+
+// Issue #437: PII フィルタ。Gmail API raw error message (受講者 email や MIME 断片を含む可能性) を
+// 外部 (logger / HTTP レスポンス) に露出させないため、固定文言の publicMessage を別途持つ。
+describe("GmailDraftError.publicMessage (Issue #437)", () => {
+  it("AC-1: 各 errorCode に対応する固定文言が GMAIL_ERROR_PUBLIC_MESSAGES から取得される", () => {
+    const err = new GmailDraftError("raw api error", "gmail_scope_required", 403);
+    expect(err.publicMessage).toBe(GMAIL_ERROR_PUBLIC_MESSAGES.gmail_scope_required);
+    // raw message と publicMessage は分離されている (Issue #437 の要)
+    expect(err.publicMessage).not.toBe(err.message);
+  });
+
+  it("AC-1: GMAIL_ERROR_PUBLIC_MESSAGES の各値に PII リテラル (@ / .com 等の email-like 文字列) が含まれない", () => {
+    for (const [code, msg] of Object.entries(GMAIL_ERROR_PUBLIC_MESSAGES)) {
+      // 各固定文言はテンプレート的に安全な文字列であること
+      expect(msg, `${code} publicMessage`).not.toMatch(/[\w.-]+@[\w.-]+/);
+    }
+  });
+
+  it("AC-5: raw email を含む Gmail API error を classifyGmailError に渡しても publicMessage に PII が含まれない", () => {
+    const piiEmail = "victim@example.com";
+    // Gmail API が返す error message に raw email が含まれているケースをシミュレート
+    const gaxiosError = {
+      response: {
+        status: 502,
+        data: {
+          error: {
+            message: `Cannot send to ${piiEmail}: invalid recipient (MIME header issue)`,
+          },
+        },
+      },
+    };
+
+    const classified = classifyGmailError(gaxiosError);
+
+    // 内部診断用 message には raw が残る (logger.error から外す責任は呼び出し側)
+    expect(classified.message).toContain(piiEmail);
+    // publicMessage は固定文言なので PII は含まれない
+    expect(classified.publicMessage).not.toContain(piiEmail);
+    expect(classified.publicMessage).not.toContain("@");
+    expect(classified.publicMessage).toBe(GMAIL_ERROR_PUBLIC_MESSAGES.gmail_api_error);
+  });
+
+  it("AC-5: scope 不足エラーで raw account info が含まれていても publicMessage は固定文言", () => {
+    const gaxiosError = {
+      response: {
+        status: 403,
+        data: {
+          error: {
+            message: "insufficientPermissions for account admin@victim-tenant.com",
+            errors: [{ reason: "insufficientPermissions" }],
+          },
+        },
+      },
+    };
+
+    const classified = classifyGmailError(gaxiosError);
+
+    expect(classified.errorCode).toBe("gmail_scope_required");
+    expect(classified.publicMessage).toBe(GMAIL_ERROR_PUBLIC_MESSAGES.gmail_scope_required);
+    expect(classified.publicMessage).not.toContain("admin@");
+    expect(classified.publicMessage).not.toContain("victim-tenant");
+  });
+
+  it("不明な errorCode (fallback) でも publicMessage は固定文言を返す", () => {
+    // ProgressPdfDraftErrorCode に存在しない code (テスト上のみ) → fallback
+    // 型システム上は通らないが、ランタイム安全性として確認
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const err = new GmailDraftError("raw", "non_existent_code" as any, 500);
+    expect(err.publicMessage).toBe("Gmail API error");
   });
 });

--- a/services/api/src/services/gmail-draft.ts
+++ b/services/api/src/services/gmail-draft.ts
@@ -12,17 +12,62 @@
 import { google } from "googleapis";
 import type { ProgressPdfDraftErrorCode } from "@lms-279/shared-types";
 
-// SECURITY (I2 / ADR-034): GaxiosError は config.headers.Authorization に
-// access token を保持するため、本クラスは raw error への参照を持たない。
-// 分類済みの errorCode / httpStatus / message のみを公開する。
+/**
+ * Issue #437 (PII フィルタ): GmailDraftError は 2 種類の message を持つ:
+ * - `message` (内部診断用): Error 標準フィールド。Gmail API の raw error message が
+ *   含まれる可能性があるため、**logger.error / HTTP レスポンスに直接出してはならない**。
+ * - `publicMessage` (外部公開用): `errorCode` ごとの固定文言。PII を含まないため
+ *   logger.error / HTTP レスポンスの `message` フィールドにそのまま出してよい。
+ *
+ * SECURITY (I2 / ADR-034): GaxiosError は config.headers.Authorization に
+ * access token を保持するため、本クラスは raw error への参照を持たない。
+ * 加えて Issue #437 対応で raw error message の外部漏洩も防ぐ。
+ */
+export const GMAIL_ERROR_PUBLIC_MESSAGES: Readonly<
+  Record<ProgressPdfDraftErrorCode, string>
+> = Object.freeze({
+  bad_request: "Bad request",
+  invalid_sections: "Invalid sections",
+  invalid_request_id: "Invalid requestId",
+  invalid_access_token: "Access token is invalid or expired",
+  access_token_owner_mismatch: "Access token owner does not match authenticated user",
+  no_sections_selected: "At least one section must be selected",
+  user_email_not_configured: "Student email is missing or invalid",
+  invalid_owner_email: "Tenant ownerEmail is invalid",
+  owner_email_not_set: "Tenant ownerEmail is not configured",
+  demo_tenant_not_supported: "Demo tenant is not supported",
+  invalid_tenant_id: "Invalid tenant ID",
+  invalid_user_id: "Invalid user ID",
+  tenant_not_found: "Tenant not found",
+  user_not_in_tenant: "User not found in the specified tenant",
+  pdf_too_large_for_gmail: "Generated PDF exceeds Gmail attachment limit",
+  pdf_generation_failed: "Failed to generate PDF",
+  gmail_scope_required: "Gmail compose scope is required (please re-authenticate)",
+  gmail_quota_exceeded: "Gmail API quota exceeded — please retry later",
+  gmail_api_error: "Gmail API error",
+  gmail_api_transient: "Gmail API is temporarily unavailable — please retry",
+});
+
 export class GmailDraftError extends Error {
   constructor(
+    /**
+     * 内部診断用 message (Error 標準フィールド)。
+     * Gmail API raw error message が含まれる可能性があるため、外部公開禁止。
+     */
     message: string,
     public errorCode: ProgressPdfDraftErrorCode,
     public httpStatus: number,
   ) {
     super(message);
     this.name = "GmailDraftError";
+  }
+
+  /**
+   * Issue #437: 外部公開用の固定文言 (PII フリー)。
+   * logger.error / HTTP レスポンスの `message` フィールドにはこちらを使う。
+   */
+  get publicMessage(): string {
+    return GMAIL_ERROR_PUBLIC_MESSAGES[this.errorCode] ?? "Gmail API error";
   }
 }
 


### PR DESCRIPTION
## Summary

Issue #437 (Codex review Medium 4): PR #434 (Issue #433) のセカンドオピニオンで検出された Phase 2 元実装 (PR #358) からの継承課題に対応。

### 旧実装の問題

Gmail API エラー (`GaxiosError`) から抽出した raw `message` を `GmailDraftError.message` に格納し、それを以下に流していた:
1. `logger.error` (Cloud Logging) で記録
2. HTTP レスポンスの `message` フィールドに含める

`response.data.error.message` の内容は Google 側で変動し、**宛先 email / MIME ヘッダ断片 / アカウント情報** を含むケースがある。LMS 文脈で個人情報を扱うため ismap 準拠の観点でも改善対象。

### 改修

1. **`gmail-draft.ts` に固定文言マップを追加**:
   - `GMAIL_ERROR_PUBLIC_MESSAGES: Record<ProgressPdfDraftErrorCode, string>` (PII フリー、固定文言)
2. **`GmailDraftError` に `publicMessage` getter を追加**:
   - `message` (内部診断用、Error 標準フィールド): raw Gmail API error 含む可能性 → **外部公開禁止**
   - `publicMessage` (外部公開用): 固定文言、PII フリー → logger / HTTP レスポンスにそのまま使用可
3. **route 層 (`progress-pdf-draft.ts`) を改修**:
   - tokeninfo failure: logger から `errorMessage` 撤去、`res.body.message` を `publicMessage` に
   - Gmail draft failure: 同上
   - logger は `errorCode` + `httpStatus` のみで運用追跡 (Cloud Logging の req/res telemetry で詳細は別途参照)
4. **ADR-034 改訂履歴に Issue #437 を追加** (§8 エラー分類)

## AC 充足

- [x] **AC-1**: Gmail API エラーレスポンスに raw email / MIME 断片が含まれても `publicMessage` に PII が含まれない
- [x] **AC-2**: `logger.error` 出力に raw message が含まれない (`errorCode` / `httpStatus` のみ)
- [x] **AC-3**: HTTP レスポンスの `message` も固定文言 (`errorCode` マッピング) のみ
- [x] **AC-4**: 既存テスト退行なし (エラー分類ロジック自体は変更しない、constructor シグネチャ保持)
- [x] **AC-5**: 単体テストで raw email を含むモックエラーを `classifyGmailError` に渡し、PII が出力されないことを検証

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `services/api/src/services/gmail-draft.ts` | `GMAIL_ERROR_PUBLIC_MESSAGES` + `GmailDraftError.publicMessage` getter |
| `services/api/src/routes/super/progress-pdf-draft.ts` | tokeninfo failure / Gmail draft failure の logger + res.body から raw message を撤去 |
| `docs/adr/ADR-034-phase2-gmail-draft.md` | 改訂履歴 + §8 |
| `services/api/src/services/__tests__/gmail-draft.test.ts` | ユニットテスト 5 件追加 |
| `services/api/src/__tests__/integration/progress-pdf-draft.test.ts` | 統合テスト 3 件追加 |

## Test plan

- [x] `npm run type-check` — 全 4 workspaces PASS
- [x] `npm run lint` — errors 0 (warning 1 件は既存 web 側、本 PR と無関係)
- [x] `npm run test -w @lms-279/api` — 1093 件 PASS (本 PR で +8 件追加)
  - [x] ユニット: publicMessage 固定文言 / 全 code PII フリー / raw email を classifyGmailError に通して publicMessage 検証 / scope 不足時 account info 漏洩なし / 不明 errorCode は fallback
  - [x] 統合: Gmail API failure / scope 不足 / tokeninfo failure 各経路で res.body.message が固定文言 + 元 raw に含まれる PII が消えていること
- [ ] マージ後の deploy → smoke (FE 経路で 201 維持、Gmail API failure 時の `message` が固定文言になっていること)

## 関連

- Issue #437 (本 PR でクローズ)
- PR #434 (Issue #433): 本 Issue 検出元
- PR #358 (Issue #346): Phase 2 元実装、課題の起源
- ADR-034 §8: 改訂済み

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)