### PR TITLE
feat(reliability): Firestore transient エラー用リトライ共通ユーティリティ + cleanupInProgressAttempts 適用 (#425)

### DIFF
--- a/services/api/src/services/lesson-session.ts
+++ b/services/api/src/services/lesson-session.ts
@@ -7,6 +7,7 @@ import type { DataSource } from "../datasource/interface.js";
 import type { LessonSession, Quiz, QuizAttempt, SessionExitReason } from "../types/entities.js";
 import { parsePositiveDurationMs } from "../utils/env-config.js";
 import { logger } from "../utils/logger.js";
+import { withTransientRetry } from "../utils/with-transient-retry.js";
 import { updateCourseProgress } from "./progress.js";
 
 // セッション制限時間（ミリ秒、正の整数）。env var SESSION_DURATION_MS で上書き可、デフォルト 2 時間、本番運用は 3 時間（10800000）。
@@ -109,7 +110,11 @@ async function cleanupInProgressAttempts(
 ): Promise<void> {
   let quiz: Quiz | null;
   try {
-    quiz = await ds.getQuizByLessonId(lessonId);
+    // Issue #425: transient Firestore エラー (UNAVAILABLE / DEADLINE_EXCEEDED 等) に対する
+    // 共通リトライ。permanent エラーは即 throw、transient は exponential backoff で最大 3 回試行。
+    quiz = await withTransientRetry(() => ds.getQuizByLessonId(lessonId), {
+      context: { operation: "cleanupInProgressAttempts.getQuizByLessonId", userId, lessonId },
+    });
   } catch (err) {
     logger.error("cleanupInProgressAttempts: failed to load quiz", {
       errorType: "cleanup_in_progress_attempts_quiz_load_failed",
@@ -132,7 +137,18 @@ async function cleanupInProgressAttempts(
 
   let attempts: QuizAttempt[];
   try {
-    attempts = await ds.getQuizAttempts({ quizId: quiz.id, userId });
+    // Issue #425: transient retry (上記 getQuizByLessonId と同じ方針)
+    attempts = await withTransientRetry(
+      () => ds.getQuizAttempts({ quizId: quiz!.id, userId }),
+      {
+        context: {
+          operation: "cleanupInProgressAttempts.getQuizAttempts",
+          userId,
+          lessonId,
+          quizId: quiz.id,
+        },
+      },
+    );
   } catch (err) {
     logger.error("cleanupInProgressAttempts: failed to load attempts", {
       errorType: "cleanup_in_progress_attempts_load_failed",
@@ -152,7 +168,19 @@ async function cleanupInProgressAttempts(
   for (const attempt of attempts) {
     if (attempt.status !== "in_progress") continue;
     try {
-      const result = await ds.transitionQuizAttemptToTimedOut(attempt.id);
+      // Issue #425: 個別 attempt の transition も transient retry。
+      // 部分救済優先 (1 件失敗でも全停止せず continue)。
+      const result = await withTransientRetry(
+        () => ds.transitionQuizAttemptToTimedOut(attempt.id),
+        {
+          context: {
+            operation: "cleanupInProgressAttempts.transitionQuizAttemptToTimedOut",
+            userId,
+            lessonId,
+            attemptId: attempt.id,
+          },
+        },
+      );
       if (result.transitioned) {
         cleaned++;
       } else {

--- a/services/api/src/utils/__tests__/with-transient-retry.test.ts
+++ b/services/api/src/utils/__tests__/with-transient-retry.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Issue #425: withTransientRetry の単体テスト。
+ *
+ * テスト観点 (AC-1 transient / permanent / max retries / 成功):
+ * - 初回成功時はリトライしない
+ * - transient エラー (UNAVAILABLE / DEADLINE_EXCEEDED / ABORTED / INTERNAL) でリトライ
+ * - permanent エラー (NOT_FOUND など) は即 throw
+ * - maxAttempts 超過で最後のエラーを throw
+ * - 数値形式 / 文字列形式の両方の grpc code を扱える
+ * - logger.warn が retry 毎に呼ばれる
+ * - context が logger payload に渡される
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { withTransientRetry } from "../with-transient-retry.js";
+import { logger } from "../logger.js";
+
+// 実時間 retry で baseDelayMs=1 を使い、テスト総時間を ~ms に抑える。
+// vi.useFakeTimers は Promise rejection の伝搬と timer 進行の組み合わせで
+// unhandled rejection を引き起こしやすいため避ける。
+const OPTS = { baseDelayMs: 1 } as const;
+
+describe("withTransientRetry (Issue #425)", () => {
+  let loggerWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    loggerWarnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    loggerWarnSpy.mockRestore();
+  });
+
+  it("AC-1 (成功): 初回で成功 → そのまま値を返す、retry なし、logger.warn なし", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+
+    const result = await withTransientRetry(fn, OPTS);
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("AC-1 (transient): UNAVAILABLE (code=14) で 2 回失敗後 3 回目で成功 → retry 2 回", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("unavail-1"), { code: 14 }))
+      .mockRejectedValueOnce(Object.assign(new Error("unavail-2"), { code: 14 }))
+      .mockResolvedValueOnce("success");
+
+    const result = await withTransientRetry(fn, OPTS);
+
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(2);
+    const firstWarnCall = loggerWarnSpy.mock.calls[0];
+    expect(firstWarnCall[0]).toBe("withTransientRetry: retrying");
+    const firstPayload = firstWarnCall[1] as Record<string, unknown>;
+    expect(firstPayload.errorType).toBe("transient_retry");
+    expect(firstPayload.attempt).toBe(1);
+    expect(firstPayload.grpcCode).toBe(14);
+  });
+
+  it("AC-1 (permanent): NOT_FOUND (code=5) は即 throw、retry なし", async () => {
+    const permanentErr = Object.assign(new Error("not found"), { code: 5 });
+    const fn = vi.fn().mockRejectedValue(permanentErr);
+
+    await expect(withTransientRetry(fn, OPTS)).rejects.toBe(permanentErr);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("AC-1 (max retries): transient で連続失敗 → maxAttempts 試行後に最後のエラーを throw", async () => {
+    const transientErrs = [
+      Object.assign(new Error("err-1"), { code: 14 }),
+      Object.assign(new Error("err-2"), { code: 14 }),
+      Object.assign(new Error("err-3-final"), { code: 14 }),
+    ];
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(transientErrs[0])
+      .mockRejectedValueOnce(transientErrs[1])
+      .mockRejectedValueOnce(transientErrs[2]);
+
+    await expect(withTransientRetry(fn, OPTS)).rejects.toBe(transientErrs[2]);
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("文字列形式の grpc code (例: 'unavailable') も transient として扱う", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("unavail-str"), { code: "unavailable" }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await withTransientRetry(fn, OPTS);
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("DEADLINE_EXCEEDED (code=4) / ABORTED (code=10) / INTERNAL (code=13) も transient", async () => {
+    for (const code of [4, 10, 13]) {
+      loggerWarnSpy.mockClear();
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(Object.assign(new Error(`code-${code}`), { code }))
+        .mockResolvedValueOnce(`ok-${code}`);
+
+      const result = await withTransientRetry(fn, OPTS);
+      expect(result).toBe(`ok-${code}`);
+      expect(fn).toHaveBeenCalledTimes(2);
+    }
+  });
+
+  it("maxAttempts オプションを指定すると試行回数が変わる", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("err-1"), { code: 14 }))
+      .mockRejectedValueOnce(Object.assign(new Error("err-2-final"), { code: 14 }));
+
+    await expect(
+      withTransientRetry(fn, { ...OPTS, maxAttempts: 2 }),
+    ).rejects.toMatchObject({ message: "err-2-final" });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("baseDelayMs オプションで待機時間を制御できる (exponential backoff: base * 2^attempt)", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("err-1"), { code: 14 }))
+      .mockRejectedValueOnce(Object.assign(new Error("err-2"), { code: 14 }))
+      .mockResolvedValueOnce("ok");
+
+    await withTransientRetry(fn, { baseDelayMs: 5 });
+
+    const warnCalls = loggerWarnSpy.mock.calls;
+    expect(warnCalls).toHaveLength(2);
+    // 1 回目 (attempt=0 → 1): base * 2^0 = 5ms
+    expect((warnCalls[0][1] as Record<string, unknown>).delay).toBe(5);
+    // 2 回目 (attempt=1 → 2): base * 2^1 = 10ms
+    expect((warnCalls[1][1] as Record<string, unknown>).delay).toBe(10);
+  });
+
+  it("context オプションが logger.warn payload に展開される (運用追跡用)", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("err"), { code: 14 }))
+      .mockResolvedValueOnce("ok");
+
+    await withTransientRetry(fn, {
+      ...OPTS,
+      context: { operation: "test_op", userId: "u1", tenantId: "t1" },
+    });
+
+    const payload = loggerWarnSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.operation).toBe("test_op");
+    expect(payload.userId).toBe("u1");
+    expect(payload.tenantId).toBe("t1");
+  });
+
+  it("code 不在のエラーは permanent 扱いで即 throw", async () => {
+    const errWithoutCode = new Error("no code");
+    const fn = vi.fn().mockRejectedValue(errWithoutCode);
+
+    await expect(withTransientRetry(fn, OPTS)).rejects.toBe(errWithoutCode);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/src/utils/__tests__/with-transient-retry.test.ts
+++ b/services/api/src/utils/__tests__/with-transient-retry.test.ts
@@ -168,4 +168,52 @@ describe("withTransientRetry (Issue #425)", () => {
     expect(fn).toHaveBeenCalledTimes(1);
     expect(loggerWarnSpy).not.toHaveBeenCalled();
   });
+
+  // Codex review (Medium 78) 対応: rules/error-handling.md §1
+  // ログ記録の失敗で復旧処理 (retry) が止まってはいけない。
+  it("Codex Medium 78: logger.warn が throw しても retry は継続する (ログ失敗 < 状態復旧)", async () => {
+    loggerWarnSpy.mockImplementation(() => {
+      throw new Error("logger pipeline broken");
+    });
+    // console.error は spy で抑制 (テストノイズ排除)
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("transient"), { code: 14 }))
+      .mockResolvedValueOnce("recovered");
+
+    try {
+      // logger.warn が throw しても fn の retry は実行され、最終的に "recovered" を返す
+      const result = await withTransientRetry(fn, OPTS);
+
+      expect(result).toBe("recovered");
+      expect(fn).toHaveBeenCalledTimes(2);
+      // logger.warn は呼ばれた (1 回、retry 直前) が throw して
+      expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+      // console.error にフォールバックされている
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  // Codex review (Low 74) 対応: 共通 util の入力検証
+  it("Codex Low 74: maxAttempts が不正値 (0 / 負数 / 非整数) → TypeError throw、fn は呼ばれない", async () => {
+    const fn = vi.fn();
+
+    await expect(withTransientRetry(fn, { maxAttempts: 0 })).rejects.toThrow(TypeError);
+    await expect(withTransientRetry(fn, { maxAttempts: -1 })).rejects.toThrow(TypeError);
+    await expect(withTransientRetry(fn, { maxAttempts: 1.5 })).rejects.toThrow(TypeError);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("Codex Low 74: baseDelayMs が不正値 (負数 / Infinity / NaN) → TypeError throw", async () => {
+    const fn = vi.fn();
+
+    await expect(withTransientRetry(fn, { baseDelayMs: -10 })).rejects.toThrow(TypeError);
+    await expect(withTransientRetry(fn, { baseDelayMs: Infinity })).rejects.toThrow(TypeError);
+    await expect(withTransientRetry(fn, { baseDelayMs: NaN })).rejects.toThrow(TypeError);
+    expect(fn).not.toHaveBeenCalled();
+  });
 });

--- a/services/api/src/utils/with-transient-retry.ts
+++ b/services/api/src/utils/with-transient-retry.ts
@@ -1,0 +1,68 @@
+/**
+ * Issue #425: Firestore (および Firebase Admin SDK) の transient エラーに対する
+ * 共通リトライユーティリティ。
+ *
+ * 設計方針:
+ * - transient/permanent の分類は `grpc-errors.ts:classifyFirestoreError` を再利用 (DRY)
+ * - exponential backoff (base * 2^attempt) で待機 (jitter なし、PR scope 内では単純化)
+ * - permanent エラーは即座に throw (retry しない)
+ * - rules/error-handling.md §3 「transient/permanent 分類」原則と整合
+ *
+ * 適用範囲:
+ * - lesson-session.ts cleanupInProgressAttempts (PR #423 follow-up)
+ * - その他 Firestore 呼び出しへの適用は段階的に別 PR で
+ */
+
+import { classifyFirestoreError } from "./grpc-errors.js";
+import { logger } from "./logger.js";
+
+export interface WithTransientRetryOptions {
+  /** 最大試行回数 (初回 + リトライ)。default 3。 */
+  maxAttempts?: number;
+  /** 初回 retry 待機時間 (ms)。default 100。指数的に baseDelayMs * 2^attempt で増加。 */
+  baseDelayMs?: number;
+  /** logger.warn に出す追加コンテキスト (tenantId / userId / operation 名等)。PII を含めない。 */
+  context?: Record<string, unknown>;
+}
+
+/**
+ * fn を実行し、transient エラーで失敗した場合に exponential backoff でリトライする。
+ *
+ * - 成功: そのまま値を返す
+ * - permanent エラー: 即座に throw (retry しない)
+ * - transient エラー: 最大 (maxAttempts - 1) 回 retry し、それでも失敗なら最後のエラーを throw
+ * - retry 毎に logger.warn で記録 (errorType=transient_retry)
+ */
+export async function withTransientRetry<T>(
+  fn: () => Promise<T>,
+  opts: WithTransientRetryOptions = {},
+): Promise<T> {
+  const maxAttempts = opts.maxAttempts ?? 3;
+  const baseDelayMs = opts.baseDelayMs ?? 100;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      const { grpcCode, isTransient } = classifyFirestoreError(err);
+      // permanent エラー or 最終試行 → 即 throw (retry しない)
+      if (!isTransient || attempt === maxAttempts - 1) {
+        throw err;
+      }
+      const delay = baseDelayMs * Math.pow(2, attempt);
+      logger.warn("withTransientRetry: retrying", {
+        errorType: "transient_retry",
+        attempt: attempt + 1,
+        maxAttempts,
+        delay,
+        grpcCode,
+        ...opts.context,
+      });
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  // unreachable (loop は throw か return で必ず抜ける) だが TypeScript 用に明示
+  throw lastError;
+}

--- a/services/api/src/utils/with-transient-retry.ts
+++ b/services/api/src/utils/with-transient-retry.ts
@@ -17,11 +17,15 @@ import { classifyFirestoreError } from "./grpc-errors.js";
 import { logger } from "./logger.js";
 
 export interface WithTransientRetryOptions {
-  /** 最大試行回数 (初回 + リトライ)。default 3。 */
+  /** 最大試行回数 (初回 + リトライ)。default 3。1 以上の整数。 */
   maxAttempts?: number;
-  /** 初回 retry 待機時間 (ms)。default 100。指数的に baseDelayMs * 2^attempt で増加。 */
+  /** 初回 retry 待機時間 (ms)。default 100。指数的に baseDelayMs * 2^attempt で増加。0 以上。 */
   baseDelayMs?: number;
-  /** logger.warn に出す追加コンテキスト (tenantId / userId / operation 名等)。PII を含めない。 */
+  /**
+   * logger.warn に出す追加コンテキスト (tenantId / userId / operation 名等)。
+   * 既存の `cleanupInProgressAttempts` 等の Cloud Logging 方針に合わせ、必要最小限の識別子のみ渡す
+   * (raw email / 個人氏名等の PII は含めない)。
+   */
   context?: Record<string, unknown>;
 }
 
@@ -39,6 +43,20 @@ export async function withTransientRetry<T>(
 ): Promise<T> {
   const maxAttempts = opts.maxAttempts ?? 3;
   const baseDelayMs = opts.baseDelayMs ?? 100;
+
+  // Codex review (Low 74) 対応: 共通 util として広く使われる前提で入力検証。
+  // 不正値で「fn が一度も呼ばれず undefined を throw」のサイレント失敗を防ぐ。
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new TypeError(
+      `withTransientRetry: maxAttempts must be a positive integer (got ${maxAttempts})`,
+    );
+  }
+  if (typeof baseDelayMs !== "number" || baseDelayMs < 0 || !Number.isFinite(baseDelayMs)) {
+    throw new TypeError(
+      `withTransientRetry: baseDelayMs must be a non-negative finite number (got ${baseDelayMs})`,
+    );
+  }
+
   let lastError: unknown;
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -52,14 +70,22 @@ export async function withTransientRetry<T>(
         throw err;
       }
       const delay = baseDelayMs * Math.pow(2, attempt);
-      logger.warn("withTransientRetry: retrying", {
-        errorType: "transient_retry",
-        attempt: attempt + 1,
-        maxAttempts,
-        delay,
-        grpcCode,
-        ...opts.context,
-      });
+      // Codex review (Medium 78) 対応: rules/error-handling.md §1「状態復旧 > ログ記録」原則に従い、
+      // logger.warn が throw (例: 循環参照付き context で JSON.stringify 失敗) しても retry 自体は継続する。
+      try {
+        logger.warn("withTransientRetry: retrying", {
+          errorType: "transient_retry",
+          attempt: attempt + 1,
+          maxAttempts,
+          delay,
+          grpcCode,
+          ...opts.context,
+        });
+      } catch (loggerErr) {
+        // logger 失敗時は console.error にだけ落とし、retry は止めない
+        // eslint-disable-next-line no-console
+        console.error("withTransientRetry: logger.warn failed (continuing retry):", loggerErr);
+      }
       await new Promise((r) => setTimeout(r, delay));
     }
   }


### PR DESCRIPTION
## Summary

Issue #425 (silent-failure-hunter I-2): PR #423 で追加された `cleanupInProgressAttempts` を含め、Firestore 呼び出しの transient エラー (UNAVAILABLE / DEADLINE_EXCEEDED 等) に対するリトライ機構が無く、1 回失敗で即諦める実装が散在していた。

## 実装

1. **`services/api/src/utils/with-transient-retry.ts` 新規追加**:
   - `withTransientRetry(fn, opts)` 共通リトライ util
   - transient/permanent 分類は既存 `classifyFirestoreError` (`utils/grpc-errors.ts`) を再利用 (DRY)
   - 数値形式 (code: 14) と文字列形式 (code: "unavailable") の両方の grpc code に対応
   - exponential backoff (base * 2^attempt)、default base=100ms / max 3 attempts
   - retry 毎に `logger.warn` (errorType=`transient_retry`) で記録
   - permanent エラーは即 throw (retry しない)
   - `context` オプションで logger payload に追加情報 (operation / userId / tenantId 等) を渡せる

2. **`lesson-session.ts cleanupInProgressAttempts`** の Firestore 呼び出し 3 箇所に適用:
   - `getQuizByLessonId`
   - `getQuizAttempts`
   - `transitionQuizAttemptToTimedOut` (各 attempt 毎、部分救済優先のため 1 件失敗でも continue)

3. 既存の `resetLessonDataForUser` (`firestore.ts:1561-1646`) の transaction レベルリトライはそのまま維持。本 util との統合は scope 外 (transaction 自体は別概念のため、AC-4 検討結果)。

## AC 充足

- [x] **AC-1**: `withTransientRetry` ユーティリティ実装 + 単体テスト 10 件 (transient / permanent / max retries / 成功 / 数値・文字列 code / DEADLINE_EXCEEDED・ABORTED・INTERNAL / maxAttempts / baseDelayMs / context / code 不在 = permanent)
- [x] **AC-2**: `cleanupInProgressAttempts` に適用 (3 箇所)
- [x] **AC-3**: `rules/error-handling.md` §3 (transient/permanent 分類) と整合 (`classifyFirestoreError` を再利用)
- [x] **AC-4**: `resetLessonDataForUser` との統合検討 → transaction レベルのリトライは別概念のため統合せず維持

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `services/api/src/utils/with-transient-retry.ts` | 新規 (共通リトライ util) |
| `services/api/src/utils/__tests__/with-transient-retry.test.ts` | 新規 (ユニットテスト 10 件) |
| `services/api/src/services/lesson-session.ts` | `cleanupInProgressAttempts` 3 箇所に `withTransientRetry` 適用 |

## Test plan

- [x] `npm run type-check` — 全 4 workspaces PASS
- [x] `npm run lint` — errors 0 (warning 1 件は既存 web 側、本 PR と無関係)
- [x] `npm run test -w @lms-279/api` — 1105 件 PASS (本 PR で +10 件追加)
- [ ] マージ後の deploy → smoke (`cleanupInProgressAttempts` 経由の transient エラー時に Cloud Logging に `errorType=transient_retry` が出ること)

## 関連

- Issue #425 (本 PR でクローズ)
- PR #423 (Issue #422): silent-failure-hunter I-2 検出元
- `rules/error-handling.md` §3: transient/permanent 分類原則
- `services/api/src/utils/grpc-errors.ts`: 既存 `classifyFirestoreError` を再利用

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)