### PR TITLE
docs(handoff): Session 43 (2026-05-22) ハンドオフ記録 + Session 42 archive

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,14 +1,14 @@
-# Session Handoff — 2026-05-22 (Session 42)
+# Session Handoff — 2026-05-22 (Session 43)
 
 ## TL;DR
 
-**Session 41 の積み残し「ADR-038 候補の作成判断 (本田様判断待ち)」を解消したセッション。** Session 41 で Next.js middleware (URL path 不可視文字 strip → 308 redirect) を導入 (PR #457) した後、ADR 化が「本田様判断待ち」として保留されていた。本セッションでユーザー (本田様) から「これは必須なのでは？」との指摘を受け、ADR-038 として後追い記録を作成 → PR #463 → main マージ済。
+**DXcollege 自動完了通知システム (4 要件) の Phase 1 残部 + Phase 2/3/4 を 1 セッションで連続実装した一気通貫セッション。** 開発者から「以前にオーダーしていた 4 要件 (DXcollege@279279.net 自動送信 / テナント別 CC / 署名 / 100% 完了時 1 度だけ送信) は解決済か」との問いに対し、設計完了・Phase 1 途中で SendAs 設定待ちブロック状態だったことを報告。SendAs 設定完了の確認後「可能なら AI のみで進めて」「呼称を本田様 → 開発者に統一」との指示に従い、Phase 1 残部 → Phase 3 → Phase 2 → Phase 4 を順次実装。各 Phase で safe-refactor + evaluator + (規模に応じて) code-review の Quality Gate を実施し、指摘事項を都度反映。**Phase 1〜4 完了で AC 全体の end-to-end 検証点に到達**、本番デプロイには Phase 5-8 を残すのみ。
 
-- **Issue Net**: **0 件** — Close 0 / 起票 0 (Session 41 の派生作業ではなく既存 PR #457 の設計記録のため起票不要)
-- **マージ済 PR**: #463 (ADR-038 後追い記録、ドキュメントのみ +154/-0)
-- **CI**: ✅ green (CI 1m45s / E2E 1m20s / Deploy to Cloud Run 3m46s)
-- **未マージ PR**: なし
-- **Open Issue**: active 0 / postponed 4 (Session 41 末から変化なし)
+- **Issue Net**: **0 件** — Close 0 / 起票 0 (Phase 実装は impl-plan の Phase 進捗で管理、Issue 起票対象外。CLAUDE.md triage 基準準拠)
+- **マージ済 PR**: 3 件 (#465 Phase 1 残部 / #466 Phase 3 Mail+Send / #467 Phase 2 Reservation/Lock/Audit)
+- **未マージ PR**: 2 件 (#468 Phase 4 Internal API+メインロジック CI green merge 認可待ち / 本 PR Session 43 handoff)
+- **CI**: ✅ 全 green (各 PR の Lint / Type Check / Test / Build / Deploy to Cloud Run all SUCCESS)
+- **Open Issue**: active 0 / postponed 4 (Session 42 末から変化なし)
 
 ---
 
@@ -22,78 +22,128 @@ cat docs/handoff/LATEST.md
 git fetch origin main && git log --oneline -10 origin/main
 gh run list --branch main --limit 5
 
-# 3. 現在の OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
+# 3. 未マージ PR #468 (Phase 4) の merge 認可判断
+#    フォーマット例:
+#    PR #468 — feat(dispatch): Phase 4 (Internal API + メインロジック) (12 files, +2059/-0) をマージしてよい
+gh pr view 468 --json statusCheckRollup,mergeable --jq '{mergeable, checks: [.statusCheckRollup[] | {name, conclusion}]}'
+
+# 4. 現在の OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
 gh issue list --state open --limit 15
 
-# 4. Session 41 派生実装の現場挙動確認 (本田様判断、AI 能動依頼禁止)
-#    - 福の種 株式会社様③ (tenant atali82i) の受講生 2 名のログイン回復
-#    - 管理ダッシュボードの CopyButton 失敗時通知 / <code> 全選択動作
+# 5. (PR #468 merge 後の続行候補) Phase 5 (Super admin API 6 endpoints) または Phase 7 (Infra + Firestore impl) のどちらを優先するか開発者判断
 ```
 
 ---
 
-## セッション成果物 (Session 42)
+## セッション成果物 (Session 43)
 
-### マージ済 PR (1 件)
+### マージ済 PR (3 件)
 
 | # | タイトル | 種別 | 差分 | 関連 |
 |---|---|---|---|---|
-| #463 | docs(adr): ADR-038 URL path 不可視文字サニタイズ middleware の導入 | docs (ADR) | 1 file / +154/-0 | Refs #456, Session 41 待ち事項 #1 |
+| #465 | feat(dispatch): Phase 1 残部 services (completion-eligibility / cc-email-validator / gmail-client) + 呼称ルール | feat (large) | 8 files / +1188/-2 | spec §5.2-5.3 改訂 |
+| #466 | feat(dispatch): Phase 3 (Mail template + Gmail DWD send) | feat (large) | 4 files / +1049/-0 | AC-3 / AC-5 / 完了条件 3 件 |
+| #467 | feat(dispatch): Phase 2 (Reservation / Run Lock / Dispatch Audit) | feat (large) | 8 files / +2028/-0 | AC-10〜AC-18 / AC-33 |
 
-### 主要技術判断 (ADR-038 の記録内容)
+### 未マージ PR (2 件)
 
-1. **Next.js middleware 配置の必然性**:
-   - routing 解決前に介入できる唯一の同居レイヤー (404 ハンドラより前段)
-   - matcher で `/_next/static`, `/_next/image`, `/favicon.ico`, `/api(?:/|$)` を除外し Web 側 path のみに作用
-2. **segment 単位 decode → strip → re-encode**:
-   - 全体 `decodeURIComponent` だと `%2F` が真の `/` に化けて別 route redirect の不可逆変換となる (Codex High 指摘済)
-3. **二重ガード**: middleware (既共有 URL 救済) + CopyButton (新規共有 URL 保証) で穴を埋める
-4. **308 Permanent Redirect**: method 保持 / cache 効率 (301 不採用理由は GET → POST 変換 browser 挙動)
-5. **除去対象 9 範囲**: 各 Unicode 範囲の採用理由を表形式で記録 (U+FE0E / bidi / TAG / VS supplement 他)。U+2065 (Unassigned) 除外の意図を脚注で明示
-6. **エラーハンドリング**: middleware throw → 全 route 500 を防ぐ全体 try/catch + segment 単位部分救済 + PII / 攻撃 payload を出力しない構造化ログ
-7. **observability**: 高頻度 normal request にログを出さず access log 経由でモニタリング
-8. **採用しなかった代替案 4 種**: catch-all routing / WAF / クライアント sanitize 単独 / 404 JS — 各不採用理由を表形式で明文化
-9. **受容トレードオフ**: ZWJ 削除で絵文字合字破壊 / 多言語 slug 将来制約 / Edge runtime API 制約
+| # | タイトル | 状態 | 差分 |
+|---|---|---|---|
+| #468 | feat(dispatch): Phase 4 (Internal API + メインロジック) を統合実装 | CI all green、merge 認可待ち | 12 files / +2059/-0 |
+| (本 PR) | docs(handoff): Session 43 ハンドオフ記録 + Session 42 archive | docs only | 2 files |
 
----
+### Phase 進捗マトリクス
 
-## レビュー対応サマリ
+| Phase | 内容 | 状態 | PR |
+|---|---|---|---|
+| 0 | 前提作業 (DWD scope / SendAs 設定) | ✅ | - |
+| 1 | 基礎 services 7 ファイル | ✅ | #442 + **#465** |
+| 2 | Reservation / Run Lock / Audit | ✅ | **#467** |
+| 3 | Mail + Send | ✅ | **#466** |
+| 4 | Internal API + メインロジック | ✅ (merge 待ち) | **#468** |
+| 5 | Super admin API 6 endpoints | ⏳ | - |
+| 6 | Frontend UI | ⏳ | - |
+| 7 | Infrastructure + Firestore impl + Cloud Scheduler | ⏳ | - |
+| 8 | Smoke check + Cutover | ⏳ | - |
 
-PR #463 (medium tier, docs-only) で `evaluator` agent を起動 → AC 7 件中 6 PASS / 1 FAIL + LOW 2 件。全 3 指摘を `ffbae8c` で反映:
-
-| 指摘 | 重み | 対応 |
-|---|---|---|
-| AC5 FAIL: ADR-035 への cross-reference 欠如 | (基準誤り可能性) | 関連 ADR に ADR-035 (フォーマット踏襲) 追記 |
-| LOW: `U+2065` (Unassigned) 扱い未言及、§5 の範囲分割意図が追跡不能 | LOW | §5 に脚注追加「U+2065 は現在 Unassigned のため対象外」 |
-| LOW: ADR-010 関係説明が浅い、middleware の next() 後 4xx の挙動が不明 | LOW | Consequences の ADR-010 関係を補強「middleware は 308 or next() のみ、next() 後の 4xx は ADR-010 形式が適用」 |
+**Phase 1〜4 完了で AC-1〜25 / NFR-2/3/11 の end-to-end 検証点に到達**。本番デプロイには Phase 5-8 (Super admin API + UI + Infra + Cutover) を残すのみ。
 
 ---
 
-## ADR / ドキュメント更新
+## 重要な技術判断 (Session 43 で確定)
 
-**今セッションでの ADR 作成: ADR-038 (URL path 不可視文字サニタイズ middleware) — main マージ済**
+### 1. AC-17 採用案変更 (spec 改訂、PR #468 に含む)
 
-ADR 候補として保留: なし (Session 41 の保留事項を本セッションで全消化)
+scope_revoked 時の挙動を当初 spec「後続 user reservation を rollback」から「rollback せず lease 期限切れで manual_review_required に降格」に変更。
+
+**理由 3 点**:
+1. 並列実行中の rollback は別 worker との race を生む
+2. scope_revoked が transient な設定ミス (管理コンソール一時不整合等) で復旧した場合、rollback 済 record は次 cron で再送試行 → 二重送信事故を起こす
+3. lease 期限切れ降格は `manual_review_required` (terminal) を経由するため idempotency が保証される
+
+### 2. DispatchStorage / TenantDataLoader 抽象 layer 導入
+
+reservation / run-lock / dispatch-audit / メインロジックを **storage 実装非依存** (InMemory / Firestore どちらでも動く設計) に分離。Phase 7 で Firestore 実装を追加し production wiring。
+
+### 3. gmail-client.ts 配置 (`dispatch/` 配下)
+
+spec §5.2 では `services/gmail-client.ts` だったが、Important-1 (gmail.send scope 他経路汚染防止) を構造的に強化するため `dispatch/gmail-client.ts` に配置。spec を `dispatch/` 配下に改訂 (PR #465)。
+
+### 4. DispatchSettings に subjectTemplate 未追加
+
+完了通知の件名は固定定数 `DEFAULT_COMPLETION_SUBJECT = "【DXcollege】受講修了のお知らせ"`。spec / DTO に subjectTemplate 未定義のため Phase 1/3 では固定 (AI 4 原則 §1 = spec 未記載の独断追加禁止)。
+
+### 5. CLAUDE.md 呼称ルール (本田様 → 開発者)
+
+プロダクトオーナー / 意思決定者 / プロジェクト発注者を「開発者」と表記するルールを project CLAUDE.md に追加 (PR #465)。既存ドキュメントの「本田様」表記は編集機会に併せて書き換え (一括置換せず混在許容)。
 
 ---
 
-## 待ち事項 (decision-maker = 本田様)
+## Quality Gate 履歴 (Session 43、各 PR ごと)
 
-Session 41 から継続中の項目 (本セッション中は本田様起点フィードバック待ち):
-
-1. **Session 41 派生実装の現場挙動確認** (CLAUDE.md `feedback_deploy_proactive_verification.md` 準拠で AI 能動依頼禁止):
-   - 福の種 株式会社様③ の受講生 2 名のログイン回復確認
-   - 管理ダッシュボードの CopyButton 失敗時通知 / `<code>` 全選択 UX 確認
-2. **follow-up Issue 起票判断** (PR レビューで defer 候補、Session 41 から継続):
-   - CopyableCode/SelectableCode 共通化 (admin/register の `<code>` onClick lambda 重複)
-   - LinkDisplay 結合テスト (register/page.tsx)
-   - 多言語 slug 将来リスクの運用方針明文化
-
-Session 41 待ち事項 #1 (ADR-038 候補) は本セッションで解消済 (PR #463 マージ)。
+| PR | safe-refactor | evaluator | code-review | 反映内容 |
+|---|---|---|---|---|
+| #465 (Phase 1 残部) | HIGH 3 / MEDIUM 4 / LOW 4 → 6 件反映 | REQUEST_CHANGES (FAIL DRY + MEDIUM 2) → spec 改訂で整合 | medium 3 件 defensive guard 追加 | 3 commits |
+| #466 (Phase 3) | HIGH 0 / MEDIUM 3 → 全件反映 | APPROVE + narrative 5 件 → 全件反映 | (省略) | 2 commits |
+| #467 (Phase 2) | HIGH 1 / MEDIUM 4 / LOW 3 → 6 件反映 | REQUEST_CHANGES (MEDIUM 1 + テスト欠如) → 2 件反映 | (省略) | 2 commits |
+| #468 (Phase 4) | HIGH 2 / MEDIUM 5 / LOW 3 → 7 件反映 | REQUEST_CHANGES (FAIL AC-17 + 2 主要) → 全件反映 | (省略) | 2 commits |
 
 ---
 
-## OPEN Issue (Session 42 末)
+## 待ち事項 (decision-maker = 開発者)
+
+1. **PR #468 (Phase 4) の merge 認可** (CLAUDE.md 4 原則 §3 番号単位明示):
+   ```
+   PR #468 — feat(dispatch): Phase 4 (Internal API + メインロジック) (12 files, +2059/-0) をマージしてよい
+   ```
+
+2. **本 PR (handoff) の merge 認可** — docs only、Session 43 記録のため早期マージ推奨
+
+3. **Phase 5/6/7 の優先順判断** (PR #468 merge 後):
+   - Phase 5 (Super admin API 6 endpoints) → スーパー管理者向け CRUD backend
+   - Phase 7 (FirestoreDispatchStorage + FirestoreTenantDataLoader + Cloud Scheduler) → 本番デプロイの前提
+   - Phase 6 (Frontend UI) → Phase 5 完了後の最有力
+
+4. **OQ-X smoke (mode=send) 実機検証認可**:
+   - SendAs 設定確認済 + 送信先 mailbox 認可が必要
+   - smoke workflow で `system@279279.net` JWT subject + From=`dxcollege@279279.net` の実送信 PoC
+
+5. **follow-up Issue 起票判断** (PR コメントに提示済):
+   - validateRecipientEmail を validateSingleEmail 呼び出しに置き換える物理統合 (§5.4 制約一時解除が必要)
+   - DispatchAuditLog["eventType"] に `cc_validation_warning` を追加 (Phase 5 spec 改訂時)
+
+---
+
+## CI / インフラ変更
+
+- main へのマージで Deploy to Cloud Run 自動実行 → 各 PR 成功
+- ローカル feature ブランチ 3 件 (#465 / #466 / #467) は `--delete-branch` で削除済
+- `feat/dispatch-phase4-main-logic` (#468) は merge 認可待ちのため保持
+- インフラ変更なし、コードと spec のみ
+
+---
+
+## OPEN Issue (Session 43 末)
 
 | # | タイトル | ラベル | 状態 |
 |---|---|---|---|
@@ -106,22 +156,77 @@ postponed ラベル付き Issue は明示指示なき限り着手しない (CLAU
 
 ---
 
-## CI / インフラ変更
-
-- main へのマージ後に Deploy to Cloud Run 自動実行 → 成功 (3m46s)
-- ローカルブランチ `docs/adr-038-url-path-invisible-char-middleware` は `--delete-branch` で削除済
-- インフラ変更なし、docs のみ (`docs/adr/` 配下)
-
----
-
-## 主要参照ファイル (本セッション新規)
-
-- `docs/adr/ADR-038-url-path-invisible-char-sanitization-middleware.md` — Session 41 PR #457 の設計判断後追い記録
-
----
-
 ## Issue Net 変化
-- Close 数: 0 件
-- 起票数: 0 件
+
+- **Close 数**: 0 件
+- **起票数**: 0 件
 - **Net: 0 件**
-- 進捗評価: Net = 0 で `feedback_issue_triage.md` の「Net ≤ 0 は進捗ゼロ扱い」基準に該当するが、本セッションは Session 41 で完了済の PR #457 (実コード) に対する設計記録 (ADR-038) のみで、新規 Issue 起票対象なし。Session 41 の待ち事項 #1 (本田様判断待ち) を解消した executor 作業のため、Issue カウンタ上の進捗は計上しない (機械的起票回避)
+
+**進捗評価**: Net = 0 で `feedback_issue_triage.md` の「Net ≤ 0 は進捗ゼロ扱い」基準に該当するが、本セッションは Issue ベースではなく **DXcollege 自動完了通知システムの impl-plan Phase 進捗 (Phase 1-4 完了)** で管理される大規模実装作業。CLAUDE.md「GitHub Issues」セクションの起票基準 (実害/再現バグ/CI破壊/rating≥7/明示指示) に該当する課題なし。review agent の rating 5-6 提案は PR コメント / spec 改訂で扱った。
+
+Issue 起票対象外の理由:
+- impl-plan で Phase 進捗が一元管理されている
+- 各 Phase 完了は PR マージで定義される (Issue 不要)
+- review 指摘は PR 内 commit で吸収済または明示的に「見送り / Phase 5 で対応」と PR コメントに記載済
+
+---
+
+## 累計テスト件数 (Session 43 末、各 PR merge 後の予測)
+
+- **dispatch tests**: 14 ファイル / **271 件** (PR #468 反映後)
+- **API tests 全体**: 83 ファイル / **1318+ 件**
+
+---
+
+## 主要参照ファイル (Session 43 新規 / 改訂、各 PR に含まれる)
+
+### 新規 (PR #465 / Phase 1 残部)
+- `services/api/src/services/dispatch/completion-eligibility.ts`
+- `services/api/src/services/dispatch/cc-email-validator.ts`
+- `services/api/src/services/dispatch/gmail-client.ts`
+
+### 新規 (PR #466 / Phase 3)
+- `services/api/src/services/dispatch/completion-notification-mail.ts`
+- `services/api/src/services/dispatch/gmail-dwd-send.ts`
+
+### 新規 (PR #467 / Phase 2)
+- `services/api/src/services/dispatch/dispatch-storage.ts`
+- `services/api/src/services/dispatch/in-memory-dispatch-storage.ts`
+- `services/api/src/services/dispatch/reservation.ts`
+- `services/api/src/services/dispatch/run-lock.ts`
+- `services/api/src/services/dispatch/dispatch-audit.ts`
+
+### 新規 (PR #468 / Phase 4、merge 待ち)
+- `services/api/src/services/dispatch/tenant-data-loader.ts`
+- `services/api/src/services/dispatch/run-completion-notifications.ts` (メインロジック ~360 行)
+- `services/api/src/services/dispatch/oidc-verify.ts`
+- `services/api/src/routes/internal/dispatch.ts`
+
+### 改訂 (各 PR に含む)
+- `docs/specs/2026-05-20-completion-notification-design.md` - §5.2/5.3/6.1 + AC-17 改訂
+- `docs/specs/2026-05-20-completion-notification-impl-plan.md` - Phase 1 完了条件改訂
+- `packages/shared-types/src/dispatch.ts` - DispatchRun に manualReviewRequired 追加
+- `services/api/src/services/google-auth.ts` - GCP_PROJECT_ID / DWD_SECRET_NAME を export
+- `CLAUDE.md` - 呼称ルール「本田様 → 開発者」追加
+
+---
+
+## ADR / ドキュメント更新
+
+**今セッションでの ADR 作成**: なし (ADR-037 は Session 39 で起票済、本セッションでは spec/impl-plan 改訂のみ)
+
+ADR 候補として保留: なし
+
+---
+
+## 残留プロセス
+
+✅ クリーンアップ済 (cleanup-node.sh 確認、残留 Node プロセスなし)
+
+---
+
+## 次セッション開始時の最優先 3 つ
+
+1. **PR #468 merge 認可待ち** — 番号単位明示認可フォーマットで認可いただければ即マージ可能
+2. **次の Phase 優先判断** — Phase 5 (Super admin API) / Phase 7 (Firestore impl + Cloud Scheduler) / Phase 6 (UI) のどれを優先するか
+3. **OQ-X smoke 実機検証認可** — Phase 7 の前提 (送信先 mailbox 認可必要、AI 単独完結不可)

--- a/docs/handoff/archive/2026-05-22-session-42.md
+++ b/docs/handoff/archive/2026-05-22-session-42.md
@@ -1,0 +1,127 @@
+# Session Handoff — 2026-05-22 (Session 42)
+
+## TL;DR
+
+**Session 41 の積み残し「ADR-038 候補の作成判断 (本田様判断待ち)」を解消したセッション。** Session 41 で Next.js middleware (URL path 不可視文字 strip → 308 redirect) を導入 (PR #457) した後、ADR 化が「本田様判断待ち」として保留されていた。本セッションでユーザー (本田様) から「これは必須なのでは？」との指摘を受け、ADR-038 として後追い記録を作成 → PR #463 → main マージ済。
+
+- **Issue Net**: **0 件** — Close 0 / 起票 0 (Session 41 の派生作業ではなく既存 PR #457 の設計記録のため起票不要)
+- **マージ済 PR**: #463 (ADR-038 後追い記録、ドキュメントのみ +154/-0)
+- **CI**: ✅ green (CI 1m45s / E2E 1m20s / Deploy to Cloud Run 3m46s)
+- **未マージ PR**: なし
+- **Open Issue**: active 0 / postponed 4 (Session 41 末から変化なし)
+
+---
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+# 1. 状況復元
+cat docs/handoff/LATEST.md
+
+# 2. main 最新と CI / Cloud Run デプロイ状況
+git fetch origin main && git log --oneline -10 origin/main
+gh run list --branch main --limit 5
+
+# 3. 現在の OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
+gh issue list --state open --limit 15
+
+# 4. Session 41 派生実装の現場挙動確認 (本田様判断、AI 能動依頼禁止)
+#    - 福の種 株式会社様③ (tenant atali82i) の受講生 2 名のログイン回復
+#    - 管理ダッシュボードの CopyButton 失敗時通知 / <code> 全選択動作
+```
+
+---
+
+## セッション成果物 (Session 42)
+
+### マージ済 PR (1 件)
+
+| # | タイトル | 種別 | 差分 | 関連 |
+|---|---|---|---|---|
+| #463 | docs(adr): ADR-038 URL path 不可視文字サニタイズ middleware の導入 | docs (ADR) | 1 file / +154/-0 | Refs #456, Session 41 待ち事項 #1 |
+
+### 主要技術判断 (ADR-038 の記録内容)
+
+1. **Next.js middleware 配置の必然性**:
+   - routing 解決前に介入できる唯一の同居レイヤー (404 ハンドラより前段)
+   - matcher で `/_next/static`, `/_next/image`, `/favicon.ico`, `/api(?:/|$)` を除外し Web 側 path のみに作用
+2. **segment 単位 decode → strip → re-encode**:
+   - 全体 `decodeURIComponent` だと `%2F` が真の `/` に化けて別 route redirect の不可逆変換となる (Codex High 指摘済)
+3. **二重ガード**: middleware (既共有 URL 救済) + CopyButton (新規共有 URL 保証) で穴を埋める
+4. **308 Permanent Redirect**: method 保持 / cache 効率 (301 不採用理由は GET → POST 変換 browser 挙動)
+5. **除去対象 9 範囲**: 各 Unicode 範囲の採用理由を表形式で記録 (U+FE0E / bidi / TAG / VS supplement 他)。U+2065 (Unassigned) 除外の意図を脚注で明示
+6. **エラーハンドリング**: middleware throw → 全 route 500 を防ぐ全体 try/catch + segment 単位部分救済 + PII / 攻撃 payload を出力しない構造化ログ
+7. **observability**: 高頻度 normal request にログを出さず access log 経由でモニタリング
+8. **採用しなかった代替案 4 種**: catch-all routing / WAF / クライアント sanitize 単独 / 404 JS — 各不採用理由を表形式で明文化
+9. **受容トレードオフ**: ZWJ 削除で絵文字合字破壊 / 多言語 slug 将来制約 / Edge runtime API 制約
+
+---
+
+## レビュー対応サマリ
+
+PR #463 (medium tier, docs-only) で `evaluator` agent を起動 → AC 7 件中 6 PASS / 1 FAIL + LOW 2 件。全 3 指摘を `ffbae8c` で反映:
+
+| 指摘 | 重み | 対応 |
+|---|---|---|
+| AC5 FAIL: ADR-035 への cross-reference 欠如 | (基準誤り可能性) | 関連 ADR に ADR-035 (フォーマット踏襲) 追記 |
+| LOW: `U+2065` (Unassigned) 扱い未言及、§5 の範囲分割意図が追跡不能 | LOW | §5 に脚注追加「U+2065 は現在 Unassigned のため対象外」 |
+| LOW: ADR-010 関係説明が浅い、middleware の next() 後 4xx の挙動が不明 | LOW | Consequences の ADR-010 関係を補強「middleware は 308 or next() のみ、next() 後の 4xx は ADR-010 形式が適用」 |
+
+---
+
+## ADR / ドキュメント更新
+
+**今セッションでの ADR 作成: ADR-038 (URL path 不可視文字サニタイズ middleware) — main マージ済**
+
+ADR 候補として保留: なし (Session 41 の保留事項を本セッションで全消化)
+
+---
+
+## 待ち事項 (decision-maker = 本田様)
+
+Session 41 から継続中の項目 (本セッション中は本田様起点フィードバック待ち):
+
+1. **Session 41 派生実装の現場挙動確認** (CLAUDE.md `feedback_deploy_proactive_verification.md` 準拠で AI 能動依頼禁止):
+   - 福の種 株式会社様③ の受講生 2 名のログイン回復確認
+   - 管理ダッシュボードの CopyButton 失敗時通知 / `<code>` 全選択 UX 確認
+2. **follow-up Issue 起票判断** (PR レビューで defer 候補、Session 41 から継続):
+   - CopyableCode/SelectableCode 共通化 (admin/register の `<code>` onClick lambda 重複)
+   - LinkDisplay 結合テスト (register/page.tsx)
+   - 多言語 slug 将来リスクの運用方針明文化
+
+Session 41 待ち事項 #1 (ADR-038 候補) は本セッションで解消済 (PR #463 マージ)。
+
+---
+
+## OPEN Issue (Session 42 末)
+
+| # | タイトル | ラベル | 状態 |
+|---|---|---|---|
+| #405 | [Phase 2 follow-up] Gmail draft filename の生 Unicode quoted-string が strict MTA 経路で reject/normalize されるリスク | enhancement, P2, postponed | 着手不可 |
+| #276 | [Phase 5] allowed_emails 削除時の即時セッション失効 + 孤児Auth掃除自動化 | enhancement, P2, postponed | 着手不可 |
+| #275 | [Phase 5] allowed_emails 管理画面UX改善 | enhancement, P2, postponed | 着手不可 |
+| #274 | [Phase 5] allowed_emails 運用の可視化・追跡性強化 | enhancement, P2, postponed | 着手不可 |
+
+postponed ラベル付き Issue は明示指示なき限り着手しない (CLAUDE.md MUST)。active Issue 0 件。
+
+---
+
+## CI / インフラ変更
+
+- main へのマージ後に Deploy to Cloud Run 自動実行 → 成功 (3m46s)
+- ローカルブランチ `docs/adr-038-url-path-invisible-char-middleware` は `--delete-branch` で削除済
+- インフラ変更なし、docs のみ (`docs/adr/` 配下)
+
+---
+
+## 主要参照ファイル (本セッション新規)
+
+- `docs/adr/ADR-038-url-path-invisible-char-sanitization-middleware.md` — Session 41 PR #457 の設計判断後追い記録
+
+---
+
+## Issue Net 変化
+- Close 数: 0 件
+- 起票数: 0 件
+- **Net: 0 件**
+- 進捗評価: Net = 0 で `feedback_issue_triage.md` の「Net ≤ 0 は進捗ゼロ扱い」基準に該当するが、本セッションは Session 41 で完了済の PR #457 (実コード) に対する設計記録 (ADR-038) のみで、新規 Issue 起票対象なし。Session 41 の待ち事項 #1 (本田様判断待ち) を解消した executor 作業のため、Issue カウンタ上の進捗は計上しない (機械的起票回避)


### PR DESCRIPTION
## Summary

Session 43 (2026-05-22) ハンドオフ記録 (docs only、2 ファイル / +294 -62)。Session 42 を archive へ移動。

## Session 43 概要

DXcollege 自動完了通知システム Phase 1 残部 + Phase 2/3/4 を **1 セッションで連続実装**した一気通貫セッション。

- **マージ済 PR**: 3 件 (#465 Phase 1 残部 / #466 Phase 3 Mail+Send / #467 Phase 2 Reservation/Lock/Audit)
- **未マージ PR**: #468 (Phase 4 Internal API+メインロジック、CI green、merge 認可待ち) + 本 PR
- **Issue Net**: 0 件 (Phase 実装は impl-plan で管理、起票対象外)

## Phase 進捗

| Phase | 状態 |
|---|---|
| 0-1-2-3-4 | ✅ 完了 (merge 待ちの Phase 4 含む) |
| 5-6-7-8 | ⏳ 未着手 |

Phase 1-4 完了で AC 全体の end-to-end 検証点に到達。本番デプロイには Phase 5-8 を残すのみ。

## 主要技術判断 (詳細はハンドオフ本文参照)

1. AC-17 採用案変更 (spec §6.1 改訂): scope_revoked 時の reservation rollback を廃止
2. DispatchStorage / TenantDataLoader 抽象 layer 導入
3. gmail-client.ts を `dispatch/` 配下に配置 (Important-1 強化)
4. CLAUDE.md 呼称ルール「本田様 → 開発者」追加

## Test plan

- [x] docs/handoff/LATEST.md を Session 43 に更新
- [x] docs/handoff/archive/2026-05-22-session-42.md に Session 42 コピー保存
- [x] 次セッション開始時の必読手順を明記
- [x] PR #468 (Phase 4) との関係 / merge 順序を明示

## 関連 PR

- #465 (Phase 1 残部、merged)
- #466 (Phase 3 Mail+Send、merged)
- #467 (Phase 2 Reservation/Lock/Audit、merged)
- #468 (Phase 4 Internal API+メインロジック、merge 認可待ち)

🤖 Generated with [Claude Code](https://claude.com/claude-code)