### PR TITLE
fix(web): URL path の不可視文字を strip して 308 redirect + CopyButton 二重ガード (#456)

### DIFF
--- a/web/__tests__/middleware.test.ts
+++ b/web/__tests__/middleware.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { NextRequest } from "next/server";
-import { middleware } from "../middleware";
+import { middleware, config } from "../middleware";
 
 function makeReq(url: string): NextRequest {
   return new NextRequest(new Request(url));
@@ -12,8 +12,9 @@ describe("middleware: invisible char path sanitization", () => {
       makeReq("https://example.com/atali82i/student\u{FE0E}"),
     );
     expect(res.status).toBe(308);
-    const loc = res.headers.get("location");
-    expect(loc).toBe("https://example.com/atali82i/student");
+    expect(res.headers.get("location")).toBe(
+      "https://example.com/atali82i/student",
+    );
   });
 
   it("U+200B (ZWSP) を含む path も 308 redirect", () => {
@@ -28,7 +29,6 @@ describe("middleware: invisible char path sanitization", () => {
 
   it("クリーンな path は redirect せず素通り", () => {
     const res = middleware(makeReq("https://example.com/atali82i/student"));
-    // NextResponse.next() returns 200 with the x-middleware-next header
     expect(res.status).toBe(200);
     expect(res.headers.get("location")).toBeNull();
   });
@@ -36,5 +36,54 @@ describe("middleware: invisible char path sanitization", () => {
   it("ルート path はそのまま素通り", () => {
     const res = middleware(makeReq("https://example.com/"));
     expect(res.status).toBe(200);
+  });
+
+  it("encoded slash (%2F) を path separator に変えない", () => {
+    const res = middleware(
+      makeReq("https://example.com/courses/a%2Fb/student\u{FE0E}"),
+    );
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe(
+      "https://example.com/courses/a%2Fb/student",
+    );
+  });
+
+  it("空 segment (//) を保持する", () => {
+    const res = middleware(
+      makeReq("https://example.com/a//student\u{FE0E}"),
+    );
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe(
+      "https://example.com/a//student",
+    );
+  });
+
+  it("不正 percent sequence を含む path でも別 segment は救済", () => {
+    const res = middleware(
+      makeReq("https://example.com/%E0%A4%A/student%EF%B8%8E"),
+    );
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe(
+      "https://example.com/%E0%A4%A/student",
+    );
+  });
+
+  it("redirect 結果に再度不可視文字が含まれない (loop 防止)", () => {
+    const res = middleware(
+      makeReq("https://example.com/atali82i/student\u{FE0E}"),
+    );
+    const location = res.headers.get("location") ?? "";
+    expect(location.includes("%EF%B8%8E")).toBe(false);
+    expect(location.includes("\u{FE0E}")).toBe(false);
+  });
+});
+
+describe("middleware: matcher config", () => {
+  it("matcher が /api (trailing slash あり/なし) と static asset を除外する", () => {
+    const matcher = config.matcher[0];
+    expect(matcher).toContain("api(?:/|$)");
+    expect(matcher).toContain("_next/static");
+    expect(matcher).toContain("_next/image");
+    expect(matcher).toContain("favicon.ico");
   });
 });

--- a/web/__tests__/middleware.test.ts
+++ b/web/__tests__/middleware.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { middleware } from "../middleware";
+
+function makeReq(url: string): NextRequest {
+  return new NextRequest(new Request(url));
+}
+
+describe("middleware: invisible char path sanitization", () => {
+  it("末尾に U+FE0E が混入した path は 308 redirect する", () => {
+    const res = middleware(
+      makeReq("https://example.com/atali82i/student\u{FE0E}"),
+    );
+    expect(res.status).toBe(308);
+    const loc = res.headers.get("location");
+    expect(loc).toBe("https://example.com/atali82i/student");
+  });
+
+  it("U+200B (ZWSP) を含む path も 308 redirect", () => {
+    const res = middleware(
+      makeReq("https://example.com/atali\u{200B}82i/student"),
+    );
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe(
+      "https://example.com/atali82i/student",
+    );
+  });
+
+  it("クリーンな path は redirect せず素通り", () => {
+    const res = middleware(makeReq("https://example.com/atali82i/student"));
+    // NextResponse.next() returns 200 with the x-middleware-next header
+    expect(res.status).toBe(200);
+    expect(res.headers.get("location")).toBeNull();
+  });
+
+  it("ルート path はそのまま素通り", () => {
+    const res = middleware(makeReq("https://example.com/"));
+    expect(res.status).toBe(200);
+  });
+});

--- a/web/app/[tenant]/admin/page.tsx
+++ b/web/app/[tenant]/admin/page.tsx
@@ -4,16 +4,21 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useTenant } from "@/lib/tenant-context";
 import { Button } from "@/components/ui/button";
+import { stripInvisibleChars } from "@/lib/sanitize-path";
 
 /**
  * コピーボタンコンポーネント
+ *
+ * Issue #456: クリップボードに書き出す前に不可視文字 (variation selector 等) を除去。
+ * navigator.clipboard.writeText に渡すテキスト自体は元々クリーンだが、
+ * 上流での DOM 加工や retain-on-paste 系拡張に備えた二重ガード。
  */
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(text);
+      await navigator.clipboard.writeText(stripInvisibleChars(text));
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {

--- a/web/lib/__tests__/sanitize-path.test.ts
+++ b/web/lib/__tests__/sanitize-path.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   stripInvisibleChars,
   hasInvisibleChars,
-  sanitizePathForRedirect,
+  sanitizeEncodedPathnameForRedirect,
 } from "../sanitize-path";
 
 describe("stripInvisibleChars", () => {
@@ -82,25 +82,81 @@ describe("hasInvisibleChars", () => {
   });
 });
 
-describe("sanitizePathForRedirect", () => {
-  it("不可視文字を含む path は redirect 対象 + サニタイズ済を返す", () => {
-    expect(sanitizePathForRedirect("/atali82i/student︎")).toEqual({
+describe("sanitizeEncodedPathnameForRedirect", () => {
+  it("末尾 segment に encoded U+FE0E を含む path は redirect 対象", () => {
+    expect(
+      sanitizeEncodedPathnameForRedirect("/atali82i/student%EF%B8%8E"),
+    ).toEqual({
       needsRedirect: true,
       cleaned: "/atali82i/student",
     });
   });
 
-  it("クリーンな path は redirect 不要", () => {
-    expect(sanitizePathForRedirect("/atali82i/student")).toEqual({
+  it("encoded ZWSP (U+200B) を含む segment も redirect", () => {
+    expect(
+      sanitizeEncodedPathnameForRedirect("/atali%E2%80%8B82i/student"),
+    ).toEqual({
+      needsRedirect: true,
+      cleaned: "/atali82i/student",
+    });
+  });
+
+  it("クリーンな path は redirect 不要 (cleaned は original そのまま)", () => {
+    expect(sanitizeEncodedPathnameForRedirect("/atali82i/student")).toEqual({
       needsRedirect: false,
       cleaned: "/atali82i/student",
     });
   });
 
+  it("encoded slash (%2F) は path separator に変えない", () => {
+    expect(
+      sanitizeEncodedPathnameForRedirect("/courses/a%2Fb/student%EF%B8%8E"),
+    ).toEqual({
+      needsRedirect: true,
+      cleaned: "/courses/a%2Fb/student",
+    });
+  });
+
+  it("encoded slash のみの path はクリーン (segment が触られない)", () => {
+    expect(
+      sanitizeEncodedPathnameForRedirect("/courses/a%2Fb"),
+    ).toEqual({
+      needsRedirect: false,
+      cleaned: "/courses/a%2Fb",
+    });
+  });
+
+  it("空 segment (//) を保持する", () => {
+    expect(
+      sanitizeEncodedPathnameForRedirect("/a//student%EF%B8%8E"),
+    ).toEqual({
+      needsRedirect: true,
+      cleaned: "/a//student",
+    });
+  });
+
+  it("不正 percent sequence を含む segment はそのまま、別 segment は救済", () => {
+    expect(
+      sanitizeEncodedPathnameForRedirect("/%E0%A4%A/student%EF%B8%8E"),
+    ).toEqual({
+      needsRedirect: true,
+      cleaned: "/%E0%A4%A/student",
+    });
+  });
+
   it("ルート path はそのまま", () => {
-    expect(sanitizePathForRedirect("/")).toEqual({
+    expect(sanitizeEncodedPathnameForRedirect("/")).toEqual({
       needsRedirect: false,
       cleaned: "/",
+    });
+  });
+
+  it("日本語を含む encoded path はクリーン (除去対象なし)", () => {
+    expect(
+      sanitizeEncodedPathnameForRedirect("/%E5%8F%97%E8%AC%9B%E8%80%85"),
+    ).toEqual({
+      needsRedirect: false,
+      cleaned: "/%E5%8F%97%E8%AC%9B%E8%80%85",
     });
   });
 });

--- a/web/lib/__tests__/sanitize-path.test.ts
+++ b/web/lib/__tests__/sanitize-path.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  stripInvisibleChars,
+  hasInvisibleChars,
+  sanitizePathForRedirect,
+} from "../sanitize-path";
+
+describe("stripInvisibleChars", () => {
+  it("U+FE0E (VARIATION SELECTOR-15) を除去する", () => {
+    expect(stripInvisibleChars("student︎")).toBe("student");
+  });
+
+  it("U+FE0F (VARIATION SELECTOR-16) を除去する", () => {
+    expect(stripInvisibleChars("foo️bar")).toBe("foobar");
+  });
+
+  it("U+200B (ZWSP) を除去する", () => {
+    expect(stripInvisibleChars("foo​bar")).toBe("foobar");
+  });
+
+  it("U+FEFF (BOM) を除去する", () => {
+    expect(stripInvisibleChars("﻿hello")).toBe("hello");
+  });
+
+  it("U+00AD (soft hyphen) を除去する", () => {
+    expect(stripInvisibleChars("co­operate")).toBe("cooperate");
+  });
+
+  it("TAG character (U+E0061) を除去する", () => {
+    expect(stripInvisibleChars("test\u{E0061}")).toBe("test");
+  });
+
+  it("VARIATION SELECTOR Supplement (U+E0100) を除去する", () => {
+    expect(stripInvisibleChars("a\u{E0100}b")).toBe("ab");
+  });
+
+  it("bidi control (U+202E RLO) を除去する", () => {
+    expect(stripInvisibleChars("safe‮evil")).toBe("safeevil");
+  });
+
+  it("クリーンな ASCII path は変化させない", () => {
+    expect(stripInvisibleChars("/atali82i/student")).toBe("/atali82i/student");
+  });
+
+  it("日本語と通常絵文字は保持する", () => {
+    expect(stripInvisibleChars("こんにちは🎉")).toBe("こんにちは🎉");
+  });
+
+  it("改行・タブ・スペースは保持する", () => {
+    expect(stripInvisibleChars("a\nb\tc d")).toBe("a\nb\tc d");
+  });
+
+  it("複数の不可視文字を全て除去する", () => {
+    expect(stripInvisibleChars("﻿a​b︎c")).toBe("abc");
+  });
+
+  it("空文字は空文字のまま", () => {
+    expect(stripInvisibleChars("")).toBe("");
+  });
+
+  it("現場事象 (Issue #456) の再現: URL path 末尾 student に U+FE0E", () => {
+    const broken = "/atali82i/student︎";
+    expect(stripInvisibleChars(broken)).toBe("/atali82i/student");
+  });
+});
+
+describe("hasInvisibleChars", () => {
+  it("U+FE0E を含む場合 true", () => {
+    expect(hasInvisibleChars("student︎")).toBe(true);
+  });
+
+  it("クリーンな文字列の場合 false", () => {
+    expect(hasInvisibleChars("/atali82i/student")).toBe(false);
+  });
+
+  it("空文字の場合 false", () => {
+    expect(hasInvisibleChars("")).toBe(false);
+  });
+
+  it("日本語のみは false", () => {
+    expect(hasInvisibleChars("受講者")).toBe(false);
+  });
+});
+
+describe("sanitizePathForRedirect", () => {
+  it("不可視文字を含む path は redirect 対象 + サニタイズ済を返す", () => {
+    expect(sanitizePathForRedirect("/atali82i/student︎")).toEqual({
+      needsRedirect: true,
+      cleaned: "/atali82i/student",
+    });
+  });
+
+  it("クリーンな path は redirect 不要", () => {
+    expect(sanitizePathForRedirect("/atali82i/student")).toEqual({
+      needsRedirect: false,
+      cleaned: "/atali82i/student",
+    });
+  });
+
+  it("ルート path はそのまま", () => {
+    expect(sanitizePathForRedirect("/")).toEqual({
+      needsRedirect: false,
+      cleaned: "/",
+    });
+  });
+});

--- a/web/lib/__tests__/sanitize-path.test.ts
+++ b/web/lib/__tests__/sanitize-path.test.ts
@@ -82,6 +82,72 @@ describe("hasInvisibleChars", () => {
   });
 });
 
+describe("INVISIBLE_CHAR_PATTERN: 範囲端点境界値", () => {
+  it("U+200B (範囲下端) を除去", () => {
+    expect(stripInvisibleChars("a\u{200B}b")).toBe("ab");
+  });
+  it("U+200F (範囲上端) を除去", () => {
+    expect(stripInvisibleChars("a\u{200F}b")).toBe("ab");
+  });
+  it("U+2010 (範囲外 HYPHEN) は保持", () => {
+    expect(stripInvisibleChars("a\u{2010}b")).toBe("a\u{2010}b");
+  });
+  it("U+202A (範囲下端 LRE) を除去", () => {
+    expect(stripInvisibleChars("a\u{202A}b")).toBe("ab");
+  });
+  it("U+202E (範囲上端 RLO) を除去", () => {
+    expect(stripInvisibleChars("a\u{202E}b")).toBe("ab");
+  });
+  it("U+202F (範囲外 NARROW NO-BREAK SPACE) は保持", () => {
+    expect(stripInvisibleChars("a\u{202F}b")).toBe("a\u{202F}b");
+  });
+  it("U+2060 (範囲下端 WJ) を除去", () => {
+    expect(stripInvisibleChars("a\u{2060}b")).toBe("ab");
+  });
+  it("U+2064 (範囲上端) を除去", () => {
+    expect(stripInvisibleChars("a\u{2064}b")).toBe("ab");
+  });
+  it("U+2065 (ギャップ範囲外) は保持", () => {
+    expect(stripInvisibleChars("a\u{2065}b")).toBe("a\u{2065}b");
+  });
+  it("U+2066 (範囲下端 LRI) を除去", () => {
+    expect(stripInvisibleChars("a\u{2066}b")).toBe("ab");
+  });
+  it("U+206F (範囲上端) を除去", () => {
+    expect(stripInvisibleChars("a\u{206F}b")).toBe("ab");
+  });
+  it("U+FE00 (範囲下端 VS-1) を除去", () => {
+    expect(stripInvisibleChars("a\u{FE00}b")).toBe("ab");
+  });
+  it("U+FE10 (範囲外 CJK 句読点) は保持", () => {
+    expect(stripInvisibleChars("a\u{FE10}b")).toBe("a\u{FE10}b");
+  });
+  it("U+E0000 (TAG 範囲下端) を除去", () => {
+    expect(stripInvisibleChars("a\u{E0000}b")).toBe("ab");
+  });
+  it("U+E007F (TAG 範囲上端) を除去", () => {
+    expect(stripInvisibleChars("a\u{E007F}b")).toBe("ab");
+  });
+  it("U+E01EF (VS Supplement 範囲上端) を除去", () => {
+    expect(stripInvisibleChars("a\u{E01EF}b")).toBe("ab");
+  });
+});
+
+describe("除去対象外の保持 (否定テスト)", () => {
+  it("Arabic 文字 (U+0627) は保持", () => {
+    expect(stripInvisibleChars("a\u{0627}b")).toBe("a\u{0627}b");
+  });
+  it("Hebrew 文字 (U+05D0) は保持", () => {
+    expect(stripInvisibleChars("a\u{05D0}b")).toBe("a\u{05D0}b");
+  });
+  it("ASCII 制御文字 (U+0001) は保持 (現状仕様: 範囲外)", () => {
+    expect(stripInvisibleChars("a\u{0001}b")).toBe("a\u{0001}b");
+  });
+  it("ZWJ (U+200D) は除去対象 → 絵文字合字 (👨‍👩) は破壊される (現状仕様、URL path 用なので許容)", () => {
+    expect(stripInvisibleChars("👨\u{200D}👩")).toBe("👨👩");
+  });
+});
+
 describe("sanitizeEncodedPathnameForRedirect", () => {
   it("末尾 segment に encoded U+FE0E を含む path は redirect 対象", () => {
     expect(

--- a/web/lib/sanitize-path.ts
+++ b/web/lib/sanitize-path.ts
@@ -54,7 +54,17 @@ export function sanitizeEncodedPathnameForRedirect(pathname: string): {
       let decoded: string;
       try {
         decoded = decodeURIComponent(segment);
-      } catch {
+      } catch (err) {
+        // 期待例外: URIError (malformed percent sequence)。部分救済のため original を
+        // 返すが、observability のため warn を残す (Cloud Run logs に severity=WARNING で乗る)。
+        // segment 本体は PII / 攻撃 payload 拡散リスクで出力しない。
+        console.warn(
+          "[sanitize-path] decodeURIComponent failed for segment",
+          {
+            segmentLength: segment.length,
+            errorName: err instanceof Error ? err.name : "unknown",
+          },
+        );
         return segment;
       }
       const stripped = stripInvisibleChars(decoded);

--- a/web/lib/sanitize-path.ts
+++ b/web/lib/sanitize-path.ts
@@ -1,0 +1,52 @@
+/**
+ * URL path 等から、レンダリング上は不可視な文字 (variation selector / zero-width / TAG 等) を除去する。
+ *
+ * Issue #456: macOS / iOS の入力履歴経由で `student` 末尾に U+FE0E が紛れ込み 404 になる事象が発生。
+ * 対象範囲:
+ *   - U+00AD                  soft hyphen
+ *   - U+200B..U+200F          zero-width / LRM / RLM
+ *   - U+202A..U+202E          bidi control
+ *   - U+2060..U+2064          word joiner / invisible operators
+ *   - U+2066..U+206F          bidi isolates / deprecated formatting
+ *   - U+FE00..U+FE0F          variation selectors 1-16
+ *   - U+FEFF                  BOM / zero-width no-break space
+ *   - U+E0000..U+E007F        TAG characters (stego 対策)
+ *   - U+E0100..U+E01EF        variation selectors supplement
+ *
+ * 通常の絵文字 (U+1F300+) や CJK / 改行 / タブ等は除去対象外。
+ */
+// no-misleading-character-class は VARIATION SELECTOR (U+FE00..U+FE0F) を combining mark とみなして
+// 警告するが、本パターンは「単独で混入した VS を除去する」ことが目的で intentional。
+// 既存の合字を破壊する用途ではないため、disable して character class に含める。
+/* eslint-disable no-misleading-character-class */
+const INVISIBLE_CHAR_PATTERN = new RegExp(
+  "[" +
+    "\\u00AD" +
+    "\\u200B-\\u200F" +
+    "\\u202A-\\u202E" +
+    "\\u2060-\\u2064" +
+    "\\u2066-\\u206F" +
+    "\\uFE00-\\uFE0F" +
+    "\\uFEFF" +
+    "]" +
+    "|[\\u{E0000}-\\u{E007F}]" +
+    "|[\\u{E0100}-\\u{E01EF}]",
+  "gu",
+);
+/* eslint-enable no-misleading-character-class */
+
+export function stripInvisibleChars(input: string): string {
+  return input.replace(INVISIBLE_CHAR_PATTERN, "");
+}
+
+export function hasInvisibleChars(input: string): boolean {
+  return input !== stripInvisibleChars(input);
+}
+
+export function sanitizePathForRedirect(pathname: string): {
+  needsRedirect: boolean;
+  cleaned: string;
+} {
+  const cleaned = stripInvisibleChars(pathname);
+  return { needsRedirect: cleaned !== pathname, cleaned };
+}

--- a/web/lib/sanitize-path.ts
+++ b/web/lib/sanitize-path.ts
@@ -1,36 +1,27 @@
 /**
  * URL path 等から、レンダリング上は不可視な文字 (variation selector / zero-width / TAG 等) を除去する。
  *
- * Issue #456: macOS / iOS の入力履歴経由で `student` 末尾に U+FE0E が紛れ込み 404 になる事象が発生。
- * 対象範囲:
- *   - U+00AD                  soft hyphen
- *   - U+200B..U+200F          zero-width / LRM / RLM
- *   - U+202A..U+202E          bidi control
- *   - U+2060..U+2064          word joiner / invisible operators
- *   - U+2066..U+206F          bidi isolates / deprecated formatting
- *   - U+FE00..U+FE0F          variation selectors 1-16
- *   - U+FEFF                  BOM / zero-width no-break space
- *   - U+E0000..U+E007F        TAG characters (stego 対策)
- *   - U+E0100..U+E01EF        variation selectors supplement
- *
- * 通常の絵文字 (U+1F300+) や CJK / 改行 / タブ等は除去対象外。
+ * Issue #456: macOS / iOS の入力履歴経由で `student` 末尾に U+FE0E が紛れ込み 404 になる事象。
+ * 各範囲の意図は INVISIBLE_CHAR_PATTERN 内のインラインコメントを参照。
+ * 通常絵文字 (U+1F300+) / CJK / 改行 / タブ / スペース は除去対象外。
  */
+
 // no-misleading-character-class は VARIATION SELECTOR (U+FE00..U+FE0F) を combining mark とみなして
 // 警告するが、本パターンは「単独で混入した VS を除去する」ことが目的で intentional。
 // 既存の合字を破壊する用途ではないため、disable して character class に含める。
 /* eslint-disable no-misleading-character-class */
 const INVISIBLE_CHAR_PATTERN = new RegExp(
   "[" +
-    "\\u00AD" +
-    "\\u200B-\\u200F" +
-    "\\u202A-\\u202E" +
-    "\\u2060-\\u2064" +
-    "\\u2066-\\u206F" +
-    "\\uFE00-\\uFE0F" +
-    "\\uFEFF" +
+    "\\u00AD" + // soft hyphen
+    "\\u200B-\\u200F" + // zero-width / LRM / RLM
+    "\\u202A-\\u202E" + // bidi control (RLO による見せかけ攻撃)
+    "\\u2060-\\u2064" + // word joiner / invisible operators
+    "\\u2066-\\u206F" + // bidi isolates / deprecated formatting
+    "\\uFE00-\\uFE0F" + // variation selectors 1-16 (Issue #456 の U+FE0E)
+    "\\uFEFF" + // BOM / zero-width no-break space
     "]" +
-    "|[\\u{E0000}-\\u{E007F}]" +
-    "|[\\u{E0100}-\\u{E01EF}]",
+    "|[\\u{E0000}-\\u{E007F}]" + // TAG characters (stego 対策)
+    "|[\\u{E0100}-\\u{E01EF}]", // variation selectors supplement
   "gu",
 );
 /* eslint-enable no-misleading-character-class */
@@ -43,10 +34,34 @@ export function hasInvisibleChars(input: string): boolean {
   return input !== stripInvisibleChars(input);
 }
 
-export function sanitizePathForRedirect(pathname: string): {
+/**
+ * URL pathname (percent-encoded) を segment 単位で decode → 不可視文字除去 → re-encode する。
+ *
+ * 経路上の URL コンストラクタ (WHATWG URL / Next.js NextRequest) は不可視文字を percent-encode するため、
+ * middleware に届く pathname は ASCII 化されている。素朴に全体 decode すると encoded path separator
+ * (`%2F`) が真の `/` に化けて別 route に redirect される不可逆変換が起きるため、segment 単位で処理する。
+ *
+ * - 不正な percent sequence を含む segment はそのまま (decode 失敗を救済漏れに繋げず部分救済)
+ * - 除去対象の不可視文字を含まない segment は original (再 encode 形式の揺れを避ける)
+ */
+export function sanitizeEncodedPathnameForRedirect(pathname: string): {
   needsRedirect: boolean;
   cleaned: string;
 } {
-  const cleaned = stripInvisibleChars(pathname);
+  const cleaned = pathname
+    .split("/")
+    .map((segment) => {
+      let decoded: string;
+      try {
+        decoded = decodeURIComponent(segment);
+      } catch {
+        return segment;
+      }
+      const stripped = stripInvisibleChars(decoded);
+      if (stripped === decoded) return segment;
+      return encodeURIComponent(stripped);
+    })
+    .join("/");
+
   return { needsRedirect: cleaned !== pathname, cleaned };
 }

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,36 +1,26 @@
 import { NextRequest, NextResponse } from "next/server";
-import { sanitizePathForRedirect } from "@/lib/sanitize-path";
+import { sanitizeEncodedPathnameForRedirect } from "@/lib/sanitize-path";
 
 /**
  * Issue #456: URL パスに混入した不可視文字 (U+FE0E 等) を除去して 308 redirect する。
  *
- * 経路上の URL コンストラクタが不可視文字を percent-encode するため、
- * middleware に届く pathname は ASCII 化されている。decode → sanitize → encode の
- * パイプラインで Unicode レベルの検出と除去を行う。
+ * Next.js は req.nextUrl.pathname を percent-encoded で受け取る (WHATWG URL 準拠)。
+ * segment 単位で decode → sanitize → re-encode することで、encoded path separator (`%2F`)
+ * を path separator に化けさせず、不正 percent sequence を含む segment があっても部分救済する。
+ * 検出対象は __tests__/middleware.test.ts のケース参照。
  */
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
-
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(pathname);
-  } catch {
-    return NextResponse.next();
-  }
-
-  const { needsRedirect, cleaned } = sanitizePathForRedirect(decoded);
+  const { needsRedirect, cleaned } = sanitizeEncodedPathnameForRedirect(pathname);
   if (!needsRedirect) {
     return NextResponse.next();
   }
-
   const url = req.nextUrl.clone();
-  url.pathname = cleaned
-    .split("/")
-    .map((seg) => encodeURIComponent(seg))
-    .join("/");
+  url.pathname = cleaned;
   return NextResponse.redirect(url, 308);
 }
 
+// matcher: static asset と /api 以下を除外。`api(?:/|$)` で `/api` 自体も除外。
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|api/).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|api(?:/|$)).*)"],
 };

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -8,16 +8,27 @@ import { sanitizeEncodedPathnameForRedirect } from "@/lib/sanitize-path";
  * segment 単位で decode → sanitize → re-encode することで、encoded path separator (`%2F`)
  * を path separator に化けさせず、不正 percent sequence を含む segment があっても部分救済する。
  * 検出対象は __tests__/middleware.test.ts のケース参照。
+ *
+ * 全体 try/catch は防御措置: middleware が throw すると Next.js は 500 を返し全 route 崩壊するため、
+ * sanitize 失敗時は元 path で続行 (後続 route が 404 を返す方が「画面真っ白」より許容できる)。
  */
 export function middleware(req: NextRequest) {
-  const { pathname } = req.nextUrl;
-  const { needsRedirect, cleaned } = sanitizeEncodedPathnameForRedirect(pathname);
-  if (!needsRedirect) {
+  try {
+    const { pathname } = req.nextUrl;
+    const { needsRedirect, cleaned } =
+      sanitizeEncodedPathnameForRedirect(pathname);
+    if (!needsRedirect) {
+      return NextResponse.next();
+    }
+    const url = req.nextUrl.clone();
+    url.pathname = cleaned;
+    return NextResponse.redirect(url, 308);
+  } catch (err) {
+    console.error("[middleware] sanitization failed, passing through", {
+      errorName: err instanceof Error ? err.name : "unknown",
+    });
     return NextResponse.next();
   }
-  const url = req.nextUrl.clone();
-  url.pathname = cleaned;
-  return NextResponse.redirect(url, 308);
 }
 
 // matcher: static asset と /api 以下を除外。`api(?:/|$)` で `/api` 自体も除外。

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sanitizePathForRedirect } from "@/lib/sanitize-path";
+
+/**
+ * Issue #456: URL パスに混入した不可視文字 (U+FE0E 等) を除去して 308 redirect する。
+ *
+ * 経路上の URL コンストラクタが不可視文字を percent-encode するため、
+ * middleware に届く pathname は ASCII 化されている。decode → sanitize → encode の
+ * パイプラインで Unicode レベルの検出と除去を行う。
+ */
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    return NextResponse.next();
+  }
+
+  const { needsRedirect, cleaned } = sanitizePathForRedirect(decoded);
+  if (!needsRedirect) {
+    return NextResponse.next();
+  }
+
+  const url = req.nextUrl.clone();
+  url.pathname = cleaned
+    .split("/")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+  return NextResponse.redirect(url, 308);
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|api/).*)"],
+};


### PR DESCRIPTION
Closes #456

## Summary
- 管理ダッシュボードの「受講者向けリンク」コピーボタン経由で取得した URL の末尾に **U+FE0E (VARIATION SELECTOR-15)** が混入し受講者が 404 になる現場事象 (福の種 株式会社様③ 受講生 2 名ログイン不可) への対応
- 原因は macOS/iOS の入力履歴経由のクリップボードペースト時の OS/IME 由来 (Gemini 解析と一致)。コード側にリテラル不可視文字は無く repo 全体 grep ゼロヒット
- 対策 A + B 併用で合意済 (Issue #456)

## 変更内容

### A) Next.js middleware で URL path の不可視文字を strip → 308 redirect (恒久救済)
- `web/middleware.ts` 新設
- 受信 path を `decodeURIComponent` → 不可視文字除去 → `encodeURIComponent` の順で処理
- 既に共有されてしまった壊れた URL も自動的に正しい path にリダイレクト

### B) CopyButton で `navigator.clipboard.writeText` 前にサニタイズ (二重ガード)
- `web/app/[tenant]/admin/page.tsx` の `CopyButton` 改修
- 元々渡すテキストはクリーンだが、上流 DOM 加工 / Clipboard 改変系拡張に備えた防御

### 共通ユーティリティ
- `web/lib/sanitize-path.ts` 新設
- 除去対象 (合意済):
  - `U+00AD` soft hyphen
  - `U+200B..U+200F` zero-width / LRM / RLM
  - `U+202A..U+202E` bidi control (RLO 等の見せかけ攻撃にも有効)
  - `U+2060..U+2064` word joiner / invisible operators
  - `U+2066..U+206F` bidi isolates / deprecated formatting
  - `U+FE00..U+FE0F` variation selectors 1-16 ← **今回の U+FE0E**
  - `U+FEFF` BOM / zero-width no-break space
  - `U+E0000..U+E007F` TAG characters (stego 対策)
  - `U+E0100..U+E01EF` variation selectors supplement

通常絵文字 (U+1F300+) や CJK / 改行・タブ・スペースは保持。

## Acceptance Criteria
- [x] `https://web-*.run.app/atali82i/student︎` (U+FE0E 付) が 404 にならず `/atali82i/student` に 308 redirect される
- [x] CopyButton の出力テキストに不可視文字が含まれない
- [x] sanitize util の単体テスト全 PASS (U+FE0E / U+200B / U+FEFF / U+00AD / TAG / VS Supplement / RLO / 正常 ASCII / 日本語 / 絵文字)
- [x] middleware の単体テスト全 PASS (U+FE0E path / U+200B path / クリーン path / ルート)
- [x] 既存テスト回帰なし (108 → 112)
- [x] type-check / lint clean

## Test plan
- [x] `npm run test` (web) — 112 PASS (sanitize-path 21 + middleware 4 + 既存 87)
- [x] `npm run type-check` — エラーなし
- [x] `npx eslint` (変更ファイル) — エラーなし
- [ ] 本番デプロイ後、現場テナント (atali82i) で受講者ログイン経路の動作確認 — マージ後

## デプロイ後の現場対応
本 PR マージ + デプロイ完了後、福の種 株式会社様③ の受講生 2 名は **元の壊れた URL (末尾 U+FE0E 付) のままでも middleware が自動的に正しい URL に redirect** するためログイン可能になります。再共有不要。

## 関連 Issue
- Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)