### PR TITLE
fix(web): スーパー管理者バナーの戻るリンク修正 + UI 改善

### DIFF
--- a/web/app/[tenant]/layout.tsx
+++ b/web/app/[tenant]/layout.tsx
@@ -110,13 +110,19 @@ function TenantLayoutInner({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* スーパー管理者アクセスバナー */}
+      {/* スーパー管理者アクセスバナー (broken link /super-admin → /super/tenants へ修正、開発者要望) */}
       {isSuperAdminAccess && (
-        <div className="bg-red-100 border-b border-red-300 text-red-800 text-center py-2 text-sm">
-          スーパー管理者としてアクセス中 -{" "}
-          <Link href="/super-admin" className="underline font-medium">
-            スーパー管理画面に戻る
-          </Link>
+        <div className="bg-red-100 border-b border-red-300 text-red-800 py-2 text-sm">
+          <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4">
+            <span>スーパー管理者としてアクセス中</span>
+            <Link
+              href="/super/tenants"
+              className="inline-flex items-center gap-1 rounded-md border border-red-400 bg-white px-3 py-1 font-medium text-red-800 hover:bg-red-50 transition"
+              aria-label="スーパー管理者ページに戻る"
+            >
+              ← スーパー管理者ページに戻る
+            </Link>
+          </div>
         </div>
       )}
       {/* デモモードバナー */}


### PR DESCRIPTION
## Summary

開発者要望に応じて、スーパー管理者がテナント管理ページに移動した後にスーパー管理者ページへ戻る UI の不具合を修正 + 視認性改善。

## 既存不具合

`web/app/[tenant]/layout.tsx` 117 行目のバナーが指す `/super-admin` ルートは存在しない（実際のスーパー管理者ページは `/super` 配下）。クリックすると 404 になっていた可能性が高い。

## 修正内容

1. **リンク先修正**: `/super-admin` (404) → `/super/tenants` (スーパー管理者ナビの最初の有効ページ)
2. **UI 改善**: テキストリンクからボタン風スタイル (`← スーパー管理者ページに戻る` + 白背景 + 角丸 + ホバー強調) に変更し視認性向上
3. **アクセシビリティ**: ARIA label 追加

## 表示条件

- `isSuperAdminAccess === true` (バックエンドが `/auth/me` で返す flag、tenant-auth middleware で設定)
- 表示場所: 全テナント配下ページ (`/[tenant]/...`) の上部バナー (red ハイライト)
- スーパー管理者がテナント管理者ページ・受講者ページ等を訪問した際に常に表示

## 関連: スケジュール設定可能性 (Phase 7 補足)

別途の質問「Cloud Scheduler のタイミングは設定可能か」については、設計仕様書および本セッションで完成した Phase 7 で **Yes**:
- `super_dispatch_settings/global` doc に `scheduleDaysOfWeek: number[]` + `scheduleHourJst: number` を保存
- Phase 5 (Super admin API) + Phase 6 (UI) で編集 UI を提供予定
- Cloud Scheduler は毎時 0 分に api を起動するだけで、api 側で DB 設定の曜日・時刻と JST 現在時刻を照合 (`shouldRunNow()`) し、一致しない場合は emptyResponse 即返却

## Test plan

- [x] `npm run type-check` 全 workspace PASS
- [x] `npm run lint` clean (1 件 pre-existing warning は本 PR 無関係)
- [x] `npm test` web 161/161 PASS
- [ ] **マージ後 dev 環境で実機確認**: 開発者アカウントでログイン後、テナント管理者ページにアクセスして上部バナーの「← スーパー管理者ページに戻る」ボタンが `/super/tenants` に正しく遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)