### PR TITLE
feat(dispatch): Phase 6 PR-F1 完了通知 配信設定ページ (core UI)

### DIFF
--- a/web/app/super/dispatch-settings/__tests__/page.test.tsx
+++ b/web/app/super/dispatch-settings/__tests__/page.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * DispatchSettingsPage (Phase 6 PR-F1) のテスト。
+ * - 初期 GET で値ロード + フォーム表示
+ * - 保存で PUT 呼び出し + 成功表示
+ * - 409 (version 競合) で再 GET + 警告表示 (AC-23)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import type { GetDispatchSettingsResponse } from "@lms-279/shared-types";
+import { ApiError } from "@/lib/api";
+import DispatchSettingsPage from "../page";
+
+const superFetchMock = vi.fn();
+vi.mock("@/lib/super-api", () => ({
+  useSuperAdminFetch: () => ({ superFetch: superFetchMock }),
+}));
+
+const baseSettings: GetDispatchSettingsResponse = {
+  enabled: false,
+  scheduleDaysOfWeek: [1, 4],
+  scheduleHourJst: 9,
+  signatureName: "DXcollege運営スタッフ",
+  completionMessageBody: "受講お疲れ様でした。",
+  senderEmail: "dxcollege@279279.net",
+  updatedAt: "2026-05-22T01:00:00.000Z",
+  updatedBy: "admin@example.com",
+  version: 3,
+};
+
+beforeEach(() => {
+  superFetchMock.mockReset();
+});
+
+describe("DispatchSettingsPage", () => {
+  it("初期 GET で設定をロードしフォームを表示する", async () => {
+    superFetchMock.mockResolvedValueOnce(baseSettings);
+    render(<DispatchSettingsPage />);
+    expect(
+      await screen.findByDisplayValue("DXcollege運営スタッフ"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("dxcollege@279279.net")).toBeInTheDocument();
+    expect(screen.getByText("version 3")).toBeInTheDocument();
+  });
+
+  it("保存で version 付き PUT を呼び、成功メッセージを出す", async () => {
+    superFetchMock
+      .mockResolvedValueOnce(baseSettings) // GET
+      .mockResolvedValueOnce({ ...baseSettings, version: 4 }); // PUT
+    render(<DispatchSettingsPage />);
+    await screen.findByDisplayValue("DXcollege運営スタッフ");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    });
+
+    await waitFor(() =>
+      expect(superFetchMock).toHaveBeenCalledWith(
+        "/api/v2/super/dispatch/settings",
+        expect.objectContaining({ method: "PUT" }),
+      ),
+    );
+    const putCall = superFetchMock.mock.calls.find((c) => c[1]?.method === "PUT");
+    expect(JSON.parse(putCall![1].body)).toMatchObject({ version: 3 });
+    expect(await screen.findByText("保存しました。")).toBeInTheDocument();
+    expect(screen.getByText("version 4")).toBeInTheDocument();
+  });
+
+  it("409 で最新値を再 GET し警告を出す (AC-23)", async () => {
+    superFetchMock
+      .mockResolvedValueOnce(baseSettings) // 初回 GET
+      .mockRejectedValueOnce(new ApiError(409, "version_conflict", "conflict")) // PUT
+      .mockResolvedValueOnce({ ...baseSettings, version: 9 }); // 再 GET
+    render(<DispatchSettingsPage />);
+    await screen.findByDisplayValue("DXcollege運営スタッフ");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    });
+
+    expect(
+      await screen.findByText(/最新の値を読み込みました/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("version 9")).toBeInTheDocument();
+  });
+
+  it("GET 失敗時はエラーと再読み込みボタンを出す", async () => {
+    superFetchMock.mockRejectedValueOnce(
+      new ApiError(403, "forbidden", "no perm"),
+    );
+    render(<DispatchSettingsPage />);
+    expect(
+      await screen.findByText("この操作を行う権限がありません。"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "再読み込み" })).toBeInTheDocument();
+  });
+});

--- a/web/app/super/dispatch-settings/components/DryRunPanel.tsx
+++ b/web/app/super/dispatch-settings/components/DryRunPanel.tsx
@@ -28,6 +28,7 @@ export function DryRunPanel() {
   const runDryRun = async () => {
     setLoading(true);
     setError(null);
+    setResult(null); // 再実行時に前回結果を消し、失敗時に古い対象が残らないようにする
     try {
       const data = await superFetch<DryRunResponse>(
         "/api/v2/super/dispatch/dry-run",

--- a/web/app/super/dispatch-settings/components/DryRunPanel.tsx
+++ b/web/app/super/dispatch-settings/components/DryRunPanel.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+/**
+ * ドライラン: 次回 cron で送信される対象を取得して表示する。
+ * POST /api/v2/super/dispatch/dry-run (Gmail 送信も Reservation も行わない、AC-8)。
+ */
+
+import { useState } from "react";
+import type { DryRunResponse } from "@lms-279/shared-types";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useSuperAdminFetch } from "@/lib/super-api";
+import { getDispatchErrorMessage } from "../errorMessage";
+
+export function DryRunPanel() {
+  const { superFetch } = useSuperAdminFetch();
+  const [result, setResult] = useState<DryRunResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runDryRun = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await superFetch<DryRunResponse>(
+        "/api/v2/super/dispatch/dry-run",
+        { method: "POST" },
+      );
+      setResult(data);
+    } catch (e) {
+      setError(getDispatchErrorMessage(e, "ドライランに失敗しました"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        <Button variant="outline" onClick={runDryRun} disabled={loading}>
+          {loading ? "実行中..." : "ドライラン実行"}
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          次回配信される対象を確認します (送信はしません)。
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div className="space-y-2">
+          <p className="text-sm">
+            送信対象: <span className="font-medium">{result.wouldNotify.length}</span> 件
+            <span className="text-muted-foreground">
+              {" "}
+              (評価時刻 {new Date(result.evaluatedAt).toLocaleString("ja-JP")})
+            </span>
+          </p>
+          {result.wouldNotify.length === 0 ? (
+            <div className="rounded-md border p-4 text-center text-muted-foreground text-sm">
+              送信対象はありません
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>テナント</TableHead>
+                  <TableHead>受講者</TableHead>
+                  <TableHead>メール</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {result.wouldNotify.map((t) => (
+                  <TableRow key={`${t.tenantId}:${t.userId}`}>
+                    <TableCell>{t.tenantId}</TableCell>
+                    <TableCell>{t.userName}</TableCell>
+                    <TableCell>{t.userEmail}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/super/dispatch-settings/components/MessageBodyEditor.tsx
+++ b/web/app/super/dispatch-settings/components/MessageBodyEditor.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * 完了通知の署名・本文編集 + プレビュー。controlled component。
+ * - signatureName: 署名 (上限 100、改行・制御文字不可)
+ * - completionMessageBody: 本文 (上限 4000、LF 改行可)
+ *
+ * プレビューは completion-notification-mail.ts の組み立て (挨拶 + 本文 + 署名) を模す。
+ */
+
+import { DISPATCH_CONSTRAINTS } from "@lms-279/shared-types";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+export interface MessageBodyValue {
+  signatureName: string;
+  completionMessageBody: string;
+}
+
+interface MessageBodyEditorProps {
+  signatureName: string;
+  completionMessageBody: string;
+  onChange: (next: MessageBodyValue) => void;
+  disabled?: boolean;
+}
+
+const SIG_MAX = DISPATCH_CONSTRAINTS.SIGNATURE_NAME_MAX_LENGTH;
+const BODY_MAX = DISPATCH_CONSTRAINTS.COMPLETION_MESSAGE_BODY_MAX_LENGTH;
+
+/** signatureName は改行・制御文字を含められない (API と同条件) */
+function hasControlChar(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    if (value.charCodeAt(i) < 0x20) return true;
+  }
+  return false;
+}
+
+export function MessageBodyEditor({
+  signatureName,
+  completionMessageBody,
+  onChange,
+  disabled = false,
+}: MessageBodyEditorProps) {
+  const sigInvalid =
+    signatureName.length > SIG_MAX || hasControlChar(signatureName);
+  const bodyEmpty = completionMessageBody.trim().length === 0;
+  const bodyTooLong = completionMessageBody.length > BODY_MAX;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-3">
+        <div className="space-y-1.5">
+          <label htmlFor="signatureName" className="text-sm font-medium">
+            署名
+          </label>
+          <Input
+            id="signatureName"
+            value={signatureName}
+            disabled={disabled}
+            aria-invalid={sigInvalid}
+            maxLength={SIG_MAX + 50}
+            onChange={(e) =>
+              onChange({ signatureName: e.target.value, completionMessageBody })
+            }
+            placeholder="DXcollege運営スタッフ"
+          />
+          <div className="flex justify-between text-xs">
+            <span className="text-muted-foreground">
+              改行・制御文字は使用できません。
+            </span>
+            <span
+              className={
+                signatureName.length > SIG_MAX
+                  ? "text-destructive"
+                  : "text-muted-foreground"
+              }
+            >
+              {signatureName.length} / {SIG_MAX}
+            </span>
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="completionMessageBody" className="text-sm font-medium">
+            本文
+          </label>
+          <Textarea
+            id="completionMessageBody"
+            value={completionMessageBody}
+            disabled={disabled}
+            aria-invalid={bodyEmpty || bodyTooLong}
+            rows={8}
+            onChange={(e) =>
+              onChange({
+                signatureName,
+                completionMessageBody: e.target.value,
+              })
+            }
+            placeholder="受講お疲れ様でした。..."
+          />
+          <div className="flex justify-between text-xs">
+            <span className="text-muted-foreground">
+              改行 (LF) は使用できます。
+            </span>
+            <span
+              className={
+                bodyTooLong ? "text-destructive" : "text-muted-foreground"
+              }
+            >
+              {completionMessageBody.length} / {BODY_MAX}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <span className="text-sm font-medium">プレビュー</span>
+        <div
+          data-testid="message-preview"
+          className="rounded-md border bg-muted/30 p-3 text-sm whitespace-pre-wrap break-words min-h-40"
+        >
+          {"〇〇 様\n\n"}
+          {completionMessageBody.trimEnd()}
+          {signatureName.trim().length > 0
+            ? `\n\n---\n${signatureName}`
+            : ""}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          冒頭の宛名は受講者名で置き換わります。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/app/super/dispatch-settings/components/ScheduleEditor.tsx
+++ b/web/app/super/dispatch-settings/components/ScheduleEditor.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+/**
+ * 配信スケジュール編集 (曜日 + 時刻)。controlled component。
+ * - daysOfWeek: 0-6 (日-土) の配列。空配列なら常に skip
+ * - hourJst: 0-23 (JST、HH:00 単位)
+ */
+
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"] as const;
+
+export interface ScheduleValue {
+  daysOfWeek: number[];
+  hourJst: number;
+}
+
+interface ScheduleEditorProps {
+  daysOfWeek: number[];
+  hourJst: number;
+  onChange: (next: ScheduleValue) => void;
+  disabled?: boolean;
+}
+
+export function ScheduleEditor({
+  daysOfWeek,
+  hourJst,
+  onChange,
+  disabled = false,
+}: ScheduleEditorProps) {
+  const toggleDay = (day: number) => {
+    const set = new Set(daysOfWeek);
+    if (set.has(day)) set.delete(day);
+    else set.add(day);
+    onChange({
+      daysOfWeek: [...set].sort((a, b) => a - b),
+      hourJst,
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <span className="text-sm font-medium">配信曜日</span>
+        <div className="flex flex-wrap gap-3">
+          {DAY_LABELS.map((label, day) => (
+            <label
+              key={day}
+              className="flex items-center gap-1.5 text-sm cursor-pointer"
+            >
+              <Checkbox
+                checked={daysOfWeek.includes(day)}
+                onCheckedChange={() => toggleDay(day)}
+                disabled={disabled}
+                aria-label={`${label}曜日`}
+              />
+              <span>{label}</span>
+            </label>
+          ))}
+        </div>
+        {daysOfWeek.length === 0 && (
+          <p className="text-xs text-muted-foreground">
+            曜日が未選択のため配信されません。
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <span className="text-sm font-medium">配信時刻 (JST)</span>
+        <Select
+          value={String(hourJst)}
+          onValueChange={(v) =>
+            onChange({ daysOfWeek, hourJst: Number(v) })
+          }
+          disabled={disabled}
+        >
+          <SelectTrigger className="w-32" aria-label="配信時刻">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {Array.from({ length: 24 }, (_, h) => (
+              <SelectItem key={h} value={String(h)}>
+                {String(h).padStart(2, "0")}:00
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          選択した曜日のこの時刻台 (毎時 cron) に配信されます。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/app/super/dispatch-settings/components/TestSendButton.tsx
+++ b/web/app/super/dispatch-settings/components/TestSendButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * テスト送信: スーパー管理者自身宛に固定ダミーメールを送る (AC-9)。
+ * POST /api/v2/super/dispatch/test-send。To はサーバー側で自分の email に強制される。
+ */
+
+import { useState } from "react";
+import type { TestSendResponse } from "@lms-279/shared-types";
+import { Button } from "@/components/ui/button";
+import { useSuperAdminFetch } from "@/lib/super-api";
+import { getDispatchErrorMessage } from "../errorMessage";
+
+export function TestSendButton() {
+  const { superFetch } = useSuperAdminFetch();
+  const [result, setResult] = useState<TestSendResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const testSend = async () => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const data = await superFetch<TestSendResponse>(
+        "/api/v2/super/dispatch/test-send",
+        { method: "POST" },
+      );
+      setResult(data);
+    } catch (e) {
+      setError(getDispatchErrorMessage(e, "テスト送信に失敗しました"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        <Button variant="outline" onClick={testSend} disabled={loading}>
+          {loading ? "送信中..." : "テスト送信"}
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          固定のダミー本文をログイン中の管理者自身宛に送信します。
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300">
+          {result.sentTo} に送信しました (messageId: {result.messageId})。
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/super/dispatch-settings/components/__tests__/DryRunPanel.test.tsx
+++ b/web/app/super/dispatch-settings/components/__tests__/DryRunPanel.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * DryRunPanel (Phase 6 PR-F1) のテスト。
+ * - 実行で POST /dispatch/dry-run、対象テーブル表示 / 0 件 / エラー
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import type { DryRunResponse } from "@lms-279/shared-types";
+import { ApiError } from "@/lib/api";
+import { DryRunPanel } from "../DryRunPanel";
+
+const superFetchMock = vi.fn();
+vi.mock("@/lib/super-api", () => ({
+  useSuperAdminFetch: () => ({ superFetch: superFetchMock }),
+}));
+
+beforeEach(() => superFetchMock.mockReset());
+
+describe("DryRunPanel", () => {
+  it("対象がある場合テーブルに表示する", async () => {
+    const res: DryRunResponse = {
+      wouldNotify: [
+        {
+          tenantId: "t1",
+          userId: "u1",
+          userEmail: "u1@example.com",
+          userName: "User 1",
+          progressSnapshot: {
+            completedLessons: 2,
+            totalLessons: 2,
+            coursesCompleted: 1,
+            coursesTotal: 1,
+          },
+        },
+      ],
+      evaluatedAt: "2026-05-22T01:00:00.000Z",
+    };
+    superFetchMock.mockResolvedValueOnce(res);
+    render(<DryRunPanel />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "ドライラン実行" }));
+    });
+    await waitFor(() =>
+      expect(superFetchMock).toHaveBeenCalledWith(
+        "/api/v2/super/dispatch/dry-run",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+    expect(await screen.findByText("u1@example.com")).toBeInTheDocument();
+    expect(screen.getByText("User 1")).toBeInTheDocument();
+  });
+
+  it("0 件の場合は対象なし表示", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      wouldNotify: [],
+      evaluatedAt: "2026-05-22T01:00:00.000Z",
+    } satisfies DryRunResponse);
+    render(<DryRunPanel />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "ドライラン実行" }));
+    });
+    expect(await screen.findByText("送信対象はありません")).toBeInTheDocument();
+  });
+
+  it("エラー時はエラーメッセージ表示", async () => {
+    superFetchMock.mockRejectedValueOnce(
+      new ApiError(500, "internal", "サーバーエラー"),
+    );
+    render(<DryRunPanel />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "ドライラン実行" }));
+    });
+    expect(await screen.findByText("サーバーエラー")).toBeInTheDocument();
+  });
+});

--- a/web/app/super/dispatch-settings/components/__tests__/DryRunPanel.test.tsx
+++ b/web/app/super/dispatch-settings/components/__tests__/DryRunPanel.test.tsx
@@ -61,6 +61,40 @@ describe("DryRunPanel", () => {
     expect(await screen.findByText("送信対象はありません")).toBeInTheDocument();
   });
 
+  it("再実行が失敗したら前回の結果テーブルを消す", async () => {
+    superFetchMock
+      .mockResolvedValueOnce({
+        wouldNotify: [
+          {
+            tenantId: "t1",
+            userId: "u1",
+            userEmail: "u1@example.com",
+            userName: "User 1",
+            progressSnapshot: {
+              completedLessons: 1,
+              totalLessons: 1,
+              coursesCompleted: 1,
+              coursesTotal: 1,
+            },
+          },
+        ],
+        evaluatedAt: "2026-05-22T01:00:00.000Z",
+      } satisfies DryRunResponse)
+      .mockRejectedValueOnce(new ApiError(500, "internal", "再実行エラー"));
+    render(<DryRunPanel />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "ドライラン実行" }));
+    });
+    expect(await screen.findByText("u1@example.com")).toBeInTheDocument();
+    // 2 回目は失敗
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "ドライラン実行" }));
+    });
+    expect(await screen.findByText("再実行エラー")).toBeInTheDocument();
+    // 前回の対象テーブルは消えている
+    expect(screen.queryByText("u1@example.com")).not.toBeInTheDocument();
+  });
+
   it("エラー時はエラーメッセージ表示", async () => {
     superFetchMock.mockRejectedValueOnce(
       new ApiError(500, "internal", "サーバーエラー"),

--- a/web/app/super/dispatch-settings/components/__tests__/TestSendButton.test.tsx
+++ b/web/app/super/dispatch-settings/components/__tests__/TestSendButton.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * TestSendButton (Phase 6 PR-F1) のテスト。
+ * - 送信で POST /dispatch/test-send、成功表示 / エラー (rate_limit 等)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import type { TestSendResponse } from "@lms-279/shared-types";
+import { ApiError } from "@/lib/api";
+import { TestSendButton } from "../TestSendButton";
+
+const superFetchMock = vi.fn();
+vi.mock("@/lib/super-api", () => ({
+  useSuperAdminFetch: () => ({ superFetch: superFetchMock }),
+}));
+
+beforeEach(() => superFetchMock.mockReset());
+
+describe("TestSendButton", () => {
+  it("成功時に sentTo / messageId を表示", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      messageId: "msg-001",
+      sentTo: "admin@example.com",
+      sentAt: "2026-05-22T01:00:00.000Z",
+    } satisfies TestSendResponse);
+    render(<TestSendButton />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "テスト送信" }));
+    });
+    expect(
+      await screen.findByText(/admin@example.com に送信しました/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/msg-001/)).toBeInTheDocument();
+  });
+
+  it("レート制限エラーを表示", async () => {
+    superFetchMock.mockRejectedValueOnce(
+      new ApiError(429, "rate_limit_exceeded", "テスト送信の 1 日あたり上限に達しました。"),
+    );
+    render(<TestSendButton />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "テスト送信" }));
+    });
+    expect(
+      await screen.findByText("テスト送信の 1 日あたり上限に達しました。"),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/app/super/dispatch-settings/components/__tests__/editors.test.tsx
+++ b/web/app/super/dispatch-settings/components/__tests__/editors.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * ScheduleEditor / MessageBodyEditor (Phase 6 PR-F1) のテスト。
+ * controlled component なので onChange の呼び出し内容と表示を検証する。
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ScheduleEditor } from "../ScheduleEditor";
+import { MessageBodyEditor } from "../MessageBodyEditor";
+
+describe("ScheduleEditor", () => {
+  it("曜日チェックでトグルし sorted な配列で onChange する", () => {
+    const onChange = vi.fn();
+    render(
+      <ScheduleEditor daysOfWeek={[4]} hourJst={9} onChange={onChange} />,
+    );
+    // 月曜 (index 1) を追加
+    fireEvent.click(screen.getByLabelText("月曜日"));
+    expect(onChange).toHaveBeenCalledWith({ daysOfWeek: [1, 4], hourJst: 9 });
+  });
+
+  it("既選択の曜日をクリックすると外れる", () => {
+    const onChange = vi.fn();
+    render(
+      <ScheduleEditor daysOfWeek={[1, 4]} hourJst={9} onChange={onChange} />,
+    );
+    fireEvent.click(screen.getByLabelText("月曜日"));
+    expect(onChange).toHaveBeenCalledWith({ daysOfWeek: [4], hourJst: 9 });
+  });
+
+  it("曜日未選択時は警告を表示", () => {
+    render(<ScheduleEditor daysOfWeek={[]} hourJst={0} onChange={vi.fn()} />);
+    expect(
+      screen.getByText("曜日が未選択のため配信されません。"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("MessageBodyEditor", () => {
+  it("文字数カウンタを表示する", () => {
+    render(
+      <MessageBodyEditor
+        signatureName="運営"
+        completionMessageBody="本文"
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("2 / 100")).toBeInTheDocument();
+    expect(screen.getByText("2 / 4000")).toBeInTheDocument();
+  });
+
+  it("本文入力で onChange する", () => {
+    const onChange = vi.fn();
+    render(
+      <MessageBodyEditor
+        signatureName="運営"
+        completionMessageBody="本文"
+        onChange={onChange}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText("受講お疲れ様でした。..."), {
+      target: { value: "新本文" },
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      signatureName: "運営",
+      completionMessageBody: "新本文",
+    });
+  });
+
+  it("プレビューに本文と署名が反映される", () => {
+    render(
+      <MessageBodyEditor
+        signatureName="運営スタッフ"
+        completionMessageBody="お疲れ様でした"
+        onChange={vi.fn()}
+      />,
+    );
+    // プレビュー領域に本文 + 署名が含まれる
+    const preview = screen.getByTestId("message-preview");
+    expect(preview).toHaveTextContent("お疲れ様でした");
+    expect(preview).toHaveTextContent("運営スタッフ");
+  });
+});

--- a/web/app/super/dispatch-settings/errorMessage.ts
+++ b/web/app/super/dispatch-settings/errorMessage.ts
@@ -1,0 +1,14 @@
+import { ApiError } from "@/lib/api";
+
+/** ApiError / Error を日本語メッセージへ。401/403 は定型文 (既存 super ページと同方針)。 */
+export function getDispatchErrorMessage(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) {
+    if (e.status === 401) {
+      return "認証の有効期限が切れました。再ログインしてください。";
+    }
+    if (e.status === 403) return "この操作を行う権限がありません。";
+    return e.message || fallback;
+  }
+  if (e instanceof Error) return e.message;
+  return fallback;
+}

--- a/web/app/super/dispatch-settings/page.tsx
+++ b/web/app/super/dispatch-settings/page.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+/**
+ * スーパー管理者: 自動完了通知 配信設定ページ (Phase 6 PR-F1)。
+ *
+ * - GET /api/v2/super/dispatch/settings で初期値ロード (doc 未作成時は default)
+ * - enabled (kill switch) / スケジュール / 署名・本文を編集し PUT で保存 (version 楽観ロック)
+ * - 409 (version 競合) は最新値を再取得してフォームへ反映 + 警告 (AC-23)
+ * - ドライラン / テスト送信を実行
+ *
+ * senderEmail は env 由来 (read-only)。テナント別 CC / 監査ログ / run 履歴は PR-F2。
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  GetDispatchSettingsResponse,
+  PutDispatchSettingsRequest,
+} from "@lms-279/shared-types";
+import { ApiError } from "@/lib/api";
+import { useSuperAdminFetch } from "@/lib/super-api";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { ScheduleEditor } from "./components/ScheduleEditor";
+import { MessageBodyEditor } from "./components/MessageBodyEditor";
+import { DryRunPanel } from "./components/DryRunPanel";
+import { TestSendButton } from "./components/TestSendButton";
+import { getDispatchErrorMessage } from "./errorMessage";
+
+interface FormState {
+  enabled: boolean;
+  scheduleDaysOfWeek: number[];
+  scheduleHourJst: number;
+  signatureName: string;
+  completionMessageBody: string;
+  version: number;
+  senderEmail: string;
+}
+
+function toFormState(s: GetDispatchSettingsResponse): FormState {
+  return {
+    enabled: s.enabled,
+    scheduleDaysOfWeek: s.scheduleDaysOfWeek,
+    scheduleHourJst: s.scheduleHourJst,
+    signatureName: s.signatureName,
+    completionMessageBody: s.completionMessageBody,
+    version: s.version,
+    senderEmail: s.senderEmail,
+  };
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-md border p-4 space-y-3">
+      <div className="space-y-0.5">
+        <h2 className="text-base font-semibold">{title}</h2>
+        {description && (
+          <p className="text-xs text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export default function DispatchSettingsPage() {
+  const { superFetch } = useSuperAdminFetch();
+  const superFetchRef = useRef(superFetch);
+  superFetchRef.current = superFetch;
+
+  const [form, setForm] = useState<FormState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const loadSettings = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await superFetchRef.current<GetDispatchSettingsResponse>(
+        "/api/v2/super/dispatch/settings",
+      );
+      setForm(toFormState(data));
+    } catch (e) {
+      setError(getDispatchErrorMessage(e, "設定の取得に失敗しました"));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
+
+  const handleSave = async () => {
+    if (!form) return;
+    setSaving(true);
+    setSaveError(null);
+    setNotice(null);
+    const body: PutDispatchSettingsRequest = {
+      enabled: form.enabled,
+      scheduleDaysOfWeek: form.scheduleDaysOfWeek,
+      scheduleHourJst: form.scheduleHourJst,
+      signatureName: form.signatureName,
+      completionMessageBody: form.completionMessageBody,
+      version: form.version,
+    };
+    try {
+      const updated =
+        await superFetchRef.current<GetDispatchSettingsResponse>(
+          "/api/v2/super/dispatch/settings",
+          { method: "PUT", body: JSON.stringify(body) },
+        );
+      setForm(toFormState(updated));
+      setNotice("保存しました。");
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 409) {
+        // version 競合: 最新値を再取得してフォームへ反映 (AC-23)
+        await loadSettings();
+        setSaveError(
+          "他の管理者が設定を更新したため、最新の値を読み込みました。内容を確認して再度保存してください。",
+        );
+      } else {
+        setSaveError(getDispatchErrorMessage(e, "保存に失敗しました"));
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="text-muted-foreground">読み込み中...</div>;
+  }
+  if (error) {
+    return (
+      <div className="space-y-3">
+        <div className="rounded-md bg-destructive/10 p-4 text-destructive text-sm">
+          {error}
+        </div>
+        <Button variant="outline" onClick={loadSettings}>
+          再読み込み
+        </Button>
+      </div>
+    );
+  }
+  if (!form) return null;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-xl font-bold">完了通知 配信設定</h1>
+        <p className="text-sm text-muted-foreground">
+          全コース 100% 完了した受講者へ自動送信する完了通知の設定です。
+        </p>
+      </div>
+
+      <Section
+        title="配信の有効化"
+        description="無効にすると次回 cron 起動時に即座に配信が停止します (kill switch)。"
+      >
+        <label className="flex items-center gap-3 text-sm">
+          <Switch
+            checked={form.enabled}
+            onCheckedChange={(v) => setForm({ ...form, enabled: v })}
+            disabled={saving}
+            aria-label="配信を有効化"
+          />
+          <span>{form.enabled ? "配信 ON" : "配信 OFF"}</span>
+        </label>
+        <p className="text-xs text-muted-foreground">
+          送信元: <span className="font-mono">{form.senderEmail}</span> (環境設定、変更不可)
+        </p>
+      </Section>
+
+      <Section title="配信スケジュール">
+        <ScheduleEditor
+          daysOfWeek={form.scheduleDaysOfWeek}
+          hourJst={form.scheduleHourJst}
+          onChange={(next) =>
+            setForm({
+              ...form,
+              scheduleDaysOfWeek: next.daysOfWeek,
+              scheduleHourJst: next.hourJst,
+            })
+          }
+          disabled={saving}
+        />
+      </Section>
+
+      <Section title="メール署名・本文">
+        <MessageBodyEditor
+          signatureName={form.signatureName}
+          completionMessageBody={form.completionMessageBody}
+          onChange={(next) =>
+            setForm({
+              ...form,
+              signatureName: next.signatureName,
+              completionMessageBody: next.completionMessageBody,
+            })
+          }
+          disabled={saving}
+        />
+      </Section>
+
+      {saveError && (
+        <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+          {saveError}
+        </div>
+      )}
+      {notice && (
+        <div className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300">
+          {notice}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? "保存中..." : "保存"}
+        </Button>
+        <span className="text-xs text-muted-foreground">version {form.version}</span>
+      </div>
+
+      <Section
+        title="ドライラン"
+        description="次回配信される対象を送信せずに確認します。"
+      >
+        <DryRunPanel />
+      </Section>
+
+      <Section
+        title="テスト送信"
+        description="設定中の送信経路を、自分宛の固定ダミーメールで確認します。"
+      >
+        <TestSendButton />
+      </Section>
+    </div>
+  );
+}

--- a/web/app/super/layout.tsx
+++ b/web/app/super/layout.tsx
@@ -21,6 +21,7 @@ export default function SuperAdminLayout({
     { href: "/super/progress", label: "受講状況" },
     { href: "/super/attendance", label: "出席レポート" },
     { href: "/super/enrollments", label: "受講期間管理" },
+    { href: "/super/dispatch-settings", label: "完了通知設定" },
     { href: "/super/settings", label: "設定" },
   ];
 


### PR DESCRIPTION
## Summary

DXcollege 完了通知システム **Phase 6 のコア部分 (PR-F1)** を実装。スーパー管理者が配信設定を編集し、ドライラン・テスト送信を実行できるページ `/super/dispatch-settings` を追加。Phase 8 cutover に必要な最重要部分を先行（CC 編集・観測テーブル・E2E は PR-F2 へ）。

### 追加 (web/app/super/dispatch-settings/)
| ファイル | 役割 |
|---------|------|
| `page.tsx` | GET 初期ロード → enabled Switch + スケジュール + 署名/本文 + 保存 (version 楽観ロック、409 で最新値再取得+警告 = AC-23) + dry-run + test-send |
| `components/ScheduleEditor.tsx` | 配信曜日 (0-6 チェックボックス) + 時刻 (0-23 Select) |
| `components/MessageBodyEditor.tsx` | 署名 + 本文 + プレビュー (文字数カウンタ・上限) |
| `components/DryRunPanel.tsx` | ドライラン → 送信対象テーブル (送信なし、AC-8) |
| `components/TestSendButton.tsx` | 自分宛テスト送信 (AC-9、宛先入力なし=サーバー強制) |
| `errorMessage.ts` | 401/403 定型 + ApiError→日本語 (共有) |

`super/layout.tsx` の nav に「完了通知設定」を追加。

### 規約準拠
`useSuperAdminFetch` / `"use client"` / shadcn UI kit + Tailwind / 日本語固定 / inline error。既存 super ページと同方針。

## Test plan
- [x] `npm run type-check`（web）PASS — shadcn UI kit (Switch/Select/Checkbox/Table) API 整合
- [x] `npm run lint` 0 errors（既存 web warning 1 件は無関係）
- [x] `npx vitest run`（web）**全 176 PASS**（新規 16: load/save/409 reload/dry-run table・空・エラー・再実行クリア/test-send 成功・rate limit/editors）
- [x] **API ゴールデンパスを in-memory 実サーバーで確認**: GET default(v0) → PUT(v1, updatedBy) → dry-run(empty) を curl で疎通
- [x] 品質ゲート: code-review（correctness、HIGH なし）+ evaluator（全 AC PASS / APPROVE）→ 指摘 1 件（DryRun 再実行時の stale 結果クリア）反映済
- [ ] **デプロイ環境で目視確認**: super ページは Firebase user 必須でローカル dev は user=null のためブラウザ表示不可。dev/staging デプロイ後に画面目視（保存・409・dry-run・test-send）を Phase 8 前に実施

## スコープ外 (PR-F2)
- テナント別 CC 編集 + EmailChipsInput（chips UI、上限 10）
- 監査ログ / run 履歴テーブル
- Playwright E2E（設定変更 → DB 反映 → audit_logs）

Refs: docs/specs/2026-05-20-completion-notification-impl-plan.md Phase 6 (PR-F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)