### PR TITLE
feat(ops): 孤児 Auth 掃除の週次 dry-run 自動化 + 通知 (#276 GCIP 独立部分)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Run tests
         run: npm run test -w @lms-279/api
 
+      - name: Run script smoke tests
+        run: npm run test:scripts
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-orphan-auth-users.yml
+++ b/.github/workflows/cleanup-orphan-auth-users.yml
@@ -1,0 +1,167 @@
+name: Cleanup Orphan Auth Users
+
+# Issue #276 GCIP 独立部分: 孤児 Firebase Auth ユーザー掃除の定期実行 + 通知。
+#
+# 背景:
+#   OAuth 同意画面 External 化（ADR-031 Phase 1）により全世界の Google ユーザーが
+#   Firebase Auth レコードを作成可能。allowed_emails で認可しているため実害はないが、
+#   未所属（孤児）ユーザーが長期蓄積する。scripts/cleanup-orphan-auth-users.ts が
+#   allowed_emails / users いずれにも無いユーザーを安全に検出・削除する。
+#
+# 実行モード:
+#   - schedule（週次）: 常に dry-run。孤児が検出されたら job を失敗させ、GitHub 標準の
+#     スケジュール失敗通知で開発者に知らせる（human-in-loop）。無人での削除は行わない。
+#   - workflow_dispatch（手動）: execute=true で実削除。dry-run 既定。
+#
+# 安全機構（スクリプト側）:
+#   - dry-run 既定（--execute で apply）
+#   - tenants 空 / 取得メール 0 件で中断（全 Auth 誤削除防止）
+#   - min-age（既定 3600 秒）未満は対象外（ログイン直後の誤削除防止）
+#   - disabled はデフォルトスキップ
+#   - 連続失敗閾値で中断 + 削除前バックアップ JSON
+#
+# スコープ外（継続 postponed）:
+#   GCIP Tenant 配下ユーザーの掃除は ADR-031 Phase 3（GCIP 移行本体）完了後に対応。
+#   本スクリプトは getAuth() デフォルトインスタンスのみ対象（Issue #276 コメント参照）。
+#
+# セキュリティ: workflow_dispatch 入力はすべて env 経由で受け、run: 内で直接 ${{ inputs.* }}
+# を補間しない（command injection 対策）。
+# 参考: https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+
+on:
+  schedule:
+    # 毎週月曜 18:37 UTC（火曜 03:37 JST）。HH:00 を避け遅延を低減。
+    - cron: '37 18 * * 1'
+  workflow_dispatch:
+    inputs:
+      execute:
+        description: '実削除モード（false=dry-run / true=apply）。schedule では常に dry-run。'
+        type: boolean
+        default: false
+      min_age_seconds:
+        description: '削除対象の最小経過秒数（既定 3600、最小 60）'
+        required: false
+        default: '3600'
+        type: string
+      include_disabled:
+        description: 'disabled ユーザーも対象に含める（既定スキップ）'
+        type: boolean
+        default: false
+      fail_streak:
+        description: '連続失敗中断閾値（既定 3、最小 1）'
+        required: false
+        default: '3'
+        type: string
+
+jobs:
+  cleanup:
+    name: Cleanup
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      FIREBASE_PROJECT_ID: lms-279
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/1034821634012/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-actions@lms-279.iam.gserviceaccount.com
+
+      - name: Run cleanup script
+        env:
+          GOOGLE_CLOUD_PROJECT: lms-279
+          EVENT_NAME: ${{ github.event_name }}
+          EXECUTE: ${{ inputs.execute }}
+          MIN_AGE_SECONDS: ${{ inputs.min_age_seconds }}
+          INCLUDE_DISABLED: ${{ inputs.include_disabled }}
+          FAIL_STREAK: ${{ inputs.fail_streak }}
+        run: |
+          set -euo pipefail
+          FLAGS=()
+          # schedule では常に dry-run（無人での削除を禁止）。手動実行のみ各フラグを反映。
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$EXECUTE" = "true" ]; then FLAGS+=("--execute"); fi
+            if [ "$INCLUDE_DISABLED" = "true" ]; then FLAGS+=("--include-disabled"); fi
+            if [ -n "$MIN_AGE_SECONDS" ]; then FLAGS+=("--min-age-seconds=$MIN_AGE_SECONDS"); fi
+            if [ -n "$FAIL_STREAK" ]; then FLAGS+=("--fail-streak=$FAIL_STREAK"); fi
+          fi
+          echo "event=$EVENT_NAME flags: ${FLAGS[*]:-(none, scheduled dry-run)}"
+          npx tsx scripts/cleanup-orphan-auth-users.ts "${FLAGS[@]}"
+
+      - name: Upload result & backup artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: orphan-cleanup-${{ github.run_id }}
+          path: |
+            orphan-cleanup-result-*.json
+            orphan-cleanup-backup-*.json
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Summarize & notify on orphans
+        if: always()
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          # 1 実行につき結果 JSON は 1 件。glob 配列で取得（SC2012 回避、nullglob で未生成時は空）。
+          shopt -s nullglob
+          result_files=(orphan-cleanup-result-*.json)
+          RESULT_FILE="${result_files[0]:-}"
+          if [ -z "$RESULT_FILE" ]; then
+            {
+              echo "## 孤児 Auth 掃除"
+              echo ""
+              echo "結果 JSON が見つかりません。スクリプトが異常終了した可能性があります"
+              echo "（SAFEGUARD による中断 / 認証エラー / 削除中の連続失敗中断 等）。"
+              echo "Run ステップの実行ログで原因を確認してください。"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # 機械可読サマリから件数を抽出（jq は ubuntu-latest に同梱）
+          MODE=$(jq -r '.mode' "$RESULT_FILE")
+          ORPHANS=$(jq -r '.orphanCount' "$RESULT_FILE")
+          TOTAL=$(jq -r '.totalUsers' "$RESULT_FILE")
+          DELETED=$(jq -r '.deleted' "$RESULT_FILE")
+          FAILED=$(jq -r '.failed' "$RESULT_FILE")
+          {
+            echo "## 孤児 Auth 掃除（mode=$MODE）"
+            echo ""
+            echo "| 指標 | 件数 |"
+            echo "|------|------|"
+            echo "| Auth ユーザー総数 | $TOTAL |"
+            echo "| 孤児候補 | $ORPHANS |"
+            echo "| 削除成功 | $DELETED |"
+            echo "| 削除失敗 | $FAILED |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # schedule（無人 dry-run）で孤児を検出したら job を失敗させ、GitHub 標準の
+          # スケジュール失敗通知で開発者に知らせる（human-in-loop）。
+          # 解消するには workflow_dispatch を execute=true で手動実行する。
+          # ORPHANS が数値でない場合（JSON 破損等）は -gt 比較が set -e でハードエラーに
+          # なるため、数値ガードしてから判定する。
+          if ! [[ "$ORPHANS" =~ ^[0-9]+$ ]]; then
+            echo "::warning::orphanCount が数値ではありません（値=\"$ORPHANS\"）。結果 JSON を確認してください。"
+            exit 1
+          fi
+          if [ "$EVENT_NAME" = "schedule" ] && [ "$ORPHANS" -gt 0 ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "⚠️ 孤児 $ORPHANS 件を検出。手動で execute=true 実行による掃除を検討してください。" >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::孤児 Auth ユーザー $ORPHANS 件を検出しました（週次 dry-run）。"
+            exit 1
+          fi

--- a/scripts/__tests__/cleanup-orphan-auth-users.smoke.ts
+++ b/scripts/__tests__/cleanup-orphan-auth-users.smoke.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env npx tsx
+/**
+ * `scripts/cleanup-orphan-auth-users.ts#classifyUser` の smoke test。
+ *
+ * 位置づけ:
+ *   - scripts/ 配下は vitest workspace 対象外のため、node:assert で最低限の回帰検知。
+ *   - classifyUser は runCleanup の listUsers ループから抽出した純粋関数。
+ *     判定順序（email → disabled → creationTime NaN → min-age → 登録有無）と
+ *     境界値（min-age ±1 / 経過時間ちょうど）・異常系（null/空 email / NaN）を検証する。
+ *
+ * 実行方法:
+ *   npx tsx scripts/__tests__/cleanup-orphan-auth-users.smoke.ts
+ */
+
+import assert from "node:assert/strict";
+import {
+  classifyUser,
+  type ClassifyUserInput,
+  type ClassifyOptions,
+  type UserClassification,
+} from "../cleanup-orphan-auth-users.ts";
+
+const nowMs = Date.parse("2026-05-22T00:00:00Z");
+const MIN_AGE_SEC = 3600; // 1 時間
+
+const registeredEmails = new Set<string>(["registered@example.com"]);
+
+// 経過時間（秒）から creationTime ISO 文字列を作る
+const createdAtAgeSec = (ageSec: number): string =>
+  new Date(nowMs - ageSec * 1000).toISOString();
+
+const baseOpts: ClassifyOptions = {
+  minAgeSec: MIN_AGE_SEC,
+  includeDisabled: false,
+  nowMs,
+};
+
+// age が十分経過した（min-age 超え）正常作成時刻
+const oldEnough = createdAtAgeSec(MIN_AGE_SEC + 100);
+
+type Case = {
+  name: string;
+  user: ClassifyUserInput;
+  opts?: Partial<ClassifyOptions>;
+  expected: UserClassification;
+};
+
+const cases: Case[] = [
+  // --- 異常系: email ---
+  {
+    name: "email undefined → skip-no-email",
+    user: { email: undefined, disabled: false, creationTime: oldEnough },
+    expected: "skip-no-email",
+  },
+  {
+    name: "email 空文字 → skip-no-email",
+    user: { email: "", disabled: false, creationTime: oldEnough },
+    expected: "skip-no-email",
+  },
+  {
+    name: "email 空白のみ（trim で空）→ skip-no-email",
+    user: { email: "   ", disabled: false, creationTime: oldEnough },
+    expected: "skip-no-email",
+  },
+  // --- 判定順序: email チェックが disabled より優先 ---
+  {
+    name: "email 空 かつ disabled=true → skip-no-email（email が優先）",
+    user: { email: "", disabled: true, creationTime: oldEnough },
+    expected: "skip-no-email",
+  },
+
+  // --- disabled ---
+  {
+    name: "disabled=true, includeDisabled=false → skip-disabled",
+    user: { email: "orphan@example.com", disabled: true, creationTime: oldEnough },
+    expected: "skip-disabled",
+  },
+  {
+    name: "disabled=true, includeDisabled=true, 未登録 → orphan",
+    user: { email: "orphan@example.com", disabled: true, creationTime: oldEnough },
+    opts: { includeDisabled: true },
+    expected: "orphan",
+  },
+
+  // --- 異常系: creationTime ---
+  {
+    name: "creationTime が parse 不能 → skip-invalid-creation-time",
+    user: { email: "orphan@example.com", disabled: false, creationTime: "not-a-date" },
+    expected: "skip-invalid-creation-time",
+  },
+  {
+    name: "creationTime 空文字 → skip-invalid-creation-time",
+    user: { email: "orphan@example.com", disabled: false, creationTime: "" },
+    expected: "skip-invalid-creation-time",
+  },
+
+  // --- 境界値: min-age ---
+  {
+    name: "経過 = min-age ちょうど（< 判定なので too-young でない）→ orphan",
+    user: {
+      email: "orphan@example.com",
+      disabled: false,
+      creationTime: createdAtAgeSec(MIN_AGE_SEC),
+    },
+    expected: "orphan",
+  },
+  {
+    name: "経過 = min-age - 1 秒 → skip-too-young",
+    user: {
+      email: "orphan@example.com",
+      disabled: false,
+      creationTime: createdAtAgeSec(MIN_AGE_SEC - 1),
+    },
+    expected: "skip-too-young",
+  },
+  {
+    name: "経過 = min-age + 1 秒 → orphan",
+    user: {
+      email: "orphan@example.com",
+      disabled: false,
+      creationTime: createdAtAgeSec(MIN_AGE_SEC + 1),
+    },
+    expected: "orphan",
+  },
+
+  // --- 登録有無 ---
+  {
+    name: "登録済みメール（age ok）→ registered（保持）",
+    user: { email: "registered@example.com", disabled: false, creationTime: oldEnough },
+    expected: "registered",
+  },
+  {
+    name: "未登録メール（age ok）→ orphan",
+    user: { email: "orphan@example.com", disabled: false, creationTime: oldEnough },
+    expected: "orphan",
+  },
+  {
+    name: "登録済みメールを大文字 + 前後空白 → 正規化されて registered",
+    user: {
+      email: "  Registered@Example.COM ",
+      disabled: false,
+      creationTime: oldEnough,
+    },
+    expected: "registered",
+  },
+];
+
+let pass = 0;
+let fail = 0;
+for (const tc of cases) {
+  try {
+    const actual = classifyUser(tc.user, registeredEmails, {
+      ...baseOpts,
+      ...tc.opts,
+    });
+    assert.equal(
+      actual,
+      tc.expected,
+      `${tc.name}: expected=${tc.expected} actual=${actual}`
+    );
+    console.log(`  PASS: ${tc.name}`);
+    pass++;
+  } catch (err) {
+    console.error(`  FAIL: ${tc.name}`);
+    console.error(`    ${err instanceof Error ? err.message : err}`);
+    fail++;
+  }
+}
+
+console.log(`\n=== ${pass} passed, ${fail} failed ===`);
+if (fail > 0) process.exit(1);

--- a/scripts/cleanup-orphan-auth-users.ts
+++ b/scripts/cleanup-orphan-auth-users.ts
@@ -23,10 +23,18 @@
  *   本スクリプトは `getAuth()` のデフォルトインスタンスのみを対象とし、
  *   GCIP Tenant 配下のユーザーは対象外。feature flag `useGcip: true` のテナントに
  *   所属するユーザーは GCIP tenant auth に移動しているため、本スクリプトで孤児判定
- *   されない。Phase 3 完了時に `tenantManager().authForTenant(gcipTenantId)` 対応を
- *   追加する（Phase 5 で正式化）。
+ *   されない。Phase 3（GCIP 移行本体）完了後に `tenantManager().authForTenant(gcipTenantId)`
+ *   対応を追加する（Issue #276 の GCIP Tenant 掃除項目として継続 postponed）。
  *
- * 運用: 週次 or 月次で実行想定（Phase 5で Cloud Scheduler に正式化）
+ * 運用（Issue #276 GCIP 独立部分）:
+ *   `.github/workflows/cleanup-orphan-auth-users.yml` が週次で dry-run 自動実行する。
+ *   孤児が検出された場合は workflow が job を失敗させ、GitHub 標準のスケジュール失敗
+ *   通知で開発者に知らせる（human-in-loop）。実削除は同 workflow を workflow_dispatch +
+ *   execute=true で手動起動した場合のみ行う（無人スケジュールでは削除しない）。
+ *
+ * 結果出力:
+ *   実行ごとに `orphan-cleanup-result-<ts>.json`（孤児件数等の機械可読サマリ）を
+ *   dry-run / execute 両方で出力する。workflow はこれを読んで通知判定 + step summary に使う。
  *
  * 使用方法:
  *   # dry-run (既定)
@@ -47,8 +55,8 @@ import {
   applicationDefault,
   type ServiceAccount,
 } from "firebase-admin/app";
-import { getAuth } from "firebase-admin/auth";
-import { getFirestore } from "firebase-admin/firestore";
+import { getAuth, type Auth } from "firebase-admin/auth";
+import { getFirestore, type Firestore } from "firebase-admin/firestore";
 import { readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
 
@@ -61,79 +69,88 @@ const KNOWN_FLAGS = [
 ];
 const MIN_ALLOWED_MIN_AGE_SEC = 60;
 
-// ---------- 引数パース ----------
-const args = process.argv.slice(2);
+// テスト import 時の副作用回避: CLI 実行（引数パース・Firebase 初期化・削除）は
+// 明示エントリーポイントでのみ分岐する。純粋関数（classifyUser 等）は副作用なく import 可能。
+const isMainEntry = import.meta.url === `file://${process.argv[1]}`;
 
-// 未知フラグ検知（typo による silent failure 防止）
-const unknownArgs = args.filter(
-  (a) => !KNOWN_FLAGS.some((k) => a === k || a.startsWith(k))
-);
-if (unknownArgs.length > 0) {
-  console.error(`[FATAL] 未知のフラグ: ${unknownArgs.join(", ")}`);
-  console.error(`  既知のフラグ: ${KNOWN_FLAGS.join(" / ")}`);
-  process.exit(1);
+if (isMainEntry) {
+  void runCli();
 }
-
-const EXECUTE = args.includes("--execute");
-const INCLUDE_DISABLED = args.includes("--include-disabled");
-
-const rawMinAge = args
-  .find((a) => a.startsWith("--min-age-seconds="))
-  ?.split("=")[1];
-const MIN_AGE_SEC = rawMinAge !== undefined ? Number(rawMinAge) : 3600;
-if (!Number.isFinite(MIN_AGE_SEC) || MIN_AGE_SEC < MIN_ALLOWED_MIN_AGE_SEC) {
-  console.error(
-    `[FATAL] --min-age-seconds は${MIN_ALLOWED_MIN_AGE_SEC}以上の数値が必要です: 受け取った値="${rawMinAge}"`
-  );
-  process.exit(1);
-}
-
-const rawFailStreak = args
-  .find((a) => a.startsWith("--fail-streak="))
-  ?.split("=")[1];
-const FAIL_ABORT_STREAK =
-  rawFailStreak !== undefined ? Number(rawFailStreak) : 3;
-if (!Number.isFinite(FAIL_ABORT_STREAK) || FAIL_ABORT_STREAK < 1) {
-  console.error(
-    `[FATAL] --fail-streak は1以上の数値が必要です: 受け取った値="${rawFailStreak}"`
-  );
-  process.exit(1);
-}
-
-// ---------- Firebase初期化 ----------
-const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-try {
-  if (credPath) {
-    // ServiceAccount JSON は絶対パスまたは CWD 基準で解決
-    const jsonPath = resolve(process.cwd(), credPath);
-    const serviceAccount = JSON.parse(
-      readFileSync(jsonPath, "utf8")
-    ) as ServiceAccount;
-    initializeApp({ credential: cert(serviceAccount) });
-    console.log(`認証: サービスアカウントJSON (${jsonPath})`);
-  } else {
-    initializeApp({ credential: applicationDefault() });
-    console.log("認証: Application Default Credentials");
-  }
-} catch (err) {
-  console.error(
-    `[FATAL] Firebase初期化失敗 (credPath=${credPath ?? "ADC"}): ${
-      err instanceof Error ? err.message : err
-    }`
-  );
-  process.exit(1);
-}
-
-const db = getFirestore();
-const auth = getAuth();
 
 // ---------- ユーティリティ ----------
 // アプリ側（tenant-auth.ts）は toLowerCase のみだが、掃除時は誤判定防止のため trim も実施
-const normalizeEmail = (email: string | undefined): string =>
+export const normalizeEmail = (email: string | undefined): string =>
   (email ?? "").trim().toLowerCase();
 
+// ---------- 孤児判定（純粋関数: smoke test 対象） ----------
+export type UserClassification =
+  | "orphan" // 登録なし → 削除候補
+  | "registered" // allowed_emails / users に登録あり → 保持
+  | "skip-no-email" // email 欠落
+  | "skip-disabled" // disabled（include 指定なし）
+  | "skip-too-young" // 経過時間が min-age 未満
+  | "skip-invalid-creation-time"; // creationTime が parse 不能
+
+export interface ClassifyUserInput {
+  email: string | undefined;
+  disabled: boolean;
+  creationTime: string; // Firebase user.metadata.creationTime
+}
+
+export interface ClassifyOptions {
+  minAgeSec: number;
+  includeDisabled: boolean;
+  nowMs: number;
+}
+
+/**
+ * 1 ユーザーを孤児/保持/各種スキップに分類する。
+ * runCleanup() の listUsers ループから抽出した純粋関数（副作用なし）。
+ * 判定順序は元実装と同一（email → disabled → creationTime NaN → min-age → 登録有無）。
+ */
+export function classifyUser(
+  user: ClassifyUserInput,
+  registeredEmails: Set<string>,
+  opts: ClassifyOptions
+): UserClassification {
+  const email = normalizeEmail(user.email);
+  if (!email) return "skip-no-email";
+  if (user.disabled && !opts.includeDisabled) return "skip-disabled";
+  const createdMs = new Date(user.creationTime).getTime();
+  if (!Number.isFinite(createdMs)) return "skip-invalid-creation-time";
+  const ageSec = (opts.nowMs - createdMs) / 1000;
+  if (ageSec < opts.minAgeSec) return "skip-too-young";
+  return registeredEmails.has(email) ? "registered" : "orphan";
+}
+
+// ---------- 結果サマリ（機械可読、workflow が読む） ----------
+export interface CleanupResult {
+  mode: "dry-run" | "execute";
+  timestamp: string;
+  totalUsers: number;
+  registeredEmails: number;
+  orphanCount: number;
+  skipped: {
+    noEmail: number;
+    disabled: number;
+    tooYoung: number;
+    invalidCreationTime: number;
+  };
+  deleted: number;
+  failed: number;
+}
+
+// 機械可読サマリを出力（workflow が orphanCount を読んで通知判定 + step summary に使う）
+function writeResultJson(result: CleanupResult): void {
+  const path = `orphan-cleanup-result-${Date.now()}.json`;
+  writeFileSync(path, JSON.stringify(result, null, 2));
+  console.log(`\n結果サマリJSON保存: ${path}`);
+}
+
 // ---------- 集約 ----------
-async function collectAllowedAndRegisteredEmails(): Promise<Set<string>> {
+async function collectAllowedAndRegisteredEmails(
+  db: Firestore
+): Promise<Set<string>> {
   const emails = new Set<string>();
   const tenantsSnap = await db.collection("tenants").get();
 
@@ -184,16 +201,28 @@ async function collectAllowedAndRegisteredEmails(): Promise<Set<string>> {
   return emails;
 }
 
+// ---------- 削除実行の依存（CLI から注入。テストでは未使用） ----------
+interface CleanupDeps {
+  auth: Auth;
+  db: Firestore;
+  execute: boolean;
+  includeDisabled: boolean;
+  minAgeSec: number;
+  failAbortStreak: number;
+}
+
 // ---------- 走査 ----------
-async function main() {
+async function runCleanup(deps: CleanupDeps): Promise<void> {
+  const { auth, db, execute, includeDisabled, minAgeSec, failAbortStreak } =
+    deps;
   console.log("=== 孤児Firebase Authユーザー掃除 ===");
-  console.log(`モード: ${EXECUTE ? "EXECUTE（実削除）" : "DRY-RUN（レポートのみ）"}`);
-  console.log(`最小経過時間: ${MIN_AGE_SEC}秒`);
-  console.log(`disabled扱い: ${INCLUDE_DISABLED ? "含める" : "スキップ"}`);
-  console.log(`連続失敗中断閾値: ${FAIL_ABORT_STREAK}件\n`);
+  console.log(`モード: ${execute ? "EXECUTE（実削除）" : "DRY-RUN（レポートのみ）"}`);
+  console.log(`最小経過時間: ${minAgeSec}秒`);
+  console.log(`disabled扱い: ${includeDisabled ? "含める" : "スキップ"}`);
+  console.log(`連続失敗中断閾値: ${failAbortStreak}件\n`);
 
   console.log("テナント内 allowed_emails + users を集約中...");
-  const registeredEmails = await collectAllowedAndRegisteredEmails();
+  const registeredEmails = await collectAllowedAndRegisteredEmails(db);
   console.log(`登録済みメール数: ${registeredEmails.size}\n`);
 
   console.log("Firebase Auth ユーザー一覧を走査中...");
@@ -211,47 +240,53 @@ async function main() {
   let skippedInvalidCreationTime = 0;
   let nextPageToken: string | undefined;
 
+  // nowMs は走査開始時点で固定（min-age 判定の基準を全ユーザーで揃える）
+  const nowMs = Date.now();
+
   do {
     const listResult = await auth.listUsers(1000, nextPageToken);
     nextPageToken = listResult.pageToken;
     for (const user of listResult.users) {
       totalUsers++;
 
-      const email = normalizeEmail(user.email);
-      if (!email) {
-        skippedNoEmail++;
-        continue;
-      }
-
-      if (user.disabled && !INCLUDE_DISABLED) {
-        skippedDisabled++;
-        continue;
-      }
-
-      // SAFEGUARD 3: creationTime の NaN チェック（min-age バイパス防止）
-      const createdMs = new Date(user.metadata.creationTime).getTime();
-      if (!Number.isFinite(createdMs)) {
-        console.warn(
-          `  警告: ${user.uid} の creationTime が不正: ${user.metadata.creationTime}`
-        );
-        skippedInvalidCreationTime++;
-        continue;
-      }
-
-      const ageSec = (Date.now() - createdMs) / 1000;
-      if (ageSec < MIN_AGE_SEC) {
-        skippedTooYoung++;
-        continue;
-      }
-
-      if (!registeredEmails.has(email)) {
-        orphans.push({
-          uid: user.uid,
-          email,
-          createdMs,
-          providers: user.providerData.map((p) => p.providerId),
+      const classification = classifyUser(
+        {
+          email: user.email,
           disabled: user.disabled,
-        });
+          creationTime: user.metadata.creationTime,
+        },
+        registeredEmails,
+        { minAgeSec, includeDisabled, nowMs }
+      );
+
+      switch (classification) {
+        case "skip-no-email":
+          skippedNoEmail++;
+          break;
+        case "skip-disabled":
+          skippedDisabled++;
+          break;
+        case "skip-invalid-creation-time":
+          // SAFEGUARD 3: creationTime の NaN チェック（min-age バイパス防止）
+          console.warn(
+            `  警告: ${user.uid} の creationTime が不正: ${user.metadata.creationTime}`
+          );
+          skippedInvalidCreationTime++;
+          break;
+        case "skip-too-young":
+          skippedTooYoung++;
+          break;
+        case "orphan":
+          orphans.push({
+            uid: user.uid,
+            email: normalizeEmail(user.email),
+            createdMs: new Date(user.metadata.creationTime).getTime(),
+            providers: user.providerData.map((p) => p.providerId),
+            disabled: user.disabled,
+          });
+          break;
+        case "registered":
+          break; // 登録あり → 保持
       }
     }
   } while (nextPageToken);
@@ -263,8 +298,25 @@ async function main() {
   console.log(`  スキップ(creationTime不正): ${skippedInvalidCreationTime}`);
   console.log(`  孤児候補: ${orphans.length}\n`);
 
+  const skipped = {
+    noEmail: skippedNoEmail,
+    disabled: skippedDisabled,
+    tooYoung: skippedTooYoung,
+    invalidCreationTime: skippedInvalidCreationTime,
+  };
+
   if (orphans.length === 0) {
     console.log("掃除対象なし。終了。");
+    writeResultJson({
+      mode: execute ? "execute" : "dry-run",
+      timestamp: new Date().toISOString(),
+      totalUsers,
+      registeredEmails: registeredEmails.size,
+      orphanCount: 0,
+      skipped,
+      deleted: 0,
+      failed: 0,
+    });
     return;
   }
 
@@ -276,10 +328,20 @@ async function main() {
     );
   }
 
-  if (!EXECUTE) {
+  if (!execute) {
     console.log(
       "\n※ dry-run モードのため削除は実行しません。--execute で実削除します。"
     );
+    writeResultJson({
+      mode: "dry-run",
+      timestamp: new Date().toISOString(),
+      totalUsers,
+      registeredEmails: registeredEmails.size,
+      orphanCount: orphans.length,
+      skipped,
+      deleted: 0,
+      failed: 0,
+    });
     return;
   }
 
@@ -321,9 +383,9 @@ async function main() {
         `  削除失敗[${code ?? "unknown"}]: ${o.uid} (${o.email})`,
         err
       );
-      if (consecutiveFailures >= FAIL_ABORT_STREAK) {
+      if (consecutiveFailures >= failAbortStreak) {
         throw new Error(
-          `${FAIL_ABORT_STREAK}件連続失敗のため中断（バックアップ: ${backupPath}）`
+          `${failAbortStreak}件連続失敗のため中断（バックアップ: ${backupPath}）`
         );
       }
     }
@@ -334,15 +396,114 @@ async function main() {
     console.log(`\n=== 削除失敗UID一覧（再試行用）===`);
     failedUids.forEach((uid) => console.log(`  ${uid}`));
   }
+
+  writeResultJson({
+    mode: "execute",
+    timestamp: new Date().toISOString(),
+    totalUsers,
+    registeredEmails: registeredEmails.size,
+    orphanCount: orphans.length,
+    skipped,
+    deleted,
+    failed,
+  });
 }
 
-main().catch((err) => {
-  console.error("[FATAL] 孤児Authユーザー掃除が失敗しました");
-  console.error(
-    `  message: ${err instanceof Error ? err.message : String(err)}`
+// ---------- CLI エントリーポイント ----------
+async function runCli(): Promise<void> {
+  // 引数パース
+  const args = process.argv.slice(2);
+
+  // 未知フラグ検知（typo による silent failure 防止）
+  const unknownArgs = args.filter(
+    (a) => !KNOWN_FLAGS.some((k) => a === k || a.startsWith(k))
   );
-  if (err instanceof Error && err.stack) {
-    console.error(`  stack: ${err.stack}`);
+  if (unknownArgs.length > 0) {
+    console.error(`[FATAL] 未知のフラグ: ${unknownArgs.join(", ")}`);
+    console.error(`  既知のフラグ: ${KNOWN_FLAGS.join(" / ")}`);
+    process.exit(1);
   }
-  process.exit(1);
-});
+
+  const execute = args.includes("--execute");
+  const includeDisabled = args.includes("--include-disabled");
+
+  const rawMinAge = args
+    .find((a) => a.startsWith("--min-age-seconds="))
+    ?.split("=")[1];
+  const minAgeSec = rawMinAge !== undefined ? Number(rawMinAge) : 3600;
+  if (!Number.isFinite(minAgeSec) || minAgeSec < MIN_ALLOWED_MIN_AGE_SEC) {
+    console.error(
+      `[FATAL] --min-age-seconds は${MIN_ALLOWED_MIN_AGE_SEC}以上の数値が必要です: 受け取った値="${rawMinAge}"`
+    );
+    process.exit(1);
+  }
+
+  const rawFailStreak = args
+    .find((a) => a.startsWith("--fail-streak="))
+    ?.split("=")[1];
+  const failAbortStreak =
+    rawFailStreak !== undefined ? Number(rawFailStreak) : 3;
+  if (!Number.isFinite(failAbortStreak) || failAbortStreak < 1) {
+    console.error(
+      `[FATAL] --fail-streak は1以上の数値が必要です: 受け取った値="${rawFailStreak}"`
+    );
+    process.exit(1);
+  }
+
+  // Firebase 初期化
+  // GOOGLE_APPLICATION_CREDENTIALS には以下のいずれかが入り得る:
+  //   1. type=service_account の JSON（ローカル開発時のサービスアカウントキー）→ cert() で初期化
+  //   2. type=external_account の JSON（GitHub Actions WIF 経由）→ applicationDefault() で初期化
+  // type を読まずに cert() を使うと WIF JSON で "project_id" property エラーになる
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  try {
+    if (credPath) {
+      const jsonPath = resolve(process.cwd(), credPath);
+      const credJson = JSON.parse(readFileSync(jsonPath, "utf8")) as {
+        type?: string;
+      };
+      if (credJson.type === "service_account") {
+        initializeApp({ credential: cert(credJson as ServiceAccount) });
+        console.log(`認証: サービスアカウントJSON (${jsonPath})`);
+      } else {
+        // External Account (WIF) は ADC 経由で初期化する
+        initializeApp({ credential: applicationDefault() });
+        console.log(
+          `認証: Application Default Credentials (cred file type=${
+            credJson.type ?? "unknown"
+          })`
+        );
+      }
+    } else {
+      initializeApp({ credential: applicationDefault() });
+      console.log("認証: Application Default Credentials");
+    }
+  } catch (err) {
+    console.error(
+      `[FATAL] Firebase初期化失敗 (credPath=${credPath ?? "ADC"}): ${
+        err instanceof Error ? err.message : err
+      }`
+    );
+    process.exit(1);
+  }
+
+  try {
+    await runCleanup({
+      auth: getAuth(),
+      db: getFirestore(),
+      execute,
+      includeDisabled,
+      minAgeSec,
+      failAbortStreak,
+    });
+  } catch (err) {
+    console.error("[FATAL] 孤児Authユーザー掃除が失敗しました");
+    console.error(
+      `  message: ${err instanceof Error ? err.message : String(err)}`
+    );
+    if (err instanceof Error && err.stack) {
+      console.error(`  stack: ${err.stack}`);
+    }
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

Issue #276 のうち **GCIP 移行に依存しない部分**（既存 `cleanup-orphan-auth-users.ts` の定期実行 + 通知）を実装。GCIP Tenant 配下ユーザーの掃除は ADR-031 Phase 3 完了待ちで継続 postponed（再開条件の前提が未充足。下記参照）。

- **週次 dry-run 自動化**: `cleanup-orphan-auth-users.yml`（GitHub Actions `schedule:` cron, Mon 18:37 UTC）。既存 admin workflow 群（cleanup-stuck / audit-*）と同じ WIF + CI SA パターン
- **通知（human-in-loop）**: scheduled dry-run で孤児を検出したら job を失敗させ、GitHub 標準のスケジュール失敗通知で開発者に知らせる。実削除は `workflow_dispatch` + `execute=true` の手動起動のみ（無人での destructive 削除は行わない）
- **スクリプト改修**: 孤児判定を純粋関数 `classifyUser` に抽出（挙動不変）/ `isMainEntry` ガードで test import の副作用排除 / **WIF external_account 対応の init 修正**（従来 `cert()` 固定で WIF workflow では init 失敗していた）/ 結果サマリ JSON 常時出力
- **テスト**: `classifyUser` の smoke テスト 14 ケース（境界値・異常系）+ ci.yml に `test:scripts` を追加し全 smoke テストを CI 保護

## なぜ「GCIP 独立部分のみ」か

#276 の再開条件は「Issue #272 の Phase 3 close」。#272 は CLOSED だが、close 理由は「緊急対応スコープ達成」であり **Phase 3（GCIP 移行本体）は完了ではなく延期**（残事項 C、再評価 2026-10-24）。コードも `useGcip` default=false の pre-canary 状態。よって GCIP Tenant 掃除は着手不可とし、GCIP に依存しない自動実行 + 通知のみを本 PR で実装。

## 設計判断（開発者承認済み）

| 判断 | 決定 | 理由 |
|------|------|------|
| 実行基盤 | GitHub Actions `schedule:` | 既存 6 workflow と同パターン、新規インフラ不要（Issue 本文の「Cloud Scheduler」は当該 workflow 群整備前の記述） |
| 無人削除 | dry-run + 通知（human-in-loop） | 無人での destructive 削除を回避 |

## Test plan

- [x] `npm run lint` → 0 errors（既存 warning 1 件は無関係な web/）
- [x] `npm run type-check` → 全 workspace PASS
- [x] `npm run test:scripts` → 全 smoke PASS（新規 classifyUser 14 ケース含む）
- [x] `actionlint` → 両 workflow clean
- [x] runCli 引数検証パス実行（未知フラグ / min-age 異常値 → exit 1）
- [ ] **マージ後**: `cleanup-orphan-auth-users.yml` を workflow_dispatch（dry-run）で手動実行し、WIF init 修正 + listUsers + 結果 JSON 出力 + step summary の full path を実機検証（本番 Firebase アクセスはローカル不可のため、CI workflow が検証経路）

## 既知の制約（本 PR では未対応）

- `isMainEntry` は全 sibling と同じ `file://${process.argv[1]}` 文字列比較。空白/非 ASCII を含むパスで no-op になりうるが、CI runner / 実行環境は該当せず fail-safe（no-op = 破壊なし）。修正するなら sibling 横断で別途。

Refs #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)