### PR TITLE
feat(dispatch): Phase 7-A Firestore storage 実装 + production wiring

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -17,6 +17,8 @@ import { tenantsRouter } from "./routes/tenants.js";
 import { superAdminRouter } from "./routes/super-admin.js";
 import { helpRoleRouter } from "./routes/help-role.js";
 import { publicRouter } from "./routes/public.js";
+import { createInternalDispatchRouter } from "./routes/internal/dispatch.js";
+import { buildDispatchFactory } from "./services/dispatch/factory.js";
 import { logger } from "./utils/logger.js";
 import { getFirestore } from "firebase-admin/firestore";
 
@@ -134,6 +136,39 @@ app.use("/api/v2/public", authLimiter, publicRouter);
 
 // テナント登録API（認証のみ、テナントコンテキスト不要）
 app.use("/api/v2/tenants", authLimiter, tenantsRouter);
+
+// 内部 API: Cloud Scheduler 経由の自動完了通知配信 (Phase 7 wiring)
+// env が揃わない環境 (local dev / 一部 E2E) では mount をスキップする。
+// ただし Cloud Run (K_SERVICE が設定される) では env 欠如を silent skip しない
+// (evaluator HIGH: 本番で Scheduler が 404 を受けても 2xx 期待で気付かないリスク回避)
+try {
+  const dispatch = buildDispatchFactory();
+  app.use(
+    "/api/v2/internal",
+    createInternalDispatchRouter({
+      expectedAudience: dispatch.expectedAudience,
+      verifier: dispatch.verifier,
+      storage: dispatch.storage,
+      loader: dispatch.loader,
+      env: dispatch.env,
+    }),
+  );
+  logger.info("Internal dispatch router mounted", { mode: dispatch.mode });
+} catch (err) {
+  const errorMsg = err instanceof Error ? err.message : String(err);
+  if (process.env.K_SERVICE) {
+    // 本番 Cloud Run で env 欠如 = fail loud (silent skip 防止)
+    logger.error(
+      "Internal dispatch router failed to mount in Cloud Run — env missing or init failed",
+      { errorType: "dispatch_router_mount_failed_in_production", error: errorMsg },
+    );
+    throw err;
+  }
+  // local dev / E2E: warn + skip (dispatch endpoint は本番のみ必要)
+  logger.warn("Internal dispatch router NOT mounted (env missing or init failed)", {
+    error: errorMsg,
+  });
+}
 
 // スーパー管理者API
 app.use("/api/v2/super", superAdminRouter);

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -138,9 +138,25 @@ app.use("/api/v2/public", authLimiter, publicRouter);
 app.use("/api/v2/tenants", authLimiter, tenantsRouter);
 
 // 内部 API: Cloud Scheduler 経由の自動完了通知配信 (Phase 7 wiring)
-// env が揃わない環境 (local dev / 一部 E2E) では mount をスキップする。
-// ただし Cloud Run (K_SERVICE が設定される) では env 欠如を silent skip しない
-// (evaluator HIGH: 本番で Scheduler が 404 を受けても 2xx 期待で気付かないリスク回避)
+//
+// env 解決方針:
+//   - GCP runtime (Cloud Run / Cloud Functions / GAE) では env 欠如 / 初期化失敗を
+//     silent skip しない (本番で Scheduler が 404 を受けても 2xx 期待で気付かない
+//     リスク回避、evaluator HIGH + Codex Important 反映)
+//   - local dev / E2E (GCP runtime シグナルなし) では warn + skip
+//
+// GCP runtime 判定: Cloud Run = K_SERVICE / Cloud Functions = FUNCTION_TARGET or
+//   FUNCTION_NAME / GAE = GAE_SERVICE を網羅 (LMS は現状 Cloud Run のみだが、防御的に
+//   全 GCP runtime を fail loud 対象とする)
+function isProductionGcpRuntime(): boolean {
+  return Boolean(
+    process.env.K_SERVICE ||
+      process.env.FUNCTION_TARGET ||
+      process.env.FUNCTION_NAME ||
+      process.env.GAE_SERVICE,
+  );
+}
+
 try {
   const dispatch = buildDispatchFactory();
   app.use(
@@ -156,10 +172,10 @@ try {
   logger.info("Internal dispatch router mounted", { mode: dispatch.mode });
 } catch (err) {
   const errorMsg = err instanceof Error ? err.message : String(err);
-  if (process.env.K_SERVICE) {
-    // 本番 Cloud Run で env 欠如 = fail loud (silent skip 防止)
+  if (isProductionGcpRuntime()) {
+    // 本番 GCP runtime で env 欠如 = fail loud (silent skip 防止)
     logger.error(
-      "Internal dispatch router failed to mount in Cloud Run — env missing or init failed",
+      "Internal dispatch router failed to mount in production GCP runtime — env missing or init failed",
       { errorType: "dispatch_router_mount_failed_in_production", error: errorMsg },
     );
     throw err;

--- a/services/api/src/services/dispatch/__tests__/factory.test.ts
+++ b/services/api/src/services/dispatch/__tests__/factory.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Dispatch factory の wiring テスト。
+ *
+ * 検証:
+ *   - 環境変数の必須チェック (silent fallback しない、rules/error-handling.md §2)
+ *   - DISPATCH_USE_IN_MEMORY=true で InMemory 実装が返る (production 切替フラグ)
+ *   - 既定では Firestore 実装が返る (productionモード) — Firebase Admin 未初期化環境では
+ *     getFirestore() が throw するため、本テストは throw も含めた挙動を確認する
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { buildDispatchFactory } from "../factory.js";
+import { InMemoryDispatchStorage } from "../in-memory-dispatch-storage.js";
+import { InMemoryTenantDataLoader } from "../tenant-data-loader.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  // 環境変数を毎回リセット (test 間の汚染防止)
+  for (const key of Object.keys(process.env)) {
+    if (
+      key.startsWith("DXCOLLEGE_") ||
+      key === "DISPATCH_OIDC_AUDIENCE" ||
+      key === "DISPATCH_USE_IN_MEMORY"
+    ) {
+      delete process.env[key];
+    }
+  }
+});
+
+afterEach(() => {
+  // 復元
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("buildDispatchFactory - production env validation (DISPATCH_USE_IN_MEMORY != true)", () => {
+  beforeEach(() => {
+    // production モード前提 (in-memory フラグ未設定)
+    delete process.env.DISPATCH_USE_IN_MEMORY;
+  });
+
+  it("DXCOLLEGE_DISPATCH_SUBJECT 未設定 → throw", () => {
+    process.env.DXCOLLEGE_SENDER_EMAIL = "dxcollege@279279.net";
+    process.env.DISPATCH_OIDC_AUDIENCE = "https://api.example.com";
+    expect(() => buildDispatchFactory()).toThrow(/DXCOLLEGE_DISPATCH_SUBJECT/);
+  });
+
+  it("DXCOLLEGE_SENDER_EMAIL 未設定 → throw", () => {
+    process.env.DXCOLLEGE_DISPATCH_SUBJECT = "system@279279.net";
+    process.env.DISPATCH_OIDC_AUDIENCE = "https://api.example.com";
+    expect(() => buildDispatchFactory()).toThrow(/DXCOLLEGE_SENDER_EMAIL/);
+  });
+
+  it("DISPATCH_OIDC_AUDIENCE 未設定 → throw", () => {
+    process.env.DXCOLLEGE_DISPATCH_SUBJECT = "system@279279.net";
+    process.env.DXCOLLEGE_SENDER_EMAIL = "dxcollege@279279.net";
+    expect(() => buildDispatchFactory()).toThrow(/DISPATCH_OIDC_AUDIENCE/);
+  });
+
+  it("env が空文字列のみ → throw (silent fallback 防止)", () => {
+    process.env.DXCOLLEGE_DISPATCH_SUBJECT = "   ";
+    process.env.DXCOLLEGE_SENDER_EMAIL = "dxcollege@279279.net";
+    process.env.DISPATCH_OIDC_AUDIENCE = "https://api.example.com";
+    expect(() => buildDispatchFactory()).toThrow(/DXCOLLEGE_DISPATCH_SUBJECT/);
+  });
+});
+
+describe("buildDispatchFactory - DISPATCH_USE_IN_MEMORY=true (env 任意化)", () => {
+  beforeEach(() => {
+    process.env.DISPATCH_USE_IN_MEMORY = "true";
+  });
+
+  it("env 全部設定済 → 設定値をそのまま採用", () => {
+    process.env.DXCOLLEGE_DISPATCH_SUBJECT = "system@279279.net";
+    process.env.DXCOLLEGE_SENDER_EMAIL = "dxcollege@279279.net";
+    process.env.DISPATCH_OIDC_AUDIENCE = "https://api.example.com";
+    const result = buildDispatchFactory();
+    expect(result.mode).toBe("in-memory");
+    expect(result.storage).toBeInstanceOf(InMemoryDispatchStorage);
+    expect(result.loader).toBeInstanceOf(InMemoryTenantDataLoader);
+    expect(result.env).toEqual({
+      subjectEmail: "system@279279.net",
+      fromEmail: "dxcollege@279279.net",
+    });
+    expect(result.expectedAudience).toBe("https://api.example.com");
+  });
+
+  it("env 全部未設定 → InMemory モードでも throw せず mock デフォルトを採用", () => {
+    // env 3 つとも未設定
+    const result = buildDispatchFactory();
+    expect(result.mode).toBe("in-memory");
+    expect(result.env.subjectEmail).toContain("@example.invalid");
+    expect(result.env.fromEmail).toContain("@example.invalid");
+    expect(result.expectedAudience).toContain("example.invalid");
+  });
+
+  it("一部 env のみ設定 → 設定済は採用、未設定はデフォルト", () => {
+    process.env.DXCOLLEGE_SENDER_EMAIL = "real-from@example.com";
+    const result = buildDispatchFactory();
+    expect(result.env.fromEmail).toBe("real-from@example.com");
+    expect(result.env.subjectEmail).toContain("@example.invalid");
+  });
+
+  it("verifier は GoogleOidcTokenVerifier (mock 動作確認のため verify メソッド存在のみ確認)", () => {
+    const result = buildDispatchFactory();
+    expect(typeof result.verifier.verify).toBe("function");
+  });
+});
+
+describe("buildDispatchFactory - production (Firestore) mode", () => {
+  it("DISPATCH_USE_IN_MEMORY=false かつ env 揃い → mode=firestore で返る", () => {
+    process.env.DXCOLLEGE_DISPATCH_SUBJECT = "system@279279.net";
+    process.env.DXCOLLEGE_SENDER_EMAIL = "dxcollege@279279.net";
+    process.env.DISPATCH_OIDC_AUDIENCE = "https://api.example.com";
+    delete process.env.DISPATCH_USE_IN_MEMORY;
+    // 本テスト環境では Firebase Admin が初期化されていないと
+    // getFirestore() が throw する可能性があるが、初期化済みなら
+    // FirestoreDispatchStorage が返る。両方の挙動を許容する。
+    try {
+      const result = buildDispatchFactory();
+      expect(result.mode).toBe("firestore");
+      expect(result.storage.constructor.name).toBe("FirestoreDispatchStorage");
+      expect(result.loader.constructor.name).toBe("FirestoreTenantDataLoader");
+    } catch (err) {
+      // Firebase Admin 未初期化環境 (一部の test 環境) では throw が想定挙動
+      expect(err).toBeInstanceOf(Error);
+    }
+  });
+});

--- a/services/api/src/services/dispatch/__tests__/factory.test.ts
+++ b/services/api/src/services/dispatch/__tests__/factory.test.ts
@@ -20,7 +20,11 @@ beforeEach(() => {
     if (
       key.startsWith("DXCOLLEGE_") ||
       key === "DISPATCH_OIDC_AUDIENCE" ||
-      key === "DISPATCH_USE_IN_MEMORY"
+      key === "DISPATCH_USE_IN_MEMORY" ||
+      key === "K_SERVICE" ||
+      key === "FUNCTION_TARGET" ||
+      key === "FUNCTION_NAME" ||
+      key === "GAE_SERVICE"
     ) {
       delete process.env[key];
     }
@@ -103,6 +107,44 @@ describe("buildDispatchFactory - DISPATCH_USE_IN_MEMORY=true (env 任意化)", (
   it("verifier は GoogleOidcTokenVerifier (mock 動作確認のため verify メソッド存在のみ確認)", () => {
     const result = buildDispatchFactory();
     expect(typeof result.verifier.verify).toBe("function");
+  });
+});
+
+describe("buildDispatchFactory - 本番 GCP runtime での in-memory 拒否 (silent no-op 防止)", () => {
+  beforeEach(() => {
+    process.env.DISPATCH_USE_IN_MEMORY = "true";
+    // env を mock 設定 (production env が揃ってても in-memory が拒否されることを確認)
+    process.env.DXCOLLEGE_DISPATCH_SUBJECT = "system@279279.net";
+    process.env.DXCOLLEGE_SENDER_EMAIL = "dxcollege@279279.net";
+    process.env.DISPATCH_OIDC_AUDIENCE = "https://api.example.com";
+  });
+
+  it("K_SERVICE (Cloud Run) + DISPATCH_USE_IN_MEMORY=true → throw", () => {
+    process.env.K_SERVICE = "lms-279-api";
+    expect(() => buildDispatchFactory()).toThrow(
+      /DISPATCH_USE_IN_MEMORY=true is forbidden in production GCP runtime/,
+    );
+  });
+
+  it("FUNCTION_TARGET (Cloud Functions) + DISPATCH_USE_IN_MEMORY=true → throw", () => {
+    process.env.FUNCTION_TARGET = "myHandler";
+    expect(() => buildDispatchFactory()).toThrow(/forbidden in production/);
+  });
+
+  it("FUNCTION_NAME (Cloud Functions 1st gen) + DISPATCH_USE_IN_MEMORY=true → throw", () => {
+    process.env.FUNCTION_NAME = "myFunction";
+    expect(() => buildDispatchFactory()).toThrow(/forbidden in production/);
+  });
+
+  it("GAE_SERVICE (App Engine) + DISPATCH_USE_IN_MEMORY=true → throw", () => {
+    process.env.GAE_SERVICE = "default";
+    expect(() => buildDispatchFactory()).toThrow(/forbidden in production/);
+  });
+
+  it("GCP runtime シグナルなし + DISPATCH_USE_IN_MEMORY=true → in-memory モードで成功", () => {
+    // K_SERVICE 等は未設定
+    const result = buildDispatchFactory();
+    expect(result.mode).toBe("in-memory");
   });
 });
 

--- a/services/api/src/services/dispatch/__tests__/firestore-dispatch-storage.test.ts
+++ b/services/api/src/services/dispatch/__tests__/firestore-dispatch-storage.test.ts
@@ -1,0 +1,704 @@
+/**
+ * FirestoreDispatchStorage の mock-based テスト。
+ *
+ * 設計仕様書 §4.1.1〜4.1.5、§6.2〜6.3、FR-7 改訂 / FR-11 / FR-12 / NFR-3 対応。
+ *
+ * テスト戦略 (ADR-028 + 既存 firestore.ts テストパターン踏襲):
+ *   - InMemoryDispatchStorage で transaction semantics は既に保証済 (Node.js single-threaded)
+ *   - 本テストは Firestore-specific I/O 契約のみ検証する:
+ *     - collection path / doc id の正しさ
+ *     - ISO 8601 string ↔ Firestore Timestamp の変換
+ *     - runTransaction の使用 (read → branch → write 流入を 1 transaction 内に閉じる)
+ *     - sanitizeForUpdate (undefined 除去で既存値を保護、production-data-safety.md)
+ *     - appendAuditLog の best-effort 性 (Firestore 例外を caller に伝播しない)
+ *
+ * 並行制御の実 race 検証は Firestore emulator / staging で別途実施 (本 Phase スコープ外)。
+ */
+import { describe, it, expect, vi } from "vitest";
+import { Timestamp, type Firestore } from "firebase-admin/firestore";
+import type { DispatchRun } from "@lms-279/shared-types";
+import { FirestoreDispatchStorage } from "../firestore-dispatch-storage.js";
+
+// ============================================================
+// Firestore mock helpers
+// ============================================================
+
+interface MockDoc {
+  exists: boolean;
+  data: () => Record<string, unknown>;
+  id?: string;
+}
+
+function buildMockDb() {
+  const docCalls: { collection: string; id: string }[] = [];
+  const collectionCalls: string[] = [];
+  const setCalls: { path: string; data: Record<string, unknown> }[] = [];
+  const updateCalls: { path: string; data: Record<string, unknown> }[] = [];
+  const queryCalls: {
+    collection: string;
+    where: [string, string, unknown][];
+    limit?: number;
+  }[] = [];
+  const docState = new Map<string, MockDoc>();
+  let nextQueryResult: { docs: MockDoc[]; empty: boolean } = { docs: [], empty: true };
+
+  function setNextQueryResult(docs: MockDoc[]): void {
+    nextQueryResult = { docs, empty: docs.length === 0 };
+  }
+
+  function buildDocRef(collectionPath: string, docId: string) {
+    const path = `${collectionPath}/${docId}`;
+    return {
+      __path: path,
+      id: docId,
+      get: vi.fn(async () => docState.get(path) ?? { exists: false, data: () => ({}) }),
+      set: vi.fn(async (data: Record<string, unknown>) => {
+        setCalls.push({ path, data });
+        docState.set(path, { exists: true, data: () => data, id: docId });
+      }),
+      update: vi.fn(async (data: Record<string, unknown>) => {
+        updateCalls.push({ path, data });
+        const existing = docState.get(path);
+        const merged = existing ? { ...existing.data(), ...data } : data;
+        docState.set(path, { exists: true, data: () => merged, id: docId });
+      }),
+    };
+  }
+
+  function buildQuery(collectionPath: string) {
+    const wheres: [string, string, unknown][] = [];
+    let limitVal: number | undefined;
+    const query: Record<string, unknown> = {
+      where(field: string, op: string, value: unknown) {
+        wheres.push([field, op, value]);
+        return query;
+      },
+      limit(n: number) {
+        limitVal = n;
+        return query;
+      },
+      async get() {
+        queryCalls.push({
+          collection: collectionPath,
+          where: [...wheres],
+          limit: limitVal,
+        });
+        return nextQueryResult;
+      },
+    };
+    return query;
+  }
+
+  function buildCollection(collectionPath: string) {
+    return {
+      doc: vi.fn((id: string) => {
+        docCalls.push({ collection: collectionPath, id });
+        return buildDocRef(collectionPath, id);
+      }),
+      where(field: string, op: string, value: unknown) {
+        const q = buildQuery(collectionPath);
+        return (q.where as (f: string, o: string, v: unknown) => unknown)(
+          field,
+          op,
+          value,
+        );
+      },
+      // collection.get() は filter なしの全件取得 (query なしクエリ) を表す
+      async get() {
+        queryCalls.push({ collection: collectionPath, where: [], limit: undefined });
+        return nextQueryResult;
+      },
+    };
+  }
+
+  const runTransaction = vi.fn(async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => {
+    const tx = {
+      async get(refOrQuery: unknown) {
+        if ((refOrQuery as { __path?: string })?.__path) {
+          const path = (refOrQuery as { __path: string }).__path;
+          return docState.get(path) ?? { exists: false, data: () => ({}) };
+        }
+        if (typeof (refOrQuery as { get?: () => unknown })?.get === "function") {
+          return (refOrQuery as { get: () => unknown }).get();
+        }
+        throw new Error("mock tx.get: unsupported argument");
+      },
+      set(ref: { __path: string }, data: Record<string, unknown>) {
+        setCalls.push({ path: ref.__path, data });
+        docState.set(ref.__path, { exists: true, data: () => data });
+      },
+      update(ref: { __path: string }, data: Record<string, unknown>) {
+        updateCalls.push({ path: ref.__path, data });
+        const existing = docState.get(ref.__path);
+        const merged = existing ? { ...existing.data(), ...data } : data;
+        docState.set(ref.__path, { exists: true, data: () => merged });
+      },
+    };
+    return fn(tx);
+  });
+
+  const db = {
+    collection: vi.fn((name: string) => {
+      collectionCalls.push(name);
+      return buildCollection(name);
+    }),
+    doc: vi.fn((path: string) => {
+      const lastSlash = path.lastIndexOf("/");
+      const colPath = path.substring(0, lastSlash);
+      const docId = path.substring(lastSlash + 1);
+      docCalls.push({ collection: colPath, id: docId });
+      return buildDocRef(colPath, docId);
+    }),
+    runTransaction,
+  } as unknown as Firestore;
+
+  return {
+    db,
+    docCalls,
+    collectionCalls,
+    setCalls,
+    updateCalls,
+    queryCalls,
+    docState,
+    setNextQueryResult,
+    runTransaction,
+    seedDoc(path: string, data: Record<string, unknown>) {
+      docState.set(path, { exists: true, data: () => data });
+    },
+  };
+}
+
+const NOW_ISO = "2026-05-22T01:00:00.000Z";
+const NOW_DATE = new Date(NOW_ISO);
+
+// ============================================================
+// getDispatchSettings
+// ============================================================
+
+describe("FirestoreDispatchStorage.getDispatchSettings", () => {
+  it("super_dispatch_settings/global を読み取り、Timestamp を ISO に変換する", async () => {
+    const m = buildMockDb();
+    const updatedAt = Timestamp.fromDate(new Date("2026-05-21T03:00:00.000Z"));
+    m.seedDoc("super_dispatch_settings/global", {
+      enabled: true,
+      scheduleDaysOfWeek: [1, 4],
+      scheduleHourJst: 9,
+      signatureName: "DXcollege運営スタッフ",
+      completionMessageBody: "受講お疲れ様でした。",
+      senderEmail: "dxcollege@279279.net",
+      updatedAt,
+      updatedBy: "admin@example.com",
+      version: 3,
+    });
+
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.getDispatchSettings();
+
+    expect(m.docCalls[0]).toEqual({
+      collection: "super_dispatch_settings",
+      id: "global",
+    });
+    expect(result).toEqual({
+      enabled: true,
+      scheduleDaysOfWeek: [1, 4],
+      scheduleHourJst: 9,
+      signatureName: "DXcollege運営スタッフ",
+      completionMessageBody: "受講お疲れ様でした。",
+      senderEmail: "dxcollege@279279.net",
+      updatedAt: "2026-05-21T03:00:00.000Z",
+      updatedBy: "admin@example.com",
+      version: 3,
+    });
+  });
+
+  it("doc 不在なら null を返す", async () => {
+    const m = buildMockDb();
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.getDispatchSettings();
+    expect(result).toBeNull();
+  });
+});
+
+// ============================================================
+// tryReserveCompletionNotification (transaction)
+// ============================================================
+
+describe("FirestoreDispatchStorage.tryReserveCompletionNotification", () => {
+  const baseInput = {
+    tenantId: "tenant-a",
+    userId: "user-1",
+    runId: "run-uuid-1",
+    now: NOW_ISO,
+    leaseExpiresAt: "2026-05-22T01:10:00.000Z",
+  };
+
+  it("レコード不在 → reserved=true、tenants/{tid}/completion_notifications/{uid} に set", async () => {
+    const m = buildMockDb();
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.tryReserveCompletionNotification(baseInput);
+
+    expect(result).toEqual({ reserved: true });
+    expect(m.runTransaction).toHaveBeenCalledTimes(1);
+    expect(m.setCalls).toHaveLength(1);
+    expect(m.setCalls[0].path).toBe(
+      "tenants/tenant-a/completion_notifications/user-1",
+    );
+    const written = m.setCalls[0].data;
+    expect(written.userId).toBe("user-1");
+    expect(written.status).toBe("reserved");
+    expect(written.runId).toBe("run-uuid-1");
+    expect((written.reservedAt as Timestamp).toDate().toISOString()).toBe(NOW_ISO);
+    expect((written.leaseExpiresAt as Timestamp).toDate().toISOString()).toBe(
+      "2026-05-22T01:10:00.000Z",
+    );
+  });
+
+  it("既存 sent → reserved=false, reason=already_sent (新規 write なし)", async () => {
+    const m = buildMockDb();
+    m.seedDoc("tenants/tenant-a/completion_notifications/user-1", {
+      userId: "user-1",
+      status: "sent",
+    });
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.tryReserveCompletionNotification(baseInput);
+    expect(result).toEqual({ reserved: false, reason: "already_sent" });
+    expect(m.setCalls).toHaveLength(0);
+    expect(m.updateCalls).toHaveLength(0);
+  });
+
+  it("既存 failed_permanent → reserved=false, reason=failed_permanent", async () => {
+    const m = buildMockDb();
+    m.seedDoc("tenants/tenant-a/completion_notifications/user-1", {
+      status: "failed_permanent",
+    });
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.tryReserveCompletionNotification(baseInput);
+    expect(result).toEqual({ reserved: false, reason: "failed_permanent" });
+  });
+
+  it("既存 manual_review_required → reserved=false, reason=manual_review_required", async () => {
+    const m = buildMockDb();
+    m.seedDoc("tenants/tenant-a/completion_notifications/user-1", {
+      status: "manual_review_required",
+    });
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.tryReserveCompletionNotification(baseInput);
+    expect(result).toEqual({ reserved: false, reason: "manual_review_required" });
+  });
+
+  it("既存 reserved (lease 期限内) → reserved=false, reason=currently_reserved_by_other_run", async () => {
+    const m = buildMockDb();
+    m.seedDoc("tenants/tenant-a/completion_notifications/user-1", {
+      status: "reserved",
+      leaseExpiresAt: Timestamp.fromDate(new Date(NOW_DATE.getTime() + 60_000)),
+    });
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.tryReserveCompletionNotification(baseInput);
+    expect(result).toEqual({
+      reserved: false,
+      reason: "currently_reserved_by_other_run",
+    });
+    expect(m.setCalls).toHaveLength(0);
+    expect(m.updateCalls).toHaveLength(0);
+  });
+
+  it("既存 reserved (lease 期限切れ) → manual_review_required に降格、reserved=false", async () => {
+    const m = buildMockDb();
+    m.seedDoc("tenants/tenant-a/completion_notifications/user-1", {
+      status: "reserved",
+      leaseExpiresAt: Timestamp.fromDate(new Date(NOW_DATE.getTime() - 60_000)),
+    });
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.tryReserveCompletionNotification(baseInput);
+    expect(result).toEqual({
+      reserved: false,
+      reason: "lease_expired_promoted_to_manual_review",
+    });
+    expect(m.updateCalls).toHaveLength(1);
+    expect(m.updateCalls[0].path).toBe(
+      "tenants/tenant-a/completion_notifications/user-1",
+    );
+    expect(m.updateCalls[0].data.status).toBe("manual_review_required");
+    expect((m.updateCalls[0].data.failedAt as Timestamp).toDate().toISOString()).toBe(
+      NOW_ISO,
+    );
+  });
+});
+
+// ============================================================
+// markCompletionNotificationSent / FailedPermanent
+// ============================================================
+
+describe("FirestoreDispatchStorage.markCompletionNotificationSent", () => {
+  it("reserved 不在なら throw", async () => {
+    const m = buildMockDb();
+    const storage = new FirestoreDispatchStorage(m.db);
+    await expect(
+      storage.markCompletionNotificationSent({
+        tenantId: "tenant-a",
+        userId: "user-1",
+        messageId: "msg-1",
+        notifiedAt: NOW_ISO,
+        courseIdsSnapshot: ["c1", "c2"],
+        progressSnapshot: {
+          completedLessons: 10,
+          totalLessons: 10,
+          coursesCompleted: 2,
+          coursesTotal: 2,
+        },
+        recipientToHash: "hash-to",
+        recipientCcHashes: ["hash-cc-1"],
+        pdfSizeBytes: 12345,
+      }),
+    ).rejects.toThrow(/no reservation/);
+  });
+
+  it("既存 reserved → update で status=sent + sent fields", async () => {
+    const m = buildMockDb();
+    m.seedDoc("tenants/tenant-a/completion_notifications/user-1", {
+      status: "reserved",
+    });
+    const storage = new FirestoreDispatchStorage(m.db);
+    await storage.markCompletionNotificationSent({
+      tenantId: "tenant-a",
+      userId: "user-1",
+      messageId: "msg-1",
+      notifiedAt: NOW_ISO,
+      courseIdsSnapshot: ["c1", "c2"],
+      progressSnapshot: {
+        completedLessons: 10,
+        totalLessons: 10,
+        coursesCompleted: 2,
+        coursesTotal: 2,
+      },
+      recipientToHash: "hash-to",
+      recipientCcHashes: ["hash-cc-1"],
+      pdfSizeBytes: 12345,
+    });
+    expect(m.updateCalls).toHaveLength(1);
+    expect(m.updateCalls[0].path).toBe(
+      "tenants/tenant-a/completion_notifications/user-1",
+    );
+    const data = m.updateCalls[0].data;
+    expect(data.status).toBe("sent");
+    expect(data.messageId).toBe("msg-1");
+    expect((data.notifiedAt as Timestamp).toDate().toISOString()).toBe(NOW_ISO);
+    expect(data.courseIdsSnapshot).toEqual(["c1", "c2"]);
+    expect(data.publishedCourseCount).toBe(2);
+    expect(data.pdfSizeBytes).toBe(12345);
+  });
+
+  it("既存 status=sent (reserved 以外) → throw", async () => {
+    const m = buildMockDb();
+    m.seedDoc("tenants/tenant-a/completion_notifications/user-1", {
+      status: "sent",
+    });
+    const storage = new FirestoreDispatchStorage(m.db);
+    await expect(
+      storage.markCompletionNotificationSent({
+        tenantId: "tenant-a",
+        userId: "user-1",
+        messageId: "msg-1",
+        notifiedAt: NOW_ISO,
+        courseIdsSnapshot: [],
+        progressSnapshot: {
+          completedLessons: 0,
+          totalLessons: 0,
+          coursesCompleted: 0,
+          coursesTotal: 0,
+        },
+        recipientToHash: "",
+        recipientCcHashes: [],
+        pdfSizeBytes: null,
+      }),
+    ).rejects.toThrow(/status must be "reserved"/);
+  });
+});
+
+describe("FirestoreDispatchStorage.markCompletionNotificationFailedPermanent", () => {
+  it("既存 reserved → status=failed_permanent + errorCode/Message/failedAt 更新", async () => {
+    const m = buildMockDb();
+    m.seedDoc("tenants/tenant-a/completion_notifications/user-1", {
+      status: "reserved",
+    });
+    const storage = new FirestoreDispatchStorage(m.db);
+    await storage.markCompletionNotificationFailedPermanent({
+      tenantId: "tenant-a",
+      userId: "user-1",
+      failedAt: NOW_ISO,
+      errorCode: "recipientRejected",
+      errorMessage: "user-bounce (sanitized)",
+    });
+    expect(m.updateCalls).toHaveLength(1);
+    const data = m.updateCalls[0].data;
+    expect(data.status).toBe("failed_permanent");
+    expect(data.errorCode).toBe("recipientRejected");
+    expect(data.errorMessage).toBe("user-bounce (sanitized)");
+    expect((data.failedAt as Timestamp).toDate().toISOString()).toBe(NOW_ISO);
+  });
+});
+
+// ============================================================
+// acquireRunLock
+// ============================================================
+
+describe("FirestoreDispatchStorage.acquireRunLock", () => {
+  const baseInput = {
+    runId: "run-uuid-1",
+    triggeredAt: NOW_ISO,
+    leaseExpiresAt: "2026-05-22T01:04:40.000Z",
+    ttlExpireAt: "2027-05-22T01:00:00.000Z",
+  };
+
+  it("既存 running なし → acquired=true、super_dispatch_runs/{runId} に set", async () => {
+    const m = buildMockDb();
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.acquireRunLock(baseInput);
+    expect(result.acquired).toBe(true);
+    if (result.acquired) {
+      expect(result.run.runId).toBe("run-uuid-1");
+      expect(result.run.status).toBe("running");
+    }
+    expect(m.setCalls).toHaveLength(1);
+    expect(m.setCalls[0].path).toBe("super_dispatch_runs/run-uuid-1");
+    const data = m.setCalls[0].data;
+    expect(data.status).toBe("running");
+    expect((data.triggeredAt as Timestamp).toDate().toISOString()).toBe(NOW_ISO);
+    expect((data.leaseExpiresAt as Timestamp).toDate().toISOString()).toBe(
+      "2026-05-22T01:04:40.000Z",
+    );
+    expect((data.ttlExpireAt as Timestamp).toDate().toISOString()).toBe(
+      "2027-05-22T01:00:00.000Z",
+    );
+  });
+
+  it("既存 duplicate runId → acquired=false, reason=duplicate_run_id (set なし)", async () => {
+    const m = buildMockDb();
+    m.seedDoc("super_dispatch_runs/run-uuid-1", { status: "running" });
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.acquireRunLock(baseInput);
+    expect(result).toEqual({ acquired: false, reason: "duplicate_run_id" });
+    expect(m.setCalls).toHaveLength(0);
+  });
+
+  it("別の running run が lease 期限内 → acquired=false, reason=another_run_active", async () => {
+    const m = buildMockDb();
+    m.setNextQueryResult([
+      {
+        exists: true,
+        data: () => ({
+          runId: "other-run",
+          status: "running",
+          triggeredAt: Timestamp.fromDate(new Date(NOW_DATE.getTime() - 60_000)),
+          leaseExpiresAt: Timestamp.fromDate(new Date(NOW_DATE.getTime() + 60_000)),
+        }),
+      },
+    ]);
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.acquireRunLock(baseInput);
+    expect(result).toEqual({ acquired: false, reason: "another_run_active" });
+    expect(m.setCalls).toHaveLength(0);
+  });
+});
+
+// ============================================================
+// updateRunStatus
+// ============================================================
+
+describe("FirestoreDispatchStorage.updateRunStatus", () => {
+  it("既存 running → update で status=completed + metrics", async () => {
+    const m = buildMockDb();
+    m.seedDoc("super_dispatch_runs/run-uuid-1", { status: "running" });
+    const storage = new FirestoreDispatchStorage(m.db);
+    await storage.updateRunStatus({
+      runId: "run-uuid-1",
+      status: "completed",
+      processedTenants: 3,
+      sent: 5,
+      skipped: 2,
+      failed: 1,
+      manualReviewRequired: 0,
+    });
+    expect(m.updateCalls).toHaveLength(1);
+    expect(m.updateCalls[0].path).toBe("super_dispatch_runs/run-uuid-1");
+    expect(m.updateCalls[0].data).toMatchObject({
+      status: "completed",
+      processedTenants: 3,
+      sent: 5,
+      skipped: 2,
+      failed: 1,
+      manualReviewRequired: 0,
+    });
+  });
+
+  it("undefined フィールドは sanitizeForUpdate で除去される (既存値保護)", async () => {
+    const m = buildMockDb();
+    m.seedDoc("super_dispatch_runs/run-uuid-1", { status: "running" });
+    const storage = new FirestoreDispatchStorage(m.db);
+    await storage.updateRunStatus({
+      runId: "run-uuid-1",
+      status: "completed",
+    });
+    expect(m.updateCalls).toHaveLength(1);
+    const data = m.updateCalls[0].data;
+    expect(data.status).toBe("completed");
+    expect("processedTenants" in data).toBe(false);
+    expect("sent" in data).toBe(false);
+  });
+
+  it("aborted 遷移時に abortedReason をセット", async () => {
+    const m = buildMockDb();
+    m.seedDoc("super_dispatch_runs/run-uuid-1", { status: "running" });
+    const storage = new FirestoreDispatchStorage(m.db);
+    await storage.updateRunStatus({
+      runId: "run-uuid-1",
+      status: "aborted",
+      abortedReason: "scope_revoked",
+    });
+    expect(m.updateCalls).toHaveLength(1);
+    expect(m.updateCalls[0].data).toMatchObject({
+      status: "aborted",
+      abortedReason: "scope_revoked",
+    });
+  });
+
+  it("run 不在 → throw", async () => {
+    const m = buildMockDb();
+    const storage = new FirestoreDispatchStorage(m.db);
+    await expect(
+      storage.updateRunStatus({ runId: "unknown", status: "completed" }),
+    ).rejects.toThrow(/no run found/);
+  });
+});
+
+// ============================================================
+// getRun
+// ============================================================
+
+describe("FirestoreDispatchStorage.getRun", () => {
+  it("doc 不在 → null", async () => {
+    const m = buildMockDb();
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.getRun("unknown");
+    expect(result).toBeNull();
+  });
+
+  it("doc 存在 → Timestamp を ISO に変換して返す", async () => {
+    const m = buildMockDb();
+    m.seedDoc("super_dispatch_runs/run-uuid-1", {
+      runId: "run-uuid-1",
+      triggeredAt: Timestamp.fromDate(NOW_DATE),
+      status: "running",
+      leaseExpiresAt: Timestamp.fromDate(new Date(NOW_DATE.getTime() + 280_000)),
+      processedTenants: 0,
+      sent: 0,
+      skipped: 0,
+      failed: 0,
+      manualReviewRequired: 0,
+      abortedReason: null,
+      ttlExpireAt: Timestamp.fromDate(
+        new Date(NOW_DATE.getTime() + 365 * 86_400_000),
+      ),
+    });
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.getRun("run-uuid-1");
+    expect(result).not.toBeNull();
+    const r = result as DispatchRun;
+    expect(r.runId).toBe("run-uuid-1");
+    expect(r.status).toBe("running");
+    expect(r.triggeredAt).toBe(NOW_ISO);
+    expect(typeof r.leaseExpiresAt).toBe("string");
+    expect(typeof r.ttlExpireAt).toBe("string");
+  });
+});
+
+// ============================================================
+// appendAuditLog (best-effort)
+// ============================================================
+
+describe("FirestoreDispatchStorage.appendAuditLog", () => {
+  const sampleInput = {
+    auditId: "audit-1",
+    runId: "run-uuid-1",
+    runStartedAt: NOW_ISO,
+    eventType: "user_notified" as const,
+    tenantId: "tenant-a",
+    userId: "user-1",
+    errorCode: null,
+    errorMessage: null,
+    durationMs: 1234,
+    createdAt: NOW_ISO,
+    ttlExpireAt: "2027-05-22T01:00:00.000Z",
+  };
+
+  it("super_dispatch_audit_logs/{auditId} に set、Timestamp 変換", async () => {
+    const m = buildMockDb();
+    const storage = new FirestoreDispatchStorage(m.db);
+    await storage.appendAuditLog(sampleInput);
+    expect(m.setCalls).toHaveLength(1);
+    expect(m.setCalls[0].path).toBe("super_dispatch_audit_logs/audit-1");
+    const data = m.setCalls[0].data;
+    expect(data.eventType).toBe("user_notified");
+    expect((data.createdAt as Timestamp).toDate().toISOString()).toBe(NOW_ISO);
+    expect((data.ttlExpireAt as Timestamp).toDate().toISOString()).toBe(
+      "2027-05-22T01:00:00.000Z",
+    );
+  });
+
+  it("Firestore 書き込みが throw しても caller に伝播しない (best-effort)", async () => {
+    const failingDb = {
+      collection: vi.fn(() => ({
+        doc: vi.fn(() => ({
+          set: vi.fn().mockRejectedValue(new Error("Firestore down")),
+        })),
+      })),
+    } as unknown as Firestore;
+    const storage = new FirestoreDispatchStorage(failingDb);
+    await expect(storage.appendAuditLog(sampleInput)).resolves.toBeUndefined();
+  });
+});
+
+describe("FirestoreDispatchStorage.listAuditLogs", () => {
+  it("filter なしで全件取得、Timestamp を ISO に変換", async () => {
+    const m = buildMockDb();
+    const ts = Timestamp.fromDate(NOW_DATE);
+    m.setNextQueryResult([
+      {
+        exists: true,
+        id: "audit-1",
+        data: () => ({
+          auditId: "audit-1",
+          runId: "run-1",
+          runStartedAt: ts,
+          eventType: "run_started",
+          tenantId: null,
+          userId: null,
+          errorCode: null,
+          errorMessage: null,
+          durationMs: null,
+          createdAt: ts,
+          ttlExpireAt: ts,
+        }),
+      },
+    ]);
+    const storage = new FirestoreDispatchStorage(m.db);
+    const result = await storage.listAuditLogs();
+    expect(result).toHaveLength(1);
+    expect(result[0].auditId).toBe("audit-1");
+    expect(result[0].createdAt).toBe(NOW_ISO);
+  });
+
+  it("runId / eventType フィルタを query に追加", async () => {
+    const m = buildMockDb();
+    const storage = new FirestoreDispatchStorage(m.db);
+    await storage.listAuditLogs({ runId: "run-1", eventType: "user_notified" });
+    expect(m.queryCalls).toHaveLength(1);
+    const wheres = m.queryCalls[0].where;
+    expect(wheres).toEqual(
+      expect.arrayContaining([
+        ["runId", "==", "run-1"],
+        ["eventType", "==", "user_notified"],
+      ]),
+    );
+  });
+});

--- a/services/api/src/services/dispatch/__tests__/firestore-tenant-data-loader.test.ts
+++ b/services/api/src/services/dispatch/__tests__/firestore-tenant-data-loader.test.ts
@@ -1,0 +1,318 @@
+/**
+ * FirestoreTenantDataLoader の mock-based テスト。
+ *
+ * 設計仕様書 §3.3 (並列度)、FR-3 (全テナント直列走査)、§4.1.2 (tenant 拡張) 対応。
+ *
+ * テスト戦略 (ADR-028 踏襲):
+ *   - InMemoryTenantDataLoader で行動契約は既に保証済 (Phase 4 で integration test)
+ *   - 本テストは Firestore-specific I/O 契約のみ検証する:
+ *     - listAllTenantIds が tenants collection から ID を抽出すること
+ *     - getTenantCcConfig が tenant doc の completionNotificationEnabled / ownerEmail /
+ *       notificationCcEmails を返すこと
+ *     - getTenantDataView が tenant scoped FirestoreDataSource をラップして
+ *       published courses / 通知対象 users / course_progress を返すこと
+ *
+ * 並行制御の実 race 検証は不要 (本 loader は read-only)。
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Firestore } from "firebase-admin/firestore";
+import { FirestoreTenantDataLoader } from "../firestore-tenant-data-loader.js";
+
+interface MockDoc {
+  id: string;
+  exists: boolean;
+  data: () => Record<string, unknown>;
+}
+
+/**
+ * 簡易 mock: db.collection("tenants").listDocuments() / get() / doc(id).get() を表現。
+ */
+function buildMockDb() {
+  // 各 collection の docs を path key で保持
+  const tenants = new Map<string, Record<string, unknown>>();
+  const courses = new Map<string, Map<string, Record<string, unknown>>>(); // tenantId -> id -> course
+  const users = new Map<string, Map<string, Record<string, unknown>>>(); // tenantId -> id -> user
+  const progresses = new Map<
+    string,
+    Map<string, Record<string, unknown>>
+  >(); // tenantId -> progressDocId -> progress
+
+  function makeCollection(path: string) {
+    const parts = path.split("/");
+    // root "tenants" or "tenants/{tid}/X"
+    if (path === "tenants") {
+      return {
+        async get() {
+          return {
+            docs: Array.from(tenants.entries()).map(([id, data]) => ({
+              id,
+              exists: true,
+              data: () => data,
+            })),
+          };
+        },
+        doc(id: string) {
+          const data = tenants.get(id);
+          return {
+            id,
+            async get() {
+              return {
+                id,
+                exists: data !== undefined,
+                data: () => data ?? {},
+              };
+            },
+          };
+        },
+      };
+    }
+    // tenants/{tid}/{coll}
+    if (parts.length === 3 && parts[0] === "tenants") {
+      const tenantId = parts[1];
+      const coll = parts[2];
+      const map =
+        coll === "courses"
+          ? courses.get(tenantId) ?? new Map()
+          : coll === "users"
+            ? users.get(tenantId) ?? new Map()
+            : coll === "course_progress"
+              ? progresses.get(tenantId) ?? new Map()
+              : new Map();
+      const wheres: [string, string, unknown][] = [];
+      const q: Record<string, unknown> = {
+        where(field: string, op: string, value: unknown) {
+          wheres.push([field, op, value]);
+          return q;
+        },
+        async get() {
+          const all = Array.from(map.entries()).map(
+            ([id, data]) =>
+              ({
+                id,
+                exists: true,
+                data: () => data,
+              }) satisfies MockDoc,
+          );
+          // 簡易 where 評価 (== のみ)
+          const filtered = wheres.reduce<MockDoc[]>((acc, [field, op, value]) => {
+            if (op !== "==") return acc;
+            return acc.filter((d) => (d.data() as Record<string, unknown>)[field] === value);
+          }, all);
+          return { docs: filtered };
+        },
+      };
+      return q;
+    }
+    return { async get() { return { docs: [] }; } };
+  }
+
+  const db = {
+    collection: vi.fn((path: string) => makeCollection(path)),
+  } as unknown as Firestore;
+
+  return {
+    db,
+    seedTenant(tenantId: string, data: Record<string, unknown>) {
+      tenants.set(tenantId, data);
+    },
+    seedCourse(tenantId: string, courseId: string, data: Record<string, unknown>) {
+      let m = courses.get(tenantId);
+      if (!m) {
+        m = new Map();
+        courses.set(tenantId, m);
+      }
+      m.set(courseId, data);
+    },
+    seedUser(tenantId: string, userId: string, data: Record<string, unknown>) {
+      let m = users.get(tenantId);
+      if (!m) {
+        m = new Map();
+        users.set(tenantId, m);
+      }
+      m.set(userId, data);
+    },
+    seedCourseProgress(
+      tenantId: string,
+      docId: string,
+      data: Record<string, unknown>,
+    ) {
+      let m = progresses.get(tenantId);
+      if (!m) {
+        m = new Map();
+        progresses.set(tenantId, m);
+      }
+      m.set(docId, data);
+    },
+  };
+}
+
+// ============================================================
+// listAllTenantIds
+// ============================================================
+
+describe("FirestoreTenantDataLoader.listAllTenantIds", () => {
+  it("tenants collection の全 ID を sorted で返す (deterministic)", async () => {
+    const m = buildMockDb();
+    m.seedTenant("c-tenant", {});
+    m.seedTenant("a-tenant", {});
+    m.seedTenant("b-tenant", {});
+    const loader = new FirestoreTenantDataLoader(m.db);
+    const ids = await loader.listAllTenantIds();
+    expect(ids).toEqual(["a-tenant", "b-tenant", "c-tenant"]);
+  });
+
+  it("tenants 不在 → 空配列", async () => {
+    const m = buildMockDb();
+    const loader = new FirestoreTenantDataLoader(m.db);
+    const ids = await loader.listAllTenantIds();
+    expect(ids).toEqual([]);
+  });
+});
+
+// ============================================================
+// getTenantCcConfig
+// ============================================================
+
+describe("FirestoreTenantDataLoader.getTenantCcConfig", () => {
+  it("tenant doc のフィールドから CcConfig を組み立てる", async () => {
+    const m = buildMockDb();
+    m.seedTenant("tenant-a", {
+      ownerEmail: "owner@a.example.com",
+      notificationCcEmails: ["cc1@a.example.com", "cc2@a.example.com"],
+      completionNotificationEnabled: true,
+    });
+    const loader = new FirestoreTenantDataLoader(m.db);
+    const config = await loader.getTenantCcConfig("tenant-a");
+    expect(config).toEqual({
+      ownerEmail: "owner@a.example.com",
+      notificationCcEmails: ["cc1@a.example.com", "cc2@a.example.com"],
+      completionNotificationEnabled: true,
+    });
+  });
+
+  it("tenant doc 不在 → null", async () => {
+    const m = buildMockDb();
+    const loader = new FirestoreTenantDataLoader(m.db);
+    const config = await loader.getTenantCcConfig("unknown");
+    expect(config).toBeNull();
+  });
+
+  it("ownerEmail / notificationCcEmails 未定義 → 安全な default", async () => {
+    const m = buildMockDb();
+    m.seedTenant("tenant-b", {
+      // ownerEmail / notificationCcEmails 未設定
+      completionNotificationEnabled: false,
+    });
+    const loader = new FirestoreTenantDataLoader(m.db);
+    const config = await loader.getTenantCcConfig("tenant-b");
+    expect(config).toEqual({
+      ownerEmail: null,
+      notificationCcEmails: [],
+      completionNotificationEnabled: false,
+    });
+  });
+
+  it("completionNotificationEnabled 未定義 → default true (既存テナントの後方互換)", async () => {
+    const m = buildMockDb();
+    m.seedTenant("tenant-c", {
+      ownerEmail: "x@example.com",
+      notificationCcEmails: [],
+    });
+    const loader = new FirestoreTenantDataLoader(m.db);
+    const config = await loader.getTenantCcConfig("tenant-c");
+    expect(config?.completionNotificationEnabled).toBe(true);
+  });
+});
+
+// ============================================================
+// getTenantDataView (listPublishedCourses / listNotificationTargetUsers / listCourseProgressForUser)
+// ============================================================
+
+describe("FirestoreTenantDataLoader.getTenantDataView", () => {
+  it("listPublishedCourses: status=published のコースのみ返す + lessonOrder 込み", async () => {
+    const m = buildMockDb();
+    m.seedTenant("tenant-a", {});
+    m.seedCourse("tenant-a", "course-1", {
+      status: "published",
+      lessonOrder: ["lesson-1", "lesson-2"],
+    });
+    m.seedCourse("tenant-a", "course-2", {
+      status: "draft",
+      lessonOrder: ["lesson-3"],
+    });
+    m.seedCourse("tenant-a", "course-3", {
+      status: "published",
+      lessonOrder: [],
+    });
+    const loader = new FirestoreTenantDataLoader(m.db);
+    const view = loader.getTenantDataView("tenant-a");
+    const courses = await view.listPublishedCourses();
+    expect(courses).toHaveLength(2);
+    expect(courses.map((c) => c.id).sort()).toEqual(["course-1", "course-3"]);
+    expect(courses.find((c) => c.id === "course-1")?.lessonOrder).toEqual([
+      "lesson-1",
+      "lesson-2",
+    ]);
+  });
+
+  it("listNotificationTargetUsers: role=student のみ、id/email/name を返す", async () => {
+    const m = buildMockDb();
+    m.seedTenant("tenant-a", {});
+    m.seedUser("tenant-a", "user-1", {
+      email: "a@example.com",
+      name: "Alice",
+      role: "student",
+    });
+    m.seedUser("tenant-a", "user-2", {
+      email: "b@example.com",
+      name: "Bob",
+      role: "admin",
+    });
+    m.seedUser("tenant-a", "user-3", {
+      email: "c@example.com",
+      name: "Carol",
+      role: "student",
+    });
+    const loader = new FirestoreTenantDataLoader(m.db);
+    const view = loader.getTenantDataView("tenant-a");
+    const users = await view.listNotificationTargetUsers();
+    expect(users).toHaveLength(2);
+    const ids = users.map((u) => u.id).sort();
+    expect(ids).toEqual(["user-1", "user-3"]);
+    expect(users.find((u) => u.id === "user-1")?.email).toBe("a@example.com");
+  });
+
+  it("listCourseProgressForUser: 該当 userId の course_progress のみ返す", async () => {
+    const m = buildMockDb();
+    m.seedTenant("tenant-a", {});
+    m.seedCourseProgress("tenant-a", "doc-1", {
+      userId: "user-1",
+      courseId: "course-1",
+      isCompleted: true,
+      totalLessons: 5,
+      completedLessons: 5,
+    });
+    m.seedCourseProgress("tenant-a", "doc-2", {
+      userId: "user-1",
+      courseId: "course-2",
+      isCompleted: false,
+      totalLessons: 3,
+      completedLessons: 1,
+    });
+    m.seedCourseProgress("tenant-a", "doc-3", {
+      userId: "user-2",
+      courseId: "course-1",
+      isCompleted: true,
+      totalLessons: 5,
+      completedLessons: 5,
+    });
+    const loader = new FirestoreTenantDataLoader(m.db);
+    const view = loader.getTenantDataView("tenant-a");
+    const progresses = await view.listCourseProgressForUser("user-1");
+    expect(progresses).toHaveLength(2);
+    expect(progresses.map((p) => p.courseId).sort()).toEqual([
+      "course-1",
+      "course-2",
+    ]);
+  });
+});

--- a/services/api/src/services/dispatch/factory.ts
+++ b/services/api/src/services/dispatch/factory.ts
@@ -74,10 +74,34 @@ const IN_MEMORY_DEFAULTS = {
   expectedAudience: "https://in-memory.example.invalid",
 } as const;
 
+/**
+ * GCP runtime 検出 (Cloud Run / Cloud Functions / GAE)。
+ * 本番 runtime では in-memory モード採用を拒否する (silent no-op 防止、Codex Important 反映)。
+ */
+function isProductionGcpRuntime(): boolean {
+  return Boolean(
+    process.env.K_SERVICE ||
+      process.env.FUNCTION_TARGET ||
+      process.env.FUNCTION_NAME ||
+      process.env.GAE_SERVICE,
+  );
+}
+
 export function buildDispatchFactory(): DispatchFactoryOutput {
   const useInMemory = process.env.DISPATCH_USE_IN_MEMORY === "true";
 
   if (useInMemory) {
+    // 本番 GCP runtime で DISPATCH_USE_IN_MEMORY=true は誤設定の可能性が極めて高い。
+    // in-memory storage は永続化されず、Gmail 実送信もスキップされるため、本番で混入
+    // すると Cloud Scheduler 起動が常に 200 empty response (silent no-op) になる。
+    // Codex Important 反映: 本番 runtime 検出時は throw して fail loud。
+    if (isProductionGcpRuntime()) {
+      throw new Error(
+        "Dispatch factory: DISPATCH_USE_IN_MEMORY=true is forbidden in production GCP runtime " +
+          "(detected K_SERVICE/FUNCTION_TARGET/FUNCTION_NAME/GAE_SERVICE). " +
+          "Unset DISPATCH_USE_IN_MEMORY or run outside Cloud Run/Functions/GAE.",
+      );
+    }
     const subjectEmail =
       process.env.DXCOLLEGE_DISPATCH_SUBJECT?.trim() || IN_MEMORY_DEFAULTS.subjectEmail;
     const fromEmail =

--- a/services/api/src/services/dispatch/factory.ts
+++ b/services/api/src/services/dispatch/factory.ts
@@ -1,0 +1,111 @@
+/**
+ * Dispatch 機能の production wiring factory。
+ *
+ * Phase 7 wiring: 環境変数に応じて Firestore / InMemory 実装を切り替える。
+ *
+ * 設計仕様書 §3 / impl-plan §3 Phase 7。
+ *
+ * 切り替え戦略:
+ *   - `DISPATCH_USE_IN_MEMORY=true` → InMemory 実装 (test / dev、Firestore 不要)
+ *   - それ以外 (本番 / Cloud Run) → Firestore 実装
+ *
+ * 必須 env (本番):
+ *   - `DXCOLLEGE_SENDER_EMAIL`: MIME From ヘッダ用の SendAs alias (例 dxcollege@279279.net)
+ *   - `DXCOLLEGE_DISPATCH_SUBJECT`: DWD JWT subject = 実 mailbox (例 system@279279.net)
+ *   - `DISPATCH_OIDC_AUDIENCE`: Cloud Run 自身の URL (Cloud Scheduler OIDC token の audience)
+ *
+ * 任意 env:
+ *   - `DISPATCH_USE_IN_MEMORY`: "true" で InMemory に強制切替 (test / 緊急時)
+ *
+ * 関連 ADR: ADR-028 (テスト戦略), ADR-037 (sender impersonation)
+ */
+
+import { getFirestore } from "firebase-admin/firestore";
+
+import { FirestoreDispatchStorage } from "./firestore-dispatch-storage.js";
+import { FirestoreTenantDataLoader } from "./firestore-tenant-data-loader.js";
+import { InMemoryDispatchStorage } from "./in-memory-dispatch-storage.js";
+import { InMemoryTenantDataLoader } from "./tenant-data-loader.js";
+import {
+  GoogleOidcTokenVerifier,
+  type OidcTokenVerifier,
+} from "./oidc-verify.js";
+import type { DispatchStorage } from "./dispatch-storage.js";
+import type { TenantDataLoader } from "./tenant-data-loader.js";
+import type { DispatchEnv } from "./run-completion-notifications.js";
+
+export interface DispatchFactoryOutput {
+  storage: DispatchStorage;
+  loader: TenantDataLoader;
+  env: DispatchEnv;
+  expectedAudience: string;
+  verifier: OidcTokenVerifier;
+  /** 切り替えモードの可視化 (logging 用) */
+  mode: "firestore" | "in-memory";
+}
+
+/**
+ * 環境変数から必須値を読む (未設定なら明示 throw、silent fallback しない)。
+ */
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim().length === 0) {
+    throw new Error(
+      `Dispatch factory: env var "${name}" is required but missing or empty`,
+    );
+  }
+  return value.trim();
+}
+
+/**
+ * Production wiring: Cloud Run / Firestore 実体に接続。
+ *
+ * test / E2E では `DISPATCH_USE_IN_MEMORY=true` を設定するか、createInternalDispatchRouter を
+ * 直接呼んで test 用 storage / loader を inject する。
+ *
+ * env 解決方針 (code-review PLAUSIBLE 反映):
+ *   - production (DISPATCH_USE_IN_MEMORY != "true"): 必須 env を requireEnv で強制
+ *   - in-memory モード (DISPATCH_USE_IN_MEMORY == "true"): test/dev 想定で env を任意化、
+ *     未設定なら mock デフォルト値を採用する (in-memory のため Gmail 実送信は発生しない)
+ */
+const IN_MEMORY_DEFAULTS = {
+  subjectEmail: "in-memory-subject@example.invalid",
+  fromEmail: "in-memory-from@example.invalid",
+  expectedAudience: "https://in-memory.example.invalid",
+} as const;
+
+export function buildDispatchFactory(): DispatchFactoryOutput {
+  const useInMemory = process.env.DISPATCH_USE_IN_MEMORY === "true";
+
+  if (useInMemory) {
+    const subjectEmail =
+      process.env.DXCOLLEGE_DISPATCH_SUBJECT?.trim() || IN_MEMORY_DEFAULTS.subjectEmail;
+    const fromEmail =
+      process.env.DXCOLLEGE_SENDER_EMAIL?.trim() || IN_MEMORY_DEFAULTS.fromEmail;
+    const expectedAudience =
+      process.env.DISPATCH_OIDC_AUDIENCE?.trim() || IN_MEMORY_DEFAULTS.expectedAudience;
+    return {
+      storage: new InMemoryDispatchStorage(),
+      loader: new InMemoryTenantDataLoader(),
+      env: { subjectEmail, fromEmail },
+      expectedAudience,
+      verifier: new GoogleOidcTokenVerifier(),
+      mode: "in-memory",
+    };
+  }
+
+  // production: env 必須 + Firestore 実装 + Google OIDC verifier
+  const subjectEmail = requireEnv("DXCOLLEGE_DISPATCH_SUBJECT");
+  const fromEmail = requireEnv("DXCOLLEGE_SENDER_EMAIL");
+  const expectedAudience = requireEnv("DISPATCH_OIDC_AUDIENCE");
+  const env: DispatchEnv = { subjectEmail, fromEmail };
+  const db = getFirestore();
+  return {
+    storage: new FirestoreDispatchStorage(db),
+    loader: new FirestoreTenantDataLoader(db),
+    env,
+    expectedAudience,
+    verifier: new GoogleOidcTokenVerifier(),
+    mode: "firestore",
+  };
+}

--- a/services/api/src/services/dispatch/firestore-dispatch-storage.ts
+++ b/services/api/src/services/dispatch/firestore-dispatch-storage.ts
@@ -1,0 +1,569 @@
+/**
+ * DispatchStorage の Firestore 実装。
+ *
+ * 設計仕様書 §4.1.1〜4.1.5、§6.2〜6.3、FR-7 改訂 / FR-11 / FR-12 / NFR-3 対応。
+ *
+ * 関連 ADR:
+ *   - ADR-028 (InMemoryDataSource 中心のテスト戦略)
+ *   - ADR-034 (PII 最小化)
+ *   - rules/production-data-safety.md §1 (sanitizeForUpdate で既存値保護)
+ *   - rules/error-handling.md §1 (audit log は best-effort、caller に伝播しない)
+ *
+ * Phase 7 で wiring され、production では本実装、test では InMemoryDispatchStorage を
+ * 切り替えて使用する (factory pattern、`route/internal/dispatch.ts` で DI)。
+ *
+ * 設計判断:
+ *   - reservation / lease 期限切れ降格は runTransaction で atomic に実行
+ *     (Codex Critical-1+3: 並列 worker による二重 sent 防止の中核)
+ *   - run-lock の "他 running が lease 内" 判定はクエリ → set で行う
+ *     (FR-11 は best-effort、per-user reservation が真の安全装置)
+ *   - audit log 書き込みは best-effort: Firestore 例外を caller に伝播せず logger.warn のみ
+ *     (spec §6.1 「audit_logs 書き込み失敗は警告ログのみ、レスポンスをブロックしない」)
+ *   - ISO 8601 string ↔ Firestore Timestamp は本層のみが変換責務を持つ
+ *     (caller / interface は全て ISO 8601 string で統一)
+ */
+
+import {
+  Timestamp,
+  type Firestore,
+  type DocumentReference,
+  type DocumentSnapshot,
+  type Transaction,
+} from "firebase-admin/firestore";
+
+import {
+  type CompletionNotification,
+  type CompletionNotificationStatus,
+  type DispatchAuditLog,
+  type DispatchRun,
+  type DispatchRunStatus,
+  type DispatchSettings,
+  type ReservationOutcome,
+} from "@lms-279/shared-types";
+
+import { logger } from "../../utils/logger.js";
+
+import type {
+  AcquireRunLockInput,
+  AcquireRunLockOutcome,
+  AppendAuditLogInput,
+  DispatchStorage,
+  MarkFailedPermanentInput,
+  MarkSentInput,
+  ReserveCompletionNotificationInput,
+  UpdateRunStatusInput,
+} from "./dispatch-storage.js";
+
+// ============================================================
+// Firestore collection paths
+// ============================================================
+
+const COLL_SETTINGS = "super_dispatch_settings";
+const DOC_SETTINGS_GLOBAL = "global";
+const COLL_RUNS = "super_dispatch_runs";
+const COLL_AUDIT_LOGS = "super_dispatch_audit_logs";
+
+function completionNotificationsCollection(tenantId: string): string {
+  return `tenants/${tenantId}/completion_notifications`;
+}
+
+// ============================================================
+// Helpers: Timestamp <-> ISO string
+// ============================================================
+
+function isoToTimestamp(iso: string): Timestamp {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`Invalid ISO 8601 string: ${iso}`);
+  }
+  return Timestamp.fromDate(d);
+}
+
+/**
+ * Firestore Timestamp / Date / null を ISO 文字列に変換。
+ *
+ * Firestore SDK は Timestamp を返すのが基本だが、emulator や移行データで Date が
+ * 混在する可能性に備えて両対応する。null / undefined は null を返す。
+ */
+function timestampToIso(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Timestamp) {
+    return value.toDate().toISOString();
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  throw new Error(
+    `timestampToIso: unsupported value type ${typeof value} (expected Timestamp/Date/string)`,
+  );
+}
+
+function requireIso(value: unknown, field: string): string {
+  const iso = timestampToIso(value);
+  if (iso === null) {
+    throw new Error(`Required Timestamp field missing: ${field}`);
+  }
+  return iso;
+}
+
+// ============================================================
+// Helpers: sanitizeForUpdate (production-data-safety.md §1)
+// ============================================================
+
+/**
+ * undefined フィールドをオブジェクトから除去し、既存 Firestore 値を保護する。
+ *
+ * `null` は明示的な値として保持する (例: abortedReason のクリア)。
+ * `undefined` は Partial Update のセマンティクス上、既存値保持を意味する。
+ */
+function sanitizeForUpdate<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined),
+  ) as Partial<T>;
+}
+
+// ============================================================
+// Doc converters (Firestore data → typed entity)
+// ============================================================
+
+function toDispatchSettings(data: Record<string, unknown>): DispatchSettings {
+  // 設計仕様書 §4.1.1 では Firestore doc に senderEmail を保存しない (env DXCOLLEGE_SENDER_EMAIL
+  // から読み取り、編集不可)。本層は raw doc を返すのみで、Phase 5 super-admin API レスポンス
+  // 層で env からの merge を行う設計 (本層では senderEmail が undefined になりうる)。
+  // 現状の Phase 7 では senderEmail を直接消費する code path が無いため、空文字列にフォールバック
+  // して下流の type-checker を満たす。Phase 5 で API 経由公開する際は必ず env 値を上書きする。
+  return {
+    enabled: data.enabled as boolean,
+    scheduleDaysOfWeek: data.scheduleDaysOfWeek as number[],
+    scheduleHourJst: data.scheduleHourJst as number,
+    signatureName: data.signatureName as string,
+    completionMessageBody: data.completionMessageBody as string,
+    senderEmail: (data.senderEmail as string | undefined) ?? "",
+    updatedAt: requireIso(data.updatedAt, "updatedAt"),
+    updatedBy: data.updatedBy as string,
+    version: data.version as number,
+  };
+}
+
+function toDispatchRun(data: Record<string, unknown>): DispatchRun {
+  return {
+    runId: data.runId as string,
+    triggeredAt: requireIso(data.triggeredAt, "triggeredAt"),
+    status: data.status as DispatchRunStatus,
+    leaseExpiresAt: requireIso(data.leaseExpiresAt, "leaseExpiresAt"),
+    processedTenants: (data.processedTenants as number) ?? 0,
+    sent: (data.sent as number) ?? 0,
+    skipped: (data.skipped as number) ?? 0,
+    failed: (data.failed as number) ?? 0,
+    manualReviewRequired: (data.manualReviewRequired as number) ?? 0,
+    abortedReason: (data.abortedReason as string | null) ?? null,
+    ttlExpireAt: requireIso(data.ttlExpireAt, "ttlExpireAt"),
+  };
+}
+
+function toCompletionNotification(
+  data: Record<string, unknown>,
+): CompletionNotification {
+  return {
+    userId: data.userId as string,
+    status: data.status as CompletionNotificationStatus,
+    runId: data.runId as string,
+    reservedAt: requireIso(data.reservedAt, "reservedAt"),
+    leaseExpiresAt: requireIso(data.leaseExpiresAt, "leaseExpiresAt"),
+    notifiedAt: timestampToIso(data.notifiedAt),
+    messageId: (data.messageId as string | null) ?? null,
+    errorCode: (data.errorCode as string | null) ?? null,
+    errorMessage: (data.errorMessage as string | null) ?? null,
+    failedAt: timestampToIso(data.failedAt),
+    progressSnapshot: (data.progressSnapshot ?? {
+      completedLessons: 0,
+      totalLessons: 0,
+      coursesCompleted: 0,
+      coursesTotal: 0,
+    }) as CompletionNotification["progressSnapshot"],
+    courseIdsSnapshot: (data.courseIdsSnapshot as string[]) ?? [],
+    publishedCourseCount: (data.publishedCourseCount as number) ?? 0,
+    recipientToHash: (data.recipientToHash as string) ?? "",
+    recipientCcHashes: (data.recipientCcHashes as string[]) ?? [],
+    pdfSizeBytes: (data.pdfSizeBytes as number | null) ?? null,
+  };
+}
+
+function toAuditLog(data: Record<string, unknown>): DispatchAuditLog {
+  return {
+    auditId: data.auditId as string,
+    runId: data.runId as string,
+    runStartedAt: requireIso(data.runStartedAt, "runStartedAt"),
+    eventType: data.eventType as DispatchAuditLog["eventType"],
+    tenantId: (data.tenantId as string | null) ?? null,
+    userId: (data.userId as string | null) ?? null,
+    errorCode: (data.errorCode as string | null) ?? null,
+    errorMessage: (data.errorMessage as string | null) ?? null,
+    durationMs: (data.durationMs as number | null) ?? null,
+    createdAt: requireIso(data.createdAt, "createdAt"),
+    ttlExpireAt: requireIso(data.ttlExpireAt, "ttlExpireAt"),
+  };
+}
+
+// ============================================================
+// FirestoreDispatchStorage
+// ============================================================
+
+export class FirestoreDispatchStorage implements DispatchStorage {
+  constructor(private readonly db: Firestore) {}
+
+  // ----- helper: doc refs -----
+  private settingsRef(): DocumentReference {
+    return this.db
+      .collection(COLL_SETTINGS)
+      .doc(DOC_SETTINGS_GLOBAL) as unknown as DocumentReference;
+  }
+
+  private completionNotificationRef(
+    tenantId: string,
+    userId: string,
+  ): DocumentReference {
+    return this.db
+      .collection(completionNotificationsCollection(tenantId))
+      .doc(userId) as unknown as DocumentReference;
+  }
+
+  private runRef(runId: string): DocumentReference {
+    return this.db.collection(COLL_RUNS).doc(runId) as unknown as DocumentReference;
+  }
+
+  private auditLogRef(auditId: string): DocumentReference {
+    return this.db
+      .collection(COLL_AUDIT_LOGS)
+      .doc(auditId) as unknown as DocumentReference;
+  }
+
+  // =====================================================================
+  // Settings
+  // =====================================================================
+
+  async getDispatchSettings(): Promise<DispatchSettings | null> {
+    const snap = (await this.settingsRef().get()) as DocumentSnapshot;
+    if (!snap.exists) return null;
+    return toDispatchSettings(snap.data() ?? {});
+  }
+
+  // =====================================================================
+  // Reservation
+  // =====================================================================
+
+  async tryReserveCompletionNotification(
+    input: ReserveCompletionNotificationInput,
+  ): Promise<ReservationOutcome> {
+    const { tenantId, userId, runId, now, leaseExpiresAt } = input;
+    const ref = this.completionNotificationRef(tenantId, userId);
+    const nowMs = new Date(now).getTime();
+
+    return this.db.runTransaction(async (tx: Transaction) => {
+      const snap = (await tx.get(ref)) as DocumentSnapshot;
+      if (snap.exists) {
+        const data = (snap.data() ?? {}) as Record<string, unknown>;
+        const status = data.status as CompletionNotificationStatus | undefined;
+        switch (status) {
+          case "sent":
+            return { reserved: false, reason: "already_sent" } satisfies ReservationOutcome;
+          case "failed_permanent":
+            return {
+              reserved: false,
+              reason: "failed_permanent",
+            } satisfies ReservationOutcome;
+          case "manual_review_required":
+            return {
+              reserved: false,
+              reason: "manual_review_required",
+            } satisfies ReservationOutcome;
+          case "reserved": {
+            const leaseIso = timestampToIso(data.leaseExpiresAt);
+            const leaseMs = leaseIso ? new Date(leaseIso).getTime() : 0;
+            if (leaseMs <= nowMs) {
+              // 期限切れ → manual_review_required に降格
+              tx.update(ref, {
+                status: "manual_review_required",
+                failedAt: isoToTimestamp(now),
+              });
+              return {
+                reserved: false,
+                reason: "lease_expired_promoted_to_manual_review",
+              } satisfies ReservationOutcome;
+            }
+            return {
+              reserved: false,
+              reason: "currently_reserved_by_other_run",
+            } satisfies ReservationOutcome;
+          }
+          default:
+            // 未知 status は破損 → throw (silent 上書き禁止、rules/error-handling.md §2)
+            throw new Error(
+              `tryReserveCompletionNotification: unexpected existing status="${String(status)}" for ${tenantId}/${userId}`,
+            );
+        }
+      }
+
+      // 新規 reservation create
+      const newRecord = {
+        userId,
+        status: "reserved" as CompletionNotificationStatus,
+        runId,
+        reservedAt: isoToTimestamp(now),
+        leaseExpiresAt: isoToTimestamp(leaseExpiresAt),
+        notifiedAt: null,
+        messageId: null,
+        errorCode: null,
+        errorMessage: null,
+        failedAt: null,
+        progressSnapshot: {
+          completedLessons: 0,
+          totalLessons: 0,
+          coursesCompleted: 0,
+          coursesTotal: 0,
+        },
+        courseIdsSnapshot: [] as string[],
+        publishedCourseCount: 0,
+        recipientToHash: "",
+        recipientCcHashes: [] as string[],
+        pdfSizeBytes: null,
+      };
+      tx.set(ref, newRecord);
+      return { reserved: true } satisfies ReservationOutcome;
+    });
+  }
+
+  async markCompletionNotificationSent(input: MarkSentInput): Promise<void> {
+    const ref = this.completionNotificationRef(input.tenantId, input.userId);
+    // evaluator MEDIUM: lease 期限切れ後の降格 (reserved → manual_review_required) と
+    // 遅延した markSent の race で manual_review_required → sent 上書きが起きうるため
+    // read-then-write を runTransaction で保護する。
+    await this.db.runTransaction(async (tx: Transaction) => {
+      const snap = (await tx.get(ref)) as DocumentSnapshot;
+      if (!snap.exists) {
+        throw new Error(
+          `markCompletionNotificationSent: no reservation for ${input.tenantId}/${input.userId}`,
+        );
+      }
+      const data = (snap.data() ?? {}) as Record<string, unknown>;
+      if (data.status !== "reserved") {
+        throw new Error(
+          `markCompletionNotificationSent: status must be "reserved" but was "${String(data.status)}" for ${input.tenantId}/${input.userId}`,
+        );
+      }
+      const updateData = {
+        status: "sent" as CompletionNotificationStatus,
+        messageId: input.messageId,
+        notifiedAt: isoToTimestamp(input.notifiedAt),
+        courseIdsSnapshot: input.courseIdsSnapshot,
+        publishedCourseCount: input.courseIdsSnapshot.length,
+        progressSnapshot: input.progressSnapshot,
+        recipientToHash: input.recipientToHash,
+        recipientCcHashes: input.recipientCcHashes,
+        pdfSizeBytes: input.pdfSizeBytes,
+      };
+      tx.update(ref, sanitizeForUpdate(updateData));
+    });
+  }
+
+  async markCompletionNotificationFailedPermanent(
+    input: MarkFailedPermanentInput,
+  ): Promise<void> {
+    const ref = this.completionNotificationRef(input.tenantId, input.userId);
+    // markSent と同様、lease 期限切れ降格との race を防ぐため runTransaction で保護
+    await this.db.runTransaction(async (tx: Transaction) => {
+      const snap = (await tx.get(ref)) as DocumentSnapshot;
+      if (!snap.exists) {
+        throw new Error(
+          `markCompletionNotificationFailedPermanent: no reservation for ${input.tenantId}/${input.userId}`,
+        );
+      }
+      const data = (snap.data() ?? {}) as Record<string, unknown>;
+      if (data.status !== "reserved") {
+        throw new Error(
+          `markCompletionNotificationFailedPermanent: status must be "reserved" but was "${String(data.status)}" for ${input.tenantId}/${input.userId}`,
+        );
+      }
+      tx.update(
+        ref,
+        sanitizeForUpdate({
+          status: "failed_permanent" as CompletionNotificationStatus,
+          errorCode: input.errorCode,
+          errorMessage: input.errorMessage,
+          failedAt: isoToTimestamp(input.failedAt),
+        }),
+      );
+    });
+  }
+
+  async getCompletionNotification(
+    tenantId: string,
+    userId: string,
+  ): Promise<CompletionNotification | null> {
+    const snap = (await this.completionNotificationRef(
+      tenantId,
+      userId,
+    ).get()) as DocumentSnapshot;
+    if (!snap.exists) return null;
+    return toCompletionNotification(snap.data() ?? {});
+  }
+
+  // =====================================================================
+  // Run lock
+  // =====================================================================
+
+  async acquireRunLock(input: AcquireRunLockInput): Promise<AcquireRunLockOutcome> {
+    // 1. duplicate runId 検出 (uuid v4 衝突は天文学的だが防御として)
+    const ref = this.runRef(input.runId);
+    const existingSnap = (await ref.get()) as DocumentSnapshot;
+    if (existingSnap.exists) {
+      return { acquired: false, reason: "duplicate_run_id" };
+    }
+
+    // 2. 直近 lease 内に他の running が居れば拒否
+    //    spec §6.3 通り、query → set は best-effort (per-user reservation が真の安全装置)
+    //
+    //    実装メモ (code-review PLAUSIBLE 反映):
+    //      理想は `where("status", "==", "running").where("leaseExpiresAt", ">", now).limit(1)`
+    //      だが、これは composite index (Phase 7-B で追加予定) を要求する。本 PR では
+    //      single-field where + アプリ側 lease 判定で fallback する。super_dispatch_runs は
+    //      TTL 365 日 + status="running" は cron 1 起動で 1 件のみ create + completed/aborted/
+    //      timeout 遷移で deselect されるため、長期残置 docs は数件レベル想定で線形 scan で
+    //      問題ない。Phase 7-B で composite index 追加後に `.where(leaseExpiresAt > now).limit(1)`
+    //      へ最適化する。
+    const nowMs = new Date(input.triggeredAt).getTime();
+    const runningSnap = await this.db
+      .collection(COLL_RUNS)
+      .where("status", "==", "running")
+      .get();
+    for (const doc of (runningSnap as { docs: DocumentSnapshot[] }).docs) {
+      const data = (doc.data() ?? {}) as Record<string, unknown>;
+      const leaseIso = timestampToIso(data.leaseExpiresAt);
+      const leaseMs = leaseIso ? new Date(leaseIso).getTime() : 0;
+      if (leaseMs > nowMs) {
+        return { acquired: false, reason: "another_run_active" };
+      }
+    }
+
+    // 3. create
+    const newRun: Record<string, unknown> = {
+      runId: input.runId,
+      triggeredAt: isoToTimestamp(input.triggeredAt),
+      status: "running",
+      leaseExpiresAt: isoToTimestamp(input.leaseExpiresAt),
+      processedTenants: 0,
+      sent: 0,
+      skipped: 0,
+      failed: 0,
+      manualReviewRequired: 0,
+      abortedReason: null,
+      ttlExpireAt: isoToTimestamp(input.ttlExpireAt),
+    };
+    await ref.set(newRun);
+    return {
+      acquired: true,
+      run: {
+        runId: input.runId,
+        triggeredAt: input.triggeredAt,
+        status: "running",
+        leaseExpiresAt: input.leaseExpiresAt,
+        processedTenants: 0,
+        sent: 0,
+        skipped: 0,
+        failed: 0,
+        manualReviewRequired: 0,
+        abortedReason: null,
+        ttlExpireAt: input.ttlExpireAt,
+      },
+    };
+  }
+
+  async updateRunStatus(input: UpdateRunStatusInput): Promise<void> {
+    const ref = this.runRef(input.runId);
+    const snap = (await ref.get()) as DocumentSnapshot;
+    if (!snap.exists) {
+      throw new Error(`updateRunStatus: no run found for ${input.runId}`);
+    }
+
+    // abortedReason は aborted 遷移時のみ上書き、それ以外は明示クリア (rules/quality-gate 反映)
+    const abortedReason =
+      input.status === "aborted"
+        ? input.abortedReason
+        : input.abortedReason ?? null;
+
+    const updateData: Record<string, unknown> = {
+      status: input.status,
+      processedTenants: input.processedTenants,
+      sent: input.sent,
+      skipped: input.skipped,
+      failed: input.failed,
+      manualReviewRequired: input.manualReviewRequired,
+      abortedReason,
+    };
+    await ref.update(sanitizeForUpdate(updateData));
+  }
+
+  async getRun(runId: string): Promise<DispatchRun | null> {
+    const snap = (await this.runRef(runId).get()) as DocumentSnapshot;
+    if (!snap.exists) return null;
+    return toDispatchRun(snap.data() ?? {});
+  }
+
+  // =====================================================================
+  // Audit log (best-effort)
+  // =====================================================================
+
+  async appendAuditLog(input: AppendAuditLogInput): Promise<void> {
+    try {
+      const data: Record<string, unknown> = {
+        auditId: input.auditId,
+        runId: input.runId,
+        runStartedAt: isoToTimestamp(input.runStartedAt),
+        eventType: input.eventType,
+        tenantId: input.tenantId,
+        userId: input.userId,
+        errorCode: input.errorCode,
+        errorMessage: input.errorMessage,
+        durationMs: input.durationMs,
+        createdAt: isoToTimestamp(input.createdAt),
+        ttlExpireAt: isoToTimestamp(input.ttlExpireAt),
+      };
+      await this.auditLogRef(input.auditId).set(data);
+    } catch (err) {
+      // spec §6.1: 書き込み失敗は警告ログのみ、caller を block しない
+      logger.warn("appendAuditLog: Firestore write failed (best-effort)", {
+        errorType: "dispatch_audit_log_write_failed",
+        auditId: input.auditId,
+        runId: input.runId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async listAuditLogs(filter?: {
+    runId?: string;
+    eventType?: DispatchAuditLog["eventType"];
+  }): Promise<DispatchAuditLog[]> {
+    let query: FirebaseFirestore.Query = this.db.collection(COLL_AUDIT_LOGS);
+    if (filter?.runId) {
+      query = query.where("runId", "==", filter.runId);
+    }
+    if (filter?.eventType) {
+      query = query.where("eventType", "==", filter.eventType);
+    }
+    const snap = (await query.get()) as { docs: DocumentSnapshot[] };
+    return snap.docs.map((doc) => toAuditLog(doc.data() ?? {}));
+  }
+}
+
+// 型網羅性チェック (将来 status 追加時のコンパイルエラー検出)
+const _statusCoverage: Record<CompletionNotificationStatus, true> = {
+  reserved: true,
+  sent: true,
+  failed_permanent: true,
+  manual_review_required: true,
+};
+void _statusCoverage;

--- a/services/api/src/services/dispatch/firestore-tenant-data-loader.ts
+++ b/services/api/src/services/dispatch/firestore-tenant-data-loader.ts
@@ -1,0 +1,121 @@
+/**
+ * TenantDataLoader の Firestore 実装。
+ *
+ * 設計仕様書 §3.3 (並列度)、FR-3 (全テナント直列走査)、§4.1.2 (tenant 拡張) 対応。
+ *
+ * Phase 7 で wiring され、production では本実装、test では InMemoryTenantDataLoader を
+ * 切り替えて使用する (factory pattern、`route/internal/dispatch.ts` で DI)。
+ *
+ * 責務:
+ *   - tenants collection の全 ID 列挙 (deterministic sorted order)
+ *   - tenant 単位の completionNotificationEnabled / ownerEmail / notificationCcEmails 取得
+ *   - tenant 単位の published コース・通知対象ユーザー・進捗の read-only view 提供
+ *
+ * 非責務:
+ *   - tenant の create / delete (本 loader は read-only)
+ *   - super_dispatch_settings 取得 (DispatchStorage の責務)
+ *   - GCS / Drive / Gmail との連携 (各 service の責務)
+ *
+ * 設計判断:
+ *   - listAllTenantIds は `db.collection("tenants").listDocuments()` ではなく
+ *     `.get()` を使う (ID + doc 存在確認の両方を行うため。空 doc も拾う場合は
+ *     listDocuments の検討余地あり)
+ *   - completionNotificationEnabled 未設定 → default `true` で扱う (既存テナント後方互換、
+ *     §4.1.2 「default true」に合致)
+ *   - getTenantDataView はクエリを発行するだけで FirestoreDataSource をネストしない
+ *     (DataSource は datasource-rule で tenant scoped に bind されているため独立保持)
+ */
+
+import type {
+  Firestore,
+  QueryDocumentSnapshot,
+} from "firebase-admin/firestore";
+
+import type { Course, CourseProgress, User } from "../../types/entities.js";
+import type {
+  DispatchTenantDataView,
+  TenantCcConfigView,
+  TenantDataLoader,
+} from "./tenant-data-loader.js";
+
+// ============================================================
+// FirestoreTenantDataLoader
+// ============================================================
+
+export class FirestoreTenantDataLoader implements TenantDataLoader {
+  constructor(private readonly db: Firestore) {}
+
+  async listAllTenantIds(): Promise<string[]> {
+    const snap = await this.db.collection("tenants").get();
+    const ids = (snap as { docs: QueryDocumentSnapshot[] }).docs.map((d) => d.id);
+    // deterministic order (テストの安定化 + audit の予測可能性)
+    return ids.sort();
+  }
+
+  getTenantDataView(tenantId: string): DispatchTenantDataView {
+    const coursesCol = this.db.collection(`tenants/${tenantId}/courses`);
+    const usersCol = this.db.collection(`tenants/${tenantId}/users`);
+    const progressCol = this.db.collection(`tenants/${tenantId}/course_progress`);
+
+    return {
+      async listPublishedCourses(): Promise<Pick<Course, "id" | "lessonOrder">[]> {
+        const snap = await coursesCol.where("status", "==", "published").get();
+        return (snap as { docs: QueryDocumentSnapshot[] }).docs.map((d) => {
+          const data = d.data() ?? {};
+          return {
+            id: d.id,
+            lessonOrder: (data.lessonOrder as string[]) ?? [],
+          };
+        });
+      },
+
+      async listNotificationTargetUsers(): Promise<
+        Pick<User, "id" | "email" | "name">[]
+      > {
+        // role=student のみを通知対象 (admin / instructor は除外)
+        const snap = await usersCol.where("role", "==", "student").get();
+        return (snap as { docs: QueryDocumentSnapshot[] }).docs.map((d) => {
+          const data = d.data() ?? {};
+          return {
+            id: d.id,
+            email: (data.email as string) ?? "",
+            name: (data.name as string | null) ?? null,
+          };
+        });
+      },
+
+      async listCourseProgressForUser(
+        userId: string,
+      ): Promise<
+        Pick<
+          CourseProgress,
+          "courseId" | "isCompleted" | "totalLessons" | "completedLessons"
+        >[]
+      > {
+        const snap = await progressCol.where("userId", "==", userId).get();
+        return (snap as { docs: QueryDocumentSnapshot[] }).docs.map((d) => {
+          const data = d.data() ?? {};
+          return {
+            courseId: (data.courseId as string) ?? "",
+            isCompleted: (data.isCompleted as boolean) ?? false,
+            totalLessons: (data.totalLessons as number) ?? 0,
+            completedLessons: (data.completedLessons as number) ?? 0,
+          };
+        });
+      },
+    };
+  }
+
+  async getTenantCcConfig(tenantId: string): Promise<TenantCcConfigView | null> {
+    const doc = await this.db.collection("tenants").doc(tenantId).get();
+    if (!doc.exists) return null;
+    const data = doc.data() ?? {};
+    return {
+      ownerEmail: (data.ownerEmail as string | null) ?? null,
+      notificationCcEmails: (data.notificationCcEmails as string[]) ?? [],
+      // §4.1.2: completionNotificationEnabled は default true (既存テナントの後方互換)
+      completionNotificationEnabled:
+        (data.completionNotificationEnabled as boolean | undefined) ?? true,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

DXcollege 自動完了通知システムの **Phase 7-A (code 層)** を実装。Firestore I/O 抽象実装 + factory + production wiring を追加し、本番デプロイの前提となる storage 実装非依存設計を完成させた。

**Phase 7 全体は 2 段階構成**:
- **Phase 7-A (本 PR)**: code 層 (Firestore impl + factory + wiring)
- **Phase 7-B (後続 PR + 番号単位明示認可)**: infra 層 (Cloud Scheduler / Firestore TTL / composite index / IAM / env)

### 新規ファイル

| ファイル | 行数 | 内容 |
|---|---|---|
| `services/dispatch/firestore-dispatch-storage.ts` | 569 | DispatchStorage の Firestore 実装 |
| `services/dispatch/firestore-tenant-data-loader.ts` | 121 | TenantDataLoader の Firestore 実装 |
| `services/dispatch/factory.ts` | 111 | env 切替 factory (in-memory / firestore) |
| 各 __tests__ | 1150 | mock-based 43 件のテスト |

### 変更ファイル

- `services/api/src/index.ts`: 内部 dispatch router を `/api/v2/internal` にマウント。Cloud Run (`K_SERVICE`) では env 欠如を fail loud (silent skip 防止)、それ以外は warn + skip。

### 設計上の重要判断

| 判断 | 根拠 |
|---|---|
| `tryReserveCompletionNotification` を runTransaction で完全保護 | Codex Critical-1+3 二重送信防止の中核 (spec §6.2) |
| `markCompletionNotificationSent` / `FailedPermanent` も runTransaction で保護 | evaluator MEDIUM 反映 (lease 期限切れ降格との TOCTOU 防止) |
| `acquireRunLock` の `another_run_active` 判定は best-effort | spec §6.3 通り、per-user reservation が真の安全装置。composite index 不要 (Phase 7-B 追加後に最適化) |
| in-memory モードでは env 任意化 + mock デフォルト | code-review PLAUSIBLE 反映、test/dev での friction を解消 |
| Cloud Run で env 欠如時 fail loud | evaluator HIGH 反映、本番で silent skip リスクを排除 |
| `senderEmail` 空文字列フォールバック | spec §4.1.1 で env-sourced 設計のため、Phase 5 API レイヤで env 値で上書き予定 |

## Quality Gate

- ✅ `/safe-refactor`: HIGH 0 / MEDIUM 0 / LOW 2 (型キャスト cosmetic、残置可)
- ✅ Evaluator 分離プロトコル (5+ ファイル変更 + 新機能):
  - HIGH `env silent skip` → K_SERVICE 検出で fail loud に修正
  - MEDIUM `markSent TOCTOU` → runTransaction で保護
- ✅ `/code-review medium`: PLAUSIBLE 4 件のうち 3 件反映 (acquireRunLock コメント / senderEmail コメント / factory in-memory env 任意化)、1 件 (role hard-code) は別 Issue 候補
- ✅ Test: dispatch **308/308 PASS** (Phase 4 末 271 件 → +37 件)
- ✅ API workspace 全体 **1362/1362 PASS**
- ✅ Type check: clean (全 workspace)
- ✅ Lint: clean (1 件 pre-existing warning は web 側、本 PR 無関係)

## AC ↔ Phase 7-A マッピング

| AC | 内容 | 達成状況 |
|---|---|---|
| FR-7 改訂 | Reservation 方式 (runTransaction で create/update) | ✅ |
| FR-11 | Run lock (super_dispatch_runs) | ✅ best-effort、Phase 7-B index 追加で強化 |
| FR-12 | snapshot (courseIdsSnapshot / publishedCourseCount / progressSnapshot) | ✅ |
| NFR-3 改訂 | atomicity (reservation の RMW は atomic transaction) | ✅ |
| NFR-11 | PII sanitize (caller 責務) | ✅ |
| Production wiring | env 切替で Firestore/InMemory 選択可 | ✅ |
| Graceful degradation | Cloud Run = fail loud / それ以外 = warn + skip | ✅ |
| production-data-safety.md §1 | sanitizeForUpdate で undefined 保護 | ✅ |
| error-handling.md §1 | audit log は best-effort (例外伝播禁止) | ✅ |

## Phase 7-B 残作業 (本 PR 範囲外)

別 PR + 開発者の番号単位明示認可で対応:

1. Cloud Scheduler job 作成 (`0 * * * *` + `time-zone=Asia/Tokyo` + OIDC token)
2. Cloud Run env 設定 (`DXCOLLEGE_SENDER_EMAIL` / `DXCOLLEGE_DISPATCH_SUBJECT` / `DISPATCH_OIDC_AUDIENCE`)
3. Firestore TTL Policy (`super_dispatch_audit_logs.ttlExpireAt` + `super_dispatch_runs.ttlExpireAt`)
4. Firestore composite index (`super_dispatch_runs.status + leaseExpiresAt`)
5. Cloud Scheduler SA 作成 + Cloud Run invoker 権限付与
6. `deploy.yml` 更新 (env 追加分)

## Test plan

- [x] `npm run lint` clean
- [x] `npm run type-check` clean (全 workspace)
- [x] `npm test` 全 PASS (API 1362 / web 161)
- [x] dispatch テスト 308/308 PASS
- [x] FirestoreDispatchStorage の 25 件 mock-based テスト (path / Timestamp 変換 / transaction 使用 / sanitize / best-effort audit)
- [x] FirestoreTenantDataLoader の 9 件テスト (tenant 列挙 / CC 設定 / view 提供)
- [x] factory の 9 件テスト (env validation / in-memory 切替 / production モード)
- [x] index.ts wiring が既存 router マウントを破壊しないこと確認 (API workspace 1362 件 PASS)
- [ ] **マージ後 Phase 7-B 着手前**: Cloud Run へ env 未設定でデプロイ → サーバ起動失敗 (fail loud) を staging で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)