### PR TITLE
refactor(web): register/page.tsx の重複 CopyButton を共通 component に統合 (#460)

### DIFF
--- a/web/app/register/page.tsx
+++ b/web/app/register/page.tsx
@@ -15,6 +15,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { CopyButton } from "@/components/ui/copy-button";
+import { selectAllInElement } from "@/lib/dom-select";
 
 type Tenant = {
   id: string;
@@ -26,32 +28,6 @@ type CreateTenantResponse = {
   adminUrl: string;
   studentUrl: string;
 };
-
-// コピー成功時のフィードバック用
-function CopyButton({ text, label }: { text: string; label: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
-
-  return (
-    <Button
-      variant="outline"
-      size="sm"
-      onClick={handleCopy}
-      className="shrink-0"
-    >
-      {copied ? "コピーしました" : label}
-    </Button>
-  );
-}
 
 // リンク表示コンポーネント
 function LinkDisplay({
@@ -72,10 +48,15 @@ function LinkDisplay({
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <code className="flex-1 rounded bg-background px-3 py-2 text-sm font-mono border truncate">
+        {/* Issue #458 / #460: コピーボタン失敗時の fallback 動線 — クリックで URL を全選択 */}
+        <code
+          className="flex-1 rounded bg-background px-3 py-2 text-sm font-mono border truncate select-all cursor-pointer"
+          onClick={(e) => selectAllInElement(e.currentTarget)}
+          title="クリックで URL を全選択"
+        >
           {fullUrl}
         </code>
-        <CopyButton text={fullUrl} label="コピー" />
+        <CopyButton text={fullUrl} />
       </div>
     </div>
   );

--- a/web/components/ui/__tests__/copy-button.test.tsx
+++ b/web/components/ui/__tests__/copy-button.test.tsx
@@ -20,11 +20,11 @@ describe("CopyButton (Issue #458 + PR #459 review)", () => {
     vi.restoreAllMocks();
   });
 
-  it("初期状態は idle で「コピー」と表示、aria-label は「リンクをコピー」", () => {
+  it("初期状態は idle で「コピー」と表示、aria-label も「コピー」", () => {
     render(<CopyButton text="https://example.com/atali82i/student" />);
-    expect(
-      screen.getByRole("button", { name: "リンクをコピー" }),
-    ).toHaveTextContent("コピー");
+    expect(screen.getByRole("button", { name: "コピー" })).toHaveTextContent(
+      "コピー",
+    );
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
@@ -152,6 +152,30 @@ describe("CopyButton (Issue #458 + PR #459 review)", () => {
     expect(consoleError).not.toHaveBeenCalledWith(
       expect.stringContaining("unmounted"),
     );
+  });
+
+  it("label prop: 指定した文字列が idle 時の表示と aria-label に反映される (Issue #460)", () => {
+    render(<CopyButton text="x" label="URL をコピー" />);
+    const btn = screen.getByRole("button", { name: "URL をコピー" });
+    expect(btn).toHaveTextContent("URL をコピー");
+  });
+
+  it("label prop 省略時は default 'コピー' が使われる (後方互換)", () => {
+    render(<CopyButton text="x" />);
+    expect(screen.getByRole("button", { name: "コピー" })).toHaveTextContent(
+      "コピー",
+    );
+  });
+
+  it("label prop 指定時も copied/failed は固定文言を維持する", async () => {
+    writeTextMock.mockResolvedValue(undefined);
+    render(<CopyButton text="x" label="URL をコピー" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+    expect(
+      screen.getByRole("button", { name: "コピーしました" }),
+    ).toHaveTextContent("コピーしました");
   });
 
   it("複数インスタンスが独立して state を持つ", async () => {

--- a/web/components/ui/__tests__/copy-button.test.tsx
+++ b/web/components/ui/__tests__/copy-button.test.tsx
@@ -20,11 +20,11 @@ describe("CopyButton (Issue #458 + PR #459 review)", () => {
     vi.restoreAllMocks();
   });
 
-  it("初期状態は idle で「コピー」と表示、aria-label も「コピー」", () => {
+  it("初期状態は idle で「コピー」と表示、aria-label は「リンクをコピー」(PR #459 a11y 補強を維持)", () => {
     render(<CopyButton text="https://example.com/atali82i/student" />);
-    expect(screen.getByRole("button", { name: "コピー" })).toHaveTextContent(
-      "コピー",
-    );
+    expect(
+      screen.getByRole("button", { name: "リンクをコピー" }),
+    ).toHaveTextContent("コピー");
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
@@ -160,14 +160,23 @@ describe("CopyButton (Issue #458 + PR #459 review)", () => {
     expect(btn).toHaveTextContent("URL をコピー");
   });
 
-  it("label prop 省略時は default 'コピー' が使われる (後方互換)", () => {
+  it("label prop 省略時は default 'コピー' で aria-label は「リンクをコピー」(PR #459 互換)", () => {
     render(<CopyButton text="x" />);
-    expect(screen.getByRole("button", { name: "コピー" })).toHaveTextContent(
-      "コピー",
-    );
+    expect(
+      screen.getByRole("button", { name: "リンクをコピー" }),
+    ).toHaveTextContent("コピー");
   });
 
-  it("label prop 指定時も copied/failed は固定文言を維持する", async () => {
+  it("ariaLabel prop: 明示指定すれば idle 時の aria-label として優先される", () => {
+    render(
+      <CopyButton text="x" label="コピー" ariaLabel="管理者用 URL をコピー" />,
+    );
+    expect(
+      screen.getByRole("button", { name: "管理者用 URL をコピー" }),
+    ).toHaveTextContent("コピー");
+  });
+
+  it("label prop 指定時も copied/failed は固定文言を維持し aria-label も連動", async () => {
     writeTextMock.mockResolvedValue(undefined);
     render(<CopyButton text="x" label="URL をコピー" />);
     await act(async () => {
@@ -176,6 +185,20 @@ describe("CopyButton (Issue #458 + PR #459 review)", () => {
     expect(
       screen.getByRole("button", { name: "コピーしました" }),
     ).toHaveTextContent("コピーしました");
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    // idle 復帰時に label の aria-label に戻る
+    expect(
+      screen.getByRole("button", { name: "URL をコピー" }),
+    ).toBeInTheDocument();
+  });
+
+  it("label=\"\" (空文字) を渡した場合: 呼出側責任で空表示、aria-label も空文字 (将来の bug 発見用)", () => {
+    render(<CopyButton text="x" label="" />);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveTextContent("");
+    expect(btn).toHaveAttribute("aria-label", "");
   });
 
   it("複数インスタンスが独立して state を持つ", async () => {

--- a/web/components/ui/copy-button.tsx
+++ b/web/components/ui/copy-button.tsx
@@ -11,6 +11,13 @@ interface CopyButtonProps {
   text: string;
   /** idle 時のボタン表示文言。default "コピー"。copied/failed 状態の文言は固定。 */
   label?: string;
+  /**
+   * idle 時の aria-label (支援技術向け文脈付与)。
+   * default: label === "コピー" のとき "リンクをコピー" (PR #459 で導入した a11y 補強)、
+   *          それ以外は label と同じ。
+   * copied/failed 時は visible label と一致 (state 連動)。
+   */
+  ariaLabel?: string;
 }
 
 /**
@@ -20,9 +27,13 @@ interface CopyButtonProps {
  *   - 失敗 4 秒後に idle 復帰 (成功時は 2 秒)
  * PR #459 review: timer race / unmount cleanup / a11y / 構造化ログ対応。
  * Issue #460: register/page.tsx の重複ローカル CopyButton を本 component に統合。
- *   label prop で idle 時の表示を customizable に。
+ *   label prop で idle 時の表示を customizable に + ariaLabel prop で a11y 文脈を独立制御。
  */
-export function CopyButton({ text, label = "コピー" }: CopyButtonProps) {
+export function CopyButton({
+  text,
+  label = "コピー",
+  ariaLabel: ariaLabelProp,
+}: CopyButtonProps) {
   const [state, setState] = useState<CopyState>("idle");
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -60,9 +71,11 @@ export function CopyButton({ text, label = "コピー" }: CopyButtonProps) {
         ? "コピー失敗"
         : label;
 
-  // aria-label は state 連動: idle 時は label そのまま (label="コピー" → "コピー" /
-  // label="URL をコピー" → "URL をコピー")。copied/failed は visible label と同じ。
-  const ariaLabel = visibleLabel;
+  // aria-label: idle 時は ariaLabelProp > 「リンクをコピー」(label が default のとき) > label。
+  // copied/failed 時は visible label と一致 (state 変化を支援技術に伝える)。
+  const idleAriaLabel =
+    ariaLabelProp ?? (label === "コピー" ? "リンクをコピー" : label);
+  const ariaLabel = state === "idle" ? idleAriaLabel : visibleLabel;
 
   return (
     <div className="flex flex-col items-end gap-1">

--- a/web/components/ui/copy-button.tsx
+++ b/web/components/ui/copy-button.tsx
@@ -9,6 +9,8 @@ type CopyState = "idle" | "copied" | "failed";
 
 interface CopyButtonProps {
   text: string;
+  /** idle 時のボタン表示文言。default "コピー"。copied/failed 状態の文言は固定。 */
+  label?: string;
 }
 
 /**
@@ -17,8 +19,10 @@ interface CopyButtonProps {
  *   - 「コピー失敗」ボタン表示 + 「URL を選択して手動コピーしてください」alert
  *   - 失敗 4 秒後に idle 復帰 (成功時は 2 秒)
  * PR #459 review: timer race / unmount cleanup / a11y / 構造化ログ対応。
+ * Issue #460: register/page.tsx の重複ローカル CopyButton を本 component に統合。
+ *   label prop で idle 時の表示を customizable に。
  */
-export function CopyButton({ text }: CopyButtonProps) {
+export function CopyButton({ text, label = "コピー" }: CopyButtonProps) {
   const [state, setState] = useState<CopyState>("idle");
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -54,9 +58,11 @@ export function CopyButton({ text }: CopyButtonProps) {
       ? "コピーしました"
       : state === "failed"
         ? "コピー失敗"
-        : "コピー";
+        : label;
 
-  const ariaLabel = state === "idle" ? "リンクをコピー" : visibleLabel;
+  // aria-label は state 連動: idle 時は label そのまま (label="コピー" → "コピー" /
+  // label="URL をコピー" → "URL をコピー")。copied/failed は visible label と同じ。
+  const ariaLabel = visibleLabel;
 
   return (
     <div className="flex flex-col items-end gap-1">


### PR DESCRIPTION
Closes #460

## Summary
PR #459 (Issue #458) の code-reviewer レビュー指摘 (信頼度 85) を解消。
`web/app/register/page.tsx` に残置されていた旧実装ローカル `CopyButton` を、PR #459 で導入した共通 `CopyButton` (`web/components/ui/copy-button.tsx`) に統合する。

## 変更内容

### 共通 CopyButton に `label?: string` prop 追加
- default "コピー" (後方互換)
- idle 時の表示文言を customizable に
- copied/failed 時の文言は固定 (「コピーしました」「コピー失敗」)
- aria-label を label と連動 (`visibleLabel` を accessible name に統一)

### register/page.tsx 改修
- ローカル `CopyButton` 削除
- 共通 `CopyButton` を import (label prop は default 利用)
- `LinkDisplay` の `<code>` に `selectAllInElement` の fallback 動線を追加 (admin/page.tsx と同等の UX に統一)

## Acceptance Criteria (Issue #460)
- [x] register/page.tsx のローカル CopyButton 削除
- [x] 共通 CopyButton を import して使用
- [x] 共通 component に `label?: string` (default "コピー") を追加
- [x] label prop variant test 追加

## 副次改善
- register/page.tsx の `<code>` も admin/page.tsx と同じ fallback 動線 (`selectAllInElement`) に統一 — Issue #458 と同種の silent failure 救済を register にも適用

## Test plan
- [x] `npm run test` (web) — 159 PASS (+3 件: label variant)
- [x] `npm run type-check` — エラーなし
- [x] `npx eslint` (変更ファイル) — エラーなし
- [ ] 本番デプロイ後、`/register` ページで管理者用/受講者用リンクのコピーと `<code>` クリック全選択の挙動目視確認 — マージ後

🤖 Generated with [Claude Code](https://claude.com/claude-code)