### PR TITLE
feat(dispatch): Phase 2 (Reservation / Run Lock / Dispatch Audit) を TDD で追加

### DIFF
--- a/services/api/src/services/dispatch/__tests__/dispatch-audit.test.ts
+++ b/services/api/src/services/dispatch/__tests__/dispatch-audit.test.ts
@@ -1,0 +1,331 @@
+/**
+ * dispatch-audit の Integration テスト。
+ *
+ * 設計仕様書 §4.1.5、§6.5、NFR-4 / NFR-11、AC-33、Phase 2 完了条件:
+ *   - audit_logs に PII 漏洩がないことを assertion
+ *
+ * 観点:
+ *   - 通常 append: auditId 生成、createdAt / ttlExpireAt 算出、storage に書き込まれる
+ *   - errorMessage が unknown / Error / string / null すべて受け付ける
+ *   - errorMessage に email を含めば sanitize されて保存される (NFR-11)
+ *   - storage が throw しても caller には例外伝搬しない (§6.1 best-effort)
+ *   - warn 注入で warning ログが呼ばれる (observability)
+ *   - auditIdGenerator 注入で固定 ID
+ *   - tenantId / userId / errorCode / durationMs が省略時 null
+ *   - ttlExpireAt = now + AUDIT_LOGS_TTL_DAYS (365 日)
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  DISPATCH_CONSTRAINTS,
+  type DispatchAuditLog,
+} from "@lms-279/shared-types";
+import { InMemoryDispatchStorage } from "../in-memory-dispatch-storage.js";
+import type {
+  AppendAuditLogInput,
+  DispatchStorage,
+} from "../dispatch-storage.js";
+import { recordAuditLog } from "../dispatch-audit.js";
+
+const NOW = new Date("2026-05-22T02:00:00.000Z");
+const RUN_ID = "run-uuid-99";
+const RUN_STARTED_AT = "2026-05-22T01:55:00.000Z";
+
+let storage: InMemoryDispatchStorage;
+
+beforeEach(() => {
+  storage = new InMemoryDispatchStorage();
+});
+
+describe("recordAuditLog - 通常 append", () => {
+  it("auditId 生成、createdAt = now、ttlExpireAt = now + 365 日", async () => {
+    await recordAuditLog(storage, {
+      runId: RUN_ID,
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "run_started",
+      now: NOW,
+      auditIdGenerator: () => "audit-fixed-1",
+    });
+
+    const logs = await storage.listAuditLogs({ runId: RUN_ID });
+    expect(logs).toHaveLength(1);
+    expect(logs[0].auditId).toBe("audit-fixed-1");
+    expect(logs[0].createdAt).toBe(NOW.toISOString());
+    const expectedTtlMs =
+      NOW.getTime() +
+      DISPATCH_CONSTRAINTS.AUDIT_LOGS_TTL_DAYS * 24 * 60 * 60 * 1000;
+    expect(logs[0].ttlExpireAt).toBe(new Date(expectedTtlMs).toISOString());
+  });
+
+  it("eventType / runId / runStartedAt が保存される", async () => {
+    await recordAuditLog(storage, {
+      runId: RUN_ID,
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "user_notified",
+      tenantId: "tenant-A",
+      userId: "user-1",
+      durationMs: 1234,
+      now: NOW,
+    });
+
+    const logs = await storage.listAuditLogs();
+    expect(logs[0].runId).toBe(RUN_ID);
+    expect(logs[0].runStartedAt).toBe(RUN_STARTED_AT);
+    expect(logs[0].eventType).toBe("user_notified");
+    expect(logs[0].tenantId).toBe("tenant-A");
+    expect(logs[0].userId).toBe("user-1");
+    expect(logs[0].durationMs).toBe(1234);
+  });
+
+  it("省略可 field は null で保存される", async () => {
+    await recordAuditLog(storage, {
+      runId: RUN_ID,
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "run_started",
+      now: NOW,
+    });
+
+    const logs = await storage.listAuditLogs();
+    expect(logs[0].tenantId).toBeNull();
+    expect(logs[0].userId).toBeNull();
+    expect(logs[0].errorCode).toBeNull();
+    expect(logs[0].errorMessage).toBeNull();
+    expect(logs[0].durationMs).toBeNull();
+  });
+});
+
+describe("recordAuditLog - PII sanitize (NFR-11、AC-33)", () => {
+  it("errorMessage に email を含めば [EMAIL] に redacted", async () => {
+    await recordAuditLog(storage, {
+      runId: RUN_ID,
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "user_failed_permanent",
+      tenantId: "tenant-A",
+      userId: "user-1",
+      errorCode: "gmail_api_error",
+      errorMessage: "Send failed to alice@example.com",
+      now: NOW,
+    });
+
+    const logs = await storage.listAuditLogs();
+    expect(logs[0].errorMessage).toBe("Send failed to [EMAIL]");
+    // 元 email が完全に除去されていることを assertion
+    expect(logs[0].errorMessage).not.toContain("alice@example.com");
+  });
+
+  it("errorMessage に access token / Bearer を含めば redacted", async () => {
+    await recordAuditLog(storage, {
+      runId: RUN_ID,
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "user_failed_permanent",
+      errorMessage:
+        "Auth failed: Bearer ya29.A0AfH6SMBxXx_test_token rejected",
+      now: NOW,
+    });
+
+    const logs = await storage.listAuditLogs();
+    expect(logs[0].errorMessage).not.toMatch(/ya29\./);
+    expect(logs[0].errorMessage).not.toContain("Bearer ya29");
+  });
+
+  it("errorMessage に MIME headers を含めば redacted", async () => {
+    await recordAuditLog(storage, {
+      runId: RUN_ID,
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "user_failed_permanent",
+      errorMessage: "Header validation failed:\nTo: victim@x.com",
+      now: NOW,
+    });
+
+    const logs = await storage.listAuditLogs();
+    expect(logs[0].errorMessage).not.toMatch(/To:\s*victim@x.com/);
+  });
+
+  it("Error オブジェクトを渡せば message を抽出して sanitize", async () => {
+    await recordAuditLog(storage, {
+      runId: RUN_ID,
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "user_failed_permanent",
+      errorMessage: new Error("Recipient rejected: charlie@example.org"),
+      now: NOW,
+    });
+
+    const logs = await storage.listAuditLogs();
+    expect(logs[0].errorMessage).toBe("Recipient rejected: [EMAIL]");
+  });
+
+  it("errorMessage = null は null のまま (sanitize しない)", async () => {
+    await recordAuditLog(storage, {
+      runId: RUN_ID,
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "run_started",
+      errorMessage: null,
+      now: NOW,
+    });
+
+    const logs = await storage.listAuditLogs();
+    expect(logs[0].errorMessage).toBeNull();
+  });
+});
+
+describe("recordAuditLog - best-effort (§6.1)", () => {
+  /** appendAuditLog が必ず throw する障害 storage */
+  function makeFailingStorage(): DispatchStorage {
+    return {
+      tryReserveCompletionNotification: vi.fn(),
+      markCompletionNotificationSent: vi.fn(),
+      markCompletionNotificationFailedPermanent: vi.fn(),
+      getCompletionNotification: vi.fn(),
+      acquireRunLock: vi.fn(),
+      updateRunStatus: vi.fn(),
+      getRun: vi.fn(),
+      appendAuditLog: vi.fn(
+        (_input: AppendAuditLogInput): Promise<void> =>
+          Promise.reject(new Error("Firestore unavailable")),
+      ),
+      listAuditLogs: vi.fn(
+        (): Promise<DispatchAuditLog[]> => Promise.resolve([]),
+      ),
+    };
+  }
+
+  it("storage が throw しても caller には例外伝搬しない (resolve)", async () => {
+    const failing = makeFailingStorage();
+    const warn = vi.fn();
+    await expect(
+      recordAuditLog(
+        failing,
+        {
+          runId: RUN_ID,
+          runStartedAt: RUN_STARTED_AT,
+          eventType: "user_notified",
+          now: NOW,
+        },
+        warn,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("storage が throw した時、warn callback が呼ばれる (observability)", async () => {
+    const failing = makeFailingStorage();
+    const warn = vi.fn();
+    await recordAuditLog(
+      failing,
+      {
+        runId: RUN_ID,
+        runStartedAt: RUN_STARTED_AT,
+        eventType: "user_notified",
+        tenantId: "tenant-A",
+        userId: "user-x",
+        now: NOW,
+      },
+      warn,
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/appendAuditLog failed/);
+    const meta = warn.mock.calls[0][1] as Record<string, unknown>;
+    expect(meta.runId).toBe(RUN_ID);
+    expect(meta.eventType).toBe("user_notified");
+    expect(meta.tenantId).toBe("tenant-A");
+    expect(meta.userId).toBe("user-x");
+  });
+
+  it("warn meta の errorMessage は storage error message を sanitize 済で出す", async () => {
+    const storageThatThrowsWithEmail: DispatchStorage = {
+      tryReserveCompletionNotification: vi.fn(),
+      markCompletionNotificationSent: vi.fn(),
+      markCompletionNotificationFailedPermanent: vi.fn(),
+      getCompletionNotification: vi.fn(),
+      acquireRunLock: vi.fn(),
+      updateRunStatus: vi.fn(),
+      getRun: vi.fn(),
+      appendAuditLog: vi.fn(() =>
+        Promise.reject(new Error("Conflict on user secret@x.com")),
+      ),
+      listAuditLogs: vi.fn(() => Promise.resolve([])),
+    };
+    const warn = vi.fn();
+    await recordAuditLog(
+      storageThatThrowsWithEmail,
+      {
+        runId: RUN_ID,
+        runStartedAt: RUN_STARTED_AT,
+        eventType: "user_failed_permanent",
+        now: NOW,
+      },
+      warn,
+    );
+    const meta = warn.mock.calls[0][1] as Record<string, unknown>;
+    expect(meta.errorMessage).toBe("Conflict on user [EMAIL]");
+  });
+});
+
+describe("recordAuditLog - auditId 自動生成 (default randomUUID)", () => {
+  it("auditIdGenerator 省略時は randomUUID で UUID 形式", async () => {
+    await recordAuditLog(storage, {
+      runId: RUN_ID,
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "run_started",
+      now: NOW,
+    });
+    const logs = await storage.listAuditLogs();
+    // UUID v4 形式 (xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
+    expect(logs[0].auditId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("複数 append で auditId が重複しない", async () => {
+    for (let i = 0; i < 5; i++) {
+      await recordAuditLog(storage, {
+        runId: RUN_ID,
+        runStartedAt: RUN_STARTED_AT,
+        eventType: "user_skipped",
+        now: NOW,
+      });
+    }
+    const logs = await storage.listAuditLogs();
+    const ids = new Set(logs.map((l) => l.auditId));
+    expect(ids.size).toBe(5);
+  });
+});
+
+describe("filter (listAuditLogs)", () => {
+  it("runId で絞り込み", async () => {
+    await recordAuditLog(storage, {
+      runId: "run-a",
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "run_started",
+      now: NOW,
+    });
+    await recordAuditLog(storage, {
+      runId: "run-b",
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "run_started",
+      now: NOW,
+    });
+
+    const a = await storage.listAuditLogs({ runId: "run-a" });
+    expect(a).toHaveLength(1);
+    expect(a[0].runId).toBe("run-a");
+  });
+
+  it("eventType で絞り込み", async () => {
+    await recordAuditLog(storage, {
+      runId: RUN_ID,
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "user_notified",
+      now: NOW,
+    });
+    await recordAuditLog(storage, {
+      runId: RUN_ID,
+      runStartedAt: RUN_STARTED_AT,
+      eventType: "user_skipped",
+      now: NOW,
+    });
+
+    const notified = await storage.listAuditLogs({ eventType: "user_notified" });
+    expect(notified).toHaveLength(1);
+    expect(notified[0].eventType).toBe("user_notified");
+  });
+});

--- a/services/api/src/services/dispatch/__tests__/reservation.test.ts
+++ b/services/api/src/services/dispatch/__tests__/reservation.test.ts
@@ -425,6 +425,67 @@ describe("markFailedPermanent", () => {
   });
 });
 
+describe("2 並列 worker 同時 reservation (evaluator narrative 反映)", () => {
+  it("Promise.all で同 (tenantId, userId) を 2 並列 reserve → 1 件のみ成功", async () => {
+    const [a, b] = await Promise.all([
+      tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-parallel-a",
+        now: NOW,
+      }),
+      tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-parallel-b",
+        now: NOW,
+      }),
+    ]);
+    // 1 件のみ reserved=true (atomicity 担保確認)
+    const successes = [a, b].filter((r) => r.reserved).length;
+    expect(successes).toBe(1);
+    const failed = a.reserved ? b : a;
+    expect(failed.reserved).toBe(false);
+    if (!failed.reserved) {
+      expect(failed.reason).toBe("currently_reserved_by_other_run");
+    }
+  });
+
+  it("Promise.all で lease 期限切れ既存 reservation を 2 並列 reserve → 1 件のみ降格成功", async () => {
+    // 既存 reservation を仕込む
+    await tryReserveOrSkip(storage, {
+      tenantId: TENANT,
+      userId: USER,
+      runId: "run-orig",
+      now: NOW,
+    });
+    const expired = new Date(
+      NOW.getTime() + DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS + 1000,
+    );
+    // 2 並列で期限切れ検出 → 両方が降格しようとする
+    const [a, b] = await Promise.all([
+      tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-a",
+        now: expired,
+      }),
+      tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-b",
+        now: expired,
+      }),
+    ]);
+    // atomicity 保証: 1 件目だけが降格、2 件目は降格後の manual_review_required を検出
+    const reasons = [a, b].map((r) => (r.reserved ? "reserved" : r.reason));
+    expect(reasons).toContain("lease_expired_promoted_to_manual_review");
+    expect(reasons).toContain("manual_review_required");
+    const record = await getReservation(storage, TENANT, USER);
+    expect(record?.status).toBe("manual_review_required");
+  });
+});
+
 describe("tenant 分離 / user 分離", () => {
   it("異なる tenantId なら独立した reservation", async () => {
     await tryReserveOrSkip(storage, {

--- a/services/api/src/services/dispatch/__tests__/reservation.test.ts
+++ b/services/api/src/services/dispatch/__tests__/reservation.test.ts
@@ -1,0 +1,460 @@
+/**
+ * reservation の Integration テスト (InMemoryDispatchStorage 中心、ADR-028 準拠)。
+ *
+ * 設計仕様書 §6.2、FR-7 改訂、AC-10/11/12、Phase 2 完了条件:
+ *   - Integration Test で transaction 競合 6 シナリオ網羅
+ *     (新規 / sent / failed_permanent / reserved-in-lease / reserved-expired / manual_review)
+ *
+ * 観点:
+ *   - 新規予約: completion_notifications 不在 → reserved=true で create
+ *   - 既存 sent: → reserved=false, reason="already_sent"
+ *   - 既存 failed_permanent: → reserved=false, reason="failed_permanent"
+ *   - 既存 manual_review_required: → reserved=false, reason="manual_review_required"
+ *   - 既存 reserved (lease 内): → reserved=false, reason="currently_reserved_by_other_run"
+ *   - 既存 reserved (lease 期限切れ): → 降格 + reserved=false, reason="lease_expired_promoted_to_manual_review"
+ *   - leaseExpiresAt = now + RESERVATION_LEASE_MS (10 分) で計算される
+ *   - markSent: reserved → sent 遷移、snapshot/messageId/PII hash がセットされる
+ *   - markFailedPermanent: reserved → failed_permanent 遷移、error code/message がセットされる
+ *   - markSent: 予約なし / reserved 以外で呼ぶと throw (caller の前提違反検出)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { DISPATCH_CONSTRAINTS } from "@lms-279/shared-types";
+import { InMemoryDispatchStorage } from "../in-memory-dispatch-storage.js";
+import {
+  tryReserveOrSkip,
+  markSent,
+  markFailedPermanent,
+  getReservation,
+} from "../reservation.js";
+
+const TENANT = "tenant-A";
+const USER = "user-1";
+const RUN_ID = "run-uuid-1";
+const NOW = new Date("2026-05-22T00:00:00.000Z");
+
+let storage: InMemoryDispatchStorage;
+
+beforeEach(() => {
+  storage = new InMemoryDispatchStorage();
+});
+
+/** 既存予約を「sent」状態でセットアップ (markSent 経由で reserved → sent 遷移) */
+async function seedSentReservation() {
+  await tryReserveOrSkip(storage, {
+    tenantId: TENANT,
+    userId: USER,
+    runId: RUN_ID,
+    now: NOW,
+  });
+  await markSent(storage, {
+    tenantId: TENANT,
+    userId: USER,
+    messageId: "msg-001",
+    notifiedAt: NOW.toISOString(),
+    courseIdsSnapshot: ["c1"],
+    progressSnapshot: {
+      completedLessons: 3,
+      totalLessons: 3,
+      coursesCompleted: 1,
+      coursesTotal: 1,
+    },
+    recipientToHash: "hash-to",
+    recipientCcHashes: ["hash-cc"],
+    pdfSizeBytes: null,
+  });
+}
+
+async function seedFailedPermanent() {
+  await tryReserveOrSkip(storage, {
+    tenantId: TENANT,
+    userId: USER,
+    runId: RUN_ID,
+    now: NOW,
+  });
+  await markFailedPermanent(storage, {
+    tenantId: TENANT,
+    userId: USER,
+    failedAt: NOW.toISOString(),
+    errorCode: "gmail_api_error",
+    errorMessage: "permanent failure",
+  });
+}
+
+/** 既存予約を manual_review_required に直接遷移させる (lease 期限切れ経路) */
+async function seedManualReview() {
+  // 一旦 reserved にしておき、その後 lease 切れの 2 回目試行で降格させる
+  await tryReserveOrSkip(storage, {
+    tenantId: TENANT,
+    userId: USER,
+    runId: RUN_ID,
+    now: NOW,
+  });
+  const expiredNow = new Date(
+    NOW.getTime() + DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS + 1000,
+  );
+  await tryReserveOrSkip(storage, {
+    tenantId: TENANT,
+    userId: USER,
+    runId: "another-run",
+    now: expiredNow,
+  });
+}
+
+describe("tryReserveOrSkip (6 シナリオ網羅、Phase 2 完了条件)", () => {
+  describe("シナリオ 1: 新規予約", () => {
+    it("completion_notifications 不在 → reserved=true で create", async () => {
+      const result = await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: RUN_ID,
+        now: NOW,
+      });
+      expect(result).toEqual({ reserved: true });
+
+      const record = await getReservation(storage, TENANT, USER);
+      expect(record).not.toBeNull();
+      expect(record?.status).toBe("reserved");
+      expect(record?.runId).toBe(RUN_ID);
+      expect(record?.reservedAt).toBe(NOW.toISOString());
+      // leaseExpiresAt = now + 10 分 (RESERVATION_LEASE_MS)
+      const expectedLease = new Date(
+        NOW.getTime() + DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS,
+      ).toISOString();
+      expect(record?.leaseExpiresAt).toBe(expectedLease);
+    });
+  });
+
+  describe("シナリオ 2: 既存 sent", () => {
+    it("status=sent なら reserved=false, reason=already_sent", async () => {
+      await seedSentReservation();
+      const result = await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "new-run",
+        now: NOW,
+      });
+      expect(result).toEqual({ reserved: false, reason: "already_sent" });
+    });
+
+    it("sent 後の record は status / messageId が保持される (state 改変なし)", async () => {
+      await seedSentReservation();
+      await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "new-run",
+        now: NOW,
+      });
+      const record = await getReservation(storage, TENANT, USER);
+      expect(record?.status).toBe("sent");
+      expect(record?.messageId).toBe("msg-001");
+    });
+  });
+
+  describe("シナリオ 3: 既存 failed_permanent", () => {
+    it("status=failed_permanent なら reserved=false, reason=failed_permanent", async () => {
+      await seedFailedPermanent();
+      const result = await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "new-run",
+        now: NOW,
+      });
+      expect(result).toEqual({ reserved: false, reason: "failed_permanent" });
+    });
+  });
+
+  describe("シナリオ 4: 既存 manual_review_required", () => {
+    it("status=manual_review_required なら reserved=false, reason=manual_review_required", async () => {
+      await seedManualReview();
+      const result = await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "new-run",
+        now: new Date(
+          NOW.getTime() + DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS * 10,
+        ),
+      });
+      expect(result).toEqual({
+        reserved: false,
+        reason: "manual_review_required",
+      });
+    });
+  });
+
+  describe("シナリオ 5: 既存 reserved (lease 期限内、他 run が処理中)", () => {
+    it("→ reserved=false, reason=currently_reserved_by_other_run", async () => {
+      // run-1 が予約取得
+      await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-1",
+        now: NOW,
+      });
+      // run-2 が直後 (lease 内) に予約試行
+      const slightlyLater = new Date(NOW.getTime() + 60_000); // 1 分後 < 10 分
+      const result = await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-2",
+        now: slightlyLater,
+      });
+      expect(result).toEqual({
+        reserved: false,
+        reason: "currently_reserved_by_other_run",
+      });
+      // record は run-1 の予約を保持
+      const record = await getReservation(storage, TENANT, USER);
+      expect(record?.runId).toBe("run-1");
+      expect(record?.status).toBe("reserved");
+    });
+  });
+
+  describe("シナリオ 6: 既存 reserved (lease 期限切れ → manual_review 降格)", () => {
+    it("→ reserved=false, reason=lease_expired_promoted_to_manual_review、record 状態が manual_review_required に降格", async () => {
+      // run-1 が予約取得
+      await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-1",
+        now: NOW,
+      });
+      // lease 期限を 1 秒超過した時点で別 run が試行
+      const expired = new Date(
+        NOW.getTime() + DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS + 1000,
+      );
+      const result = await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-2",
+        now: expired,
+      });
+      expect(result).toEqual({
+        reserved: false,
+        reason: "lease_expired_promoted_to_manual_review",
+      });
+      const record = await getReservation(storage, TENANT, USER);
+      expect(record?.status).toBe("manual_review_required");
+      expect(record?.failedAt).toBe(expired.toISOString());
+    });
+
+    it("降格後の再 reserve 試行は manual_review_required で skip (再送防止)", async () => {
+      await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-1",
+        now: NOW,
+      });
+      const expired = new Date(
+        NOW.getTime() + DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS + 1000,
+      );
+      await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-2",
+        now: expired,
+      });
+      // run-3 が更に後で試行 (manual_review_required 検出)
+      const muchLater = new Date(expired.getTime() + 3_600_000);
+      const result = await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-3",
+        now: muchLater,
+      });
+      expect(result).toEqual({
+        reserved: false,
+        reason: "manual_review_required",
+      });
+    });
+  });
+
+  describe("lease 境界 (=)", () => {
+    it("leaseExpiresAt === now (秒同値) なら期限切れ扱いで降格", async () => {
+      await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-1",
+        now: NOW,
+      });
+      const exactlyAtLease = new Date(
+        NOW.getTime() + DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS,
+      );
+      const result = await tryReserveOrSkip(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        runId: "run-2",
+        now: exactlyAtLease,
+      });
+      // <= 比較なので「期限ちょうど」も期限切れと判定
+      expect(result.reserved).toBe(false);
+      if (!result.reserved) {
+        expect(result.reason).toBe("lease_expired_promoted_to_manual_review");
+      }
+    });
+  });
+});
+
+describe("markSent", () => {
+  it("reserved → sent 遷移、snapshot/messageId/PII hash がセットされる", async () => {
+    await tryReserveOrSkip(storage, {
+      tenantId: TENANT,
+      userId: USER,
+      runId: RUN_ID,
+      now: NOW,
+    });
+    await markSent(storage, {
+      tenantId: TENANT,
+      userId: USER,
+      messageId: "msg-xyz",
+      notifiedAt: NOW.toISOString(),
+      courseIdsSnapshot: ["c1", "c2"],
+      progressSnapshot: {
+        completedLessons: 5,
+        totalLessons: 5,
+        coursesCompleted: 2,
+        coursesTotal: 2,
+      },
+      recipientToHash: "sha-to",
+      recipientCcHashes: ["sha-cc1", "sha-cc2"],
+      pdfSizeBytes: 12345,
+    });
+
+    const record = await getReservation(storage, TENANT, USER);
+    expect(record?.status).toBe("sent");
+    expect(record?.messageId).toBe("msg-xyz");
+    expect(record?.notifiedAt).toBe(NOW.toISOString());
+    expect(record?.courseIdsSnapshot).toEqual(["c1", "c2"]);
+    expect(record?.publishedCourseCount).toBe(2);
+    expect(record?.progressSnapshot.completedLessons).toBe(5);
+    expect(record?.recipientToHash).toBe("sha-to");
+    expect(record?.recipientCcHashes).toEqual(["sha-cc1", "sha-cc2"]);
+    expect(record?.pdfSizeBytes).toBe(12345);
+  });
+
+  it("予約なしで呼ぶと throw (caller 前提違反検出)", async () => {
+    await expect(
+      markSent(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        messageId: "msg",
+        notifiedAt: NOW.toISOString(),
+        courseIdsSnapshot: [],
+        progressSnapshot: {
+          completedLessons: 0,
+          totalLessons: 0,
+          coursesCompleted: 0,
+          coursesTotal: 0,
+        },
+        recipientToHash: "",
+        recipientCcHashes: [],
+        pdfSizeBytes: null,
+      }),
+    ).rejects.toThrow(/no reservation/);
+  });
+
+  it("reserved 以外 (sent) で呼ぶと throw", async () => {
+    await seedSentReservation();
+    await expect(
+      markSent(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        messageId: "msg-2nd",
+        notifiedAt: NOW.toISOString(),
+        courseIdsSnapshot: [],
+        progressSnapshot: {
+          completedLessons: 0,
+          totalLessons: 0,
+          coursesCompleted: 0,
+          coursesTotal: 0,
+        },
+        recipientToHash: "",
+        recipientCcHashes: [],
+        pdfSizeBytes: null,
+      }),
+    ).rejects.toThrow(/status must be "reserved"/);
+  });
+});
+
+describe("markFailedPermanent", () => {
+  it("reserved → failed_permanent 遷移、error code/message がセットされる", async () => {
+    await tryReserveOrSkip(storage, {
+      tenantId: TENANT,
+      userId: USER,
+      runId: RUN_ID,
+      now: NOW,
+    });
+    await markFailedPermanent(storage, {
+      tenantId: TENANT,
+      userId: USER,
+      failedAt: NOW.toISOString(),
+      errorCode: "gmail_recipient_rejected",
+      errorMessage: "Recipient rejected (sanitized)",
+    });
+
+    const record = await getReservation(storage, TENANT, USER);
+    expect(record?.status).toBe("failed_permanent");
+    expect(record?.errorCode).toBe("gmail_recipient_rejected");
+    expect(record?.errorMessage).toBe("Recipient rejected (sanitized)");
+    expect(record?.failedAt).toBe(NOW.toISOString());
+  });
+
+  it("予約なしで呼ぶと throw", async () => {
+    await expect(
+      markFailedPermanent(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        failedAt: NOW.toISOString(),
+        errorCode: "x",
+        errorMessage: "y",
+      }),
+    ).rejects.toThrow(/no reservation/);
+  });
+
+  it("reserved 以外 (failed_permanent) で呼ぶと throw", async () => {
+    await seedFailedPermanent();
+    await expect(
+      markFailedPermanent(storage, {
+        tenantId: TENANT,
+        userId: USER,
+        failedAt: NOW.toISOString(),
+        errorCode: "x",
+        errorMessage: "y",
+      }),
+    ).rejects.toThrow(/status must be "reserved"/);
+  });
+});
+
+describe("tenant 分離 / user 分離", () => {
+  it("異なる tenantId なら独立した reservation", async () => {
+    await tryReserveOrSkip(storage, {
+      tenantId: "tenant-A",
+      userId: USER,
+      runId: RUN_ID,
+      now: NOW,
+    });
+    const result = await tryReserveOrSkip(storage, {
+      tenantId: "tenant-B",
+      userId: USER,
+      runId: RUN_ID,
+      now: NOW,
+    });
+    expect(result).toEqual({ reserved: true });
+  });
+
+  it("異なる userId なら独立した reservation", async () => {
+    await tryReserveOrSkip(storage, {
+      tenantId: TENANT,
+      userId: "user-a",
+      runId: RUN_ID,
+      now: NOW,
+    });
+    const result = await tryReserveOrSkip(storage, {
+      tenantId: TENANT,
+      userId: "user-b",
+      runId: RUN_ID,
+      now: NOW,
+    });
+    expect(result).toEqual({ reserved: true });
+  });
+});

--- a/services/api/src/services/dispatch/__tests__/run-lock.test.ts
+++ b/services/api/src/services/dispatch/__tests__/run-lock.test.ts
@@ -1,0 +1,241 @@
+/**
+ * run-lock の Integration テスト。
+ *
+ * 設計仕様書 §6.3、FR-11、AC-16、Phase 2 完了条件:
+ *   - run lock 同時起動 2 件で 1 つだけ成功するシナリオ確認
+ *
+ * 観点:
+ *   - 単独 acquireRunLock → acquired=true、status=running、メトリクス 0 で create
+ *   - 同時 acquireRunLock 2 件 → 1 件 acquired=true、もう 1 件 acquired=false (another_run_active)
+ *   - duplicate runId → acquired=false (duplicate_run_id)
+ *   - lease 期限切れ後の新規 acquire → 取得成功 (現在の lease 内に running が無いため)
+ *   - completeRun / abortRun の status 遷移
+ *   - メトリクス update (processedTenants/sent/skipped/failed)
+ *   - abortedReason は sanitized 文字列のみを保存
+ *   - leaseExpiresAt = now + DISPATCH_RUN_LEASE_MS (280s)
+ *   - ttlExpireAt = now + AUDIT_LOGS_TTL_DAYS (365 days)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { DISPATCH_CONSTRAINTS } from "@lms-279/shared-types";
+import { InMemoryDispatchStorage } from "../in-memory-dispatch-storage.js";
+import {
+  acquireRunLockOrSkip,
+  finalizeRun,
+  completeRun,
+  abortRun,
+} from "../run-lock.js";
+
+const NOW = new Date("2026-05-22T01:00:00.000Z");
+
+let storage: InMemoryDispatchStorage;
+
+beforeEach(() => {
+  storage = new InMemoryDispatchStorage();
+});
+
+describe("acquireRunLockOrSkip - 単独起動", () => {
+  it("running run なし → acquired=true, status=running, メトリクス 0", async () => {
+    const result = await acquireRunLockOrSkip(storage, {
+      now: NOW,
+      runId: "run-uuid-1",
+    });
+    expect(result.acquired).toBe(true);
+    if (result.acquired) {
+      expect(result.run.runId).toBe("run-uuid-1");
+      expect(result.run.status).toBe("running");
+      expect(result.run.processedTenants).toBe(0);
+      expect(result.run.sent).toBe(0);
+      expect(result.run.skipped).toBe(0);
+      expect(result.run.failed).toBe(0);
+      expect(result.run.abortedReason).toBeNull();
+      expect(result.run.triggeredAt).toBe(NOW.toISOString());
+    }
+  });
+
+  it("leaseExpiresAt = now + DISPATCH_RUN_LEASE_MS (280s)", async () => {
+    const result = await acquireRunLockOrSkip(storage, {
+      now: NOW,
+      runId: "run-uuid-2",
+    });
+    expect(result.acquired).toBe(true);
+    if (result.acquired) {
+      const expected = new Date(
+        NOW.getTime() + DISPATCH_CONSTRAINTS.DISPATCH_RUN_LEASE_MS,
+      ).toISOString();
+      expect(result.run.leaseExpiresAt).toBe(expected);
+    }
+  });
+
+  it("ttlExpireAt = now + AUDIT_LOGS_TTL_DAYS (365 days)", async () => {
+    const result = await acquireRunLockOrSkip(storage, {
+      now: NOW,
+      runId: "run-uuid-3",
+    });
+    expect(result.acquired).toBe(true);
+    if (result.acquired) {
+      const expectedMs =
+        NOW.getTime() +
+        DISPATCH_CONSTRAINTS.AUDIT_LOGS_TTL_DAYS * 24 * 60 * 60 * 1000;
+      expect(result.run.ttlExpireAt).toBe(new Date(expectedMs).toISOString());
+    }
+  });
+});
+
+describe("acquireRunLockOrSkip - 重複起動 (AC-16)", () => {
+  it("同時 2 件で 1 件のみ acquired=true、もう 1 件 acquired=false (another_run_active)", async () => {
+    // 2 つの request を同時に発行 (Promise.all で並列)
+    const [a, b] = await Promise.all([
+      acquireRunLockOrSkip(storage, { now: NOW, runId: "run-a" }),
+      acquireRunLockOrSkip(storage, { now: NOW, runId: "run-b" }),
+    ]);
+    const acquiredCount = [a.acquired, b.acquired].filter(Boolean).length;
+    expect(acquiredCount).toBe(1);
+
+    const failed = a.acquired ? b : a;
+    expect(failed.acquired).toBe(false);
+    if (!failed.acquired) {
+      expect(failed.reason).toBe("another_run_active");
+    }
+  });
+
+  it("逐次の重複起動でも同様 (run 1 取得後の run 2 試行)", async () => {
+    const first = await acquireRunLockOrSkip(storage, {
+      now: NOW,
+      runId: "run-1",
+    });
+    expect(first.acquired).toBe(true);
+
+    const second = await acquireRunLockOrSkip(storage, {
+      now: new Date(NOW.getTime() + 1000), // 1 秒後
+      runId: "run-2",
+    });
+    expect(second.acquired).toBe(false);
+    if (!second.acquired) {
+      expect(second.reason).toBe("another_run_active");
+    }
+  });
+
+  it("duplicate runId (同 runId 2 回目) → acquired=false, reason=duplicate_run_id", async () => {
+    await acquireRunLockOrSkip(storage, { now: NOW, runId: "run-dup" });
+    const second = await acquireRunLockOrSkip(storage, {
+      now: new Date(NOW.getTime() + 1000),
+      runId: "run-dup", // 同 ID 再試行
+    });
+    expect(second.acquired).toBe(false);
+    if (!second.acquired) {
+      expect(second.reason).toBe("duplicate_run_id");
+    }
+  });
+});
+
+describe("acquireRunLockOrSkip - lease 期限切れ後の再取得", () => {
+  it("既存 run の lease が期限切れになったら新規 acquire 成功", async () => {
+    const first = await acquireRunLockOrSkip(storage, {
+      now: NOW,
+      runId: "run-1",
+    });
+    expect(first.acquired).toBe(true);
+
+    // lease 期限を超過した時点で別 run を試行
+    const afterLease = new Date(
+      NOW.getTime() + DISPATCH_CONSTRAINTS.DISPATCH_RUN_LEASE_MS + 1000,
+    );
+    const second = await acquireRunLockOrSkip(storage, {
+      now: afterLease,
+      runId: "run-2",
+    });
+    expect(second.acquired).toBe(true);
+    // run-1 はそのまま保持 (lease 切れだが status は running のまま、別途 caller が timeout 更新する想定)
+    const r1 = await storage.getRun("run-1");
+    expect(r1?.status).toBe("running");
+  });
+
+  it("completed 状態の run は lease 期限内でも他 run の acquire を妨げない", async () => {
+    const first = await acquireRunLockOrSkip(storage, {
+      now: NOW,
+      runId: "run-1",
+    });
+    expect(first.acquired).toBe(true);
+    await completeRun(storage, "run-1", {
+      processedTenants: 2,
+      sent: 5,
+      skipped: 0,
+      failed: 0,
+    });
+
+    // lease 内だが completed なので新規 acquire OK
+    const second = await acquireRunLockOrSkip(storage, {
+      now: new Date(NOW.getTime() + 10_000),
+      runId: "run-2",
+    });
+    expect(second.acquired).toBe(true);
+  });
+});
+
+describe("finalizeRun / completeRun / abortRun", () => {
+  it("completeRun: status=completed + メトリクス積算", async () => {
+    await acquireRunLockOrSkip(storage, { now: NOW, runId: "run-x" });
+    await completeRun(storage, "run-x", {
+      processedTenants: 3,
+      sent: 7,
+      skipped: 2,
+      failed: 1,
+    });
+
+    const run = await storage.getRun("run-x");
+    expect(run?.status).toBe("completed");
+    expect(run?.processedTenants).toBe(3);
+    expect(run?.sent).toBe(7);
+    expect(run?.skipped).toBe(2);
+    expect(run?.failed).toBe(1);
+    expect(run?.abortedReason).toBeNull();
+  });
+
+  it("abortRun: status=aborted + abortedReason がセットされる (sanitized 前提)", async () => {
+    await acquireRunLockOrSkip(storage, { now: NOW, runId: "run-y" });
+    await abortRun(
+      storage,
+      "run-y",
+      "gmail_scope_revoked",
+      { processedTenants: 1, sent: 0, skipped: 0, failed: 0 },
+    );
+
+    const run = await storage.getRun("run-y");
+    expect(run?.status).toBe("aborted");
+    expect(run?.abortedReason).toBe("gmail_scope_revoked");
+  });
+
+  it("abortRun は metrics 省略可 (既存値が保持される)", async () => {
+    await acquireRunLockOrSkip(storage, { now: NOW, runId: "run-z" });
+    await abortRun(storage, "run-z", "early_abort");
+
+    const run = await storage.getRun("run-z");
+    expect(run?.status).toBe("aborted");
+    expect(run?.abortedReason).toBe("early_abort");
+    // メトリクスは初期値 0 のまま
+    expect(run?.sent).toBe(0);
+  });
+
+  it("finalizeRun: 任意 status (timeout) も指定可", async () => {
+    await acquireRunLockOrSkip(storage, { now: NOW, runId: "run-t" });
+    await finalizeRun(storage, {
+      runId: "run-t",
+      status: "timeout",
+      processedTenants: 1,
+      sent: 0,
+      skipped: 0,
+      failed: 5,
+    });
+
+    const run = await storage.getRun("run-t");
+    expect(run?.status).toBe("timeout");
+    expect(run?.failed).toBe(5);
+  });
+
+  it("存在しない runId への finalizeRun は throw", async () => {
+    await expect(
+      finalizeRun(storage, { runId: "missing", status: "completed" }),
+    ).rejects.toThrow(/no run found/);
+  });
+});

--- a/services/api/src/services/dispatch/dispatch-audit.ts
+++ b/services/api/src/services/dispatch/dispatch-audit.ts
@@ -20,14 +20,12 @@
  */
 
 import { randomUUID } from "node:crypto";
+import type { DispatchAuditLog } from "@lms-279/shared-types";
 import {
-  DISPATCH_CONSTRAINTS,
-  type DispatchAuditLog,
-} from "@lms-279/shared-types";
-import type { DispatchStorage } from "./dispatch-storage.js";
+  DISPATCH_AUDIT_TTL_MS,
+  type DispatchStorage,
+} from "./dispatch-storage.js";
 import { sanitizeErrorForAudit } from "./dispatch-error-sanitizer.js";
-
-const TTL_MS = DISPATCH_CONSTRAINTS.AUDIT_LOGS_TTL_DAYS * 24 * 60 * 60 * 1000;
 
 export interface RecordAuditLogInput {
   runId: string;
@@ -39,11 +37,14 @@ export interface RecordAuditLogInput {
   /** sanitized error code (PII を含まない短い識別子) */
   errorCode?: string | null;
   /**
-   * error message。raw `unknown` を渡せば本 layer で sanitize する。
-   * すでに sanitize 済の string を渡しても再度 sanitize されるが冪等
-   * (二重 redaction でも plain text は安全に保たれる)。
+   * error message。`null` 指定なら no-op、`string` / `Error` / その他 `unknown` は
+   * すべて `sanitizeErrorForAudit` で string 化 + PII redaction する。
+   *
+   * 二重 sanitize 安全性: caller が既に sanitize 済の string を渡しても、
+   * `[EMAIL]` 等の redaction marker は再 sanitize しても変化しない冪等性を持つ
+   * ため安全。本 layer での sanitize は caller の漏れ防止 (NFR-11 二重防御)。
    */
-  errorMessage?: string | unknown | null;
+  errorMessage?: unknown;
   durationMs?: number | null;
   /** 現在時刻 (テスト時固定可、Date 注入) */
   now: Date;
@@ -65,9 +66,10 @@ export async function recordAuditLog(
   warn: (message: string, meta: Record<string, unknown>) => void = (msg, meta) =>
     console.warn(msg, meta),
 ): Promise<void> {
-  const nowMs = input.now.getTime();
-  const createdAt = new Date(nowMs).toISOString();
-  const ttlExpireAt = new Date(nowMs + TTL_MS).toISOString();
+  const createdAt = input.now.toISOString();
+  const ttlExpireAt = new Date(
+    input.now.getTime() + DISPATCH_AUDIT_TTL_MS,
+  ).toISOString();
   const auditId = (input.auditIdGenerator ?? randomUUID)();
 
   // errorMessage を null/undefined/string/unknown いずれでも安全に正規化

--- a/services/api/src/services/dispatch/dispatch-audit.ts
+++ b/services/api/src/services/dispatch/dispatch-audit.ts
@@ -1,0 +1,104 @@
+/**
+ * super_dispatch_audit_logs 書き込みの薄い service layer。
+ *
+ * 設計仕様書 §4.1.5、§6.5、NFR-4 / NFR-11、AC-33 対応。
+ *
+ * 責務:
+ *   - auditId 生成 (uuid v4)
+ *   - createdAt / ttlExpireAt 算出
+ *   - DispatchStorage.appendAuditLog に委譲 (best-effort、例外を caller に伝搬しない)
+ *   - errorMessage が渡されている場合は **念のため** sanitizeErrorForAudit で
+ *     redaction (caller 側で sanitize 漏れ防止の二重防御)
+ *
+ * 設計仕様書 §6.1「super_dispatch_audit_logs 書き込み失敗は警告ログのみ、
+ * レスポンスをブロックしない」原則を本 layer で構造的に保証する。
+ *
+ * 注意:
+ *   - storage 側の appendAuditLog が throw した場合でも本関数は warning ログを
+ *     出して resolve する (caller の業務処理を block しない)
+ *   - audit 書き込みの可観測性は caller 側の logger.warn でカバーする
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  DISPATCH_CONSTRAINTS,
+  type DispatchAuditLog,
+} from "@lms-279/shared-types";
+import type { DispatchStorage } from "./dispatch-storage.js";
+import { sanitizeErrorForAudit } from "./dispatch-error-sanitizer.js";
+
+const TTL_MS = DISPATCH_CONSTRAINTS.AUDIT_LOGS_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+export interface RecordAuditLogInput {
+  runId: string;
+  /** run 開始時刻 (caller が run lock 取得時の triggeredAt を保持して渡す) */
+  runStartedAt: string;
+  eventType: DispatchAuditLog["eventType"];
+  tenantId?: string | null;
+  userId?: string | null;
+  /** sanitized error code (PII を含まない短い識別子) */
+  errorCode?: string | null;
+  /**
+   * error message。raw `unknown` を渡せば本 layer で sanitize する。
+   * すでに sanitize 済の string を渡しても再度 sanitize されるが冪等
+   * (二重 redaction でも plain text は安全に保たれる)。
+   */
+  errorMessage?: string | unknown | null;
+  durationMs?: number | null;
+  /** 現在時刻 (テスト時固定可、Date 注入) */
+  now: Date;
+  /** auditId 生成を差し替えたい場合 (主にテスト) */
+  auditIdGenerator?: () => string;
+}
+
+/**
+ * Audit log を append する。書き込み失敗時も throw せず warning ログを出して
+ * resolve する (best-effort)。
+ *
+ * caller 側で本関数を await しても安全 (Gmail 送信成功後の audit 失敗で本来の
+ * 送信成功状態を巻き戻さない原則、設計仕様書 §6.1)。
+ */
+export async function recordAuditLog(
+  storage: DispatchStorage,
+  input: RecordAuditLogInput,
+  // 警告ログ注入 (テストで spy)、既定で console.warn
+  warn: (message: string, meta: Record<string, unknown>) => void = (msg, meta) =>
+    console.warn(msg, meta),
+): Promise<void> {
+  const nowMs = input.now.getTime();
+  const createdAt = new Date(nowMs).toISOString();
+  const ttlExpireAt = new Date(nowMs + TTL_MS).toISOString();
+  const auditId = (input.auditIdGenerator ?? randomUUID)();
+
+  // errorMessage を null/undefined/string/unknown いずれでも安全に正規化
+  let sanitizedMessage: string | null = null;
+  if (input.errorMessage !== null && input.errorMessage !== undefined) {
+    sanitizedMessage = sanitizeErrorForAudit(input.errorMessage);
+  }
+
+  try {
+    await storage.appendAuditLog({
+      auditId,
+      runId: input.runId,
+      runStartedAt: input.runStartedAt,
+      eventType: input.eventType,
+      tenantId: input.tenantId ?? null,
+      userId: input.userId ?? null,
+      errorCode: input.errorCode ?? null,
+      errorMessage: sanitizedMessage,
+      durationMs: input.durationMs ?? null,
+      createdAt,
+      ttlExpireAt,
+    });
+  } catch (err) {
+    // best-effort: 業務処理 block しない、観測性は warning ログのみ
+    warn("dispatch-audit: appendAuditLog failed (suppressed)", {
+      runId: input.runId,
+      eventType: input.eventType,
+      tenantId: input.tenantId ?? null,
+      userId: input.userId ?? null,
+      // err message は sanitize して再 PII 漏洩を防ぐ
+      errorMessage: sanitizeErrorForAudit(err),
+    });
+  }
+}

--- a/services/api/src/services/dispatch/dispatch-storage.ts
+++ b/services/api/src/services/dispatch/dispatch-storage.ts
@@ -18,14 +18,21 @@
  * 関連 ADR: ADR-028 (テスト戦略), ADR-029 (JST), ADR-034 (PII 最小化)
  */
 
-import type {
-  CompletionNotification,
-  CompletionNotificationStatus,
-  DispatchAuditLog,
-  DispatchRun,
-  DispatchRunStatus,
-  ReservationOutcome,
+import {
+  DISPATCH_CONSTRAINTS,
+  type CompletionNotification,
+  type DispatchAuditLog,
+  type DispatchRun,
+  type DispatchRunStatus,
+  type ReservationOutcome,
 } from "@lms-279/shared-types";
+
+/**
+ * audit log / dispatch run の TTL (ミリ秒、365 日)。
+ * run-lock.ts / dispatch-audit.ts から共通参照される (重複定義回避)。
+ */
+export const DISPATCH_AUDIT_TTL_MS =
+  DISPATCH_CONSTRAINTS.AUDIT_LOGS_TTL_DAYS * 24 * 60 * 60 * 1000;
 
 // ============================================================
 // Reservation (tenants/{tenantId}/completion_notifications/{userId})
@@ -158,6 +165,17 @@ export interface DispatchStorage {
    *
    * 設計仕様書 §6.2 (Reservation 方式)、AC-10/11/12、FR-7 改訂、NFR-3 改訂 対応。
    *
+   * **実装契約 (atomicity 必須)**:
+   *   本操作全体は **atomic transaction** で実行すること。
+   *   - Firestore 実装: `db.runTransaction(...)` で「status 読み取り → 既存 state 判定
+   *     → 降格 update / 新規 create」を 1 transaction 内に包む。read-modify-write の
+   *     間に他 worker の write が割り込まないことを保証する。
+   *   - InMemory 実装: Node.js single-threaded 性質を活かし、本 method 実行中に
+   *     `await` を挟まないことで atomicity を担保する (event loop 上では同期実行)。
+   *   atomicity が破られると、2 並列 worker が `lease_expired_promoted_to_manual_review`
+   *   を同時検出して両方が降格 update を発火し、二重送信 → 二重 sent 確定の事故に
+   *   繋がる (Codex Critical-1+3 の中核)。
+   *
    * 戻り値:
    *   - `reserved: true`: 新規 create 成功または lease 期限切れ降格後の再 create
    *   - `reserved: false` + reason: 既存 state により skip
@@ -172,10 +190,25 @@ export interface DispatchStorage {
     input: ReserveCompletionNotificationInput,
   ): Promise<ReservationOutcome>;
 
-  /** 送信成功時の status=sent 遷移 + sent fields 更新 (FR-12 含む snapshot 保存) */
+  /**
+   * 送信成功時の status=sent 遷移 + sent fields 更新 (FR-12 含む snapshot 保存)。
+   *
+   * 実装契約:
+   *   - 呼び出し時に既存 record が `status=reserved` であることを前提とする
+   *     (caller が `tryReserveCompletionNotification` で reserved=true を取得済)
+   *   - 既存 record の status が "reserved" 以外 (sent / failed_permanent /
+   *     manual_review_required) の場合は throw する。これは caller の状態管理
+   *     不整合を早期検出する意図 (idempotency より一貫性優先)。
+   *   - Firestore 実装で網起こりうる partial-failure retry シナリオ
+   *     (write timeout 後の status 不確実) では、caller 側で再 reserve を試行
+   *     し reservation outcome (already_sent 等) で skip するフローを推奨する。
+   */
   markCompletionNotificationSent(input: MarkSentInput): Promise<void>;
 
-  /** Permanent 失敗時の status=failed_permanent 遷移 + error fields 更新 */
+  /**
+   * Permanent 失敗時の status=failed_permanent 遷移 + error fields 更新。
+   * 状態遷移契約は markCompletionNotificationSent と同様 (reserved → failed_permanent)。
+   */
   markCompletionNotificationFailedPermanent(
     input: MarkFailedPermanentInput,
   ): Promise<void>;
@@ -224,13 +257,3 @@ export interface DispatchStorage {
   }): Promise<DispatchAuditLog[]>;
 }
 
-// ============================================================
-// 内部 helper: status 表現の型 narrowing
-// ============================================================
-
-/**
- * 既存 reservation を skip 対象として扱うべき status 一覧 (lease 評価前)。
- * reservation.ts / DispatchStorage 実装で共通参照する。
- */
-export const TERMINAL_RESERVATION_STATUSES: ReadonlySet<CompletionNotificationStatus> =
-  new Set(["sent", "failed_permanent", "manual_review_required"]);

--- a/services/api/src/services/dispatch/dispatch-storage.ts
+++ b/services/api/src/services/dispatch/dispatch-storage.ts
@@ -1,0 +1,236 @@
+/**
+ * DXcollege 自動完了通知システムの Firestore I/O 抽象 layer。
+ *
+ * 設計仕様書 §4.1.3-4.1.5、§6.2-6.3、FR-7 改訂 / FR-11 / FR-12 / NFR-3 改訂 に対応。
+ *
+ * 目的:
+ *   - reservation.ts / run-lock.ts / dispatch-audit.ts の 3 services を
+ *     storage 実装非依存 (InMemory / Firestore どちらでも動く) にする
+ *   - ADR-028 「InMemoryDataSource 中心の統合テスト」に準拠した unit/integration test
+ *   - Phase 2 では InMemoryDispatchStorage のみ実装、Firestore 実装は Phase 4 で
+ *     接続 (run-completion-notifications.ts と同時)
+ *
+ * 設計原則:
+ *   - reservation / run-lock は **transactional atomicity** を保証する
+ *     (Firestore: runTransaction、InMemory: process 内排他制御)
+ *   - audit log は best-effort (write 失敗で caller の処理を block しない)
+ *
+ * 関連 ADR: ADR-028 (テスト戦略), ADR-029 (JST), ADR-034 (PII 最小化)
+ */
+
+import type {
+  CompletionNotification,
+  CompletionNotificationStatus,
+  DispatchAuditLog,
+  DispatchRun,
+  DispatchRunStatus,
+  ReservationOutcome,
+} from "@lms-279/shared-types";
+
+// ============================================================
+// Reservation (tenants/{tenantId}/completion_notifications/{userId})
+// ============================================================
+
+/**
+ * Reservation 試行入力。
+ *
+ * lease 期間 (ms) は呼び出し側で算出して渡す
+ * (`DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS` = 10 分が既定)。
+ */
+export interface ReserveCompletionNotificationInput {
+  tenantId: string;
+  userId: string;
+  runId: string;
+  /** 現在時刻 (ISO 8601、テスト時固定可) */
+  now: string;
+  /** lease 有効期限 (now + RESERVATION_LEASE_MS、ISO 8601) */
+  leaseExpiresAt: string;
+}
+
+/**
+ * 送信成功時の completion_notifications 更新入力。
+ * Reservation で create したレコードに sent state field を追加更新する。
+ */
+export interface MarkSentInput {
+  tenantId: string;
+  userId: string;
+  /** Gmail API messageId */
+  messageId: string;
+  /** 送信成功時刻 (ISO 8601) */
+  notifiedAt: string;
+  /** 通知時点 published course ID 一覧 (案 C、FR-12) */
+  courseIdsSnapshot: string[];
+  /** 通知時点進捗スナップショット */
+  progressSnapshot: CompletionNotification["progressSnapshot"];
+  /** 受講者 email の sha256 (ADR-034、PII 最小化) */
+  recipientToHash: string;
+  /** CC email 配列の sha256 (順序保持) */
+  recipientCcHashes: string[];
+  /** PDF 添付サイズ (添付なしなら null) */
+  pdfSizeBytes: number | null;
+}
+
+/**
+ * Permanent 失敗時の completion_notifications 更新入力。
+ * caller は errorMessage を `sanitizeErrorForAudit()` で sanitize 済を渡す。
+ */
+export interface MarkFailedPermanentInput {
+  tenantId: string;
+  userId: string;
+  /** 失敗時刻 (ISO 8601) */
+  failedAt: string;
+  /** sanitized error code (caller 責務、PII 含まない) */
+  errorCode: string;
+  /** sanitized error message (caller 責務、PII 含まない) */
+  errorMessage: string;
+}
+
+// ============================================================
+// Run lock (super_dispatch_runs/{runId})
+// ============================================================
+
+export interface AcquireRunLockInput {
+  /** uuid v4 (caller 生成、競合検出に使う) */
+  runId: string;
+  /** cron 起動時刻 (ISO 8601) */
+  triggeredAt: string;
+  /** lease 有効期限 (triggeredAt + DISPATCH_RUN_LEASE_MS、ISO 8601) */
+  leaseExpiresAt: string;
+  /** TTL 自動削除期限 (triggeredAt + AUDIT_LOGS_TTL_DAYS、ISO 8601) */
+  ttlExpireAt: string;
+}
+
+export type AcquireRunLockOutcome =
+  | { acquired: true; run: DispatchRun }
+  | {
+      acquired: false;
+      reason:
+        | "another_run_active"
+        | "duplicate_run_id";
+    };
+
+export interface UpdateRunStatusInput {
+  runId: string;
+  status: DispatchRunStatus;
+  /** completed/aborted/timeout 時のメトリクス (積算結果) */
+  processedTenants?: number;
+  sent?: number;
+  skipped?: number;
+  failed?: number;
+  /** aborted 時の理由 (sanitized) */
+  abortedReason?: string;
+}
+
+// ============================================================
+// Audit log (super_dispatch_audit_logs/{auditId})
+// ============================================================
+
+export interface AppendAuditLogInput {
+  /** uuid v4 (caller 生成、重複検出/idempotency 不要) */
+  auditId: string;
+  /** 紐付く run の ID */
+  runId: string;
+  /** run 開始時刻 (ISO 8601、フィルタ用) */
+  runStartedAt: string;
+  eventType: DispatchAuditLog["eventType"];
+  tenantId: string | null;
+  userId: string | null;
+  /** sanitized (PII 含まない) */
+  errorCode: string | null;
+  /** sanitized (PII 含まない、caller が sanitizeErrorForAudit 済を渡す) */
+  errorMessage: string | null;
+  /** 処理経過時間 (null 可) */
+  durationMs: number | null;
+  /** 書き込み時刻 (ISO 8601) */
+  createdAt: string;
+  /** TTL 自動削除期限 (ISO 8601、createdAt + AUDIT_LOGS_TTL_DAYS) */
+  ttlExpireAt: string;
+}
+
+// ============================================================
+// DispatchStorage interface
+// ============================================================
+
+export interface DispatchStorage {
+  // ----- Reservation -----
+  /**
+   * Pre-send reservation を transactional に取得する。
+   *
+   * 設計仕様書 §6.2 (Reservation 方式)、AC-10/11/12、FR-7 改訂、NFR-3 改訂 対応。
+   *
+   * 戻り値:
+   *   - `reserved: true`: 新規 create 成功または lease 期限切れ降格後の再 create
+   *   - `reserved: false` + reason: 既存 state により skip
+   *     - "already_sent": status=sent
+   *     - "failed_permanent": status=failed_permanent
+   *     - "manual_review_required": status=manual_review_required
+   *     - "currently_reserved_by_other_run": status=reserved & lease 期限内
+   *     - "lease_expired_promoted_to_manual_review": status=reserved & lease 期限切れ
+   *       → manual_review_required に降格し、本 run は skip
+   */
+  tryReserveCompletionNotification(
+    input: ReserveCompletionNotificationInput,
+  ): Promise<ReservationOutcome>;
+
+  /** 送信成功時の status=sent 遷移 + sent fields 更新 (FR-12 含む snapshot 保存) */
+  markCompletionNotificationSent(input: MarkSentInput): Promise<void>;
+
+  /** Permanent 失敗時の status=failed_permanent 遷移 + error fields 更新 */
+  markCompletionNotificationFailedPermanent(
+    input: MarkFailedPermanentInput,
+  ): Promise<void>;
+
+  /**
+   * 完了通知レコードの取得 (主にテスト/audit/dry-run 用)。
+   * 通常の業務ロジックでは reserve → mark sent/failed のフローで使うため、本メソッド
+   * は副作用なしの read-only 用途のみに使う。
+   */
+  getCompletionNotification(
+    tenantId: string,
+    userId: string,
+  ): Promise<CompletionNotification | null>;
+
+  // ----- Run lock -----
+  /**
+   * Run lock を transactional に取得する。
+   *
+   * 設計仕様書 §6.3、FR-11、AC-16 対応。
+   * 直近 lease 期限内に他の running run があれば取得拒否
+   * (Cloud Scheduler 重複起動対策)。
+   */
+  acquireRunLock(input: AcquireRunLockInput): Promise<AcquireRunLockOutcome>;
+
+  /** Run status 遷移 (completed / timeout / aborted) + メトリクス積算更新 */
+  updateRunStatus(input: UpdateRunStatusInput): Promise<void>;
+
+  /** Run 取得 (主にテスト/audit 用) */
+  getRun(runId: string): Promise<DispatchRun | null>;
+
+  // ----- Audit log -----
+  /**
+   * Audit log 追記。設計仕様書 §6.1「super_dispatch_audit_logs 書き込み失敗は
+   * 警告ログのみ、レスポンスをブロックしない」原則に従い、実装側で best-effort
+   * (例外を throw しない) を保証する。caller は本メソッドを await しても安全。
+   *
+   * NFR-11 (PII sanitize): caller は errorMessage を sanitizeErrorForAudit 済の
+   * 値で渡す前提。storage 側で再 sanitize はしない (二重 redaction のリスク回避)。
+   */
+  appendAuditLog(input: AppendAuditLogInput): Promise<void>;
+
+  /** Audit log 全件取得 (主にテスト用、本番 API は別 query で paginate) */
+  listAuditLogs(filter?: {
+    runId?: string;
+    eventType?: DispatchAuditLog["eventType"];
+  }): Promise<DispatchAuditLog[]>;
+}
+
+// ============================================================
+// 内部 helper: status 表現の型 narrowing
+// ============================================================
+
+/**
+ * 既存 reservation を skip 対象として扱うべき status 一覧 (lease 評価前)。
+ * reservation.ts / DispatchStorage 実装で共通参照する。
+ */
+export const TERMINAL_RESERVATION_STATUSES: ReadonlySet<CompletionNotificationStatus> =
+  new Set(["sent", "failed_permanent", "manual_review_required"]);

--- a/services/api/src/services/dispatch/in-memory-dispatch-storage.ts
+++ b/services/api/src/services/dispatch/in-memory-dispatch-storage.ts
@@ -33,10 +33,17 @@ import type {
   UpdateRunStatusInput,
 } from "./dispatch-storage.js";
 
-/** completion_notifications の compound key: `${tenantId}/${userId}` */
+/**
+ * completion_notifications の compound key 生成。
+ *
+ * separator に `|` (パイプ) を採用。Firestore doc ID 規約 / 一般的な tenant slug
+ * (英数 + ハイフン) / userId (uuid 系) のいずれにも `|` は出現しないため、
+ * `tenant-a/b` 形式 (evaluator narrative の collision 例) でも安全。
+ */
 type NotificationKey = string;
+const KEY_SEPARATOR = "|";
 function nkey(tenantId: string, userId: string): NotificationKey {
-  return `${tenantId}/${userId}`;
+  return `${tenantId}${KEY_SEPARATOR}${userId}`;
 }
 
 export class InMemoryDispatchStorage implements DispatchStorage {
@@ -231,6 +238,16 @@ export class InMemoryDispatchStorage implements DispatchStorage {
     if (!existing) {
       throw new Error(`updateRunStatus: no run found for ${input.runId}`);
     }
+    // abortedReason: completed/timeout 遷移時は明示的に null クリアする。
+    // aborted 遷移時は input.abortedReason で上書き (省略時のみ既存値保持)。
+    // safe-refactor MEDIUM-3 反映。
+    let abortedReason: string | null;
+    if (input.status === "aborted") {
+      abortedReason = input.abortedReason ?? existing.abortedReason;
+    } else {
+      // completed / timeout / running 等の非 aborted 遷移は abortedReason をクリア
+      abortedReason = input.abortedReason ?? null;
+    }
     this.runs.set(input.runId, {
       ...existing,
       status: input.status,
@@ -238,7 +255,7 @@ export class InMemoryDispatchStorage implements DispatchStorage {
       sent: input.sent ?? existing.sent,
       skipped: input.skipped ?? existing.skipped,
       failed: input.failed ?? existing.failed,
-      abortedReason: input.abortedReason ?? existing.abortedReason,
+      abortedReason,
     });
   }
 

--- a/services/api/src/services/dispatch/in-memory-dispatch-storage.ts
+++ b/services/api/src/services/dispatch/in-memory-dispatch-storage.ts
@@ -1,0 +1,301 @@
+/**
+ * DispatchStorage の InMemory 実装 (test / dev 用)。
+ *
+ * 設計仕様書 §4.1.3-4.1.5、ADR-028 「InMemoryDataSource 中心の統合テスト」に準拠。
+ *
+ * Phase 2 では本実装のみを用いて reservation / run-lock / audit の services を
+ * Integration 検証する。Phase 4 で FirestoreDispatchStorage を追加し、
+ * run-completion-notifications.ts は同 interface を介して両 backend で動作する。
+ *
+ * 並行制御:
+ *   Node.js は single-threaded のため、await 境界以外では同期的に Map 操作が
+ *   完結する。本実装は read-then-write の間に await を挟まないことで atomicity
+ *   を担保する (Firestore runTransaction と同等のセマンティクスを単純な制御で実現)。
+ */
+
+import type {
+  CompletionNotification,
+  CompletionNotificationStatus,
+  DispatchAuditLog,
+  DispatchRun,
+  DispatchRunStatus,
+  ReservationOutcome,
+} from "@lms-279/shared-types";
+
+import type {
+  AcquireRunLockInput,
+  AcquireRunLockOutcome,
+  AppendAuditLogInput,
+  DispatchStorage,
+  MarkFailedPermanentInput,
+  MarkSentInput,
+  ReserveCompletionNotificationInput,
+  UpdateRunStatusInput,
+} from "./dispatch-storage.js";
+
+/** completion_notifications の compound key: `${tenantId}/${userId}` */
+type NotificationKey = string;
+function nkey(tenantId: string, userId: string): NotificationKey {
+  return `${tenantId}/${userId}`;
+}
+
+export class InMemoryDispatchStorage implements DispatchStorage {
+  private notifications = new Map<NotificationKey, CompletionNotification>();
+  private runs = new Map<string, DispatchRun>();
+  private auditLogs: DispatchAuditLog[] = [];
+
+  // テスト用クリアメソッド (production には呼ばない)
+  __resetForTest(): void {
+    this.notifications.clear();
+    this.runs.clear();
+    this.auditLogs = [];
+  }
+
+  // ===================================================================
+  // Reservation
+  // ===================================================================
+
+  async tryReserveCompletionNotification(
+    input: ReserveCompletionNotificationInput,
+  ): Promise<ReservationOutcome> {
+    const { tenantId, userId, runId, now, leaseExpiresAt } = input;
+    const key = nkey(tenantId, userId);
+    const existing = this.notifications.get(key);
+
+    // 状態判定 → 早期 return (await を挟まないため atomic)
+    if (existing) {
+      switch (existing.status) {
+        case "sent":
+          return { reserved: false, reason: "already_sent" };
+        case "failed_permanent":
+          return { reserved: false, reason: "failed_permanent" };
+        case "manual_review_required":
+          return { reserved: false, reason: "manual_review_required" };
+        case "reserved": {
+          // lease 期限判定
+          const leaseExpired =
+            Date.parse(existing.leaseExpiresAt) <= Date.parse(now);
+          if (leaseExpired) {
+            // manual_review_required に降格
+            this.notifications.set(key, {
+              ...existing,
+              status: "manual_review_required",
+              failedAt: now,
+            });
+            return {
+              reserved: false,
+              reason: "lease_expired_promoted_to_manual_review",
+            };
+          }
+          return {
+            reserved: false,
+            reason: "currently_reserved_by_other_run",
+          };
+        }
+        default: {
+          // 想定外 status は型網羅性チェック (将来 status 追加時の早期検出)
+          const _exhaustive: never = existing.status;
+          throw new Error(`Unhandled reservation status: ${String(_exhaustive)}`);
+        }
+      }
+    }
+
+    // 新規予約 create
+    const reserved: CompletionNotification = {
+      userId,
+      status: "reserved",
+      runId,
+      reservedAt: now,
+      leaseExpiresAt,
+      notifiedAt: null,
+      messageId: null,
+      errorCode: null,
+      errorMessage: null,
+      failedAt: null,
+      // snapshot は markSent 時にセット (Phase 4 caller 責務)、ここでは初期値
+      progressSnapshot: {
+        completedLessons: 0,
+        totalLessons: 0,
+        coursesCompleted: 0,
+        coursesTotal: 0,
+      },
+      courseIdsSnapshot: [],
+      publishedCourseCount: 0,
+      recipientToHash: "",
+      recipientCcHashes: [],
+      pdfSizeBytes: null,
+    };
+    this.notifications.set(key, reserved);
+    return { reserved: true };
+  }
+
+  async markCompletionNotificationSent(input: MarkSentInput): Promise<void> {
+    const key = nkey(input.tenantId, input.userId);
+    const existing = this.notifications.get(key);
+    if (!existing) {
+      throw new Error(
+        `markCompletionNotificationSent: no reservation for ${key} (caller must reserve first)`,
+      );
+    }
+    if (existing.status !== "reserved") {
+      throw new Error(
+        `markCompletionNotificationSent: status must be "reserved" but was "${existing.status}" for ${key}`,
+      );
+    }
+    this.notifications.set(key, {
+      ...existing,
+      status: "sent",
+      notifiedAt: input.notifiedAt,
+      messageId: input.messageId,
+      courseIdsSnapshot: input.courseIdsSnapshot,
+      publishedCourseCount: input.courseIdsSnapshot.length,
+      progressSnapshot: input.progressSnapshot,
+      recipientToHash: input.recipientToHash,
+      recipientCcHashes: input.recipientCcHashes,
+      pdfSizeBytes: input.pdfSizeBytes,
+    });
+  }
+
+  async markCompletionNotificationFailedPermanent(
+    input: MarkFailedPermanentInput,
+  ): Promise<void> {
+    const key = nkey(input.tenantId, input.userId);
+    const existing = this.notifications.get(key);
+    if (!existing) {
+      throw new Error(
+        `markCompletionNotificationFailedPermanent: no reservation for ${key}`,
+      );
+    }
+    if (existing.status !== "reserved") {
+      throw new Error(
+        `markCompletionNotificationFailedPermanent: status must be "reserved" but was "${existing.status}" for ${key}`,
+      );
+    }
+    this.notifications.set(key, {
+      ...existing,
+      status: "failed_permanent",
+      errorCode: input.errorCode,
+      errorMessage: input.errorMessage,
+      failedAt: input.failedAt,
+    });
+  }
+
+  async getCompletionNotification(
+    tenantId: string,
+    userId: string,
+  ): Promise<CompletionNotification | null> {
+    return this.notifications.get(nkey(tenantId, userId)) ?? null;
+  }
+
+  // ===================================================================
+  // Run lock
+  // ===================================================================
+
+  async acquireRunLock(
+    input: AcquireRunLockInput,
+  ): Promise<AcquireRunLockOutcome> {
+    // duplicate runId は即時拒否 (uuid 衝突は天文学的だが防御として)
+    if (this.runs.has(input.runId)) {
+      return { acquired: false, reason: "duplicate_run_id" };
+    }
+
+    // 直近 lease 内に running run が他にいれば拒否
+    const nowMs = Date.parse(input.triggeredAt);
+    for (const run of this.runs.values()) {
+      if (
+        run.status === "running" &&
+        Date.parse(run.leaseExpiresAt) > nowMs
+      ) {
+        return { acquired: false, reason: "another_run_active" };
+      }
+    }
+
+    const newRun: DispatchRun = {
+      runId: input.runId,
+      triggeredAt: input.triggeredAt,
+      status: "running",
+      leaseExpiresAt: input.leaseExpiresAt,
+      processedTenants: 0,
+      sent: 0,
+      skipped: 0,
+      failed: 0,
+      abortedReason: null,
+      ttlExpireAt: input.ttlExpireAt,
+    };
+    this.runs.set(input.runId, newRun);
+    return { acquired: true, run: newRun };
+  }
+
+  async updateRunStatus(input: UpdateRunStatusInput): Promise<void> {
+    const existing = this.runs.get(input.runId);
+    if (!existing) {
+      throw new Error(`updateRunStatus: no run found for ${input.runId}`);
+    }
+    this.runs.set(input.runId, {
+      ...existing,
+      status: input.status,
+      processedTenants: input.processedTenants ?? existing.processedTenants,
+      sent: input.sent ?? existing.sent,
+      skipped: input.skipped ?? existing.skipped,
+      failed: input.failed ?? existing.failed,
+      abortedReason: input.abortedReason ?? existing.abortedReason,
+    });
+  }
+
+  async getRun(runId: string): Promise<DispatchRun | null> {
+    return this.runs.get(runId) ?? null;
+  }
+
+  // ===================================================================
+  // Audit log
+  // ===================================================================
+
+  async appendAuditLog(input: AppendAuditLogInput): Promise<void> {
+    // best-effort: spec §6.1「書き込み失敗は警告ログのみ」のため try-catch
+    try {
+      this.auditLogs.push({
+        auditId: input.auditId,
+        runId: input.runId,
+        runStartedAt: input.runStartedAt,
+        eventType: input.eventType,
+        tenantId: input.tenantId,
+        userId: input.userId,
+        errorCode: input.errorCode,
+        errorMessage: input.errorMessage,
+        durationMs: input.durationMs,
+        createdAt: input.createdAt,
+        ttlExpireAt: input.ttlExpireAt,
+      });
+    } catch {
+      // InMemory では発生しないが、Firestore impl と同じ best-effort 契約を維持
+    }
+  }
+
+  async listAuditLogs(filter?: {
+    runId?: string;
+    eventType?: DispatchAuditLog["eventType"];
+  }): Promise<DispatchAuditLog[]> {
+    return this.auditLogs.filter((log) => {
+      if (filter?.runId && log.runId !== filter.runId) return false;
+      if (filter?.eventType && log.eventType !== filter.eventType) return false;
+      return true;
+    });
+  }
+}
+
+// 型網羅性チェック (CompletionNotificationStatus 追加時のコンパイルエラー検出)
+const _statusCoverage: Record<CompletionNotificationStatus, true> = {
+  reserved: true,
+  sent: true,
+  failed_permanent: true,
+  manual_review_required: true,
+};
+void _statusCoverage;
+
+const _runStatusCoverage: Record<DispatchRunStatus, true> = {
+  running: true,
+  completed: true,
+  timeout: true,
+  aborted: true,
+};
+void _runStatusCoverage;

--- a/services/api/src/services/dispatch/reservation.ts
+++ b/services/api/src/services/dispatch/reservation.ts
@@ -1,0 +1,97 @@
+/**
+ * Pre-send reservation の薄い service layer。
+ *
+ * 設計仕様書 §6.2、FR-7 改訂、AC-10/11/12、NFR-3 改訂 (Codex Critical-1+3) 対応。
+ *
+ * 責務:
+ *   - `DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS` から leaseExpiresAt を算出して
+ *     DispatchStorage.tryReserveCompletionNotification に委譲
+ *   - markSent / markFailed は引数 passthrough (storage 実装に応じた atomicity を提供)
+ *
+ * caller (Phase 4 run-completion-notifications.ts) のフロー:
+ *   1. tryReserveOrSkip(...) → ReservationOutcome
+ *   2. reserved=true なら Gmail 送信、その後 markSent または markFailed
+ *   3. reserved=false なら caller 側で audit log のみ書き skip
+ *
+ * 本 layer は storage 抽象を介すため Firestore / InMemory 両方で動作する。
+ */
+
+import {
+  DISPATCH_CONSTRAINTS,
+  type CompletionNotification,
+  type ReservationOutcome,
+} from "@lms-279/shared-types";
+import type {
+  DispatchStorage,
+  MarkFailedPermanentInput,
+  MarkSentInput,
+} from "./dispatch-storage.js";
+
+export interface TryReserveOrSkipInput {
+  tenantId: string;
+  userId: string;
+  runId: string;
+  /** 現在時刻 (テスト時固定可、Date 注入) */
+  now: Date;
+}
+
+/**
+ * Reservation 試行。成功時は storage 側で reserved レコードが create される。
+ * 既存レコードがあれば status により skip 理由を返す。
+ *
+ * lease 期限切れの reserved は manual_review_required に降格された上で skip 扱い
+ * (storage 側で同 transaction 内に降格 update が実施される)。
+ */
+export async function tryReserveOrSkip(
+  storage: DispatchStorage,
+  input: TryReserveOrSkipInput,
+): Promise<ReservationOutcome> {
+  const { tenantId, userId, runId, now } = input;
+  const nowMs = now.getTime();
+  const leaseExpiresAtMs = nowMs + DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS;
+
+  return storage.tryReserveCompletionNotification({
+    tenantId,
+    userId,
+    runId,
+    now: new Date(nowMs).toISOString(),
+    leaseExpiresAt: new Date(leaseExpiresAtMs).toISOString(),
+  });
+}
+
+/**
+ * 送信成功時の reserved → sent 遷移。caller は reservation 取得済 (reserved=true)
+ * の前提で呼び出す。reservation なしで呼ぶと storage 側で throw する。
+ */
+export async function markSent(
+  storage: DispatchStorage,
+  input: MarkSentInput,
+): Promise<void> {
+  return storage.markCompletionNotificationSent(input);
+}
+
+/**
+ * Permanent 失敗時の reserved → failed_permanent 遷移。
+ *
+ * 注意: caller は errorMessage を `sanitizeErrorForAudit()` 済の値で渡すこと
+ * (PII 漏洩防止、NFR-11)。本 layer は再 sanitize しない (二重 redaction 回避)。
+ */
+export async function markFailedPermanent(
+  storage: DispatchStorage,
+  input: MarkFailedPermanentInput,
+): Promise<void> {
+  return storage.markCompletionNotificationFailedPermanent(input);
+}
+
+/**
+ * Reservation レコード取得 (主に dry-run / audit / テスト用)。
+ * 本フロー中の status 確認には reserve 戻り値を使うこと (read-modify-write race
+ * 防止のため、storage 側 atomic op を経由する)。
+ */
+export async function getReservation(
+  storage: DispatchStorage,
+  tenantId: string,
+  userId: string,
+): Promise<CompletionNotification | null> {
+  return storage.getCompletionNotification(tenantId, userId);
+}

--- a/services/api/src/services/dispatch/reservation.ts
+++ b/services/api/src/services/dispatch/reservation.ts
@@ -47,15 +47,16 @@ export async function tryReserveOrSkip(
   input: TryReserveOrSkipInput,
 ): Promise<ReservationOutcome> {
   const { tenantId, userId, runId, now } = input;
-  const nowMs = now.getTime();
-  const leaseExpiresAtMs = nowMs + DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS;
+  const leaseExpiresAt = new Date(
+    now.getTime() + DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS,
+  ).toISOString();
 
   return storage.tryReserveCompletionNotification({
     tenantId,
     userId,
     runId,
-    now: new Date(nowMs).toISOString(),
-    leaseExpiresAt: new Date(leaseExpiresAtMs).toISOString(),
+    now: now.toISOString(),
+    leaseExpiresAt,
   });
 }
 

--- a/services/api/src/services/dispatch/run-lock.ts
+++ b/services/api/src/services/dispatch/run-lock.ts
@@ -14,17 +14,13 @@
  *   3. acquired=false なら 409 で即時返却 (Cloud Scheduler 重複起動の正常系)
  */
 
-import {
-  DISPATCH_CONSTRAINTS,
-  type DispatchRunStatus,
-} from "@lms-279/shared-types";
+import { DISPATCH_CONSTRAINTS } from "@lms-279/shared-types";
 import type {
   AcquireRunLockOutcome,
   DispatchStorage,
   UpdateRunStatusInput,
 } from "./dispatch-storage.js";
-
-const TTL_MS = DISPATCH_CONSTRAINTS.AUDIT_LOGS_TTL_DAYS * 24 * 60 * 60 * 1000;
+import { DISPATCH_AUDIT_TTL_MS } from "./dispatch-storage.js";
 
 export interface AcquireRunLockOrSkipInput {
   /** 現在時刻 (テスト時固定可、Date 注入) */
@@ -48,11 +44,11 @@ export async function acquireRunLockOrSkip(
   const leaseExpiresAt = new Date(
     nowMs + DISPATCH_CONSTRAINTS.DISPATCH_RUN_LEASE_MS,
   ).toISOString();
-  const ttlExpireAt = new Date(nowMs + TTL_MS).toISOString();
+  const ttlExpireAt = new Date(nowMs + DISPATCH_AUDIT_TTL_MS).toISOString();
 
   return storage.acquireRunLock({
     runId,
-    triggeredAt: new Date(nowMs).toISOString(),
+    triggeredAt: now.toISOString(),
     leaseExpiresAt,
     ttlExpireAt,
   });
@@ -83,7 +79,7 @@ export async function completeRun(
 ): Promise<void> {
   return finalizeRun(storage, {
     runId,
-    status: "completed" as DispatchRunStatus,
+    status: "completed",
     ...metrics,
   });
 }
@@ -102,7 +98,7 @@ export async function abortRun(
 ): Promise<void> {
   return finalizeRun(storage, {
     runId,
-    status: "aborted" as DispatchRunStatus,
+    status: "aborted",
     abortedReason,
     ...metrics,
   });

--- a/services/api/src/services/dispatch/run-lock.ts
+++ b/services/api/src/services/dispatch/run-lock.ts
@@ -1,0 +1,109 @@
+/**
+ * Run-level lock の薄い service layer。
+ *
+ * 設計仕様書 §6.3、FR-11、AC-16 (Codex Important-3) 対応。
+ *
+ * 責務:
+ *   - runId 生成 (uuid v4) + leaseExpiresAt / ttlExpireAt 算出
+ *   - DispatchStorage.acquireRunLock に委譲
+ *   - completed / aborted / timeout 遷移を caller から受領
+ *
+ * caller (Phase 4 internal endpoint) のフロー:
+ *   1. acquireRunLockOrSkip(now=Date.now()) → { acquired: true, runId } または skip
+ *   2. acquired=true なら ② tenant 走査 ... ⑫ audit log ⑬ completeRun
+ *   3. acquired=false なら 409 で即時返却 (Cloud Scheduler 重複起動の正常系)
+ */
+
+import {
+  DISPATCH_CONSTRAINTS,
+  type DispatchRunStatus,
+} from "@lms-279/shared-types";
+import type {
+  AcquireRunLockOutcome,
+  DispatchStorage,
+  UpdateRunStatusInput,
+} from "./dispatch-storage.js";
+
+const TTL_MS = DISPATCH_CONSTRAINTS.AUDIT_LOGS_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+export interface AcquireRunLockOrSkipInput {
+  /** 現在時刻 (テスト時固定可、Date 注入) */
+  now: Date;
+  /** caller 生成の runId (uuid v4 等)。テスト時固定可 */
+  runId: string;
+}
+
+/**
+ * Run lock 取得試行。
+ *
+ * 既存 running run が lease 期限内なら拒否 (Cloud Scheduler 重複起動対策、AC-16)。
+ * 取得成功時は status=running、processedTenants=sent=skipped=failed=0 で create。
+ */
+export async function acquireRunLockOrSkip(
+  storage: DispatchStorage,
+  input: AcquireRunLockOrSkipInput,
+): Promise<AcquireRunLockOutcome> {
+  const { now, runId } = input;
+  const nowMs = now.getTime();
+  const leaseExpiresAt = new Date(
+    nowMs + DISPATCH_CONSTRAINTS.DISPATCH_RUN_LEASE_MS,
+  ).toISOString();
+  const ttlExpireAt = new Date(nowMs + TTL_MS).toISOString();
+
+  return storage.acquireRunLock({
+    runId,
+    triggeredAt: new Date(nowMs).toISOString(),
+    leaseExpiresAt,
+    ttlExpireAt,
+  });
+}
+
+/**
+ * Run 完了/中断時の status 更新。caller は集計済メトリクスを渡す。
+ *
+ * abortedReason は sanitized 文字列 (PII を含まない、caller 責務)。
+ */
+export async function finalizeRun(
+  storage: DispatchStorage,
+  input: UpdateRunStatusInput,
+): Promise<void> {
+  return storage.updateRunStatus(input);
+}
+
+/** convenience: completed 用ヘルパー (status を明示せず metrics のみ渡す) */
+export async function completeRun(
+  storage: DispatchStorage,
+  runId: string,
+  metrics: {
+    processedTenants: number;
+    sent: number;
+    skipped: number;
+    failed: number;
+  },
+): Promise<void> {
+  return finalizeRun(storage, {
+    runId,
+    status: "completed" as DispatchRunStatus,
+    ...metrics,
+  });
+}
+
+/** convenience: aborted 用ヘルパー (403 scope_revoked 等の全体中断) */
+export async function abortRun(
+  storage: DispatchStorage,
+  runId: string,
+  abortedReason: string,
+  metrics?: {
+    processedTenants: number;
+    sent: number;
+    skipped: number;
+    failed: number;
+  },
+): Promise<void> {
+  return finalizeRun(storage, {
+    runId,
+    status: "aborted" as DispatchRunStatus,
+    abortedReason,
+    ...metrics,
+  });
+}


### PR DESCRIPTION
## Summary

DXcollege 自動完了通知システム Phase 2 を完了。spec/impl-plan に従い **2 abstraction + 3 services + 3 integration test files** を TDD で実装。Phase 1 (基礎 services) と Phase 3 (Mail + Send) の上に、Phase 4 (Internal API + メインロジック) のための storage layer を整備。

**進捗**:

| Phase | Status |
|---|---|
| Phase 0 (前提作業) | ✅ |
| Phase 1 (基礎 services 7 ファイル) | ✅ #442 + #465 |
| **Phase 2 (Reservation / Run Lock / Audit)** | ✅ **本 PR** |
| Phase 3 (Mail + Send) | ✅ #466 |
| Phase 4 (Internal API + メインロジック) | ⏳ Phase 1+2+3 を統合、AC 全体検証ポイント |
| Phase 5-8 | ⏳ |

## アーキテクチャ判断

### DispatchStorage 抽象 layer の導入

reservation / run-lock / dispatch-audit の 3 services を **storage 実装非依存** (InMemory / Firestore どちらでも動く設計) に分離。Phase 2 では InMemoryDispatchStorage のみ実装し、Integration test の主軸とする (ADR-028「InMemoryDataSource 中心の統合テスト」準拠)。Firestore 実装は Phase 4 で接続。

理由:
- Phase 4 で run-completion-notifications.ts を結合テストする際、InMemory backend なら全 6 競合シナリオを deterministic に検証できる
- Firestore SDK の transaction emulator は単体テストに不向き、本番 Firestore は CI で頻繁に叩けない
- 既存 DataSource interface を膨張させず、dispatch 機能の独立性を保つ

## 新規ファイル

### dispatch-storage.ts (interface)

DispatchStorage interface (8 methods) + 入力型 (6 種) を定義:
- tryReserveCompletionNotification (AC-10/11/12, NFR-3 改訂)
- markCompletionNotificationSent (FR-12 snapshot 保存)
- markCompletionNotificationFailedPermanent (NFR-11 sanitize 済受領)
- acquireRunLock (AC-16, FR-11)
- updateRunStatus / getRun
- appendAuditLog (best-effort, §6.1)
- listAuditLogs / getCompletionNotification (read-only)

### in-memory-dispatch-storage.ts (InMemory 実装)

Node.js single-threaded 性質を活かし、await 境界以外を同期で完結させて atomicity を担保 (Firestore runTransaction と同等)。`CompletionNotificationStatus` / `DispatchRunStatus` の網羅性チェックを const satisfies で行い、新 status 追加時のコンパイルエラー検出を保証。

### reservation.ts (FR-7 改訂 / AC-10/11/12 / NFR-3 改訂)

`tryReserveOrSkip`: DISPATCH_CONSTRAINTS.RESERVATION_LEASE_MS (10 分) から leaseExpiresAt を算出し storage に委譲。`markSent` / `markFailedPermanent` は状態遷移の薄い passthrough。

### run-lock.ts (FR-11 / AC-16)

`acquireRunLockOrSkip`: leaseExpiresAt (280s) と ttlExpireAt (365 days) を算出。`completeRun` / `abortRun` / `finalizeRun` convenience helper。設計仕様書 §6.3 に従い、直近 lease 期限内に running run があれば取得拒否 (Cloud Scheduler 重複起動対策)。

### dispatch-audit.ts (NFR-4 / NFR-11 / AC-33)

`recordAuditLog`: best-effort 書き込み (storage throw でも caller 例外伝搬しない)。errorMessage を `sanitizeErrorForAudit` で二重防御 (caller の sanitize 漏れ対策)。`warn` callback 注入で observability 確保 (テスト時は spy)。auditIdGenerator 注入で固定 ID。

## Phase 2 完了条件チェック (impl-plan §Phase 2)

| 条件 | 検証 |
|---|---|
| transaction 競合 6 シナリオ網羅 | ✅ reservation.test.ts (新規/sent/failed_permanent/manual_review/reserved-in-lease/reserved-expired) |
| run lock 同時起動 2 件で 1 件のみ成功 | ✅ run-lock.test.ts (Promise.all + duplicate runId + lease 期限切れ後再取得) |
| audit_logs に PII 漏洩がない | ✅ dispatch-audit.test.ts (email / Bearer / MIME headers の sanitize 検証、storage error も sanitize) |

## Test plan

- [x] dispatch tests 11 ファイル / 227 件 PASS (前回 182 → +45)
- [x] API tests 全体 80 ファイル / 1275 件 PASS (前回 1226 → +49)
- [x] lint: 0 errors (1 pre-existing warning は本 PR 範囲外)
- [x] type-check (services/api / root): PASS
- [ ] CI green
- [ ] Quality gates (safe-refactor + evaluator + code-review)
- [ ] (Phase 4 着手時) reservation / run-lock / audit を実際に呼び出す run-completion-notifications.ts の Integration test で結合確認

## 参考

- 設計仕様書: \`docs/specs/2026-05-20-completion-notification-design.md\`
- 実装計画: \`docs/specs/2026-05-20-completion-notification-impl-plan.md\`
- ADR-028 (テスト戦略 InMemoryDataSource 中心)
- ADR-037 (sender impersonation 案 X SendAs)
- 前 PR (Phase 1 残部): #465 / 前 PR (Phase 3): #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)