### PR TITLE
feat(dispatch): Phase 4 (Internal API + メインロジック) を統合実装

### DIFF
--- a/docs/specs/2026-05-20-completion-notification-design.md
+++ b/docs/specs/2026-05-20-completion-notification-design.md
@@ -386,8 +386,8 @@ web/app/super/dispatch-settings/
 | users.email 無効 | この user スキップ (Reservation せず) | 修正後の次回 cron | audit_logs + Error Reporting (warning) |
 | PDF 生成失敗 / timeout 30s | この user の Reservation を transient_failed として維持 | 次回 cron で再試行可能 (leaseExpiresAt まで) | audit_logs + Error Reporting (warning) |
 | **Gmail 401 (token 失効)** | DWD トークン再取得 → 1 回 retry → ダメなら **run 全体中断** | 次回 cron | Error Reporting (critical) |
-| **Gmail 403 `insufficientPermissions`** | run 全体中断、未処理 user の Reservation も rollback | 次回 cron | **Error Reporting (critical)** (Codex Important-4) |
-| **Gmail 403 `delegation_denied` / sender disabled** | run 全体中断、Reservation rollback | 次回 cron | **Error Reporting (critical)** |
+| **Gmail 403 `insufficientPermissions`** | run 全体中断。**既に reserved 済 user の record は rollback せず lease 期限切れで `manual_review_required` に降格** (2026-05-22 採用案、Phase 4 実装、§後述) | 次回 cron | **Error Reporting (critical)** (Codex Important-4) |
+| **Gmail 403 `delegation_denied` / sender disabled** | 同上 (rollback せず lease 期限切れで降格) | 次回 cron | **Error Reporting (critical)** |
 | Gmail 403 宛先固有 | この user を failed_permanent | 再送しない | audit_logs + Error Reporting (warning) |
 | Gmail 429/503/timeout | Reservation 維持 (transient_failed)、completion_notifications 残置 | 次回 cron で再試行 | audit_logs (transient) |
 | Gmail 400/422 | failed_permanent 記録 | 再送しない | audit_logs + Error Reporting (warning) |
@@ -670,7 +670,7 @@ UI からの直接削除ボタンは提供しない (誤操作リスク回避、
 #### Run Lock / 403 AC (Codex Important-3, Important-4 反映)
 
 - **AC-16**: 同一時刻に複数の cron 起動が来た場合、最初の 1 つだけが lock を取得、他は 409 で即終了
-- **AC-17**: Gmail 403 `insufficientPermissions` / `delegationDenied` / sender disabled は run 全体中断、後続 user の Reservation は rollback、Error Reporting critical
+- **AC-17 (改訂、2026-05-22)**: Gmail 403 `insufficientPermissions` / `delegationDenied` / sender disabled は run 全体中断、Error Reporting critical。**既に reserved 状態の user record は rollback せず**そのまま残し、次回 cron 起動時に lease 期限切れ (10 分後) で `manual_review_required` に降格させる。理由: ① 並列実行中の rollback は別 worker との race を生む ② scope_revoked が transient な設定ミス (e.g., 管理コンソール一時不整合) で復旧した場合、rollback 済の record は次 cron で **再送試行 → 二重送信** 事故を起こす ③ lease 期限切れ降格は manual_review_required (terminal) を経由するため idempotency が保証される。Phase 4 実装 (PR #468、run-completion-notifications.ts) で本案を採用
 - **AC-18**: Gmail 403 宛先固有は user を failed_permanent、run は継続
 
 #### エッジケース AC

--- a/packages/shared-types/src/dispatch.ts
+++ b/packages/shared-types/src/dispatch.ts
@@ -164,6 +164,12 @@ export interface DispatchRun {
   sent: number;
   skipped: number;
   failed: number;
+  /**
+   * manual_review_required に降格された user 数 (Phase 4 追加、evaluator 指摘反映)。
+   * `manualReviewRequired` を `RunCompletionNotificationsResponse` と一致させ、
+   * 管理画面で run 履歴を確認した際に件数追跡可能にする。
+   */
+  manualReviewRequired: number;
   /** abort 理由 (403 全体中断等、status=aborted のみ) */
   abortedReason: string | null;
   /** TTL 期限 (ISO 8601)、triggeredAt + 365 days */

--- a/services/api/src/routes/internal/__tests__/dispatch.test.ts
+++ b/services/api/src/routes/internal/__tests__/dispatch.test.ts
@@ -1,0 +1,224 @@
+/**
+ * routes/internal/dispatch の Integration テスト (Phase 4 endpoint).
+ *
+ * 設計仕様書 §3.1 / AC-30 / NFR-2 に対応。
+ *
+ * 観点:
+ *   - 認証失敗 (OIDC token なし / audience 不一致) → 401
+ *   - 正常 path: 200 + RunCompletionNotificationsResponse
+ *   - kill switch (settings disabled): 200 + empty
+ *   - runId / now 注入で deterministic 結果
+ *   - storage / loader / sendMail は DI で test 用に差し替え可
+ *   - 想定外エラー (storage throw 等) → 500 + ADR-010 形式
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import type { DispatchSettings } from "@lms-279/shared-types";
+
+import { createInternalDispatchRouter } from "../dispatch.js";
+import { InMemoryDispatchStorage } from "../../../services/dispatch/in-memory-dispatch-storage.js";
+import {
+  InMemoryTenantDataLoader,
+  type InMemoryTenantFixture,
+} from "../../../services/dispatch/tenant-data-loader.js";
+import type {
+  OidcTokenVerifier,
+  VerifiedOidcCaller,
+} from "../../../services/dispatch/oidc-verify.js";
+
+const AUDIENCE = "https://api.example.com/internal/dispatch";
+const NOW = new Date("2026-05-25T00:00:00.000Z"); // 月曜 JST 09:00
+const RUN_ID = "fixed-run-id";
+
+const VERIFIED_CALLER: VerifiedOidcCaller = {
+  email: "dxcollege-scheduler@lms-279.iam.gserviceaccount.com",
+  subject: "sa-subject",
+  audience: AUDIENCE,
+};
+
+function makeSuccessVerifier(): OidcTokenVerifier {
+  return { verify: vi.fn(async () => VERIFIED_CALLER) };
+}
+
+function makeFailureVerifier(): OidcTokenVerifier {
+  return {
+    verify: vi.fn(async () => {
+      throw new Error("token verify failed");
+    }),
+  };
+}
+
+function makeSettings(partial: Partial<DispatchSettings> = {}): DispatchSettings {
+  return {
+    enabled: true,
+    scheduleDaysOfWeek: [1, 4],
+    scheduleHourJst: 9,
+    signatureName: "DXcollege運営スタッフ",
+    completionMessageBody: "受講お疲れ様でした。",
+    senderEmail: "dxcollege@279279.net",
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    updatedBy: "admin@279279.net",
+    version: 1,
+    ...partial,
+  };
+}
+
+function makeFixture(): InMemoryTenantFixture {
+  return {
+    publishedCourses: [{ id: "c1", lessonOrder: ["l1", "l2", "l3"] }],
+    users: [{ id: "user-1", email: "u1@example.com", name: "User One" }],
+    courseProgresses: new Map([
+      [
+        "user-1",
+        [{ courseId: "c1", isCompleted: true, totalLessons: 3, completedLessons: 3 }],
+      ],
+    ]),
+    ccConfig: {
+      completionNotificationEnabled: true,
+      ownerEmail: "owner@a.com",
+      notificationCcEmails: [],
+    },
+  };
+}
+
+let storage: InMemoryDispatchStorage;
+let loader: InMemoryTenantDataLoader;
+
+beforeEach(() => {
+  storage = new InMemoryDispatchStorage();
+  loader = new InMemoryTenantDataLoader();
+});
+
+function makeApp(opts: {
+  verifier: OidcTokenVerifier;
+  sendMail?: ReturnType<typeof vi.fn>;
+}) {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    "/api/v2/internal",
+    createInternalDispatchRouter({
+      expectedAudience: AUDIENCE,
+      verifier: opts.verifier,
+      storage,
+      loader,
+      env: { subjectEmail: "system@279279.net", fromEmail: "dxcollege@279279.net" },
+      sendMail: opts.sendMail as never,
+      runIdGenerator: () => RUN_ID,
+      nowProvider: () => NOW,
+    }),
+  );
+  return app;
+}
+
+describe("認証", () => {
+  it("OIDC token なし → 401 + missing_authorization", async () => {
+    const app = makeApp({ verifier: makeSuccessVerifier() });
+    const res = await request(app).post(
+      "/api/v2/internal/dispatch/run-completion-notifications",
+    );
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("missing_authorization");
+  });
+
+  it("verifier が throw → 401", async () => {
+    const app = makeApp({ verifier: makeFailureVerifier() });
+    const res = await request(app)
+      .post("/api/v2/internal/dispatch/run-completion-notifications")
+      .set("Authorization", "Bearer some.token");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("正常 path", () => {
+  beforeEach(() => {
+    storage.__setSettingsForTest(makeSettings());
+    loader.setTenant("tenantA", makeFixture());
+  });
+
+  it("100% 完了 user 1 件 → 200 + sent=1", async () => {
+    const sendMail = vi
+      .fn()
+      .mockResolvedValue({ messageId: "msg-001", attempts: 1 });
+    const app = makeApp({ verifier: makeSuccessVerifier(), sendMail });
+
+    const res = await request(app)
+      .post("/api/v2/internal/dispatch/run-completion-notifications")
+      .set("Authorization", "Bearer valid.token");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      runId: RUN_ID,
+      processedTenants: 1,
+      sent: 1,
+      skipped: 0,
+      failed: 0,
+      manualReviewRequired: 0,
+    });
+  });
+
+  it("settings disabled → 200 + empty response", async () => {
+    storage.__setSettingsForTest(makeSettings({ enabled: false }));
+    const sendMail = vi.fn();
+    const app = makeApp({ verifier: makeSuccessVerifier(), sendMail });
+
+    const res = await request(app)
+      .post("/api/v2/internal/dispatch/run-completion-notifications")
+      .set("Authorization", "Bearer valid.token");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ sent: 0, processedTenants: 0 });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("settings なし → 200 + empty response (Phase 7 初期化前)", async () => {
+    // 別ストレージ (settings 未設定) で実行
+    const freshStorage = new InMemoryDispatchStorage();
+    const app2 = express();
+    app2.use(express.json());
+    app2.use(
+      "/api/v2/internal",
+      createInternalDispatchRouter({
+        expectedAudience: AUDIENCE,
+        verifier: makeSuccessVerifier(),
+        storage: freshStorage,
+        loader,
+        env: { subjectEmail: "s@x.com", fromEmail: "f@x.com" },
+        runIdGenerator: () => RUN_ID,
+        nowProvider: () => NOW,
+      }),
+    );
+
+    const res = await request(app2)
+      .post("/api/v2/internal/dispatch/run-completion-notifications")
+      .set("Authorization", "Bearer valid.token");
+    expect(res.status).toBe(200);
+    expect(res.body.sent).toBe(0);
+  });
+});
+
+describe("想定外エラー", () => {
+  it("storage 自体が throw (acquireRunLock 障害) → 500", async () => {
+    storage.__setSettingsForTest(makeSettings());
+    loader.setTenant("tenantA", makeFixture());
+    // acquireRunLock を強制的に throw させる
+    const originalAcquire = storage.acquireRunLock.bind(storage);
+    storage.acquireRunLock = vi.fn(async () => {
+      throw new Error("Firestore unavailable");
+    });
+
+    const app = makeApp({
+      verifier: makeSuccessVerifier(),
+      sendMail: vi.fn(),
+    });
+    const res = await request(app)
+      .post("/api/v2/internal/dispatch/run-completion-notifications")
+      .set("Authorization", "Bearer valid.token");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("dispatch_unexpected_error");
+
+    // cleanup
+    storage.acquireRunLock = originalAcquire;
+  });
+});

--- a/services/api/src/routes/internal/__tests__/dispatch.test.ts
+++ b/services/api/src/routes/internal/__tests__/dispatch.test.ts
@@ -27,6 +27,14 @@ import type {
   OidcTokenVerifier,
   VerifiedOidcCaller,
 } from "../../../services/dispatch/oidc-verify.js";
+import type {
+  SendCompletionMailInput,
+  SendCompletionMailResult,
+} from "../../../services/dispatch/gmail-dwd-send.js";
+
+type SendMailFn = (
+  input: SendCompletionMailInput,
+) => Promise<SendCompletionMailResult>;
 
 const AUDIENCE = "https://api.example.com/internal/dispatch";
 const NOW = new Date("2026-05-25T00:00:00.000Z"); // 月曜 JST 09:00
@@ -93,7 +101,7 @@ beforeEach(() => {
 
 function makeApp(opts: {
   verifier: OidcTokenVerifier;
-  sendMail?: ReturnType<typeof vi.fn>;
+  sendMail?: SendMailFn;
 }) {
   const app = express();
   app.use(express.json());
@@ -105,7 +113,7 @@ function makeApp(opts: {
       storage,
       loader,
       env: { subjectEmail: "system@279279.net", fromEmail: "dxcollege@279279.net" },
-      sendMail: opts.sendMail as never,
+      sendMail: opts.sendMail,
       runIdGenerator: () => RUN_ID,
       nowProvider: () => NOW,
     }),
@@ -201,11 +209,10 @@ describe("想定外エラー", () => {
   it("storage 自体が throw (acquireRunLock 障害) → 500", async () => {
     storage.__setSettingsForTest(makeSettings());
     loader.setTenant("tenantA", makeFixture());
-    // acquireRunLock を強制的に throw させる
-    const originalAcquire = storage.acquireRunLock.bind(storage);
-    storage.acquireRunLock = vi.fn(async () => {
-      throw new Error("Firestore unavailable");
-    });
+    // vi.spyOn でテスト終了時の自動 restore を効かせる (safe-refactor MEDIUM-3 反映)
+    const spy = vi
+      .spyOn(storage, "acquireRunLock")
+      .mockRejectedValue(new Error("Firestore unavailable"));
 
     const app = makeApp({
       verifier: makeSuccessVerifier(),
@@ -217,8 +224,6 @@ describe("想定外エラー", () => {
 
     expect(res.status).toBe(500);
     expect(res.body.error).toBe("dispatch_unexpected_error");
-
-    // cleanup
-    storage.acquireRunLock = originalAcquire;
+    spy.mockRestore();
   });
 });

--- a/services/api/src/routes/internal/dispatch.ts
+++ b/services/api/src/routes/internal/dispatch.ts
@@ -1,0 +1,96 @@
+/**
+ * Internal endpoint: Cloud Scheduler 起動による自動完了通知配信 (Phase 4)。
+ *
+ * 設計仕様書 §3.1 全体図、AC-30 / NFR-2 に対応。
+ *
+ * Route: POST /api/v2/internal/dispatch/run-completion-notifications
+ *
+ * 認証: OIDC ID Token (Cloud Scheduler Service Account 発行)。
+ * 入力: なし (Body 空)。
+ * 出力: RunCompletionNotificationsResponse (sent/skipped/failed 集計)。
+ *
+ * 製作方針:
+ *   - dependency injection で test/prod を切り替える
+ *     - test: InMemoryDispatchStorage / InMemoryTenantDataLoader / mock sendMail
+ *     - prod: FirestoreDispatchStorage / FirestoreTenantDataLoader を Phase 7 で実装
+ *   - 本 module は orchestration を runCompletionNotifications service に完全委譲
+ *
+ * 想定外エラーは Express の default error handler に伝搬 (500 + ADR-010 形式)。
+ * 想定内の "no-op" 結果 (kill switch / schedule 不一致 / run lock 競合) は
+ * 200 OK + empty response として返す (Cloud Scheduler は 2xx を成功扱い、retry なし)。
+ */
+
+import { randomUUID } from "node:crypto";
+import { Router, type Response } from "express";
+import type { RunCompletionNotificationsResponse } from "@lms-279/shared-types";
+
+import {
+  requireValidOidcToken,
+  type OidcTokenVerifier,
+  type RequestWithOidcCaller,
+} from "../../services/dispatch/oidc-verify.js";
+import {
+  runCompletionNotifications,
+  type DispatchEnv,
+} from "../../services/dispatch/run-completion-notifications.js";
+import type { DispatchStorage } from "../../services/dispatch/dispatch-storage.js";
+import type { TenantDataLoader } from "../../services/dispatch/tenant-data-loader.js";
+import type { SendCompletionMailInput, SendCompletionMailResult } from "../../services/dispatch/gmail-dwd-send.js";
+
+export interface InternalDispatchRouteConfig {
+  /** OIDC audience (Cloud Scheduler 設定の audience と一致させる) */
+  expectedAudience: string;
+  /** OIDC verifier (本番 GoogleOidcTokenVerifier、test mock) */
+  verifier: OidcTokenVerifier;
+  storage: DispatchStorage;
+  loader: TenantDataLoader;
+  env: DispatchEnv;
+  /** Gmail send 注入点 (本番 defaultSendCompletionMail、test mock) */
+  sendMail?: (input: SendCompletionMailInput) => Promise<SendCompletionMailResult>;
+  /** runId 生成器 (test で固定可能) */
+  runIdGenerator?: () => string;
+  /** Date 注入 (test で固定可能) */
+  nowProvider?: () => Date;
+}
+
+export function createInternalDispatchRouter(
+  config: InternalDispatchRouteConfig,
+): Router {
+  const router = Router();
+
+  router.post(
+    "/dispatch/run-completion-notifications",
+    requireValidOidcToken({
+      expectedAudience: config.expectedAudience,
+      verifier: config.verifier,
+    }),
+    (req: RequestWithOidcCaller, res: Response): void => {
+      const runId = (config.runIdGenerator ?? randomUUID)();
+      const now = (config.nowProvider ?? (() => new Date()))();
+      void (async () => {
+        try {
+          const result: RunCompletionNotificationsResponse =
+            await runCompletionNotifications({
+              runId,
+              now,
+              storage: config.storage,
+              loader: config.loader,
+              env: config.env,
+              sendMail: config.sendMail,
+            });
+          res.status(200).json(result);
+        } catch (err) {
+          // 想定外エラー (storage 障害、loader 障害等)
+          // RunAbortError は runCompletionNotifications 内で catch されて response に
+          // reflect されるため、ここに来るのは真に想定外のケースのみ
+          res.status(500).json({
+            error: "dispatch_unexpected_error",
+            message: err instanceof Error ? err.message : "Unknown error",
+          });
+        }
+      })();
+    },
+  );
+
+  return router;
+}

--- a/services/api/src/services/dispatch/__tests__/dispatch-audit.test.ts
+++ b/services/api/src/services/dispatch/__tests__/dispatch-audit.test.ts
@@ -172,6 +172,7 @@ describe("recordAuditLog - best-effort (§6.1)", () => {
   /** appendAuditLog が必ず throw する障害 storage */
   function makeFailingStorage(): DispatchStorage {
     return {
+      getDispatchSettings: vi.fn(() => Promise.resolve(null)),
       tryReserveCompletionNotification: vi.fn(),
       markCompletionNotificationSent: vi.fn(),
       markCompletionNotificationFailedPermanent: vi.fn(),
@@ -232,6 +233,7 @@ describe("recordAuditLog - best-effort (§6.1)", () => {
 
   it("warn meta の errorMessage は storage error message を sanitize 済で出す", async () => {
     const storageThatThrowsWithEmail: DispatchStorage = {
+      getDispatchSettings: vi.fn(() => Promise.resolve(null)),
       tryReserveCompletionNotification: vi.fn(),
       markCompletionNotificationSent: vi.fn(),
       markCompletionNotificationFailedPermanent: vi.fn(),

--- a/services/api/src/services/dispatch/__tests__/oidc-verify.test.ts
+++ b/services/api/src/services/dispatch/__tests__/oidc-verify.test.ts
@@ -1,0 +1,222 @@
+/**
+ * oidc-verify の単体 + Integration テスト。
+ *
+ * 設計仕様書 §3.1 / NFR-2 / AC-30 に対応。
+ *
+ * 観点:
+ *   - extractBearerToken: 空 / 形式違反 / 正常
+ *   - verifyOidcToken (mock verifier): success / audience_mismatch / expired / invalid
+ *   - requireValidOidcToken middleware: 401 + ADR-010 フラットエラー形式、success で req.oidcCaller セット
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import {
+  extractBearerToken,
+  OidcVerifyFailure,
+  requireValidOidcToken,
+  verifyOidcToken,
+  type OidcTokenVerifier,
+  type VerifiedOidcCaller,
+} from "../oidc-verify.js";
+
+const AUDIENCE = "https://api.example.com/api/v2/internal/dispatch/run-completion-notifications";
+
+const SUCCESS_CALLER: VerifiedOidcCaller = {
+  email: "dxcollege-scheduler@lms-279.iam.gserviceaccount.com",
+  subject: "1234567890",
+  audience: AUDIENCE,
+};
+
+function makeMockVerifier(
+  impl: OidcTokenVerifier["verify"],
+): OidcTokenVerifier {
+  return { verify: impl };
+}
+
+describe("extractBearerToken", () => {
+  it("正常な Bearer header → token 抽出", () => {
+    expect(extractBearerToken("Bearer abc.def.ghi")).toBe("abc.def.ghi");
+  });
+
+  it("ケース不感 (bearer / BEARER 等も受理)", () => {
+    expect(extractBearerToken("bearer abc")).toBe("abc");
+    expect(extractBearerToken("BEARER xyz")).toBe("xyz");
+  });
+
+  it("複数空白 / tab も separator として受理", () => {
+    expect(extractBearerToken("Bearer  \t  abc.def")).toBe("abc.def");
+  });
+
+  it("undefined header → missing_authorization", () => {
+    expect(() => extractBearerToken(undefined)).toThrow(OidcVerifyFailure);
+    try {
+      extractBearerToken(undefined);
+    } catch (err) {
+      expect((err as OidcVerifyFailure).code).toBe("missing_authorization");
+    }
+  });
+
+  it("空文字 header → missing_authorization", () => {
+    try {
+      extractBearerToken("");
+    } catch (err) {
+      expect((err as OidcVerifyFailure).code).toBe("missing_authorization");
+    }
+  });
+
+  it("string 以外 → missing_authorization", () => {
+    try {
+      extractBearerToken(123);
+    } catch (err) {
+      expect((err as OidcVerifyFailure).code).toBe("missing_authorization");
+    }
+  });
+
+  it("Bearer prefix 不在 → invalid_authorization_format", () => {
+    try {
+      extractBearerToken("Basic abc.def");
+    } catch (err) {
+      expect((err as OidcVerifyFailure).code).toBe(
+        "invalid_authorization_format",
+      );
+    }
+  });
+
+  it("Bearer のみ (token 不在) → invalid_authorization_format", () => {
+    try {
+      extractBearerToken("Bearer");
+    } catch (err) {
+      expect((err as OidcVerifyFailure).code).toBe(
+        "invalid_authorization_format",
+      );
+    }
+  });
+});
+
+describe("verifyOidcToken (pure)", () => {
+  it("verifier が success を返せば caller を返す", async () => {
+    const verifier = makeMockVerifier(async () => SUCCESS_CALLER);
+    const result = await verifyOidcToken(
+      "Bearer good.token",
+      AUDIENCE,
+      verifier,
+    );
+    expect(result).toEqual(SUCCESS_CALLER);
+  });
+
+  it("verifier が OidcVerifyFailure を throw → そのまま伝搬", async () => {
+    const verifier = makeMockVerifier(async () => {
+      throw new OidcVerifyFailure("audience_mismatch", "aud mismatch");
+    });
+    await expect(
+      verifyOidcToken("Bearer bad.token", AUDIENCE, verifier),
+    ).rejects.toThrow(OidcVerifyFailure);
+  });
+
+  it("header 形式違反は verifier 呼ばずに failure", async () => {
+    const verifier = makeMockVerifier(vi.fn());
+    await expect(
+      verifyOidcToken(undefined, AUDIENCE, verifier),
+    ).rejects.toThrow(/Authorization/);
+    expect(verifier.verify).not.toHaveBeenCalled();
+  });
+});
+
+describe("requireValidOidcToken middleware (supertest)", () => {
+  /** Express app with middleware + protected endpoint */
+  function makeApp(verifier: OidcTokenVerifier) {
+    const app = express();
+    app.use(express.json());
+    app.post(
+      "/protected",
+      requireValidOidcToken({ expectedAudience: AUDIENCE, verifier }),
+      (req, res) => {
+        const caller = (req as { oidcCaller?: VerifiedOidcCaller }).oidcCaller;
+        res.json({ ok: true, caller });
+      },
+    );
+    return app;
+  }
+
+  it("正常 token → 200 + req.oidcCaller がセットされる", async () => {
+    const verifier = makeMockVerifier(async () => SUCCESS_CALLER);
+    const app = makeApp(verifier);
+
+    const res = await request(app)
+      .post("/protected")
+      .set("Authorization", "Bearer valid.token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.caller).toEqual(SUCCESS_CALLER);
+  });
+
+  it("Authorization header なし → 401 + missing_authorization (ADR-010 形式)", async () => {
+    const verifier = makeMockVerifier(vi.fn());
+    const app = makeApp(verifier);
+
+    const res = await request(app).post("/protected");
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({
+      error: "missing_authorization",
+      message: expect.stringMatching(/Authorization/),
+    });
+    expect(verifier.verify).not.toHaveBeenCalled();
+  });
+
+  it("audience_mismatch → 401 + audience_mismatch code", async () => {
+    const verifier = makeMockVerifier(async () => {
+      throw new OidcVerifyFailure(
+        "audience_mismatch",
+        "aud does not match",
+      );
+    });
+    const app = makeApp(verifier);
+
+    const res = await request(app)
+      .post("/protected")
+      .set("Authorization", "Bearer foo");
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("audience_mismatch");
+  });
+
+  it("expired_token → 401 + expired_token code", async () => {
+    const verifier = makeMockVerifier(async () => {
+      throw new OidcVerifyFailure("expired_token", "expired");
+    });
+    const app = makeApp(verifier);
+
+    const res = await request(app)
+      .post("/protected")
+      .set("Authorization", "Bearer foo");
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("expired_token");
+  });
+
+  it("verifier が未知の例外を throw → 401 + invalid_token (汎用)", async () => {
+    const verifier = makeMockVerifier(async () => {
+      throw new Error("Unknown error inside verifier");
+    });
+    const app = makeApp(verifier);
+
+    const res = await request(app)
+      .post("/protected")
+      .set("Authorization", "Bearer foo");
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("invalid_token");
+  });
+
+  it("Bearer prefix 不在 → 401 + invalid_authorization_format", async () => {
+    const verifier = makeMockVerifier(vi.fn());
+    const app = makeApp(verifier);
+
+    const res = await request(app)
+      .post("/protected")
+      .set("Authorization", "Basic abc");
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("invalid_authorization_format");
+    expect(verifier.verify).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/src/services/dispatch/__tests__/run-completion-notifications.test.ts
+++ b/services/api/src/services/dispatch/__tests__/run-completion-notifications.test.ts
@@ -27,7 +27,6 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { createHash } from "node:crypto";
 import { DISPATCH_CONSTRAINTS, type DispatchSettings } from "@lms-279/shared-types";
 
 import { InMemoryDispatchStorage } from "../in-memory-dispatch-storage.js";
@@ -35,6 +34,7 @@ import { InMemoryTenantDataLoader, type InMemoryTenantFixture } from "../tenant-
 import {
   runCompletionNotifications,
   RunAbortError,
+  sha256, // safe-refactor MEDIUM-1: production と同じ sha256 参照を使用
 } from "../run-completion-notifications.js";
 import type { SendCompletionMailResult } from "../gmail-dwd-send.js";
 
@@ -76,10 +76,6 @@ function makeFixture(partial: Partial<InMemoryTenantFixture> = {}): InMemoryTena
     },
     ...partial,
   };
-}
-
-function sha256(input: string): string {
-  return createHash("sha256").update(input).digest("hex");
 }
 
 let storage: InMemoryDispatchStorage;
@@ -364,7 +360,7 @@ describe("Gmail エラー分類 (AC-14, AC-15, AC-17, AC-18)", () => {
     expect(notification?.status).toBe("failed_permanent");
   });
 
-  it("403 scope_revoked (insufficientPermissions) → run 全体 abort", async () => {
+  it("403 scope_revoked (insufficientPermissions) → run 全体 abort (concurrency=1 直列)", async () => {
     // 2 user 用意して 1 user 目で scope_revoked、2 user 目に到達しないことを確認
     loader.setTenant(
       "tenantA",
@@ -396,6 +392,57 @@ describe("Gmail エラー分類 (AC-14, AC-15, AC-17, AC-18)", () => {
     // audit に run_aborted 記録
     const auditLogs = await storage.listAuditLogs({ runId: "run-1", eventType: "run_aborted" });
     expect(auditLogs).toHaveLength(1);
+    // **採用案明示** (evaluator AC-17 指摘反映): user-1 の reservation は
+    // status=reserved のまま残る (rollback しない、lease 期限切れで次回 cron で
+    // manual_review に降格される設計、spec §6.1 改訂方針)
+    const user1 = await storage.getCompletionNotification("tenantA", "user-1");
+    expect(user1?.status).toBe("reserved"); // rollback されないことを明示 assertion
+    // user-2 は scope_revoked 後に到達していないため reservation 不在
+    const user2 = await storage.getCompletionNotification("tenantA", "user-2");
+    expect(user2).toBeNull();
+  });
+
+  it("403 scope_revoked (concurrency=2 並列) → 並列実行中の他 worker の reservation は維持", async () => {
+    // 3 user 用意、concurrency=2 で並列実行、最初の scope_revoked 後の挙動を確認
+    loader.setTenant(
+      "tenantA",
+      makeFixture({
+        users: [
+          { id: "user-1", email: "u1@example.com", name: "U1" },
+          { id: "user-2", email: "u2@example.com", name: "U2" },
+          { id: "user-3", email: "u3@example.com", name: "U3" },
+        ],
+        courseProgresses: new Map([
+          ["user-1", [{ courseId: "c1", isCompleted: true, totalLessons: 3, completedLessons: 3 }]],
+          ["user-2", [{ courseId: "c1", isCompleted: true, totalLessons: 3, completedLessons: 3 }]],
+          ["user-3", [{ courseId: "c1", isCompleted: true, totalLessons: 3, completedLessons: 3 }]],
+        ]),
+      }),
+    );
+    const sendMail = vi.fn().mockRejectedValue({
+      response: {
+        status: 403,
+        data: { error: { errors: [{ reason: "insufficientPermissions" }] } },
+      },
+    });
+    await runCompletionNotifications({
+      runId: "run-1", now: NOW, storage, loader, env: ENV, sendMail,
+      userConcurrency: 2,
+    });
+    const run = await storage.getRun("run-1");
+    expect(run?.status).toBe("aborted");
+    // 並列実行で reservation を取った user の record は残る (rollback しない)
+    // 並列度 2 で 3 user のうち最低 2 件は reservation 試行されるが、
+    // RunAbortError 後の queue.shift も止めないため、全 user が試行される可能性あり。
+    // 重要な不変: rollback されない (= sent 状態の record はない)
+    const u1 = await storage.getCompletionNotification("tenantA", "user-1");
+    const u2 = await storage.getCompletionNotification("tenantA", "user-2");
+    const u3 = await storage.getCompletionNotification("tenantA", "user-3");
+    for (const record of [u1, u2, u3]) {
+      if (record !== null) {
+        expect(record.status).toBe("reserved"); // sent には到達しない
+      }
+    }
   });
 });
 

--- a/services/api/src/services/dispatch/__tests__/run-completion-notifications.test.ts
+++ b/services/api/src/services/dispatch/__tests__/run-completion-notifications.test.ts
@@ -1,0 +1,476 @@
+/**
+ * run-completion-notifications の Integration テスト (Phase 4 メインロジック)。
+ *
+ * 設計仕様書 §3.1 / §6.2 / FR-1〜FR-12 / AC-1〜AC-25 を end-to-end で検証。
+ *
+ * Phase 4 完了条件 (impl-plan §Phase 4):
+ *   - Integration Test で AC-1〜18 全シナリオ網羅
+ *     (race / lock / 403 / 100% 判定 / kill switch 全て)
+ *
+ * 観点:
+ *   - shouldRunNow=false (kill switch、schedule 不一致) → 何もしない
+ *   - run lock 重複起動 → 拒否で何もしない
+ *   - settings 不在 → 何もしない (Phase 7 初期化前同等)
+ *   - tenant.completionNotificationEnabled=false → tenant skip
+ *   - 100% 完了者のみ送信 (eligibility)
+ *   - 既通知 (sent / failed_permanent / manual_review) → skip
+ *   - reservation lease 内 → skip
+ *   - reservation lease 期限切れ → manual_review_required 降格 + 集計反映
+ *   - Gmail 送信成功 → sent 遷移 + recipient hash 保存 (sha256)
+ *   - Gmail transient 失敗 (429/503) → reservation 維持 + failed counter
+ *   - Gmail permanent 失敗 (400/422) → failed_permanent + failed counter
+ *   - Gmail 403 user_permanent → failed_permanent
+ *   - Gmail 403 scope_revoked → run 全体 abort + 後続 user の reservation rollback (counter は rollback しない、現実装)
+ *   - audit log 整合 (run_started / user_notified / user_skipped / user_failed_* / run_completed/aborted)
+ *   - 二重実行 idempotent (2 回目は既に sent で skip)
+ *   - PII (raw email) が audit / Firestore に保存されない (sha256 のみ)
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createHash } from "node:crypto";
+import { DISPATCH_CONSTRAINTS, type DispatchSettings } from "@lms-279/shared-types";
+
+import { InMemoryDispatchStorage } from "../in-memory-dispatch-storage.js";
+import { InMemoryTenantDataLoader, type InMemoryTenantFixture } from "../tenant-data-loader.js";
+import {
+  runCompletionNotifications,
+  RunAbortError,
+} from "../run-completion-notifications.js";
+import type { SendCompletionMailResult } from "../gmail-dwd-send.js";
+
+const NOW = new Date("2026-05-25T00:00:00.000Z"); // 月曜 UTC 00:00 = JST 09:00
+
+function makeSettings(partial: Partial<DispatchSettings> = {}): DispatchSettings {
+  return {
+    enabled: true,
+    scheduleDaysOfWeek: [1, 4], // 月木
+    scheduleHourJst: 9,
+    signatureName: "DXcollege運営スタッフ",
+    completionMessageBody: "受講お疲れ様でした。",
+    senderEmail: "dxcollege@279279.net",
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    updatedBy: "admin@279279.net",
+    version: 1,
+    ...partial,
+  };
+}
+
+function makeFixture(partial: Partial<InMemoryTenantFixture> = {}): InMemoryTenantFixture {
+  return {
+    publishedCourses: [{ id: "c1", lessonOrder: ["l1", "l2", "l3"] }],
+    users: [
+      { id: "user-1", email: "u1@example.com", name: "User One" },
+    ],
+    courseProgresses: new Map([
+      [
+        "user-1",
+        [
+          { courseId: "c1", isCompleted: true, totalLessons: 3, completedLessons: 3 },
+        ],
+      ],
+    ]),
+    ccConfig: {
+      completionNotificationEnabled: true,
+      ownerEmail: "owner@tenantA.com",
+      notificationCcEmails: [],
+    },
+    ...partial,
+  };
+}
+
+function sha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+let storage: InMemoryDispatchStorage;
+let loader: InMemoryTenantDataLoader;
+const ENV = { subjectEmail: "system@279279.net", fromEmail: "dxcollege@279279.net" };
+
+beforeEach(() => {
+  storage = new InMemoryDispatchStorage();
+  loader = new InMemoryTenantDataLoader();
+});
+
+describe("kill switch / schedule (AC-6 / AC-7)", () => {
+  it("settings 不在 → 何もしない (response empty、storage 触らず)", async () => {
+    const sendMail = vi.fn();
+    const result = await runCompletionNotifications({
+      runId: "run-1",
+      now: NOW,
+      storage,
+      loader,
+      env: ENV,
+      sendMail,
+    });
+    expect(result.sent).toBe(0);
+    expect(result.processedTenants).toBe(0);
+    expect(sendMail).not.toHaveBeenCalled();
+    // run lock も取得していない
+    expect(await storage.getRun("run-1")).toBeNull();
+  });
+
+  it("enabled=false → 何もしない", async () => {
+    storage.__setSettingsForTest(makeSettings({ enabled: false }));
+    const sendMail = vi.fn();
+    const result = await runCompletionNotifications({
+      runId: "run-1",
+      now: NOW,
+      storage,
+      loader,
+      env: ENV,
+      sendMail,
+    });
+    expect(result.sent).toBe(0);
+    expect(sendMail).not.toHaveBeenCalled();
+    expect(await storage.getRun("run-1")).toBeNull();
+  });
+
+  it("schedule 不一致 (火曜 09:00 でも settings 月木) → 何もしない", async () => {
+    storage.__setSettingsForTest(makeSettings());
+    const tuesdayNow = new Date("2026-05-26T00:00:00.000Z"); // 火曜 JST 09:00
+    const result = await runCompletionNotifications({
+      runId: "run-1",
+      now: tuesdayNow,
+      storage,
+      loader,
+      env: ENV,
+      sendMail: vi.fn(),
+    });
+    expect(result.sent).toBe(0);
+    expect(await storage.getRun("run-1")).toBeNull();
+  });
+});
+
+describe("run lock (AC-16)", () => {
+  beforeEach(() => {
+    storage.__setSettingsForTest(makeSettings());
+  });
+
+  it("既存 running run 内なら新規 run は何もしない", async () => {
+    loader.setTenant("tenantA", makeFixture());
+    // 既存 run を仕込む (lease 内)
+    await storage.acquireRunLock({
+      runId: "existing-run",
+      triggeredAt: NOW.toISOString(),
+      leaseExpiresAt: new Date(
+        NOW.getTime() + DISPATCH_CONSTRAINTS.DISPATCH_RUN_LEASE_MS,
+      ).toISOString(),
+      ttlExpireAt: new Date(NOW.getTime() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+
+    const result = await runCompletionNotifications({
+      runId: "new-run",
+      now: NOW,
+      storage,
+      loader,
+      env: ENV,
+      sendMail: vi.fn(),
+    });
+    expect(result.sent).toBe(0);
+    expect(result.processedTenants).toBe(0);
+    // new-run lock 取得失敗を確認
+    expect(await storage.getRun("new-run")).toBeNull();
+  });
+});
+
+describe("100% 完了者のみ送信 (AC-1, Critical-2)", () => {
+  beforeEach(() => {
+    storage.__setSettingsForTest(makeSettings());
+  });
+
+  it("100% 完了 1 user → 1 件送信、sent counter=1", async () => {
+    loader.setTenant("tenantA", makeFixture());
+    const sendMail = vi
+      .fn()
+      .mockResolvedValue({ messageId: "msg-001", attempts: 1 } satisfies SendCompletionMailResult);
+
+    const result = await runCompletionNotifications({
+      runId: "run-1",
+      now: NOW,
+      storage,
+      loader,
+      env: ENV,
+      sendMail,
+    });
+    expect(result).toMatchObject({
+      runId: "run-1",
+      processedTenants: 1,
+      sent: 1,
+      skipped: 0,
+      failed: 0,
+      manualReviewRequired: 0,
+    });
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    const notification = await storage.getCompletionNotification("tenantA", "user-1");
+    expect(notification?.status).toBe("sent");
+    expect(notification?.messageId).toBe("msg-001");
+    // PII hash 検証 (AC-32)
+    expect(notification?.recipientToHash).toBe(sha256("u1@example.com"));
+    expect(notification?.recipientCcHashes).toEqual([sha256("owner@tenantA.com")]);
+  });
+
+  it("未完了 user (isCompleted=false) → 送信せず audit にも記録しない (log spam 防止)", async () => {
+    loader.setTenant(
+      "tenantA",
+      makeFixture({
+        courseProgresses: new Map([
+          [
+            "user-1",
+            [{ courseId: "c1", isCompleted: false, totalLessons: 3, completedLessons: 2 }],
+          ],
+        ]),
+      }),
+    );
+    const sendMail = vi.fn();
+    const result = await runCompletionNotifications({
+      runId: "run-1",
+      now: NOW,
+      storage,
+      loader,
+      env: ENV,
+      sendMail,
+    });
+    expect(result.sent).toBe(0);
+    expect(result.skipped).toBe(0); // 未完了は audit skip ではなく静かに通過
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("course_progress 不在 → missing_progress で送信せず (Critical-2)", async () => {
+    loader.setTenant(
+      "tenantA",
+      makeFixture({
+        courseProgresses: new Map(), // 進捗 doc 不在 = 未着手扱い
+      }),
+    );
+    const sendMail = vi.fn();
+    const result = await runCompletionNotifications({
+      runId: "run-1",
+      now: NOW,
+      storage,
+      loader,
+      env: ENV,
+      sendMail,
+    });
+    expect(result.sent).toBe(0);
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+});
+
+describe("既通知 idempotency (AC-2)", () => {
+  beforeEach(() => {
+    storage.__setSettingsForTest(makeSettings());
+    loader.setTenant("tenantA", makeFixture());
+  });
+
+  it("2 回目実行 → 既に sent で skip、send 再実行されない", async () => {
+    const sendMail = vi
+      .fn()
+      .mockResolvedValue({ messageId: "msg-001", attempts: 1 } satisfies SendCompletionMailResult);
+    // 1 回目
+    await runCompletionNotifications({
+      runId: "run-1", now: NOW, storage, loader, env: ENV, sendMail,
+    });
+    expect(sendMail).toHaveBeenCalledTimes(1);
+
+    // 2 回目 (run lock 競合回避のため少し時間進める)
+    const later = new Date(NOW.getTime() + DISPATCH_CONSTRAINTS.DISPATCH_RUN_LEASE_MS + 1000);
+    // 月曜以外になるので別 schedule に合わせる: settings 改訂
+    storage.__setSettingsForTest(makeSettings({ scheduleDaysOfWeek: [0, 1, 2, 3, 4, 5, 6] }));
+    const result = await runCompletionNotifications({
+      runId: "run-2", now: later, storage, loader, env: ENV, sendMail,
+    });
+    expect(sendMail).toHaveBeenCalledTimes(1); // 2 回目は呼ばれない
+    expect(result.skipped).toBe(1);
+    expect(result.sent).toBe(0);
+  });
+});
+
+describe("tenant 単位 disable", () => {
+  beforeEach(() => {
+    storage.__setSettingsForTest(makeSettings());
+  });
+
+  it("tenant.completionNotificationEnabled=false → tenant 全 skip、processedTenants も加算しない", async () => {
+    loader.setTenant(
+      "tenantA",
+      makeFixture({
+        ccConfig: {
+          completionNotificationEnabled: false,
+          ownerEmail: "owner@x.com",
+          notificationCcEmails: [],
+        },
+      }),
+    );
+    const sendMail = vi.fn();
+    const result = await runCompletionNotifications({
+      runId: "run-1", now: NOW, storage, loader, env: ENV, sendMail,
+    });
+    expect(result.processedTenants).toBe(0);
+    expect(result.sent).toBe(0);
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("tenant cc config null → tenant 全 skip", async () => {
+    loader.setTenant(
+      "tenantA",
+      makeFixture({ ccConfig: null }),
+    );
+    const result = await runCompletionNotifications({
+      runId: "run-1", now: NOW, storage, loader, env: ENV, sendMail: vi.fn(),
+    });
+    expect(result.processedTenants).toBe(0);
+  });
+});
+
+describe("Gmail エラー分類 (AC-14, AC-15, AC-17, AC-18)", () => {
+  beforeEach(() => {
+    storage.__setSettingsForTest(makeSettings());
+    loader.setTenant("tenantA", makeFixture());
+  });
+
+  it("transient 429 → reservation 維持、status は reserved のまま、failed counter +1", async () => {
+    const sendMail = vi.fn().mockRejectedValue({ response: { status: 429 } });
+    const result = await runCompletionNotifications({
+      runId: "run-1", now: NOW, storage, loader, env: ENV, sendMail,
+    });
+    expect(result.failed).toBe(1);
+    expect(result.sent).toBe(0);
+    const notification = await storage.getCompletionNotification("tenantA", "user-1");
+    expect(notification?.status).toBe("reserved"); // 維持
+  });
+
+  it("permanent 400 → status=failed_permanent、failed counter +1、再送されない", async () => {
+    const sendMail = vi.fn().mockRejectedValue({ response: { status: 400 } });
+    const result = await runCompletionNotifications({
+      runId: "run-1", now: NOW, storage, loader, env: ENV, sendMail,
+    });
+    expect(result.failed).toBe(1);
+    const notification = await storage.getCompletionNotification("tenantA", "user-1");
+    expect(notification?.status).toBe("failed_permanent");
+  });
+
+  it("403 user_permanent (recipientRejected) → failed_permanent", async () => {
+    const sendMail = vi.fn().mockRejectedValue({
+      response: {
+        status: 403,
+        data: { error: { errors: [{ reason: "recipientRejected" }] } },
+      },
+    });
+    const result = await runCompletionNotifications({
+      runId: "run-1", now: NOW, storage, loader, env: ENV, sendMail,
+    });
+    expect(result.failed).toBe(1);
+    const notification = await storage.getCompletionNotification("tenantA", "user-1");
+    expect(notification?.status).toBe("failed_permanent");
+  });
+
+  it("403 scope_revoked (insufficientPermissions) → run 全体 abort", async () => {
+    // 2 user 用意して 1 user 目で scope_revoked、2 user 目に到達しないことを確認
+    loader.setTenant(
+      "tenantA",
+      makeFixture({
+        users: [
+          { id: "user-1", email: "u1@example.com", name: "U1" },
+          { id: "user-2", email: "u2@example.com", name: "U2" },
+        ],
+        courseProgresses: new Map([
+          ["user-1", [{ courseId: "c1", isCompleted: true, totalLessons: 3, completedLessons: 3 }]],
+          ["user-2", [{ courseId: "c1", isCompleted: true, totalLessons: 3, completedLessons: 3 }]],
+        ]),
+      }),
+    );
+    const sendMail = vi.fn().mockRejectedValue({
+      response: {
+        status: 403,
+        data: { error: { errors: [{ reason: "insufficientPermissions" }] } },
+      },
+    });
+    await runCompletionNotifications({
+      runId: "run-1", now: NOW, storage, loader, env: ENV, sendMail,
+      userConcurrency: 1, // 直列化して scope_revoked 直後 abort を確実に
+    });
+    // run 状態が aborted で abortedReason がセット
+    const run = await storage.getRun("run-1");
+    expect(run?.status).toBe("aborted");
+    expect(run?.abortedReason).toBe("gmail_scope_revoked");
+    // audit に run_aborted 記録
+    const auditLogs = await storage.listAuditLogs({ runId: "run-1", eventType: "run_aborted" });
+    expect(auditLogs).toHaveLength(1);
+  });
+});
+
+describe("audit log 整合", () => {
+  beforeEach(() => {
+    storage.__setSettingsForTest(makeSettings());
+    loader.setTenant("tenantA", makeFixture());
+  });
+
+  it("成功 path: run_started → user_notified → run_completed が記録される", async () => {
+    const sendMail = vi
+      .fn()
+      .mockResolvedValue({ messageId: "msg-001", attempts: 1 } satisfies SendCompletionMailResult);
+    await runCompletionNotifications({
+      runId: "run-1", now: NOW, storage, loader, env: ENV, sendMail,
+    });
+    const allLogs = await storage.listAuditLogs({ runId: "run-1" });
+    const eventTypes = allLogs.map((l) => l.eventType);
+    expect(eventTypes).toContain("run_started");
+    expect(eventTypes).toContain("user_notified");
+    expect(eventTypes).toContain("run_completed");
+  });
+
+  it("audit log の errorMessage に raw email が含まれない (PII sanitize)", async () => {
+    const sendMail = vi
+      .fn()
+      .mockRejectedValue({ response: { status: 400 }, message: "Rejected: leak@evil.com" });
+    await runCompletionNotifications({
+      runId: "run-1", now: NOW, storage, loader, env: ENV, sendMail,
+    });
+    const allLogs = await storage.listAuditLogs({ runId: "run-1" });
+    for (const log of allLogs) {
+      if (log.errorMessage) {
+        expect(log.errorMessage).not.toContain("leak@evil.com");
+      }
+    }
+    // failed_permanent の errorMessage も sanitize 済
+    const notification = await storage.getCompletionNotification("tenantA", "user-1");
+    expect(notification?.errorMessage).not.toContain("leak@evil.com");
+  });
+});
+
+describe("user.email validation (AC-19)", () => {
+  beforeEach(() => {
+    storage.__setSettingsForTest(makeSettings());
+  });
+
+  it("user.email が CRLF を含む → skip + audit、reservation せず", async () => {
+    loader.setTenant(
+      "tenantA",
+      makeFixture({
+        users: [{ id: "user-bad", email: "bad@x.com\r\nBcc: evil@x.com", name: "Bad" }],
+        courseProgresses: new Map([
+          ["user-bad", [{ courseId: "c1", isCompleted: true, totalLessons: 3, completedLessons: 3 }]],
+        ]),
+      }),
+    );
+    const sendMail = vi.fn();
+    const result = await runCompletionNotifications({
+      runId: "run-1", now: NOW, storage, loader, env: ENV, sendMail,
+    });
+    expect(result.skipped).toBe(1);
+    expect(sendMail).not.toHaveBeenCalled();
+    // reservation 作成されていないこと
+    expect(await storage.getCompletionNotification("tenantA", "user-bad")).toBeNull();
+  });
+});
+
+describe("RunAbortError class", () => {
+  it("name === 'RunAbortError'、cause が保持される", () => {
+    const inner = new Error("original");
+    const err = new RunAbortError("test_reason", { cause: inner });
+    expect(err.name).toBe("RunAbortError");
+    expect(err.reason).toBe("test_reason");
+    // Node 16+ Error.cause が保持される
+    expect(err.cause).toBe(inner);
+  });
+});

--- a/services/api/src/services/dispatch/__tests__/run-lock.test.ts
+++ b/services/api/src/services/dispatch/__tests__/run-lock.test.ts
@@ -162,6 +162,7 @@ describe("acquireRunLockOrSkip - lease 期限切れ後の再取得", () => {
       sent: 5,
       skipped: 0,
       failed: 0,
+      manualReviewRequired: 0,
     });
 
     // lease 内だが completed なので新規 acquire OK
@@ -181,6 +182,7 @@ describe("finalizeRun / completeRun / abortRun", () => {
       sent: 7,
       skipped: 2,
       failed: 1,
+      manualReviewRequired: 0,
     });
 
     const run = await storage.getRun("run-x");
@@ -189,6 +191,7 @@ describe("finalizeRun / completeRun / abortRun", () => {
     expect(run?.sent).toBe(7);
     expect(run?.skipped).toBe(2);
     expect(run?.failed).toBe(1);
+    expect(run?.manualReviewRequired).toBe(0);
     expect(run?.abortedReason).toBeNull();
   });
 
@@ -198,7 +201,7 @@ describe("finalizeRun / completeRun / abortRun", () => {
       storage,
       "run-y",
       "gmail_scope_revoked",
-      { processedTenants: 1, sent: 0, skipped: 0, failed: 0 },
+      { processedTenants: 1, sent: 0, skipped: 0, failed: 0, manualReviewRequired: 2 },
     );
 
     const run = await storage.getRun("run-y");

--- a/services/api/src/services/dispatch/dispatch-storage.ts
+++ b/services/api/src/services/dispatch/dispatch-storage.ts
@@ -125,6 +125,8 @@ export interface UpdateRunStatusInput {
   sent?: number;
   skipped?: number;
   failed?: number;
+  /** manual_review_required に降格された user 数 (Phase 4 追加) */
+  manualReviewRequired?: number;
   /** aborted 時の理由 (sanitized) */
   abortedReason?: string;
 }

--- a/services/api/src/services/dispatch/dispatch-storage.ts
+++ b/services/api/src/services/dispatch/dispatch-storage.ts
@@ -24,6 +24,7 @@ import {
   type DispatchAuditLog,
   type DispatchRun,
   type DispatchRunStatus,
+  type DispatchSettings,
   type ReservationOutcome,
 } from "@lms-279/shared-types";
 
@@ -159,6 +160,16 @@ export interface AppendAuditLogInput {
 // ============================================================
 
 export interface DispatchStorage {
+  // ----- Settings -----
+  /**
+   * super_dispatch_settings/global の読み取り。
+   * doc が存在しなければ null を返す (Phase 7 で初期化される想定)。
+   *
+   * Phase 5 super-admin API で settings 編集 (PUT) を追加するが、本 interface は
+   * Phase 4 では read-only のみ公開 (write は別 method を Phase 5 で追加)。
+   */
+  getDispatchSettings(): Promise<DispatchSettings | null>;
+
   // ----- Reservation -----
   /**
    * Pre-send reservation を transactional に取得する。

--- a/services/api/src/services/dispatch/in-memory-dispatch-storage.ts
+++ b/services/api/src/services/dispatch/in-memory-dispatch-storage.ts
@@ -242,6 +242,7 @@ export class InMemoryDispatchStorage implements DispatchStorage {
       sent: 0,
       skipped: 0,
       failed: 0,
+      manualReviewRequired: 0,
       abortedReason: null,
       ttlExpireAt: input.ttlExpireAt,
     };
@@ -271,6 +272,8 @@ export class InMemoryDispatchStorage implements DispatchStorage {
       sent: input.sent ?? existing.sent,
       skipped: input.skipped ?? existing.skipped,
       failed: input.failed ?? existing.failed,
+      manualReviewRequired:
+        input.manualReviewRequired ?? existing.manualReviewRequired,
       abortedReason,
     });
   }

--- a/services/api/src/services/dispatch/in-memory-dispatch-storage.ts
+++ b/services/api/src/services/dispatch/in-memory-dispatch-storage.ts
@@ -19,6 +19,7 @@ import type {
   DispatchAuditLog,
   DispatchRun,
   DispatchRunStatus,
+  DispatchSettings,
   ReservationOutcome,
 } from "@lms-279/shared-types";
 
@@ -50,12 +51,27 @@ export class InMemoryDispatchStorage implements DispatchStorage {
   private notifications = new Map<NotificationKey, CompletionNotification>();
   private runs = new Map<string, DispatchRun>();
   private auditLogs: DispatchAuditLog[] = [];
+  private settings: DispatchSettings | null = null;
 
   // テスト用クリアメソッド (production には呼ばない)
   __resetForTest(): void {
     this.notifications.clear();
     this.runs.clear();
     this.auditLogs = [];
+    this.settings = null;
+  }
+
+  /** テスト用 settings setter (Phase 5 で PUT API 経由のメソッドに置き換える) */
+  __setSettingsForTest(settings: DispatchSettings | null): void {
+    this.settings = settings;
+  }
+
+  // ===================================================================
+  // Settings
+  // ===================================================================
+
+  async getDispatchSettings(): Promise<DispatchSettings | null> {
+    return this.settings;
   }
 
   // ===================================================================

--- a/services/api/src/services/dispatch/oidc-verify.ts
+++ b/services/api/src/services/dispatch/oidc-verify.ts
@@ -97,10 +97,18 @@ export class GoogleOidcTokenVerifier implements OidcTokenVerifier {
     if (!payload) {
       throw new OidcVerifyFailure("invalid_token", "OIDC token has no payload");
     }
-    if (payload.aud !== expectedAudience) {
+    // OIDC 仕様で aud は string | string[]。google-auth-library 内部でも検証されるが
+    // 二重防御として明示的に配列ケースも扱う (safe-refactor HIGH-1 反映)。
+    const audMatch = Array.isArray(payload.aud)
+      ? payload.aud.includes(expectedAudience)
+      : payload.aud === expectedAudience;
+    if (!audMatch) {
+      const audDisplay = Array.isArray(payload.aud)
+        ? `[${payload.aud.join(", ")}]`
+        : String(payload.aud ?? "");
       throw new OidcVerifyFailure(
         "audience_mismatch",
-        `Expected audience '${expectedAudience}' but got '${String(payload.aud ?? "")}'`,
+        `Expected audience '${expectedAudience}' but got '${audDisplay}'`,
       );
     }
     return {

--- a/services/api/src/services/dispatch/oidc-verify.ts
+++ b/services/api/src/services/dispatch/oidc-verify.ts
@@ -1,0 +1,162 @@
+/**
+ * Cloud Scheduler から受け取る OIDC ID Token を検証する pure 関数 + Express middleware。
+ *
+ * 設計仕様書 §3.1 / NFR-2 / AC-30 に対応。
+ *
+ * 認証フロー:
+ *   1. Cloud Scheduler が internal endpoint を呼び出す際、Service Account の
+ *      OIDC ID Token を `Authorization: Bearer <jwt>` として送る
+ *   2. 本 module が JWT 署名 (Google 公開鍵で verify) + audience の一致を確認
+ *   3. caller (Cloud Scheduler の SA email) を req に attach
+ *
+ * Audience 検証:
+ *   Cloud Scheduler 設定で audience = endpoint URL を指定する想定。OIDC ID Token の
+ *   aud claim が configured DISPATCH_INTERNAL_AUDIENCE env と一致しなければ
+ *   401 で reject (token reuse / cross-environment attack 対策)。
+ */
+
+import type { Request, Response, NextFunction } from "express";
+import { OAuth2Client } from "google-auth-library";
+
+/** OIDC 検証結果。caller の subject (Service Account email) を含む */
+export interface VerifiedOidcCaller {
+  /** Service Account email (e.g., dxcollege-scheduler@lms-279.iam.gserviceaccount.com) */
+  email: string;
+  /** JWT subject (通常は SA の unique ID) */
+  subject: string;
+  /** 検証成功時の audience (env と一致したもの) */
+  audience: string;
+}
+
+export type OidcVerifyError =
+  | "missing_authorization"
+  | "invalid_authorization_format"
+  | "invalid_token"
+  | "audience_mismatch"
+  | "expired_token";
+
+export class OidcVerifyFailure extends Error {
+  constructor(
+    public readonly code: OidcVerifyError,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "OidcVerifyFailure";
+  }
+}
+
+/** Authorization header から Bearer token を抽出 */
+export function extractBearerToken(headerValue: unknown): string {
+  if (typeof headerValue !== "string" || headerValue.length === 0) {
+    throw new OidcVerifyFailure(
+      "missing_authorization",
+      "Authorization header is missing",
+    );
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(headerValue);
+  if (!match) {
+    throw new OidcVerifyFailure(
+      "invalid_authorization_format",
+      "Authorization header must be in 'Bearer <token>' format",
+    );
+  }
+  return match[1].trim();
+}
+
+/** Token verifier 抽象。本番は google-auth-library、テストは mock */
+export interface OidcTokenVerifier {
+  verify(
+    idToken: string,
+    expectedAudience: string,
+  ): Promise<VerifiedOidcCaller>;
+}
+
+/** 本番用 OIDC verifier (google-auth-library 利用) */
+export class GoogleOidcTokenVerifier implements OidcTokenVerifier {
+  private client = new OAuth2Client();
+
+  async verify(
+    idToken: string,
+    expectedAudience: string,
+  ): Promise<VerifiedOidcCaller> {
+    let ticket;
+    try {
+      ticket = await this.client.verifyIdToken({
+        idToken,
+        audience: expectedAudience,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/expired/i.test(msg)) {
+        throw new OidcVerifyFailure("expired_token", msg, { cause: err });
+      }
+      throw new OidcVerifyFailure("invalid_token", msg, { cause: err });
+    }
+    const payload = ticket.getPayload();
+    if (!payload) {
+      throw new OidcVerifyFailure("invalid_token", "OIDC token has no payload");
+    }
+    if (payload.aud !== expectedAudience) {
+      throw new OidcVerifyFailure(
+        "audience_mismatch",
+        `Expected audience '${expectedAudience}' but got '${String(payload.aud ?? "")}'`,
+      );
+    }
+    return {
+      email: typeof payload.email === "string" ? payload.email : "",
+      subject: typeof payload.sub === "string" ? payload.sub : "",
+      audience: expectedAudience,
+    };
+  }
+}
+
+/** Authorization header の Bearer token を verify して caller を返す */
+export async function verifyOidcToken(
+  headerValue: unknown,
+  expectedAudience: string,
+  verifier: OidcTokenVerifier,
+): Promise<VerifiedOidcCaller> {
+  const token = extractBearerToken(headerValue);
+  return verifier.verify(token, expectedAudience);
+}
+
+/** VerifiedOidcCaller を request に attach する augmentation */
+export interface RequestWithOidcCaller extends Request {
+  oidcCaller?: VerifiedOidcCaller;
+}
+
+/**
+ * Express middleware factory。expectedAudience / verifier を closure で固定。
+ * 失敗時は 401 + ADR-010 フラットエラー形式 `{ error, message }` を返す。
+ */
+export function requireValidOidcToken(opts: {
+  expectedAudience: string;
+  verifier: OidcTokenVerifier;
+}): (req: RequestWithOidcCaller, res: Response, next: NextFunction) => void {
+  return (req, res, next) => {
+    void (async () => {
+      try {
+        const caller = await verifyOidcToken(
+          req.headers.authorization,
+          opts.expectedAudience,
+          opts.verifier,
+        );
+        req.oidcCaller = caller;
+        next();
+      } catch (err) {
+        if (err instanceof OidcVerifyFailure) {
+          res.status(401).json({
+            error: err.code,
+            message: err.message,
+          });
+          return;
+        }
+        res.status(401).json({
+          error: "invalid_token",
+          message: "OIDC token verification failed",
+        });
+      }
+    })();
+  };
+}

--- a/services/api/src/services/dispatch/run-completion-notifications.ts
+++ b/services/api/src/services/dispatch/run-completion-notifications.ts
@@ -63,7 +63,11 @@ import { recordAuditLog } from "./dispatch-audit.js";
 import { sanitizeErrorForAudit } from "./dispatch-error-sanitizer.js";
 
 import type { DispatchStorage } from "./dispatch-storage.js";
-import type { TenantDataLoader } from "./tenant-data-loader.js";
+import type {
+  TenantDataLoader,
+  DispatchTenantDataView,
+  TenantCcConfigView,
+} from "./tenant-data-loader.js";
 
 /** デフォルト並列度 (FR-3、§3.3 既存 LESSON_FETCH_CONCURRENCY と同値) */
 const DEFAULT_USER_CONCURRENCY = 8;
@@ -105,8 +109,11 @@ export class RunAbortError extends Error {
   }
 }
 
-/** sha256(email) で PII を最小化 (ADR-034、NFR-1) */
-function sha256(input: string): string {
+/**
+ * sha256(email) で PII を最小化 (ADR-034、NFR-1)。
+ * test からも参照可能にして実装の divergence を防ぐため export (safe-refactor MEDIUM-1)。
+ */
+export function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex");
 }
 
@@ -235,6 +242,7 @@ export async function runCompletionNotifications(
       sent: metrics.sent,
       skipped: metrics.skipped,
       failed: metrics.failed,
+      manualReviewRequired: metrics.manualReviewRequired,
     });
     await recordAuditLog(storage, {
       runId,
@@ -258,13 +266,18 @@ export async function runCompletionNotifications(
         sent: metrics.sent,
         skipped: metrics.skipped,
         failed: metrics.failed,
+        manualReviewRequired: metrics.manualReviewRequired,
       });
+      // err.cause は raw object (Gmail API error 等、PII / token を含みうる) のため
+      // 明示的に sanitize してから audit log に渡す (safe-refactor HIGH-2 反映)。
+      // recordAuditLog 側でも二重 sanitize されるが冪等なので安全。
+      const sanitizedCauseMessage = sanitizeErrorForAudit(err.cause ?? err.message);
       await recordAuditLog(storage, {
         runId,
         runStartedAt,
         eventType: "run_aborted",
         errorCode: err.reason,
-        errorMessage: err.cause ?? err.message,
+        errorMessage: sanitizedCauseMessage,
         now,
       });
       return {
@@ -282,6 +295,7 @@ export async function runCompletionNotifications(
       sent: metrics.sent,
       skipped: metrics.skipped,
       failed: metrics.failed,
+      manualReviewRequired: metrics.manualReviewRequired,
     });
     throw err;
   }
@@ -302,16 +316,10 @@ interface ProcessUserContext {
   tenantId: string;
   user: { id: string; email: string; name: string | null };
   publishedCourses: Awaited<
-    ReturnType<
-      ReturnType<TenantDataLoader["getTenantDataView"]>["listPublishedCourses"]
-    >
+    ReturnType<DispatchTenantDataView["listPublishedCourses"]>
   >;
-  ccConfig: {
-    completionNotificationEnabled: boolean;
-    ownerEmail: string | null;
-    notificationCcEmails: string[];
-  };
-  dataView: ReturnType<TenantDataLoader["getTenantDataView"]>;
+  ccConfig: TenantCcConfigView;
+  dataView: DispatchTenantDataView;
   settings: DispatchSettings;
   runId: string;
   runStartedAt: string;

--- a/services/api/src/services/dispatch/run-completion-notifications.ts
+++ b/services/api/src/services/dispatch/run-completion-notifications.ts
@@ -1,0 +1,585 @@
+/**
+ * DXcollege 自動完了通知メインロジック (Phase 4 統合点)。
+ *
+ * 設計仕様書 §3.1 全体図、§6.2 送信フロー、FR-1〜FR-12、AC-1〜AC-25 を統合。
+ * Phase 1 (pure 関数) + Phase 2 (storage / reservation) + Phase 3 (mail / send)
+ * を結合し、Cloud Scheduler 起動 → tenant 走査 → user 送信 → run 完了の
+ * end-to-end フローを実装する。
+ *
+ * 処理順 (設計仕様書 §3.1 ① ~ ⑬):
+ *   ① OIDC verify (caller 側 middleware で実施、本関数到達前)
+ *   ② run lock 取得 (acquireRunLockOrSkip)
+ *   ③ settings 読み取り (storage.getDispatchSettings)
+ *   ④ enabled & schedule 一致判定 (shouldRunNow)
+ *   ⑤ tenant 走査 (直列、FR-3)
+ *   ⑥ user 走査 (並列度 8、Phase 1 LESSON_FETCH_CONCURRENCY と整合)
+ *   ⑦ eligibility 判定 (evaluateCompletionEligibility、Critical-2)
+ *   ⑧ reservation transaction (tryReserveOrSkip、Critical-1+3)
+ *   ⑨ mail build + Gmail send (buildCompletionMail + sendCompletionMail)
+ *   ⑩ markSent / markFailedPermanent (status 遷移)
+ *   ⑪ audit log (recordAuditLog、PII sanitize 済)
+ *   ⑫ run 完了 (completeRun) または abort (abortRun on scope_revoked)
+ *
+ * caller の責務 (Phase 4 endpoint):
+ *   - OIDC verify
+ *   - DispatchStorage / TenantDataLoader / env を build して inject
+ *   - 返却された結果を internal API response として返す
+ */
+
+import { createHash } from "node:crypto";
+import {
+  type DispatchSettings,
+  type RunCompletionNotificationsResponse,
+} from "@lms-279/shared-types";
+
+import { shouldRunNow } from "./schedule-matcher.js";
+import { evaluateCompletionEligibility } from "./completion-eligibility.js";
+import {
+  validateAndDedupeCcEmails,
+  validateSingleEmail,
+} from "./cc-email-validator.js";
+import {
+  buildCompletionMail,
+  DEFAULT_COMPLETION_SUBJECT,
+} from "./completion-notification-mail.js";
+import {
+  isTransientGmailError,
+  sendCompletionMail as defaultSendCompletionMail,
+  type SendCompletionMailInput,
+  type SendCompletionMailResult,
+} from "./gmail-dwd-send.js";
+import { classifyGmail403 } from "./dispatch-403-classifier.js";
+import {
+  tryReserveOrSkip,
+  markSent,
+  markFailedPermanent,
+} from "./reservation.js";
+import {
+  acquireRunLockOrSkip,
+  completeRun,
+  abortRun,
+} from "./run-lock.js";
+import { recordAuditLog } from "./dispatch-audit.js";
+import { sanitizeErrorForAudit } from "./dispatch-error-sanitizer.js";
+
+import type { DispatchStorage } from "./dispatch-storage.js";
+import type { TenantDataLoader } from "./tenant-data-loader.js";
+
+/** デフォルト並列度 (FR-3、§3.3 既存 LESSON_FETCH_CONCURRENCY と同値) */
+const DEFAULT_USER_CONCURRENCY = 8;
+
+export interface DispatchEnv {
+  /** DXCOLLEGE_DISPATCH_SUBJECT (JWT subject = 実 mailbox) */
+  subjectEmail: string;
+  /** DXCOLLEGE_SENDER_EMAIL (MIME From = SendAs alias) */
+  fromEmail: string;
+}
+
+export interface RunCompletionNotificationsInput {
+  /** caller 生成の runId (uuid v4) */
+  runId: string;
+  /** 現在時刻 (テスト時固定可) */
+  now: Date;
+  storage: DispatchStorage;
+  loader: TenantDataLoader;
+  env: DispatchEnv;
+  /** user 並列度 (default DEFAULT_USER_CONCURRENCY=8) */
+  userConcurrency?: number;
+  /** Gmail send 関数注入点 (テスト時 mock) */
+  sendMail?: (
+    input: SendCompletionMailInput,
+  ) => Promise<SendCompletionMailResult>;
+}
+
+/**
+ * run 全体中断シグナル (scope_revoked 等の致命的エラー専用)。
+ * caller (本関数 / endpoint) で catch して abortRun → 適切な response にマッピング。
+ */
+export class RunAbortError extends Error {
+  constructor(
+    public readonly reason: string,
+    options?: { cause?: unknown },
+  ) {
+    super(reason, options);
+    this.name = "RunAbortError";
+  }
+}
+
+/** sha256(email) で PII を最小化 (ADR-034、NFR-1) */
+function sha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+/** Promise の並列度制御 (簡易 semaphore、外部依存を避ける) */
+async function runWithConcurrency<T>(
+  items: readonly T[],
+  concurrency: number,
+  task: (item: T) => Promise<void>,
+): Promise<void> {
+  const queue = [...items];
+  const workers: Promise<void>[] = [];
+  const effectiveConcurrency = Math.max(1, Math.min(concurrency, items.length));
+  for (let i = 0; i < effectiveConcurrency; i++) {
+    workers.push(
+      (async () => {
+        while (queue.length > 0) {
+          const item = queue.shift();
+          if (item === undefined) break;
+          await task(item);
+        }
+      })(),
+    );
+  }
+  await Promise.all(workers);
+}
+
+interface RunMetrics {
+  processedTenants: number;
+  sent: number;
+  skipped: number;
+  failed: number;
+  manualReviewRequired: number;
+}
+
+/**
+ * Phase 4 メインロジック。
+ *
+ * 戻り値: `RunCompletionNotificationsResponse` (Cloud Scheduler への HTTP response)。
+ * 戻り値の `runId` は呼び出し時の input.runId とは別: 本関数内で acquire された
+ * 場合のみセットされる (lock 拒否時は元 input.runId のままだが skip 扱い)。
+ *
+ * RunAbortError (scope_revoked) は本関数内で catch して response に reflect する
+ * (caller の HTTP endpoint には throw しない、結果として 200 OK + abortedReason)。
+ */
+export async function runCompletionNotifications(
+  input: RunCompletionNotificationsInput,
+): Promise<RunCompletionNotificationsResponse> {
+  const { runId, now, storage, loader, env } = input;
+  const userConcurrency = input.userConcurrency ?? DEFAULT_USER_CONCURRENCY;
+  const sendMail = input.sendMail ?? defaultSendCompletionMail;
+
+  // ③ settings 読み取り
+  const settings = await storage.getDispatchSettings();
+  if (!settings) {
+    // 初期化前の状態。kill switch 同等扱いで何もしない。
+    return emptyResponse(runId);
+  }
+
+  // ④ enabled & schedule 一致判定 (AC-6 / AC-7)
+  if (!shouldRunNow(settings, now)) {
+    return emptyResponse(runId);
+  }
+
+  // ② run lock 取得 (AC-16、Cloud Scheduler 重複起動対策)
+  const lockOutcome = await acquireRunLockOrSkip(storage, { now, runId });
+  if (!lockOutcome.acquired) {
+    return emptyResponse(runId);
+  }
+
+  const runStartedAt = lockOutcome.run.triggeredAt;
+  await recordAuditLog(storage, {
+    runId,
+    runStartedAt,
+    eventType: "run_started",
+    now,
+  });
+
+  const metrics: RunMetrics = {
+    processedTenants: 0,
+    sent: 0,
+    skipped: 0,
+    failed: 0,
+    manualReviewRequired: 0,
+  };
+
+  try {
+    const tenantIds = await loader.listAllTenantIds();
+    for (const tenantId of tenantIds) {
+      const ccConfig = await loader.getTenantCcConfig(tenantId);
+      if (!ccConfig?.completionNotificationEnabled) {
+        // テナント単位で disable (tenant config なし or 明示 false)
+        continue;
+      }
+      metrics.processedTenants += 1;
+
+      const dataView = loader.getTenantDataView(tenantId);
+      const publishedCourses = await dataView.listPublishedCourses();
+      if (publishedCourses.length === 0) {
+        // テナントに published コースなし → 全 user 不適格
+        continue;
+      }
+      const users = await dataView.listNotificationTargetUsers();
+
+      await runWithConcurrency(users, userConcurrency, async (user) => {
+        await processUser({
+          tenantId,
+          user,
+          publishedCourses,
+          ccConfig,
+          dataView,
+          settings,
+          runId,
+          runStartedAt,
+          now,
+          storage,
+          env,
+          sendMail,
+          metrics,
+        });
+      });
+    }
+
+    // ⑫ run 完了
+    await completeRun(storage, runId, {
+      processedTenants: metrics.processedTenants,
+      sent: metrics.sent,
+      skipped: metrics.skipped,
+      failed: metrics.failed,
+    });
+    await recordAuditLog(storage, {
+      runId,
+      runStartedAt,
+      eventType: "run_completed",
+      now,
+    });
+    return {
+      runId,
+      processedTenants: metrics.processedTenants,
+      sent: metrics.sent,
+      skipped: metrics.skipped,
+      failed: metrics.failed,
+      manualReviewRequired: metrics.manualReviewRequired,
+    };
+  } catch (err) {
+    // ⑫ scope_revoked 等の致命的エラーで run 全体中断 (AC-17)
+    if (err instanceof RunAbortError) {
+      await abortRun(storage, runId, err.reason, {
+        processedTenants: metrics.processedTenants,
+        sent: metrics.sent,
+        skipped: metrics.skipped,
+        failed: metrics.failed,
+      });
+      await recordAuditLog(storage, {
+        runId,
+        runStartedAt,
+        eventType: "run_aborted",
+        errorCode: err.reason,
+        errorMessage: err.cause ?? err.message,
+        now,
+      });
+      return {
+        runId,
+        processedTenants: metrics.processedTenants,
+        sent: metrics.sent,
+        skipped: metrics.skipped,
+        failed: metrics.failed,
+        manualReviewRequired: metrics.manualReviewRequired,
+      };
+    }
+    // 想定外エラーは abort 扱いで上位に伝搬 (caller の HTTP 500 経路へ)
+    await abortRun(storage, runId, "unexpected_error", {
+      processedTenants: metrics.processedTenants,
+      sent: metrics.sent,
+      skipped: metrics.skipped,
+      failed: metrics.failed,
+    });
+    throw err;
+  }
+}
+
+function emptyResponse(runId: string): RunCompletionNotificationsResponse {
+  return {
+    runId,
+    processedTenants: 0,
+    sent: 0,
+    skipped: 0,
+    failed: 0,
+    manualReviewRequired: 0,
+  };
+}
+
+interface ProcessUserContext {
+  tenantId: string;
+  user: { id: string; email: string; name: string | null };
+  publishedCourses: Awaited<
+    ReturnType<
+      ReturnType<TenantDataLoader["getTenantDataView"]>["listPublishedCourses"]
+    >
+  >;
+  ccConfig: {
+    completionNotificationEnabled: boolean;
+    ownerEmail: string | null;
+    notificationCcEmails: string[];
+  };
+  dataView: ReturnType<TenantDataLoader["getTenantDataView"]>;
+  settings: DispatchSettings;
+  runId: string;
+  runStartedAt: string;
+  now: Date;
+  storage: DispatchStorage;
+  env: DispatchEnv;
+  sendMail: (
+    input: SendCompletionMailInput,
+  ) => Promise<SendCompletionMailResult>;
+  metrics: RunMetrics;
+}
+
+async function processUser(ctx: ProcessUserContext): Promise<void> {
+  const {
+    tenantId,
+    user,
+    publishedCourses,
+    ccConfig,
+    dataView,
+    settings,
+    runId,
+    runStartedAt,
+    now,
+    storage,
+    env,
+    sendMail,
+    metrics,
+  } = ctx;
+
+  // user.email validation (AC-19)
+  const toValidation = validateSingleEmail(user.email);
+  if (!toValidation.ok) {
+    await recordAuditLog(storage, {
+      runId,
+      runStartedAt,
+      eventType: "user_skipped",
+      tenantId,
+      userId: user.id,
+      errorCode: `invalid_user_email_${toValidation.reason}`,
+      now,
+    });
+    metrics.skipped += 1;
+    return;
+  }
+  const toEmail = toValidation.value;
+
+  // ⑦ eligibility 判定 (AC-1、Critical-2)
+  let courseProgresses;
+  try {
+    courseProgresses = await dataView.listCourseProgressForUser(user.id);
+  } catch (err) {
+    await recordAuditLog(storage, {
+      runId,
+      runStartedAt,
+      eventType: "user_failed_transient",
+      tenantId,
+      userId: user.id,
+      errorCode: "course_progress_read_failed",
+      errorMessage: err,
+      now,
+    });
+    metrics.failed += 1;
+    return;
+  }
+  const eligibility = evaluateCompletionEligibility(
+    publishedCourses,
+    courseProgresses,
+  );
+  if (!eligibility.eligible) {
+    // 未完了 user は audit に記録せず静かに skip (大量にあるため log spam 防止)
+    return;
+  }
+
+  // ⑧ reservation transaction (AC-10/11/12)
+  const reservation = await tryReserveOrSkip(storage, {
+    tenantId,
+    userId: user.id,
+    runId,
+    now,
+  });
+  if (!reservation.reserved) {
+    // 状態別 skip 種別を audit に記録
+    if (reservation.reason === "lease_expired_promoted_to_manual_review") {
+      metrics.manualReviewRequired += 1;
+      await recordAuditLog(storage, {
+        runId,
+        runStartedAt,
+        eventType: "manual_review_required",
+        tenantId,
+        userId: user.id,
+        errorCode: reservation.reason,
+        now,
+      });
+    } else {
+      metrics.skipped += 1;
+      await recordAuditLog(storage, {
+        runId,
+        runStartedAt,
+        eventType: "user_skipped",
+        tenantId,
+        userId: user.id,
+        errorCode: reservation.reason,
+        now,
+      });
+    }
+    return;
+  }
+
+  // ⑨ CC validation + mail build
+  const ccResult = validateAndDedupeCcEmails(
+    ccConfig.notificationCcEmails,
+    ccConfig.ownerEmail,
+  );
+  // CC validation 失敗要素は MIME に含めず audit のみ (orphan_send 相当の警告)
+  // 但し sent counter は spec 通り「成功」として進める (AC-25 部分採用)
+  if (ccResult.invalidEntries.length > 0) {
+    await recordAuditLog(storage, {
+      runId,
+      runStartedAt,
+      eventType: "user_skipped", // 失敗ではなく警告 audit (skip ではないが現行 eventType に該当なし)
+      tenantId,
+      userId: user.id,
+      errorCode: `cc_validation_partial_${ccResult.invalidEntries[0].reason}`,
+      now,
+    });
+    // skipped カウンタには加算しない (audit ログのみ)
+  }
+
+  const mail = buildCompletionMail({
+    userName: user.name,
+    completionMessageBody: settings.completionMessageBody,
+    signatureName: settings.signatureName,
+  });
+
+  // ⑩ Gmail send → mark sent / failed
+  try {
+    const sendResult = await sendMail({
+      subjectEmail: env.subjectEmail,
+      fromEmail: env.fromEmail,
+      to: toEmail,
+      cc: ccResult.validCcEmails,
+      subject: mail.subject,
+      body: mail.body,
+    });
+    await markSent(storage, {
+      tenantId,
+      userId: user.id,
+      messageId: sendResult.messageId,
+      notifiedAt: now.toISOString(),
+      courseIdsSnapshot: eligibility.courseIdsSnapshot,
+      progressSnapshot: eligibility.progressSnapshot,
+      recipientToHash: sha256(toEmail),
+      recipientCcHashes: ccResult.validCcEmails.map(sha256),
+      pdfSizeBytes: null,
+    });
+    await recordAuditLog(storage, {
+      runId,
+      runStartedAt,
+      eventType: "user_notified",
+      tenantId,
+      userId: user.id,
+      now,
+    });
+    metrics.sent += 1;
+  } catch (err) {
+    await classifyAndRecord({
+      err,
+      tenantId,
+      userId: user.id,
+      runId,
+      runStartedAt,
+      now,
+      storage,
+      metrics,
+    });
+  }
+}
+
+interface ClassifyContext {
+  err: unknown;
+  tenantId: string;
+  userId: string;
+  runId: string;
+  runStartedAt: string;
+  now: Date;
+  storage: DispatchStorage;
+  metrics: RunMetrics;
+}
+
+async function classifyAndRecord(ctx: ClassifyContext): Promise<void> {
+  const { err, tenantId, userId, runId, runStartedAt, now, storage, metrics } =
+    ctx;
+
+  // 1. HTTP status 取得
+  const status = getHttpStatus(err);
+
+  // 2. 403 → classify scope_revoked vs user_permanent (AC-17, AC-18)
+  if (status === 403) {
+    const classification = classifyGmail403(err);
+    if (classification === "scope_revoked") {
+      // run 全体中断 (AC-17)
+      throw new RunAbortError("gmail_scope_revoked", { cause: err });
+    }
+    // user_permanent (AC-18)
+    await markFailedPermanent(storage, {
+      tenantId,
+      userId,
+      failedAt: now.toISOString(),
+      errorCode: "gmail_user_permanent_403",
+      errorMessage: sanitizeErrorForAudit(err),
+    });
+    await recordAuditLog(storage, {
+      runId,
+      runStartedAt,
+      eventType: "user_failed_permanent",
+      tenantId,
+      userId,
+      errorCode: "gmail_user_permanent_403",
+      errorMessage: err,
+      now,
+    });
+    metrics.failed += 1;
+    return;
+  }
+
+  // 3. transient (429 / 503 / network) → reservation 維持 (AC-14)
+  if (isTransientGmailError(err)) {
+    await recordAuditLog(storage, {
+      runId,
+      runStartedAt,
+      eventType: "user_failed_transient",
+      tenantId,
+      userId,
+      errorCode: `gmail_transient_${status ?? "network"}`,
+      errorMessage: err,
+      now,
+    });
+    metrics.failed += 1;
+    return;
+  }
+
+  // 4. それ以外 (400 / 422 / 401 等) → permanent (AC-15)
+  await markFailedPermanent(storage, {
+    tenantId,
+    userId,
+    failedAt: now.toISOString(),
+    errorCode: `gmail_permanent_${status ?? "unknown"}`,
+    errorMessage: sanitizeErrorForAudit(err),
+  });
+  await recordAuditLog(storage, {
+    runId,
+    runStartedAt,
+    eventType: "user_failed_permanent",
+    tenantId,
+    userId,
+    errorCode: `gmail_permanent_${status ?? "unknown"}`,
+    errorMessage: err,
+    now,
+  });
+  metrics.failed += 1;
+}
+
+function getHttpStatus(err: unknown): number | null {
+  if (!err || typeof err !== "object") return null;
+  const e = err as { response?: { status?: unknown } };
+  const status = e.response?.status;
+  return typeof status === "number" ? status : null;
+}
+
+// re-export 用 (caller が直接参照)
+export { DEFAULT_COMPLETION_SUBJECT };

--- a/services/api/src/services/dispatch/run-lock.ts
+++ b/services/api/src/services/dispatch/run-lock.ts
@@ -66,16 +66,19 @@ export async function finalizeRun(
   return storage.updateRunStatus(input);
 }
 
+export interface RunMetricsForFinalize {
+  processedTenants: number;
+  sent: number;
+  skipped: number;
+  failed: number;
+  manualReviewRequired: number;
+}
+
 /** convenience: completed 用ヘルパー (status を明示せず metrics のみ渡す) */
 export async function completeRun(
   storage: DispatchStorage,
   runId: string,
-  metrics: {
-    processedTenants: number;
-    sent: number;
-    skipped: number;
-    failed: number;
-  },
+  metrics: RunMetricsForFinalize,
 ): Promise<void> {
   return finalizeRun(storage, {
     runId,
@@ -89,12 +92,7 @@ export async function abortRun(
   storage: DispatchStorage,
   runId: string,
   abortedReason: string,
-  metrics?: {
-    processedTenants: number;
-    sent: number;
-    skipped: number;
-    failed: number;
-  },
+  metrics?: RunMetricsForFinalize,
 ): Promise<void> {
   return finalizeRun(storage, {
     runId,

--- a/services/api/src/services/dispatch/tenant-data-loader.ts
+++ b/services/api/src/services/dispatch/tenant-data-loader.ts
@@ -1,0 +1,138 @@
+/**
+ * Dispatch 機能用の tenant データ読み取り抽象 layer。
+ *
+ * 設計仕様書 §3.3 (並列度)、FR-3 (全テナント直列走査)、§4.1 / §4.1.4 関連。
+ *
+ * 目的:
+ *   - run-completion-notifications.ts のメインロジックを DataSource 実装非依存に
+ *     する (test では InMemoryTenantDataLoader、production では FirestoreDataSource
+ *     ベースの実装を inject)
+ *   - tenant 一覧取得 (platform レベル) と tenant 内データ取得 (per-tenant DataSource)
+ *     の責務を 1 interface に統合し、orchestration の caller 側 wiring を簡略化
+ *
+ * 非責務:
+ *   - tenant の作成 / 削除 (本 layer は読み取り専用)
+ *   - 配信設定 (super_dispatch_settings) の取得 (DispatchStorage の責務)
+ *
+ * Phase 4 では InMemoryTenantDataLoader のみ実装、Phase 7 で Firestore 実装と
+ * production wiring を追加。
+ */
+
+import type {
+  Course,
+  CourseProgress,
+  User,
+} from "../../types/entities.js";
+
+/**
+ * テナント別の通知 CC 設定 (tenants/{tenantId} 拡張フィールドの抜粋)。
+ *
+ * shared-types の `TenantNotificationCcConfig` と同じ形状だが、本 layer が
+ * 必要な field のみに絞った read-only view として独立定義。Phase 5 で
+ * spec/shared-types 側に確定したら型統合を検討 (本 Phase ではスコープ外)。
+ */
+export interface TenantCcConfigView {
+  /** テナント単位の通知有効化フラグ (false なら本テナントは配信対象外、AC-7 拡張) */
+  completionNotificationEnabled: boolean;
+  /** CC に固定で含める owner email (validate 前の raw、null なら CC 追加しない) */
+  ownerEmail: string | null;
+  /** 追加 CC email 配列 (cc-email-validator で個別検証される、AC-25) */
+  notificationCcEmails: string[];
+}
+
+/**
+ * Dispatch 機能向けの tenant 単位 read-only データソース。
+ * DataSource interface 全体ではなく、dispatch 機能が必要とする最小 API のみを公開。
+ */
+export interface DispatchTenantDataView {
+  /** published コース一覧 (eligibility 母集合、Critical-2) */
+  listPublishedCourses(): Promise<Pick<Course, "id" | "lessonOrder">[]>;
+  /** テナント内 user 一覧 (role フィルタは loader 側で実施済) */
+  listNotificationTargetUsers(): Promise<
+    Pick<User, "id" | "email" | "name">[]
+  >;
+  /** 単一 user の course_progress 一覧 (eligibility 判定入力) */
+  listCourseProgressForUser(
+    userId: string,
+  ): Promise<
+    Pick<
+      CourseProgress,
+      "courseId" | "isCompleted" | "totalLessons" | "completedLessons"
+    >[]
+  >;
+}
+
+/**
+ * Platform レベルの tenant 一覧 + テナント単位データの取得を抽象化。
+ */
+export interface TenantDataLoader {
+  /** 全 tenant ID の列挙 (Phase 4 では順序はソート済前提、deterministic) */
+  listAllTenantIds(): Promise<string[]>;
+  /** テナント単位のデータビュー */
+  getTenantDataView(tenantId: string): DispatchTenantDataView;
+  /** テナント単位の CC 設定 (null なら通知 disable と同等扱い) */
+  getTenantCcConfig(tenantId: string): Promise<TenantCcConfigView | null>;
+}
+
+// ============================================================
+// InMemory 実装 (test / dev 用)
+// ============================================================
+
+export interface InMemoryTenantFixture {
+  /** publishedCourses は status="published" の判定後の入力 (loader 側 filter 済) */
+  publishedCourses: Pick<Course, "id" | "lessonOrder">[];
+  /** 通知対象 user (role フィルタ済) */
+  users: Pick<User, "id" | "email" | "name">[];
+  /** courseProgress (キー: userId、value: progress 配列) */
+  courseProgresses: Map<
+    string,
+    Pick<
+      CourseProgress,
+      "courseId" | "isCompleted" | "totalLessons" | "completedLessons"
+    >[]
+  >;
+  /** CC 設定 (null なら disable と同等) */
+  ccConfig: TenantCcConfigView | null;
+}
+
+export class InMemoryTenantDataLoader implements TenantDataLoader {
+  private fixtures = new Map<string, InMemoryTenantFixture>();
+  /** 列挙順序固定 (テストの deterministic 化) */
+  private tenantOrder: string[] = [];
+
+  setTenant(tenantId: string, fixture: InMemoryTenantFixture): void {
+    if (!this.fixtures.has(tenantId)) {
+      this.tenantOrder.push(tenantId);
+    }
+    this.fixtures.set(tenantId, fixture);
+  }
+
+  async listAllTenantIds(): Promise<string[]> {
+    return [...this.tenantOrder];
+  }
+
+  getTenantDataView(tenantId: string): DispatchTenantDataView {
+    const fixture = this.fixtures.get(tenantId);
+    if (!fixture) {
+      throw new Error(
+        `InMemoryTenantDataLoader: unknown tenantId ${tenantId} (test fixture not registered)`,
+      );
+    }
+    return {
+      async listPublishedCourses() {
+        return fixture.publishedCourses;
+      },
+      async listNotificationTargetUsers() {
+        return fixture.users;
+      },
+      async listCourseProgressForUser(userId) {
+        return fixture.courseProgresses.get(userId) ?? [];
+      },
+    };
+  }
+
+  async getTenantCcConfig(tenantId: string): Promise<TenantCcConfigView | null> {
+    const fixture = this.fixtures.get(tenantId);
+    return fixture?.ccConfig ?? null;
+  }
+}


### PR DESCRIPTION
## Summary

DXcollege 自動完了通知システム Phase 4 を完了。Phase 1+2+3 を結合し、Cloud Scheduler 起動 → tenant 走査 → user 送信 → run 完了の end-to-end フローを実装。**10 ファイル / +1932 行** で全 AC (FR-1〜FR-12 / AC-1〜AC-25 / NFR-2/3/11) の主要パスを Integration test で網羅。

**進捗**:

| Phase | Status |
|---|---|
| 0 (前提作業) | ✅ |
| 1 (基礎 services 7 ファイル) | ✅ #442 + #465 |
| 2 (Reservation / Run Lock / Audit) | ✅ #467 |
| 3 (Mail + Send) | ✅ #466 |
| **4 (Internal API + メインロジック)** | ✅ **本 PR** |
| 5 (Super admin API) | ⏳ |
| 6 (Frontend UI) | ⏳ |
| 7 (Infra + ADR + Firestore impl) | ⏳ |
| 8 (Smoke + Cutover) | ⏳ |

## 新規実装

### services/dispatch/run-completion-notifications.ts (Phase 4 メイン、~360 行)

設計仕様書 §3.1 ① ~ ⑬ を完全実装:
- ② run lock 取得 (acquireRunLockOrSkip)
- ③ settings 読み取り
- ④ enabled & schedule 一致判定 (AC-6/AC-7)
- ⑤ tenant 走査 (直列、FR-3)
- ⑥ user 走査 (並列度 8 default、簡易 semaphore)
- ⑦ eligibility 判定 (Critical-2)
- ⑧ reservation transaction (Critical-1+3)
- ⑨ mail build + Gmail send
- ⑩ markSent / markFailedPermanent (AC-13/AC-15)
- ⑪ audit log (PII sanitize 済)
- ⑫ run 完了 / abort (AC-17)

PII 最小化: `sha256(email)` で `recipientToHash` / `recipientCcHashes` を計算 (ADR-034 / NFR-1 / AC-32)。

`RunAbortError` class: scope_revoked 等の致命的エラー専用 signal。

### services/dispatch/oidc-verify.ts (AC-30 / NFR-2)

Cloud Scheduler OIDC ID Token 検証 + Express middleware。`OidcTokenVerifier` interface (本番 `GoogleOidcTokenVerifier`、test mock)、ADR-010 フラットエラー形式で 401 返却。

### services/dispatch/tenant-data-loader.ts

`TenantDataLoader` interface + `InMemoryTenantDataLoader` 実装。tenant 単位 read-only データソース抽象 (publishedCourses / users / courseProgress / ccConfig)。DataSource 全体ではなく dispatch が必要とする最小 API のみ公開。

### routes/internal/dispatch.ts

POST /api/v2/internal/dispatch/run-completion-notifications。DI で test/prod 切り替え。`createInternalDispatchRouter(config)` factory。

## DispatchStorage 拡張

`getDispatchSettings()` を interface + InMemory 実装に追加。Phase 5 で PUT 系を追加予定。

## Phase 4 完了条件チェック (impl-plan §Phase 4)

| 条件 | 検証 |
|---|---|
| Integration Test で AC-1〜18 全シナリオ網羅 | ✅ run-completion-notifications.test.ts (20 件): kill switch / schedule / run lock / 100% 判定 / idempotency / tenant disable / Gmail 4xx/5xx 分類 / 403 user_permanent / 403 scope_revoked / audit / PII sanitize / user.email validation |
| Evaluator 分離プロトコル発動 | (PR 内で実施予定) |
| error-handling.md 状態復旧 > ログ記録 > 通知 の原則準拠 | ✅ try-catch 構造で reservation 状態維持 → audit log → metrics 集計の順 |

## Test plan

- [x] dispatch tests 14 ファイル / 270 件 PASS (前回 229 → +41)
- [x] API tests 全体 83 ファイル / 1318 件 PASS (前回 1275 → +43)
- [x] lint: 0 errors (1 pre-existing warning は本 PR 範囲外)
- [x] type-check (services/api / root): PASS
- [ ] CI green
- [ ] Quality gates (safe-refactor + evaluator + code-review medium)
- [ ] (Phase 7 着手時) FirestoreDispatchStorage / FirestoreTenantDataLoader 実装 + production wiring

## Phase 7 で対応 (未着手)

- FirestoreDispatchStorage 実装 (本 PR の DispatchStorage interface に conform)
- FirestoreTenantDataLoader 実装 (本 PR の TenantDataLoader interface に conform)
- routes/internal/dispatch.ts の production wiring (env / Firestore client / SA 設定)
- Cloud Scheduler job 作成 + OIDC audience 設定
- Cloud Run env (DXCOLLEGE_DISPATCH_SUBJECT / DXCOLLEGE_SENDER_EMAIL / DISPATCH_INTERNAL_AUDIENCE)
- Firestore TTL Policy / composite index

## 参考

- 設計仕様書: \`docs/specs/2026-05-20-completion-notification-design.md\`
- 実装計画: \`docs/specs/2026-05-20-completion-notification-impl-plan.md\`
- ADR-028 (テスト戦略) / ADR-029 (JST) / ADR-034 (PII 最小化) / ADR-037 (SendAs)
- 前 PR: #465 (Phase 1) / #466 (Phase 3) / #467 (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)