### PR TITLE
feat(dispatch): Phase 3 (Mail template + Gmail DWD send) を TDD で追加

### DIFF
--- a/services/api/src/services/dispatch/__tests__/completion-notification-mail.test.ts
+++ b/services/api/src/services/dispatch/__tests__/completion-notification-mail.test.ts
@@ -1,0 +1,198 @@
+/**
+ * completion-notification-mail の単体テスト。
+ *
+ * 設計仕様書 §7.1 / FR-5 改訂 / AC-5 / Phase 3 完了条件:
+ *   - 完了通知本文が completionMessageBody + signatureName を含む
+ *
+ * 観点:
+ *   - 件名は固定 DEFAULT_COMPLETION_SUBJECT
+ *   - userName あり → 「{name} 様」宛名、空/null/undefined → 「受講者各位」フォールバック
+ *   - completionMessageBody が本文に含まれる
+ *   - signatureName が末尾に挿入される (区切り `---` 付き)
+ *   - signatureName 空文字なら署名 block を出さない
+ *   - userName / subject に CR/LF があれば throw (header injection 防御)
+ *   - body 内 CR/LF は許容 (base64 エンコードされるため安全)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildCompletionMail,
+  DEFAULT_COMPLETION_SUBJECT,
+} from "../completion-notification-mail.js";
+
+const DEFAULT_BODY = "受講お疲れ様でした。全受講修了致しました。";
+const DEFAULT_SIG = "DXcollege運営スタッフ";
+
+describe("DEFAULT_COMPLETION_SUBJECT", () => {
+  it("固定文字列で CR/LF を含まない", () => {
+    expect(DEFAULT_COMPLETION_SUBJECT).toBe("【DXcollege】受講修了のお知らせ");
+    expect(DEFAULT_COMPLETION_SUBJECT).not.toMatch(/[\r\n]/);
+  });
+});
+
+describe("buildCompletionMail", () => {
+  describe("件名", () => {
+    it("常に DEFAULT_COMPLETION_SUBJECT を返す", () => {
+      const result = buildCompletionMail({
+        userName: "山田太郎",
+        completionMessageBody: DEFAULT_BODY,
+        signatureName: DEFAULT_SIG,
+      });
+      expect(result.subject).toBe(DEFAULT_COMPLETION_SUBJECT);
+    });
+  });
+
+  describe("宛名 (userName)", () => {
+    it("userName あり → 「{name} 様」", () => {
+      const result = buildCompletionMail({
+        userName: "山田太郎",
+        completionMessageBody: DEFAULT_BODY,
+        signatureName: DEFAULT_SIG,
+      });
+      expect(result.body.startsWith("山田太郎 様")).toBe(true);
+    });
+
+    it("userName 空文字 → 「受講者各位」フォールバック", () => {
+      const result = buildCompletionMail({
+        userName: "",
+        completionMessageBody: DEFAULT_BODY,
+        signatureName: DEFAULT_SIG,
+      });
+      expect(result.body.startsWith("受講者各位")).toBe(true);
+    });
+
+    it("userName null → 「受講者各位」フォールバック", () => {
+      const result = buildCompletionMail({
+        userName: null,
+        completionMessageBody: DEFAULT_BODY,
+        signatureName: DEFAULT_SIG,
+      });
+      expect(result.body.startsWith("受講者各位")).toBe(true);
+    });
+
+    it("userName undefined → 「受講者各位」フォールバック", () => {
+      const result = buildCompletionMail({
+        userName: undefined,
+        completionMessageBody: DEFAULT_BODY,
+        signatureName: DEFAULT_SIG,
+      });
+      expect(result.body.startsWith("受講者各位")).toBe(true);
+    });
+
+    it("userName 前後空白 → trim 後の名前で宛名", () => {
+      const result = buildCompletionMail({
+        userName: "  山田太郎  ",
+        completionMessageBody: DEFAULT_BODY,
+        signatureName: DEFAULT_SIG,
+      });
+      expect(result.body.startsWith("山田太郎 様")).toBe(true);
+    });
+  });
+
+  describe("本文 (completionMessageBody)", () => {
+    it("本文設定値が body に含まれる (AC-5)", () => {
+      const body = "受講お疲れ様でした。ご質問は本メールにご返信ください。";
+      const result = buildCompletionMail({
+        userName: "山田太郎",
+        completionMessageBody: body,
+        signatureName: DEFAULT_SIG,
+      });
+      expect(result.body).toContain(body);
+    });
+
+    it("本文の改行 (LF) は保持される", () => {
+      const body = "line1\nline2\nline3";
+      const result = buildCompletionMail({
+        userName: "山田太郎",
+        completionMessageBody: body,
+        signatureName: DEFAULT_SIG,
+      });
+      expect(result.body).toContain("line1\nline2\nline3");
+    });
+
+    it("本文末尾の余分な改行は trimEnd される", () => {
+      const result = buildCompletionMail({
+        userName: "山田太郎",
+        completionMessageBody: "本文\n\n\n",
+        signatureName: DEFAULT_SIG,
+      });
+      // 「本文」の直後に余分な空行が連続しない (trimEnd 効果)
+      expect(result.body).toContain("本文\n\n---");
+    });
+  });
+
+  describe("署名 (signatureName)", () => {
+    it("signatureName が末尾に区切り `---` 付きで挿入される (AC-5)", () => {
+      const result = buildCompletionMail({
+        userName: "山田太郎",
+        completionMessageBody: DEFAULT_BODY,
+        signatureName: "DXcollege運営スタッフ",
+      });
+      expect(result.body).toMatch(/\n---\nDXcollege運営スタッフ\n?$/);
+    });
+
+    it("signatureName 空文字 → 署名 block を出さない", () => {
+      const result = buildCompletionMail({
+        userName: "山田太郎",
+        completionMessageBody: DEFAULT_BODY,
+        signatureName: "",
+      });
+      expect(result.body).not.toContain("---");
+    });
+
+    it("signatureName 空白のみ → 署名 block を出さない", () => {
+      const result = buildCompletionMail({
+        userName: "山田太郎",
+        completionMessageBody: DEFAULT_BODY,
+        signatureName: "   ",
+      });
+      expect(result.body).not.toContain("---");
+    });
+  });
+
+  describe("ヘッダ injection 防御 (CR/LF)", () => {
+    it("userName に CR/LF を含めば throw", () => {
+      expect(() =>
+        buildCompletionMail({
+          userName: "山田\r\nBcc: evil@x.com",
+          completionMessageBody: DEFAULT_BODY,
+          signatureName: DEFAULT_SIG,
+        }),
+      ).toThrow(/userName/);
+    });
+
+    it("userName に LF のみでも throw", () => {
+      expect(() =>
+        buildCompletionMail({
+          userName: "山田\n太郎",
+          completionMessageBody: DEFAULT_BODY,
+          signatureName: DEFAULT_SIG,
+        }),
+      ).toThrow(/userName/);
+    });
+
+    it("completionMessageBody 内の CR/LF は許容 (本文は base64 化される)", () => {
+      // 本文中の CRLF は base64 安全、throw しない
+      expect(() =>
+        buildCompletionMail({
+          userName: "山田太郎",
+          completionMessageBody: "line1\r\nline2",
+          signatureName: DEFAULT_SIG,
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("構造 (順序)", () => {
+    it("body 順序: 宛名 → 空行 → 本文 → 空行 → '---' → 署名 → 末尾空行", () => {
+      const result = buildCompletionMail({
+        userName: "山田太郎",
+        completionMessageBody: "本文テスト",
+        signatureName: "DXcollege運営スタッフ",
+      });
+      expect(result.body).toBe(
+        "山田太郎 様\n\n本文テスト\n\n---\nDXcollege運営スタッフ\n",
+      );
+    });
+  });
+});

--- a/services/api/src/services/dispatch/__tests__/completion-notification-mail.test.ts
+++ b/services/api/src/services/dispatch/__tests__/completion-notification-mail.test.ts
@@ -181,6 +181,26 @@ describe("buildCompletionMail", () => {
         }),
       ).not.toThrow();
     });
+
+    it("signatureName に CR/LF を含めば throw (本文注入リスク防御、evaluator narrative)", () => {
+      expect(() =>
+        buildCompletionMail({
+          userName: "山田太郎",
+          completionMessageBody: DEFAULT_BODY,
+          signatureName: "DXcollege運営スタッフ\r\n--\nfake-signature",
+        }),
+      ).toThrow(/signatureName/);
+    });
+
+    it("signatureName に LF のみでも throw", () => {
+      expect(() =>
+        buildCompletionMail({
+          userName: "山田太郎",
+          completionMessageBody: DEFAULT_BODY,
+          signatureName: "line1\nline2",
+        }),
+      ).toThrow(/signatureName/);
+    });
   });
 
   describe("構造 (順序)", () => {

--- a/services/api/src/services/dispatch/__tests__/gmail-dwd-send.test.ts
+++ b/services/api/src/services/dispatch/__tests__/gmail-dwd-send.test.ts
@@ -218,20 +218,22 @@ describe("buildCompletionMime", () => {
   });
 
   describe("CR/LF header injection 防御", () => {
+    // defaults を先に展開し、`partial` で override する形にして同 key 重複指定を回避
+    // (TS2783 "specified more than once" を防ぐ。order matters: spread が後)
+    const mimeDefaults = {
+      fromEmail: "f@x.com",
+      to: "t@x.com",
+      cc: [] as readonly string[],
+      subject: "s",
+      body: "b",
+    };
     it.each([
-      ["fromEmail", { fromEmail: "evil@x.com\r\nBcc: leak@x.com", to: "t@x.com" }],
-      ["to", { fromEmail: "f@x.com", to: "evil@x.com\r\nBcc: leak@x.com" }],
-      ["subject", { fromEmail: "f@x.com", to: "t@x.com", subject: "s\r\nX-Inject: 1" }],
+      ["fromEmail", { fromEmail: "evil@x.com\r\nBcc: leak@x.com" }],
+      ["to", { to: "evil@x.com\r\nBcc: leak@x.com" }],
+      ["subject", { subject: "s\r\nX-Inject: 1" }],
     ])("%s に CR/LF を含めば throw", (_label, partial) => {
       expect(() =>
-        buildCompletionMime({
-          fromEmail: "f@x.com",
-          to: "t@x.com",
-          cc: [],
-          subject: "s",
-          body: "b",
-          ...partial,
-        }),
+        buildCompletionMime({ ...mimeDefaults, ...partial }),
       ).toThrow();
     });
 

--- a/services/api/src/services/dispatch/__tests__/gmail-dwd-send.test.ts
+++ b/services/api/src/services/dispatch/__tests__/gmail-dwd-send.test.ts
@@ -161,7 +161,7 @@ describe("buildCompletionMime", () => {
       expect(decoded).toContain(Buffer.from("本文テスト", "utf-8").toString("base64"));
     });
 
-    it("行区切りは CRLF", () => {
+    it("全行区切りが CRLF (LF 単独なし、evaluator narrative 反映で証明力強化)", () => {
       const raw = buildCompletionMime({
         fromEmail: "from@x.com",
         to: "to@x.com",
@@ -170,8 +170,12 @@ describe("buildCompletionMime", () => {
         body: "b",
       });
       const decoded = base64UrlDecode(raw);
-      expect(decoded).toContain("\r\n");
-      expect(decoded).not.toContain("\n\n"); // LF のみは禁
+      // 全 CRLF を取り除いた残り文字列に LF が残らないことで「LF 単独なし」を保証
+      const stripped = decoded.replace(/\r\n/g, "");
+      expect(stripped).not.toMatch(/\n/);
+      expect(stripped).not.toMatch(/\r/);
+      // ヘッダ区切り空行 (\r\n\r\n) の存在も確認
+      expect(decoded).toContain("\r\n\r\n");
     });
   });
 
@@ -284,19 +288,23 @@ describe("buildCompletionMime", () => {
   });
 });
 
+// テスト全体で再利用する base input (重複定義を排除、safe-refactor M-3 反映)
+const BASE_INPUT = {
+  subjectEmail: "system@279279.net",
+  fromEmail: "dxcollege@279279.net",
+  to: "student@example.com",
+  cc: [] as readonly string[],
+  subject: "テスト件名",
+  body: "本文",
+};
+
 describe("sendCompletionMail (retry / success)", () => {
   beforeEach(() => {
     setSecretManagerOk();
   });
 
-  const baseInput = {
-    subjectEmail: "system@279279.net",
-    fromEmail: "dxcollege@279279.net",
-    to: "student@example.com",
-    cc: ["owner@example.com"] as readonly string[],
-    subject: "テスト件名",
-    body: "本文",
-  };
+  // owner CC 入りの retry / success ケース用
+  const baseInput = { ...BASE_INPUT, cc: ["owner@example.com"] as readonly string[] };
 
   it("1 回目で成功 → attempts=1、messageId 返却", async () => {
     gmailSendMock.mockResolvedValueOnce({ data: { id: "msg-001" } });
@@ -350,6 +358,28 @@ describe("sendCompletionMail (retry / success)", () => {
     expect(result.messageId).toBe("msg-econn");
     expect(result.attempts).toBe(2);
   });
+
+  it("503 単独 1 回 → 2 回目成功 (evaluator narrative 反映、独立 retry 確認)", async () => {
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+    gmailSendMock
+      .mockRejectedValueOnce({ response: { status: 503 } })
+      .mockResolvedValueOnce({ data: { id: "msg-503" } });
+    const result = await sendCompletionMail(baseInput, { sleep: sleepMock });
+    expect(result.messageId).toBe("msg-503");
+    expect(result.attempts).toBe(2);
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+    expect(sleepMock).toHaveBeenCalledWith(500);
+  });
+
+  it("Secret Manager network error は transient 扱いせず caller に伝搬", async () => {
+    accessSecretVersionMock.mockReset();
+    accessSecretVersionMock.mockRejectedValue(
+      Object.assign(new Error("network"), { code: "ECONNRESET" }),
+    );
+    await expect(sendCompletionMail(baseInput)).rejects.toThrow(/network/);
+    // Gmail send 自体は実行されない
+    expect(gmailSendMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("sendCompletionMail (permanent errors → 即時 throw)", () => {
@@ -357,14 +387,8 @@ describe("sendCompletionMail (permanent errors → 即時 throw)", () => {
     setSecretManagerOk();
   });
 
-  const baseInput = {
-    subjectEmail: "system@279279.net",
-    fromEmail: "dxcollege@279279.net",
-    to: "student@example.com",
-    cc: [] as readonly string[],
-    subject: "s",
-    body: "b",
-  };
+  // BASE_INPUT を共有 (safe-refactor M-3 反映、重複排除)
+  const baseInput = { ...BASE_INPUT, subject: "s", body: "b" };
 
   it.each([
     ["401 (token 失効)", 401],

--- a/services/api/src/services/dispatch/__tests__/gmail-dwd-send.test.ts
+++ b/services/api/src/services/dispatch/__tests__/gmail-dwd-send.test.ts
@@ -1,0 +1,444 @@
+/**
+ * gmail-dwd-send の単体テスト。
+ *
+ * 設計仕様書 §3.1 / FR-5 改訂 / NFR-9 / AC-3 / AC-32 / Phase 3 完了条件:
+ *   - DWD JWT 生成 (gmail-client.ts 経由、subject=実 mailbox、scope=gmail.send)
+ *   - MIME 組立 (添付なし、From=SendAs エイリアス、To=受講者本人、Cc=配列)
+ *   - 429 / 503 / transient ネットワークエラーで exponential backoff retry 最大 3 回
+ *   - 401 / 4xx / その他は即時 throw (caller 分類)
+ *   - CC 配列空のとき Cc: ヘッダを省略
+ *
+ * 観点:
+ *   - MIME 構造: From / To / Cc / Subject ヘッダ、base64 body、base64url 全体
+ *   - Cc 空配列 → Cc: ヘッダ省略 (Phase 3 完了条件)
+ *   - Cc 複数件 → カンマ + 半角空白で連結
+ *   - 件名の日本語 → =?UTF-8?B?...?= encode
+ *   - 件名 ASCII のみ → encode しない
+ *   - CR/LF 注入 reject: From / To / Subject / Cc[]
+ *   - 1 回目で成功 → attempts=1、messageId 返却
+ *   - 429 1 回 → 2 回目成功 → attempts=2
+ *   - 429 3 回連続 → throw (caller 側分類)
+ *   - 503 retry, ECONNRESET retry
+ *   - 401 / 400 / 403 → 即時 throw (no retry)
+ *   - response.data.id が空 → throw
+ *   - retry sleep の backoff が exponential (500 → 1000)
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const jwtConstructorMock = vi.hoisted(() => vi.fn());
+const gmailSendMock = vi.hoisted(() => vi.fn());
+const accessSecretVersionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("googleapis", () => {
+  class MockJWT {
+    constructor(opts: Record<string, unknown>) {
+      jwtConstructorMock(opts);
+    }
+  }
+  return {
+    google: {
+      auth: { JWT: MockJWT },
+      gmail: vi.fn(() => ({
+        users: {
+          messages: {
+            send: gmailSendMock,
+          },
+        },
+      })),
+    },
+  };
+});
+
+vi.mock("@google-cloud/secret-manager", () => {
+  class MockSecretManagerServiceClient {
+    accessSecretVersion = accessSecretVersionMock;
+  }
+  return { SecretManagerServiceClient: MockSecretManagerServiceClient };
+});
+
+// 動的 import (gmail-client.test.ts と同じ hoisted pattern)
+const {
+  buildCompletionMime,
+  encodeMimeHeader,
+  isTransientGmailError,
+  sendCompletionMail,
+  TRANSIENT_NETWORK_CODES,
+} = await import("../gmail-dwd-send.js");
+const { __resetCacheForTest } = await import("../gmail-client.js");
+
+const FAKE_KEY = {
+  client_email: "dwd-sa@lms-279.iam.gserviceaccount.com",
+  private_key: "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+};
+
+function setSecretManagerOk() {
+  accessSecretVersionMock.mockResolvedValue([
+    { payload: { data: JSON.stringify(FAKE_KEY) } },
+  ]);
+}
+
+beforeEach(() => {
+  __resetCacheForTest();
+  jwtConstructorMock.mockClear();
+  gmailSendMock.mockReset();
+  accessSecretVersionMock.mockReset();
+});
+
+/** base64url decode helper */
+function base64UrlDecode(s: string): string {
+  return Buffer.from(s, "base64url").toString("utf-8");
+}
+
+describe("encodeMimeHeader (RFC 2047)", () => {
+  it("ASCII のみはそのまま返す", () => {
+    expect(encodeMimeHeader("Hello World")).toBe("Hello World");
+  });
+
+  it("日本語を =?UTF-8?B?...?= で encode", () => {
+    const encoded = encodeMimeHeader("テスト");
+    expect(encoded).toMatch(/^=\?UTF-8\?B\?[A-Za-z0-9+/=]+\?=$/);
+    const base64 = encoded.replace(/^=\?UTF-8\?B\?/, "").replace(/\?=$/, "");
+    expect(Buffer.from(base64, "base64").toString("utf-8")).toBe("テスト");
+  });
+});
+
+describe("isTransientGmailError", () => {
+  it("HTTP 429 → transient", () => {
+    expect(isTransientGmailError({ response: { status: 429 } })).toBe(true);
+  });
+  it("HTTP 503 → transient", () => {
+    expect(isTransientGmailError({ response: { status: 503 } })).toBe(true);
+  });
+  it("HTTP 500 → not transient (caller permanent 分類予定)", () => {
+    expect(isTransientGmailError({ response: { status: 500 } })).toBe(false);
+  });
+  it("HTTP 401 → not transient", () => {
+    expect(isTransientGmailError({ response: { status: 401 } })).toBe(false);
+  });
+  it("HTTP 403 → not transient (caller scope_revoked 分類)", () => {
+    expect(isTransientGmailError({ response: { status: 403 } })).toBe(false);
+  });
+  it("ECONNRESET → transient (transport)", () => {
+    expect(isTransientGmailError({ code: "ECONNRESET" })).toBe(true);
+  });
+  it("UND_ERR_SOCKET (cause) → transient", () => {
+    expect(isTransientGmailError({ cause: { code: "UND_ERR_SOCKET" } })).toBe(true);
+  });
+  it("UNKNOWN_CODE → not transient", () => {
+    expect(isTransientGmailError({ code: "UNKNOWN_CODE" })).toBe(false);
+  });
+  it("非 object (null, string) → not transient", () => {
+    expect(isTransientGmailError(null)).toBe(false);
+    expect(isTransientGmailError("ECONNRESET")).toBe(false);
+  });
+  it("TRANSIENT_NETWORK_CODES に主要 transport code が含まれる", () => {
+    expect(TRANSIENT_NETWORK_CODES.has("ECONNRESET")).toBe(true);
+    expect(TRANSIENT_NETWORK_CODES.has("ETIMEDOUT")).toBe(true);
+    expect(TRANSIENT_NETWORK_CODES.has("UND_ERR_CONNECT_TIMEOUT")).toBe(true);
+  });
+});
+
+describe("buildCompletionMime", () => {
+  describe("MIME 構造", () => {
+    it("From / To / Subject / MIME-Version / Content-Type / base64 body を含む", () => {
+      const raw = buildCompletionMime({
+        fromEmail: "dxcollege@279279.net",
+        to: "student@example.com",
+        cc: [],
+        subject: "テスト件名",
+        body: "本文テスト",
+      });
+      const decoded = base64UrlDecode(raw);
+      expect(decoded).toContain("From: dxcollege@279279.net");
+      expect(decoded).toContain("To: student@example.com");
+      expect(decoded).toContain("MIME-Version: 1.0");
+      expect(decoded).toContain("Content-Type: text/plain; charset=UTF-8");
+      expect(decoded).toContain("Content-Transfer-Encoding: base64");
+      // 件名は RFC 2047 encode
+      expect(decoded).toMatch(/Subject: =\?UTF-8\?B\?[A-Za-z0-9+/=]+\?=/);
+      // 本文は base64 化される
+      expect(decoded).toContain(Buffer.from("本文テスト", "utf-8").toString("base64"));
+    });
+
+    it("行区切りは CRLF", () => {
+      const raw = buildCompletionMime({
+        fromEmail: "from@x.com",
+        to: "to@x.com",
+        cc: [],
+        subject: "s",
+        body: "b",
+      });
+      const decoded = base64UrlDecode(raw);
+      expect(decoded).toContain("\r\n");
+      expect(decoded).not.toContain("\n\n"); // LF のみは禁
+    });
+  });
+
+  describe("Cc 配列の扱い (Phase 3 完了条件)", () => {
+    it("Cc 空配列 → Cc: ヘッダを出さない", () => {
+      const raw = buildCompletionMime({
+        fromEmail: "from@x.com",
+        to: "to@x.com",
+        cc: [],
+        subject: "s",
+        body: "b",
+      });
+      const decoded = base64UrlDecode(raw);
+      expect(decoded).not.toMatch(/^Cc:/m);
+    });
+
+    it("Cc 1 件 → Cc: 単一", () => {
+      const raw = buildCompletionMime({
+        fromEmail: "from@x.com",
+        to: "to@x.com",
+        cc: ["cc1@x.com"],
+        subject: "s",
+        body: "b",
+      });
+      const decoded = base64UrlDecode(raw);
+      expect(decoded).toContain("Cc: cc1@x.com");
+    });
+
+    it("Cc 複数 → カンマ + 半角空白で連結", () => {
+      const raw = buildCompletionMime({
+        fromEmail: "from@x.com",
+        to: "to@x.com",
+        cc: ["a@x.com", "b@x.com", "c@x.com"],
+        subject: "s",
+        body: "b",
+      });
+      const decoded = base64UrlDecode(raw);
+      expect(decoded).toContain("Cc: a@x.com, b@x.com, c@x.com");
+    });
+  });
+
+  describe("CR/LF header injection 防御", () => {
+    it.each([
+      ["fromEmail", { fromEmail: "evil@x.com\r\nBcc: leak@x.com", to: "t@x.com" }],
+      ["to", { fromEmail: "f@x.com", to: "evil@x.com\r\nBcc: leak@x.com" }],
+      ["subject", { fromEmail: "f@x.com", to: "t@x.com", subject: "s\r\nX-Inject: 1" }],
+    ])("%s に CR/LF を含めば throw", (_label, partial) => {
+      expect(() =>
+        buildCompletionMime({
+          fromEmail: "f@x.com",
+          to: "t@x.com",
+          cc: [],
+          subject: "s",
+          body: "b",
+          ...partial,
+        }),
+      ).toThrow();
+    });
+
+    it("Cc[] に CR/LF があれば throw", () => {
+      expect(() =>
+        buildCompletionMime({
+          fromEmail: "f@x.com",
+          to: "t@x.com",
+          cc: ["good@x.com", "evil@x.com\nBcc: leak@x.com"],
+          subject: "s",
+          body: "b",
+        }),
+      ).toThrow();
+    });
+
+    it("body 内 CR/LF は許容 (base64 化されるため安全)", () => {
+      expect(() =>
+        buildCompletionMime({
+          fromEmail: "f@x.com",
+          to: "t@x.com",
+          cc: [],
+          subject: "s",
+          body: "line1\r\nline2",
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("型 validation", () => {
+    it("fromEmail が空文字なら throw", () => {
+      expect(() =>
+        buildCompletionMime({
+          fromEmail: "",
+          to: "t@x.com",
+          cc: [],
+          subject: "s",
+          body: "b",
+        }),
+      ).toThrow(/fromEmail/);
+    });
+
+    it("cc が非配列なら throw", () => {
+      expect(() =>
+        buildCompletionMime({
+          fromEmail: "f@x.com",
+          to: "t@x.com",
+          // @ts-expect-error 非配列注入
+          cc: "cc@x.com",
+          subject: "s",
+          body: "b",
+        }),
+      ).toThrow(/cc must be an array/);
+    });
+  });
+});
+
+describe("sendCompletionMail (retry / success)", () => {
+  beforeEach(() => {
+    setSecretManagerOk();
+  });
+
+  const baseInput = {
+    subjectEmail: "system@279279.net",
+    fromEmail: "dxcollege@279279.net",
+    to: "student@example.com",
+    cc: ["owner@example.com"] as readonly string[],
+    subject: "テスト件名",
+    body: "本文",
+  };
+
+  it("1 回目で成功 → attempts=1、messageId 返却", async () => {
+    gmailSendMock.mockResolvedValueOnce({ data: { id: "msg-001" } });
+    const result = await sendCompletionMail(baseInput);
+    expect(result).toEqual({ messageId: "msg-001", attempts: 1 });
+    expect(gmailSendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("429 1 回 → 2 回目成功 → attempts=2、sleep 1 回", async () => {
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+    gmailSendMock
+      .mockRejectedValueOnce({ response: { status: 429 } })
+      .mockResolvedValueOnce({ data: { id: "msg-002" } });
+    const result = await sendCompletionMail(baseInput, { sleep: sleepMock });
+    expect(result).toEqual({ messageId: "msg-002", attempts: 2 });
+    expect(gmailSendMock).toHaveBeenCalledTimes(2);
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+    expect(sleepMock).toHaveBeenCalledWith(500); // BACKOFF_INITIAL_MS
+  });
+
+  it("429 → 503 → 成功 → attempts=3、backoff 2 回 (500ms, 1000ms)", async () => {
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+    gmailSendMock
+      .mockRejectedValueOnce({ response: { status: 429 } })
+      .mockRejectedValueOnce({ response: { status: 503 } })
+      .mockResolvedValueOnce({ data: { id: "msg-003" } });
+    const result = await sendCompletionMail(baseInput, { sleep: sleepMock });
+    expect(result).toEqual({ messageId: "msg-003", attempts: 3 });
+    expect(sleepMock.mock.calls).toEqual([[500], [1000]]); // exponential
+  });
+
+  it("429 3 回連続 → throw (最後の error)、sleep 2 回 (最後の attempt 後は sleep しない)", async () => {
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+    gmailSendMock
+      .mockRejectedValueOnce({ response: { status: 429 } })
+      .mockRejectedValueOnce({ response: { status: 429 } })
+      .mockRejectedValueOnce({ response: { status: 429 }, message: "final" });
+    await expect(
+      sendCompletionMail(baseInput, { sleep: sleepMock }),
+    ).rejects.toMatchObject({ response: { status: 429 } });
+    expect(gmailSendMock).toHaveBeenCalledTimes(3);
+    expect(sleepMock).toHaveBeenCalledTimes(2); // attempts 1, 2 の後のみ
+  });
+
+  it("ECONNRESET transient → retry 後成功", async () => {
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+    gmailSendMock
+      .mockRejectedValueOnce({ code: "ECONNRESET" })
+      .mockResolvedValueOnce({ data: { id: "msg-econn" } });
+    const result = await sendCompletionMail(baseInput, { sleep: sleepMock });
+    expect(result.messageId).toBe("msg-econn");
+    expect(result.attempts).toBe(2);
+  });
+});
+
+describe("sendCompletionMail (permanent errors → 即時 throw)", () => {
+  beforeEach(() => {
+    setSecretManagerOk();
+  });
+
+  const baseInput = {
+    subjectEmail: "system@279279.net",
+    fromEmail: "dxcollege@279279.net",
+    to: "student@example.com",
+    cc: [] as readonly string[],
+    subject: "s",
+    body: "b",
+  };
+
+  it.each([
+    ["401 (token 失効)", 401],
+    ["403 (scope/permission)", 403],
+    ["400 (Bad Request)", 400],
+    ["422 (Unprocessable)", 422],
+  ])("%s → retry せず即時 throw", async (_label, status) => {
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+    gmailSendMock.mockRejectedValueOnce({ response: { status } });
+    await expect(
+      sendCompletionMail(baseInput, { sleep: sleepMock }),
+    ).rejects.toMatchObject({ response: { status } });
+    expect(gmailSendMock).toHaveBeenCalledTimes(1);
+    expect(sleepMock).not.toHaveBeenCalled();
+  });
+
+  it("response.data.id が空 → throw", async () => {
+    gmailSendMock.mockResolvedValueOnce({ data: { id: "" } });
+    await expect(sendCompletionMail(baseInput)).rejects.toThrow(/messageId/);
+  });
+
+  it("response.data.id が undefined → throw", async () => {
+    gmailSendMock.mockResolvedValueOnce({ data: {} });
+    await expect(sendCompletionMail(baseInput)).rejects.toThrow(/messageId/);
+  });
+});
+
+describe("sendCompletionMail (gmail-client 連携)", () => {
+  beforeEach(() => {
+    setSecretManagerOk();
+  });
+
+  it("getGmailClientForSender 経由で JWT subject=subjectEmail、scope=gmail.send のみ", async () => {
+    gmailSendMock.mockResolvedValueOnce({ data: { id: "msg-jwt" } });
+    await sendCompletionMail({
+      subjectEmail: "system@279279.net",
+      fromEmail: "dxcollege@279279.net",
+      to: "s@x.com",
+      cc: [],
+      subject: "s",
+      body: "b",
+    });
+
+    expect(jwtConstructorMock).toHaveBeenCalledTimes(1);
+    const jwtArgs = jwtConstructorMock.mock.calls[0][0] as {
+      subject: string;
+      scopes: string[];
+    };
+    expect(jwtArgs.subject).toBe("system@279279.net");
+    expect(jwtArgs.scopes).toEqual([
+      "https://www.googleapis.com/auth/gmail.send",
+    ]);
+  });
+
+  it("gmail.users.messages.send は raw=base64url MIME を渡す", async () => {
+    gmailSendMock.mockResolvedValueOnce({ data: { id: "msg-mime" } });
+    await sendCompletionMail({
+      subjectEmail: "system@279279.net",
+      fromEmail: "dxcollege@279279.net",
+      to: "s@x.com",
+      cc: ["cc@x.com"],
+      subject: "件名",
+      body: "本文",
+    });
+
+    const sendArgs = gmailSendMock.mock.calls[0][0] as {
+      userId: string;
+      requestBody: { raw: string };
+    };
+    expect(sendArgs.userId).toBe("me");
+    expect(sendArgs.requestBody.raw).toMatch(/^[A-Za-z0-9_-]+$/); // base64url chars
+    const decoded = base64UrlDecode(sendArgs.requestBody.raw);
+    expect(decoded).toContain("From: dxcollege@279279.net");
+    expect(decoded).toContain("To: s@x.com");
+    expect(decoded).toContain("Cc: cc@x.com");
+  });
+});

--- a/services/api/src/services/dispatch/completion-notification-mail.ts
+++ b/services/api/src/services/dispatch/completion-notification-mail.ts
@@ -21,8 +21,6 @@
  *   override 可能にする想定 (本 Phase ではスコープ外、spec 未記載のため独断追加しない)。
  */
 
-import type { CcEmailValidationFailure } from "./cc-email-validator.js";
-
 /**
  * 完了通知メールの既定件名 (テナント・受講者横断で固定)。
  * 将来 settings に持たせるための export。
@@ -36,12 +34,6 @@ export interface BuildCompletionMailInput {
   completionMessageBody: string;
   /** スーパー管理者が設定する署名 (DispatchSettings.signatureName) */
   signatureName: string;
-  /**
-   * 任意の CC validation 警告 (cc-email-validator から伝搬)。
-   * UI / audit_logs 表示には使うが本文には混入しないため、本関数は受領のみで
-   * 出力には影響しない (将来 audit log に同梱する際の引き渡し pass-through)。
-   */
-  ccValidationWarnings?: readonly CcEmailValidationFailure[];
 }
 
 export interface BuiltCompletionMail {
@@ -50,7 +42,16 @@ export interface BuiltCompletionMail {
   body: string;
 }
 
-/** MIME ヘッダ系フィールドへの CRLF 注入を防ぐ defensive guard */
+/**
+ * MIME ヘッダ系フィールドへの CRLF 注入を防ぐ defensive guard。
+ *
+ * 注意: gmail-dwd-send.ts の同名関数は **空文字 reject** も含むが、本関数では
+ * 空文字ガードを意図的に持たない。理由: 本関数の caller (`buildCompletionMail`) は
+ * userName を `normalizeUserName` で trim 後の長さチェックを通してから渡し、
+ * subject は固定定数 `DEFAULT_COMPLETION_SUBJECT` を渡すため、空文字パスは
+ * 本関数到達前に排除されている。空文字を許容しない上位制約があるため、本関数
+ * 自体は CRLF 検出のみに責務を限定する (Single Responsibility)。
+ */
 function assertHeaderSafe(value: string, fieldName: string): void {
   if (/[\r\n]/.test(value)) {
     throw new Error(
@@ -77,6 +78,13 @@ export function buildCompletionMail(
   const normalizedName = normalizeUserName(input.userName);
   if (normalizedName.length > 0) {
     assertHeaderSafe(normalizedName, "userName");
+  }
+  // signatureName は本文中に展開されるため MIME ヘッダ直接注入は発生しないが、
+  // 受信側 (Gmail UI / Outlook) の表示で意図せぬ改行になるとフィッシング偽装等
+  // に流用される懸念があるため、CRLF を含めれば throw する (本文 base64 化前に
+  // 早期検出)。evaluator narrative 反映。
+  if (signatureName.trim().length > 0) {
+    assertHeaderSafe(signatureName, "signatureName");
   }
 
   // 本文組み立て: 宛名 + 設定本文 + 区切り + 署名 (空 signature は許容、行のみ追加しない)

--- a/services/api/src/services/dispatch/completion-notification-mail.ts
+++ b/services/api/src/services/dispatch/completion-notification-mail.ts
@@ -1,0 +1,95 @@
+/**
+ * DXcollege 自動完了通知の件名・本文を組み立てる純粋関数。
+ *
+ * 設計仕様書 §7.1 (Unit Test 観点)、FR-5 改訂、AC-5 に対応。
+ *
+ * 責務:
+ *   - 件名 (subject) と本文 (body) を pure に組み立てる
+ *   - 入力 (userName / completionMessageBody / signatureName) の CRLF を
+ *     サニタイズ (MIME ヘッダインジェクション防止の二重防御、route 層も検証)
+ *   - 文字数上限の超過は呼び出し側 (Phase 5 super-admin API) で検出する想定。
+ *     本関数は組み立て pure 関数として責務を限定
+ *
+ * 非責務:
+ *   - To/Cc の組み立て: gmail-dwd-send.ts 側で MIME ヘッダとして直接挿入
+ *   - PII (受講者 email) のハッシュ化: Phase 4 reservation.ts で実施
+ *
+ * 件名の固定方針 (本 Phase での暫定):
+ *   設計仕様書および DispatchSettings DTO には件名テンプレート field がない
+ *   ため、Phase 1 / Phase 3 では **定数の件名** を使う。将来テナント別カスタマイズ
+ *   要望が出たら DispatchSettings に subjectTemplate を追加して呼び出し側で
+ *   override 可能にする想定 (本 Phase ではスコープ外、spec 未記載のため独断追加しない)。
+ */
+
+import type { CcEmailValidationFailure } from "./cc-email-validator.js";
+
+/**
+ * 完了通知メールの既定件名 (テナント・受講者横断で固定)。
+ * 将来 settings に持たせるための export。
+ */
+export const DEFAULT_COMPLETION_SUBJECT = "【DXcollege】受講修了のお知らせ";
+
+export interface BuildCompletionMailInput {
+  /** 受講者名 (本文冒頭の宛名)。trim 後空文字なら「受講者各位」にフォールバック */
+  userName: string | null | undefined;
+  /** スーパー管理者が設定する本文 (DispatchSettings.completionMessageBody) */
+  completionMessageBody: string;
+  /** スーパー管理者が設定する署名 (DispatchSettings.signatureName) */
+  signatureName: string;
+  /**
+   * 任意の CC validation 警告 (cc-email-validator から伝搬)。
+   * UI / audit_logs 表示には使うが本文には混入しないため、本関数は受領のみで
+   * 出力には影響しない (将来 audit log に同梱する際の引き渡し pass-through)。
+   */
+  ccValidationWarnings?: readonly CcEmailValidationFailure[];
+}
+
+export interface BuiltCompletionMail {
+  subject: string;
+  /** 本文 (text/plain UTF-8)。改行は LF (MIME 側で CRLF に正規化される) */
+  body: string;
+}
+
+/** MIME ヘッダ系フィールドへの CRLF 注入を防ぐ defensive guard */
+function assertHeaderSafe(value: string, fieldName: string): void {
+  if (/[\r\n]/.test(value)) {
+    throw new Error(
+      `completion-notification-mail: ${fieldName} contains CR/LF (header injection blocked)`,
+    );
+  }
+}
+
+function normalizeUserName(userName: string | null | undefined): string {
+  if (typeof userName !== "string") return "";
+  return userName.trim();
+}
+
+export function buildCompletionMail(
+  input: BuildCompletionMailInput,
+): BuiltCompletionMail {
+  const { completionMessageBody, signatureName } = input;
+
+  // ヘッダ系 (subject / userName) の CRLF 注入を library 層で阻止 (二重防御)。
+  // body 内の CR/LF は base64 エンコードされるため許容するが、subject は MIME
+  // ヘッダ行に直接乗るので reject する。
+  assertHeaderSafe(DEFAULT_COMPLETION_SUBJECT, "subject");
+
+  const normalizedName = normalizeUserName(input.userName);
+  if (normalizedName.length > 0) {
+    assertHeaderSafe(normalizedName, "userName");
+  }
+
+  // 本文組み立て: 宛名 + 設定本文 + 区切り + 署名 (空 signature は許容、行のみ追加しない)
+  const greeting = normalizedName.length > 0 ? `${normalizedName} 様` : "受講者各位";
+  const lines: string[] = [greeting, "", completionMessageBody.trimEnd()];
+  if (signatureName.trim().length > 0) {
+    lines.push("", "---", signatureName);
+  }
+  // 末尾に改行 1 行 (一般的なメール本文の見やすさ)
+  lines.push("");
+
+  return {
+    subject: DEFAULT_COMPLETION_SUBJECT,
+    body: lines.join("\n"),
+  };
+}

--- a/services/api/src/services/dispatch/gmail-dwd-send.ts
+++ b/services/api/src/services/dispatch/gmail-dwd-send.ts
@@ -1,0 +1,220 @@
+/**
+ * DXcollege 自動完了通知の DWD なりすまし送信 (Gmail API users.messages.send)。
+ *
+ * 設計仕様書 §3.1 / FR-5 改訂 / NFR-9 / AC-3 / AC-32 / Phase 3 完了条件:
+ *   - DWD JWT 生成 (gmail-client.ts 経由、subject=実 mailbox、scope=gmail.send)
+ *   - MIME 組立 (添付なし、From=SendAs エイリアス、To=受講者本人、Cc=配列)
+ *   - 429 / 503 / transient ネットワークエラーで exponential backoff retry (最大 3 回)
+ *   - 401 / 403 / 4xx は即時 throw (caller 側で dispatch-403-classifier 等で分類)
+ *   - CC 配列空のとき Cc: ヘッダを省略 (空ヘッダ生成防止、Phase 3 完了条件)
+ *
+ * SendAs 方針 (ADR-037 案 X):
+ *   - JWT subject = 実在 mailbox (`system@279279.net`、DXCOLLEGE_DISPATCH_SUBJECT env)
+ *   - MIME `From:` = `dxcollege@279279.net` (DXCOLLEGE_SENDER_EMAIL env、SendAs 登録済)
+ *   - Gmail API は subject mailbox の context で動作し、SendAs 登録済の alias を
+ *     `From:` に許可する。SendAs 設定漏れの場合は 400 invalidFrom 等で失敗 (caller 検知)
+ *
+ * 非責務:
+ *   - エラー分類: caller (run-completion-notifications.ts) が
+ *     dispatch-403-classifier.ts と組み合わせて scope_revoked / user_permanent を判定
+ *   - Reservation 状態更新: caller の責務 (reservation.ts)
+ *   - PII ハッシュ化: caller の責務 (完了後 recipientToHash 等を Firestore に書く際)
+ */
+
+import { getGmailClientForSender } from "./gmail-client.js";
+
+const MAX_ATTEMPTS = 3;
+const BACKOFF_INITIAL_MS = 500;
+const BACKOFF_MAX_MS = 4000;
+
+/**
+ * Node.js / undici / gaxios の transport-level error code (transient 候補)。
+ * 既存 gmail-draft.ts の TRANSIENT_NETWORK_CODES と意図的に同期させる。重複は
+ * §5.4「PR #434 影響ゼロ」遵守のため受容、将来 common util へ抽出予定。
+ */
+export const TRANSIENT_NETWORK_CODES: ReadonlySet<string> = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ESOCKETTIMEDOUT",
+  "ECONNABORTED",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/**
+ * HTTP status / 例外を transient (retry 可) と判定するか。
+ * - 429 / 503 → transient (Gmail API レート制限・一時障害)
+ * - 上記 transport code → transient (ネットワーク不安定)
+ * - その他 → permanent (caller 側で 401/403/4xx を分類)
+ */
+export function isTransientGmailError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as {
+    response?: { status?: number };
+    code?: unknown;
+    cause?: { code?: unknown };
+  };
+  const status = e.response?.status;
+  if (status === 429 || status === 503) return true;
+  const code = typeof e.code === "string" ? e.code : null;
+  if (code && TRANSIENT_NETWORK_CODES.has(code)) return true;
+  const causeCode = typeof e.cause?.code === "string" ? e.cause.code : null;
+  if (causeCode && TRANSIENT_NETWORK_CODES.has(causeCode)) return true;
+  return false;
+}
+
+/** 件名 (subject) の日本語を RFC 2047 で base64 エンコード */
+export function encodeMimeHeader(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  if (!/[^\x00-\x7F]/.test(value)) return value;
+  const base64 = Buffer.from(value, "utf-8").toString("base64");
+  return `=?UTF-8?B?${base64}?=`;
+}
+
+/** MIME ヘッダ系フィールドの CRLF 注入を library 層で阻止 (二重防御) */
+function assertHeaderSafe(value: string, fieldName: string): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`gmail-dwd-send: ${fieldName} must be a non-empty string`);
+  }
+  if (/[\r\n]/.test(value)) {
+    throw new Error(
+      `gmail-dwd-send: ${fieldName} contains CR/LF (header injection blocked)`,
+    );
+  }
+}
+
+export interface BuildCompletionMimeInput {
+  /** MIME From (SendAs エイリアス、`dxcollege@279279.net` 等) */
+  fromEmail: string;
+  /** To (受講者本人、1 件のみ) */
+  to: string;
+  /** Cc 配列 (cc-email-validator で validate + dedup 済)。空配列なら Cc ヘッダ省略 */
+  cc: readonly string[];
+  /** 件名 */
+  subject: string;
+  /** 本文 (text/plain UTF-8) */
+  body: string;
+}
+
+/**
+ * 完了通知メールの raw MIME メッセージを base64url で返す。
+ * Gmail API `users.messages.send` の raw フィールドに渡す形式。
+ *
+ * 添付なし固定 (Phase 3 仕様: 進捗 PDF は Phase 4+ で別途検討)。
+ */
+export function buildCompletionMime(input: BuildCompletionMimeInput): string {
+  const { fromEmail, to, cc, subject, body } = input;
+
+  assertHeaderSafe(fromEmail, "fromEmail");
+  assertHeaderSafe(to, "to");
+  assertHeaderSafe(subject, "subject");
+
+  // Cc は配列、空なら Cc: 行を出さない (Phase 3 完了条件「CC validation 失敗時に
+  // MIME に Cc: ヘッダが出ない」の構造保証)
+  if (!Array.isArray(cc)) {
+    throw new Error("gmail-dwd-send: cc must be an array");
+  }
+  for (const entry of cc) {
+    assertHeaderSafe(entry, "cc[]");
+  }
+  const ccLines = cc.length > 0 ? [`Cc: ${cc.join(", ")}`] : [];
+
+  const encodedSubject = encodeMimeHeader(subject);
+
+  // 添付なしの text/plain メッセージ
+  const headerLines: string[] = [
+    `From: ${fromEmail}`,
+    `To: ${to}`,
+    ...ccLines,
+    `Subject: ${encodedSubject}`,
+    "MIME-Version: 1.0",
+    "Content-Type: text/plain; charset=UTF-8",
+    "Content-Transfer-Encoding: base64",
+    "",
+    Buffer.from(body, "utf-8").toString("base64"),
+  ];
+  const raw = headerLines.join("\r\n");
+  return Buffer.from(raw, "utf-8").toString("base64url");
+}
+
+export interface SendCompletionMailInput {
+  /** DWD JWT subject (実在 mailbox、`DXCOLLEGE_DISPATCH_SUBJECT` env) */
+  subjectEmail: string;
+  /** MIME From ヘッダ (SendAs alias、`DXCOLLEGE_SENDER_EMAIL` env) */
+  fromEmail: string;
+  /** To (受講者本人) */
+  to: string;
+  /** Cc 配列 (空可) */
+  cc: readonly string[];
+  /** 件名 */
+  subject: string;
+  /** 本文 (text/plain UTF-8) */
+  body: string;
+}
+
+export interface SendCompletionMailResult {
+  /** Gmail API が返した messageId (完了通知レコードに保存) */
+  messageId: string;
+  /** 最終的に成功したのが何回目の attempt か (audit 用) */
+  attempts: number;
+}
+
+export interface SendCompletionMailOptions {
+  /** retry の sleep 注入点 (テスト時は同期 resolve で短縮) */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Gmail API users.messages.send で完了通知を送信する。
+ * 429 / 503 / transient ネットワークエラーは exponential backoff で最大
+ * MAX_ATTEMPTS 回まで retry。それ以外は 1 回目で throw。
+ *
+ * 戻り値の messageId は caller が completion_notifications.messageId に保存する。
+ *
+ * @throws raw Gmail API error (caller 側で dispatch-403-classifier 等で分類)
+ */
+export async function sendCompletionMail(
+  input: SendCompletionMailInput,
+  options: SendCompletionMailOptions = {},
+): Promise<SendCompletionMailResult> {
+  const { subjectEmail, fromEmail, to, cc, subject, body } = input;
+  const sleep = options.sleep ?? defaultSleep;
+
+  const raw = buildCompletionMime({ fromEmail, to, cc, subject, body });
+  const gmail = await getGmailClientForSender(subjectEmail, fromEmail);
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const response = await gmail.users.messages.send({
+        userId: "me",
+        requestBody: { raw },
+      });
+      const messageId = response?.data?.id;
+      if (typeof messageId !== "string" || messageId.length === 0) {
+        throw new Error("Gmail API send returned no messageId");
+      }
+      return { messageId, attempts: attempt };
+    } catch (err) {
+      lastError = err;
+      const transient = isTransientGmailError(err);
+      if (!transient || attempt === MAX_ATTEMPTS) {
+        throw err;
+      }
+      const backoffMs = Math.min(
+        BACKOFF_INITIAL_MS * 2 ** (attempt - 1),
+        BACKOFF_MAX_MS,
+      );
+      await sleep(backoffMs);
+    }
+  }
+  // ループ脱出パスは throw 済のため到達不可だが TypeScript の網羅性のために残す
+  throw lastError;
+}

--- a/services/api/src/services/dispatch/gmail-dwd-send.ts
+++ b/services/api/src/services/dispatch/gmail-dwd-send.ts
@@ -75,7 +75,16 @@ export function encodeMimeHeader(value: string): string {
   return `=?UTF-8?B?${base64}?=`;
 }
 
-/** MIME ヘッダ系フィールドの CRLF 注入を library 層で阻止 (二重防御) */
+/**
+ * MIME ヘッダ系フィールドの CRLF 注入を library 層で阻止 (二重防御)。
+ *
+ * 注意: completion-notification-mail.ts の同名関数は **空文字 reject を持たない**
+ * (本関数とは責務範囲が異なる)。本関数は MIME ヘッダ行 (`From:` / `To:` /
+ * `Subject:` / `Cc:`) に直接乗る値を扱うため、空文字は受信側で空ヘッダになり
+ * 配送拒否や受信側 UI 不具合の原因となるため reject する。caller の Phase 4
+ * dispatcher は env から fromEmail / subjectEmail を渡すため空文字発生時は
+ * env 未設定のバグであり、ここで早期検出する。
+ */
 function assertHeaderSafe(value: string, fieldName: string): void {
   if (typeof value !== "string" || value.length === 0) {
     throw new Error(`gmail-dwd-send: ${fieldName} must be a non-empty string`);
@@ -126,6 +135,7 @@ export function buildCompletionMime(input: BuildCompletionMimeInput): string {
   const encodedSubject = encodeMimeHeader(subject);
 
   // 添付なしの text/plain メッセージ
+  // 配列要素の `""` は join("\r\n") により空行 (ヘッダとボディ区切り、RFC 2822) になる
   const headerLines: string[] = [
     `From: ${fromEmail}`,
     `To: ${to}`,
@@ -134,7 +144,7 @@ export function buildCompletionMime(input: BuildCompletionMimeInput): string {
     "MIME-Version: 1.0",
     "Content-Type: text/plain; charset=UTF-8",
     "Content-Transfer-Encoding: base64",
-    "",
+    "", // ← ヘッダとボディの区切り空行 (RFC 2822 §2.1)
     Buffer.from(body, "utf-8").toString("base64"),
   ];
   const raw = headerLines.join("\r\n");


### PR DESCRIPTION
## Summary

DXcollege 自動完了通知システム Phase 3 を完了。spec/impl-plan に従い **2 services + 2 test files** を TDD で実装。Phase 1 (基礎 services) で確定した `gmail-client.ts` の上に MIME 組立と Gmail API send retry を構築。

**進捗**:

| Phase | Status |
|---|---|
| Phase 0 (前提作業) | ✅ OQ-2 RESOLVED / SendAs 設定済 |
| Phase 1 (基礎 services 7 ファイル) | ✅ PR #442 + #465 |
| Phase 2 (Reservation / Run Lock) | ⏳ 未着手 (本 PR と並列着手可だった) |
| **Phase 3 (Mail + Send)** | ✅ **本 PR** |
| Phase 4-8 | ⏳ 未着手 |

## 新規 services

### completion-notification-mail.ts (AC-5 / Phase 3 完了条件)

完了通知メールの件名・本文を組み立てる pure 関数。

- **件名**: 定数 `DEFAULT_COMPLETION_SUBJECT` (\`【DXcollege】受講修了のお知らせ\`)
  - spec / DispatchSettings DTO に subjectTemplate 未定義のため Phase 1/3 では固定
  - 将来 settings 拡張要望が出たら DispatchSettings に追加して override 可能 (spec 未記載のため独断追加せず、4 原則 §1 遵守)
- **本文構造**: 「{userName} 様」(空なら「受講者各位」フォールバック) → 空行 → completionMessageBody → 空行 → 区切り `---` → signatureName
- signatureName が空文字 / 空白のみなら署名 block を省略 (defensive)
- **CRLF injection 防御**: userName / subject に CR/LF があれば throw
- body 内の CR/LF は許容 (base64 化される)

### gmail-dwd-send.ts (FR-5 改訂 / AC-3 / Phase 3 完了条件)

DWD なりすまし送信本体。

- **buildCompletionMime** (pure): From=SendAs alias, To, Cc (空配列なら省略), RFC 2047 件名 encode, text/plain UTF-8 base64 body, base64url 全体 encode
- **isTransientGmailError**: HTTP 429/503 + transport code (ECONNRESET 等) を判定
- **sendCompletionMail** (async):
  - exponential backoff retry (500ms → 1000ms → 2000ms, 最大 3 attempts)
  - 401/403/4xx は **即時 throw** (caller 側 dispatch-403-classifier で分類)
  - sleep injection 対応 (テスト時 vi.fn で短縮)
- `TRANSIENT_NETWORK_CODES` を export (テスト共有用)

### SendAs 方針 (ADR-037 案 X)

- JWT subject = 実 mailbox (`system@279279.net`, DXCOLLEGE_DISPATCH_SUBJECT env)
- MIME From = SendAs alias (`dxcollege@279279.net`, DXCOLLEGE_SENDER_EMAIL env)
- Gmail API は subject mailbox の context で動作し、SendAs 登録済の alias を From に許可

## Phase 3 完了条件チェック (impl-plan §Phase 3)

| 条件 | 検証 |
|---|---|
| 完了通知本文が completionMessageBody + signatureName を含む | ✅ AC-5 tests (17 件) |
| CC validation 失敗時に MIME に Cc: ヘッダが出ない | ✅ buildCompletionMime tests (Cc 空配列で `Cc:` 行省略を assert) |
| Gmail API 429 retry が exponential backoff で 3 回まで | ✅ sendCompletionMail tests (429×3 → throw、backoff 500→1000ms 検証) |

## 既存 PR #434 影響: ゼロ

`services/api/src/services/gmail-draft.ts` は完全に独立した別ファイル。`TRANSIENT_NETWORK_CODES` / `encodeMimeHeader` / MIME 組立ロジックは意図的に duplicate (spec §5.4 「PR #434 への影響ゼロ」遵守、follow-up Issue で共通 utility 抽出予定)。

## Test plan

- [x] dispatch tests 8 ファイル / 178 件 PASS (前回 124 → +54)
- [x] API tests 全体 77 ファイル / 1226 件 PASS (前回 1163 → +63)
- [x] lint: 0 errors (1 pre-existing warning は本 PR 範囲外)
- [x] type-check: 全 workspace PASS
- [ ] CI green
- [ ] code review (PR 内で実施予定: safe-refactor → evaluator → code-review medium)
- [ ] (Phase 4 着手時) sendCompletionMail を実際に呼び出す結合テストで integration 確認

## 参考

- 設計仕様書: \`docs/specs/2026-05-20-completion-notification-design.md\`
- 実装計画: \`docs/specs/2026-05-20-completion-notification-impl-plan.md\`
- ADR-037 (sender impersonation, SendAs 案 X): \`docs/adr/ADR-037-completion-notification-sender-impersonation.md\`
- 前 PR (Phase 1 残部): #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)