### PR TITLE
feat(dispatch): Phase 7-B code-only (deploy env + firestore index)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,9 +91,19 @@ jobs:
           # PDF object は master lesson prefix (lessons/{masterLessonId}/...) で管理し、
           # tenant 配信は Firestore メタ (pdfGcsPath) のディープコピーで分離する。
           # 2026-05-17 にバケット作成済み + default compute SA に objectAdmin (bucket scope) 付与済み。
-          ENV_VARS="NODE_ENV=production,DEMO_ENABLED=true,AUTH_MODE=firebase,CORS_ORIGIN=https://web-3zcica5euq-an.a.run.app,GOOGLE_WORKSPACE_ADMIN_EMAIL=system@279279.net,SESSION_DURATION_MS=10800000,GCS_RESOURCE_BUCKET=lms-279-resources"
+          # DXCOLLEGE_DISPATCH_SUBJECT / DXCOLLEGE_SENDER_EMAIL: Phase 7 DXcollege 自動完了通知用
+          #   (ADR-037 案 X、SendAs alias 送信)。subject = DWD JWT impersonation 対象 (実 mailbox)、
+          #   sender = MIME From ヘッダ用 alias。spec §5/§8.2 で確定済みの固定値。
+          # DISPATCH_OIDC_AUDIENCE: Cloud Scheduler が発行する OIDC token の audience。
+          #   api Cloud Run service URL と一致させる必要があるため secret 経由 (環境ごとに異なる)。
+          #   未設定なら mount スキップ (services/api/src/index.ts の isProductionGcpRuntime で
+          #   fail loud → 設定漏れを起動時に検知)。
+          ENV_VARS="NODE_ENV=production,DEMO_ENABLED=true,AUTH_MODE=firebase,CORS_ORIGIN=https://web-3zcica5euq-an.a.run.app,GOOGLE_WORKSPACE_ADMIN_EMAIL=system@279279.net,SESSION_DURATION_MS=10800000,GCS_RESOURCE_BUCKET=lms-279-resources,DXCOLLEGE_DISPATCH_SUBJECT=system@279279.net,DXCOLLEGE_SENDER_EMAIL=dxcollege@279279.net"
           if [ -n "${{ secrets.SUPER_ADMIN_EMAILS }}" ]; then
             ENV_VARS="${ENV_VARS},SUPER_ADMIN_EMAILS=${{ secrets.SUPER_ADMIN_EMAILS }}"
+          fi
+          if [ -n "${{ secrets.DISPATCH_OIDC_AUDIENCE }}" ]; then
+            ENV_VARS="${ENV_VARS},DISPATCH_OIDC_AUDIENCE=${{ secrets.DISPATCH_OIDC_AUDIENCE }}"
           fi
           gcloud run deploy api \
             --image=${{ env.ARTIFACT_REGISTRY }}/api:${{ github.sha }} \

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -203,6 +203,14 @@
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "exitAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "super_dispatch_runs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "leaseExpiresAt", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [


### PR DESCRIPTION
## Summary

DXcollege 自動完了通知システム **Phase 7-B のうち code-only 部分** を実装。Phase 7-A (#471) で完成した Firestore impl + production wiring の本番デプロイ準備として、env 注入と composite index 定義を追加する。

## 変更内容

### `.github/workflows/deploy.yml`

ENV_VARS に Phase 7 完了通知用の固定値 2 件を追加:
- `DXCOLLEGE_DISPATCH_SUBJECT=system@279279.net` (DWD JWT impersonation 実 mailbox)
- `DXCOLLEGE_SENDER_EMAIL=dxcollege@279279.net` (MIME From ヘッダ用 SendAs alias)

`DISPATCH_OIDC_AUDIENCE` は secret 経由で conditional 設定 (api Cloud Run service URL は環境ごとに異なるため):
- 既存 `secrets.SUPER_ADMIN_EMAILS` と同パターン
- 未設定なら router mount スキップ → 本番 GCP runtime で `isProductionGcpRuntime()` 経由で fail loud (設定漏れを起動時に検知)

### `firestore.indexes.json`

`super_dispatch_runs` に composite index `(status ASC, leaseExpiresAt ASC)` 追加:
- 設計仕様書 §6.3 / impl-plan §8.1 で要求
- Phase 7-B infra 適用時に `firebase deploy --only firestore:indexes` で deploy
- 現状の `FirestoreDispatchStorage.acquireRunLock` は単一 where + アプリ側 lease 判定で fallback 中。本 index 配備後に `.where(leaseExpiresAt > now).limit(1)` へ最適化 (別 PR)

## Phase 7-B 残作業 (本 PR 範囲外、番号単位明示認可必須)

gcloud commands での destructive 操作:

1. **Cloud Scheduler job 作成** (`0 * * * *` + `Asia/Tokyo` + OIDC token)
2. **Cloud Scheduler SA 作成 + Cloud Run invoker 権限付与**
3. **Cloud Run env 設定** (`gcloud run services update` + `secrets DISPATCH_OIDC_AUDIENCE` 登録)
4. **Firestore TTL Policy 設定** (`super_dispatch_audit_logs.ttlExpireAt` + `super_dispatch_runs.ttlExpireAt`)
5. **Firestore composite index deploy** (`firebase deploy --only firestore:indexes` 手動実行、CI/CD 範囲外)

これらは本 PR merge 後、開発者の番号単位明示認可で個別実行する。

## Test plan

- [x] `firestore.indexes.json`: jq で valid JSON 確認
- [x] `deploy.yml`: grep で env 追加内容確認、既存 `SUPER_ADMIN_EMAILS` パターン踏襲
- [x] 既存 CI への影響なし (workflow ファイルの env_vars 追加のみ、ロジック変更なし)
- [ ] **マージ後 Phase 7-B 着手前**: dev 環境で `firebase deploy --only firestore:indexes` による index 作成完了 (数分待機) を確認
- [ ] **secret 登録後**: `secrets.DISPATCH_OIDC_AUDIENCE` 登録 + 再 deploy で api Cloud Run の env に反映されることを `gcloud run services describe api` で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)