### PR TITLE
docs(handoff): Session 45 - Phase 5/6 + #276 GCIP 独立

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,14 +1,19 @@
-# Session Handoff — 2026-05-22 (Session 44)
+# Session Handoff — 2026-05-23 (Session 45)
 
 ## TL;DR
 
-**DXcollege 自動完了通知システム Phase 7 全体 (7-A code + 7-B code-only + 7-B infra) を 1 セッションで連続完了**。前セッション (Session 43) の残作業だった PR #468 (Phase 4) と PR #470 (Session 43 handoff) を冒頭でマージ後、開発者の「次は Phase 7 を進める」判断に基づき、Firestore I/O 実装 + production wiring + factory + Quality Gate 4 段 (safe-refactor / evaluator / code-review / codex) を実施。続けて deploy.yml への env 追加と firestore.indexes.json への composite index 追加を別 PR で実装、最後に Phase 7-B infra 5 件 (Firestore index / TTL / Cloud Scheduler SA + IAM / secret 登録 + 再 deploy / Cloud Scheduler job) を番号単位明示認可で順次実行。**Phase 7 完了**で残るは Phase 5 (Super admin API + settings 初期化) / Phase 6 (UI) / Phase 8 (cutover) のみ。次回 cron 起動 (22:00 JST) では super_dispatch_settings 未作成のため emptyResponse で kill switch 効果。
+**DXcollege 自動完了通知システム Phase 5 (Super admin API) + Phase 6 コア UI (PR-F1) を完了 + Issue #276 GCIP 独立部分を実装**。3 PR をすべて番号単位明示認可でマージ。
+1. **PR #477** (Issue #276 GCIP 独立部分): 孤児 Firebase Auth 掃除を GitHub Actions schedule で週次 dry-run 自動化 + 通知 (孤児検出時 job 失敗 → GitHub 標準メール、human-in-loop)。WIF external_account init 修正 + classifyUser 抽出 + ci.yml に test:scripts 追加。GCIP Tenant 掃除は **#272 Phase 3 (GCIP 移行本体) 未完了**のため継続 postponed (再開条件を「#272 close」→「Phase 3 close」に訂正)。
+2. **PR #478** (Phase 5 PR-E): Super admin API 6 endpoints (settings GET/PUT・tenant CC GET/PUT・audit-logs・runs・dry-run・test-send)。storage に updateDispatchSettings (version 楽観ロック) / listRuns 追加。新規 77 テスト、全 api 1417 PASS。
+3. **PR #479** (Phase 6 PR-F1): スーパー管理者 `/super/dispatch-settings` ページ (enabled Switch + ScheduleEditor + MessageBodyEditor + 保存(409 reload) + DryRunPanel + TestSendButton)。新規 16 テスト。
 
-- **Issue Net**: **0 件** — Close 0 / 起票 0 (Phase 進捗は impl-plan 管理、Issue 起票対象外。本セッションでも triage 基準該当の課題なし)
-- **マージ済 PR**: **7 件** (#468 Phase 4 / #470 Session 43 handoff / #471 Phase 7-A Firestore impl / #472 Phase 7-B code-only / #473 Session 44 handoff (初版) / #474 Session 44 handoff (Phase 7-B infra 追記) / #475 super admin 戻るリンク fix + UI 改善)
-- **GCP infra 適用**: **5 件** ([1] Firestore composite index / [2] TTL Policy (2 collections) / [3] Cloud Scheduler SA + IAM / [4] DISPATCH_OIDC_AUDIENCE secret 登録 + 再 deploy / [5] Cloud Scheduler job)
-- **CI**: ✅ 全 green (各 PR で Lint / Type Check / Test / Build / Deploy to Cloud Run all SUCCESS。途中 PR #471/472 の deploy が fail loud で失敗していたが、Phase 7-B [4] 完了 (secret 登録) で正常 deploy に復旧)
-- **Open Issue**: active 0 / postponed 4 (#274/275/276/405、Session 43 末から変化なし)
+各 PR で code-review + evaluator 分離を実施 (全 AC PASS / 指摘反映済)。
+
+- **Issue Net**: **0 件** — Close 0 / 起票 0。dispatch Phase は impl-plan 管理 (Issue 起票対象外)。#276 は GCIP 独立部分のみ実装し postponed 維持 (GCIP Tenant 部分が残るため close せず)。triage 基準該当の新規課題なし
+- **マージ済 PR**: **3 件** (#477 / #478 / #479)
+- **CI**: ✅ 全 green
+- **Open Issue**: active 0 / postponed 4 (#274/275/276/405、変化なし)
+- **残留プロセス**: ✅ なし (ローカル api smoke 後 kill 済)
 
 ---
 
@@ -18,243 +23,70 @@
 # 1. 状況復元
 cat docs/handoff/LATEST.md
 
-# 2. main 最新と CI / Cloud Run デプロイ状況
+# 2. main 最新と CI
 git fetch origin main && git log --oneline -10 origin/main
 gh run list --branch main --limit 5
 
-# 3. 現在の OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
+# 3. OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
 gh issue list --state open --limit 15
-
-# 4. Phase 7-B 残作業 (gcloud commands 5 件) を進めるか開発者判断
-#    各コマンドは番号単位明示認可必須 (CLAUDE.md 4 原則 §3)
-#    準備: Cloud Scheduler API / Firestore TTL Policy / Cloud Run secret 機能の事前確認
 ```
 
 ---
 
-## セッション成果物 (Session 44)
+## セッション成果物 (Session 45)
 
-### マージ済 PR (4 件)
+### マージ済 PR (3 件)
 
 | # | タイトル | 種別 | 差分 | merge commit |
 |---|---|---|---|---|
-| #468 | feat(dispatch): Phase 4 (Internal API + メインロジック) を統合実装 | feat (large) | 14 files / +2028/-16 | b4bf171 |
-| #470 | docs(handoff): Session 43 (2026-05-22) ハンドオフ記録 + Session 42 archive | docs | 2 files / +294/-62 | 39f3f60 |
-| #471 | feat(dispatch): Phase 7-A Firestore storage 実装 + production wiring | feat (large) | 7 files / +2068/-0 | cc5c643 |
-| #472 | feat(dispatch): Phase 7-B code-only (deploy env + firestore index) | feat (small) | 2 files / +19/-1 | 01bd1c4 |
+| #477 | feat(ops): 孤児 Auth 掃除の週次 dry-run 自動化 + 通知 (Issue #276 GCIP 独立部分) | feat | 4 files / +619/-117 | 33b8c34 |
+| #478 | feat(dispatch): Phase 5 Super admin API 6 endpoints (PR-E) | feat (large) | 23 files / +2212/-9 | e5cde89 |
+| #479 | feat(dispatch): Phase 6 PR-F1 完了通知 配信設定ページ (core UI) | feat (large) | 11 files / +990/-0 | d55cd2b |
 
-### Phase 進捗マトリクス
+### Phase 進捗マトリクス (dispatch)
 
 | Phase | 内容 | 状態 | 関連 PR |
 |---|---|---|---|
-| 0 | 前提作業 (DWD scope / SendAs 設定) | ✅ | - |
-| 1 | 基礎 services 7 ファイル | ✅ | #442 + #465 |
-| 2 | Reservation / Run Lock / Audit | ✅ | #467 |
-| 3 | Mail + Send | ✅ | #466 |
-| 4 | Internal API + メインロジック | ✅ | **#468 (本セッションでマージ)** |
-| 5 | Super admin API 6 endpoints | ⏳ | - |
-| 6 | Frontend UI | ⏳ | - |
-| 7-A | Firestore storage impl + production wiring | ✅ | **#471 (本セッション)** |
-| 7-B-code | deploy.yml env + firestore.indexes.json | ✅ | **#472 (本セッション)** |
-| 7-B-infra | gcloud commands (5 件、番号単位明示認可で実行) | ✅ **本セッション** | - (gcloud 直接適用) |
+| 1-4 | 基礎 services / Reservation / Mail / Internal API | ✅ | #442/465/467/466/468 |
+| 5 | Super admin API 6 endpoints | ✅ **本セッション** | **#478** |
+| 6 | Frontend UI | 🟡 **コア (F1) のみ完了** | **#479** |
+| 7 | Infrastructure (Cloud Scheduler / TTL / env) | ✅ | #471/472 + gcloud |
 | 8 | Smoke check + Cutover | ⏳ | - |
 
-**Phase 7 全体完了**で残るは Phase 5 (Super admin API + settings 初期化) / Phase 6 (Frontend UI) / Phase 8 (cutover) のみ。
+### Phase 6 残作業 (PR-F2、次セッション候補)
 
-### Phase 7-B infra 適用詳細 (本セッションで実行)
+- テナント別 CC 編集 UI (EmailChipsInput chips、上限 10) — API は #478 で実装済 (`/super/tenants/:id/notification-cc-emails`)
+- 監査ログ / run 履歴テーブル (audit-logs / runs API は #478 実装済)
+- Playwright E2E (設定変更 → DB 反映 → audit_logs 記録)
 
-| # | 内容 | 結果 |
-|---|---|---|
-| 1 | Firestore composite index `super_dispatch_runs (status + leaseExpiresAt)` | ✅ READY (既存、index ID `CICAgOi39IkK`) |
-| 2 | Firestore TTL Policy `super_dispatch_audit_logs.ttlExpireAt` + `super_dispatch_runs.ttlExpireAt` | ✅ 両 collection で ACTIVE |
-| 3 | Cloud Scheduler SA `dxcollege-scheduler@lms-279.iam.gserviceaccount.com` + `roles/run.invoker` on api Cloud Run | ✅ 作成済 |
-| 4 | GitHub secret `DISPATCH_OIDC_AUDIENCE=https://api-3zcica5euq-an.a.run.app` + `gh workflow run deploy.yml` で再 deploy | ✅ revision `api-00340-s89` 起動済、env 3 件反映確認 |
-| 5 | Cloud Scheduler job `dxcollege-completion-notifications` (location=asia-northeast1, schedule=`0 * * * *` JST, OIDC token) | ✅ ENABLED、初回起動 22:00 JST 予定 |
+### Phase 8 cutover の前提 (人手作業待ち)
 
-### Phase 7 完了後の補足対応 (PR #475)
-
-開発者からの 2 つの質問対応:
-
-**Q1: スケジュールタイミングは設定可能か** → ✅ 設計済み (Phase 5/6 で UI 提供予定)
-- `super_dispatch_settings/global` doc の `scheduleDaysOfWeek: number[]` (0-6) + `scheduleHourJst: number` (0-23) で設定
-- Cloud Scheduler は毎時 0 分固定起動だが、api 側で `shouldRunNow()` 判定し設定変更が即時反映される設計
-
-**Q2: スーパー管理者→テナント管理ページからの戻り UI** → ✅ PR #475 でバグ修正 + UI 改善
-- 既存バナーのリンク先 `/super-admin` が 404 (該当ルート不在) だったため `/super/tenants` に修正
-- ボタン風スタイル (白背景 / 角丸 / ホバー強調) + ARIA label で視認性向上
-- 表示条件: `isSuperAdminAccess === true` (バックエンド `/auth/me` の flag)、全 `/[tenant]/...` ページ上部
+- **開発者の SendAs 登録**: `system@279279.net` の Gmail で `dxcollege@279279.net` を SendAs 追加 (ADR-037、これが無いと From 偽装不可)
+- **デプロイ環境での画面目視**: super ページは Firebase user 必須でローカル dev (user=null) ではブラウザ表示不可。dev/staging デプロイ後に `/super/dispatch-settings` の保存・409・dry-run・test-send を目視確認
+- cutover 手順: `super_dispatch_settings/global` を enabled=false で初期化 → SendAs send smoke → enabled=true 切替 (impl-plan Phase 8)
 
 ---
 
-## 重要な技術判断 (Session 44 で確定)
+## 重要な技術判断 (本セッション)
 
-### 1. FirestoreDispatchStorage の transaction 保護範囲拡張 (PR #471)
+### #276 再開条件の前提誤り訂正
+- 旧再開条件「#272 close で着手」は誤り。#272 は **緊急対応スコープ達成**で close されたが、**Phase 3 (GCIP 移行本体) は延期** (残事項 C、再評価 2026-10-24)。`useGcip` default=false の pre-canary 状態。よって GCIP Tenant 掃除は着手不可とし、GCIP 非依存の自動実行 + 通知のみ実装。#276 にこの経緯と訂正後再開条件 (Phase 3 close) をコメント済
 
-設計仕様書 §6.2 は `markCompletionNotificationSent` を plain `update` で記述しているが、evaluator MEDIUM 指摘 (lease 期限切れ降格 → manual_review_required と遅延 markSent の race) に基づき、**markSent / markFailedPermanent も runTransaction で保護**する設計を採用。これにより `manual_review_required` → `sent` の silent overwrite を完全に防止。spec §6.2 とは差分があるが、より安全側の設計判断として確定。
+### Phase 5 設計判断 (PR-E)
+- settings GET は doc 未作成時 default (enabled=false/version=0) を返し初回 PUT で create。senderEmail は env overlay (NFR-8)
+- 409 は current (env overlay 済) を併せ返す。audit-logs/runs は全件取得 + in-memory paginate (小規模 + TTL 365d、composite index 不要)、存在しない cursor は終端扱い
+- dispatch super router は superAdminRouter の後に mount + 明示 auth (頻出パス二重 auth 回避)
 
-### 2. GCP runtime 検出を K_SERVICE のみから網羅化 (PR #471 + Codex IMPORTANT-1)
-
-`isProductionGcpRuntime()` を `K_SERVICE || FUNCTION_TARGET || FUNCTION_NAME || GAE_SERVICE` に拡張。本プロジェクトは現状 Cloud Run のみだが、将来 Cloud Functions / GAE を追加した際の silent skip リスクを排除する防御的設計。
-
-### 3. DISPATCH_USE_IN_MEMORY=true を本番 GCP runtime で拒否 (PR #471 + Codex IMPORTANT-2)
-
-本番 Cloud Run で誤って `DISPATCH_USE_IN_MEMORY=true` が設定されると、in-memory storage で 200 empty response を返し続け、Cloud Scheduler は成功扱いで通知が永久に届かない (silent no-op)。factory で本番 runtime 検出時に throw する fail loud パターンを採用。
-
-### 4. acquireRunLock の inequality query を Phase 7-B index 配備後に延期 (PR #471)
-
-設計仕様書 §6.3 は `.where("status", "==", "running").where("leaseExpiresAt", ">", now).limit(1)` を提示するが、composite index (`status + leaseExpiresAt`) が必要。Phase 7-A では single-field where + アプリ側 lease 判定で fallback し、Phase 7-B (index 配備、PR #472) 適用後に最適化する 2 段階配備を確定。
-
-### 5. Phase 7-B を code-only / infra で分割 (PR #472 + 別途認可待ち)
-
-deploy.yml env 追加 + firestore.indexes.json は PR で管理 (本セッションで PR #472 マージ済)、gcloud commands (Cloud Scheduler / TTL Policy / IAM / secret 登録 / index deploy) は別途番号単位明示認可で実行する 2 段階配備を確定。decision-maker 領分の境界を明確化。
-
-### 6. DISPATCH_OIDC_AUDIENCE は secret 経由 conditional (PR #472)
-
-api Cloud Run service URL は環境ごとに異なるため secrets.DISPATCH_OIDC_AUDIENCE で注入。既存 secrets.SUPER_ADMIN_EMAILS と同パターン。未設定時は router mount スキップ → 本番 GCP runtime では fail loud で設定漏れを起動時に検知。
-
----
-
-## Quality Gate 履歴 (Session 44、各 PR ごと)
-
-| PR | safe-refactor | evaluator | code-review | codex review | 反映内容 |
-|---|---|---|---|---|---|
-| #471 (Phase 7-A) | LOW 2 (cosmetic、残置) | REQUEST_CHANGES (HIGH 1: env silent skip、MEDIUM 1: markSent TOCTOU) → 全反映 | PLAUSIBLE 4 → 3 反映 (acquireRunLock コメント / senderEmail fallback / factory in-memory env 任意化)、1 件 (role hard-code) は別 Issue 候補 | IMPORTANT 2 (K_SERVICE 単独依存 / in-memory モード本番拒否) → 両反映 | 4 commits |
-| #472 (Phase 7-B code-only) | (small tier) | (small tier、適用外) | (small tier、手動 checklist) | (適用外) | 1 commit |
-
----
-
-## 待ち事項 (decision-maker = 開発者)
-
-### Phase 7-B infra 5 件 (番号単位明示認可必須、各 destructive 操作)
-
-1. **Cloud Scheduler job 作成** (`gcloud scheduler jobs create http`)
-   - cron: `0 * * * *`、time-zone: `Asia/Tokyo`
-   - target: api Cloud Run の `/api/v2/internal/dispatch/run-completion-notifications`
-   - OIDC token (Service Account 経由)
-   
-2. **Cloud Scheduler SA 作成 + IAM**
-   - `dxcollege-scheduler@lms-279.iam.gserviceaccount.com` 作成
-   - api Cloud Run の `roles/run.invoker` 権限付与
-   
-3. **DISPATCH_OIDC_AUDIENCE secret 登録**
-   - GitHub Actions secret に api Cloud Run service URL を登録
-   - 再 deploy で env に反映
-   - `gcloud run services describe api` で確認
-   
-4. **Firestore TTL Policy 設定**
-   - `super_dispatch_audit_logs.ttlExpireAt` (1 年)
-   - `super_dispatch_runs.ttlExpireAt` (1 年)
-   - GCP コンソールまたは `gcloud firestore fields ttls update`
-   
-5. **Firestore composite index deploy**
-   - `firebase deploy --only firestore:indexes`
-   - super_dispatch_runs (status + leaseExpiresAt) を本番 Firestore に作成
-   - 数分で build 完了する
-
-### その他 (Session 43 末から継続)
-
-6. **OQ-X smoke (mode=send) 実機検証認可** — SendAs 設定確認済 + 送信先 mailbox 認可必要 (Phase 7-B 完了後)
-7. **OQ-8 (TTL 法務確認)** — 法務確認後 (Phase 7-B 着手前にあれば望ましい)
-8. **follow-up Issue 起票判断 2 件** (Session 43 引き継ぎ):
-   - validateRecipientEmail を validateSingleEmail 呼び出しに置き換える物理統合
-   - DispatchAuditLog["eventType"] に `cc_validation_warning` を追加 (Phase 5 spec 改訂時)
-9. **dependabot PR 8 件** (#395-#402、5/15 から open、まとめて処理判断)
-
----
-
-## CI / インフラ変更
-
-- main へのマージで Deploy to Cloud Run 自動実行 → 各 PR 成功
-- ローカル feature ブランチ 3 件 (#468 / #471 / #472) は `--delete-branch` で削除済
-- インフラ変更なし (Phase 7-B infra は次セッション以降で実施)
-
----
-
-## OPEN Issue (Session 44 末)
-
-| # | タイトル | ラベル | 状態 |
-|---|---|---|---|
-| #405 | [Phase 2 follow-up] Gmail draft filename の生 Unicode quoted-string が strict MTA 経路で reject/normalize されるリスク | enhancement, P2, postponed | 着手不可 |
-| #276 | [Phase 5] allowed_emails 削除時の即時セッション失効 + 孤児Auth掃除自動化 | enhancement, P2, postponed | 着手不可 |
-| #275 | [Phase 5] allowed_emails 管理画面UX改善 | enhancement, P2, postponed | 着手不可 |
-| #274 | [Phase 5] allowed_emails 運用の可視化・追跡性強化 | enhancement, P2, postponed | 着手不可 |
-
-postponed ラベル付き Issue は明示指示なき限り着手しない (CLAUDE.md MUST)。active Issue 0 件、Session 43 末から変化なし。
+### Phase 6 設計判断 (PR-F1)
+- 全 super ページは Firebase user 必須 → ローカル dev (user=null) ではブラウザ表示不可。API ゴールデンパスは in-memory 実サーバー (curl) で疎通確認、UI ロジックは 16 component テストでカバー
+- 既存規約準拠 (useSuperAdminFetch / shadcn UI / 日本語固定 / inline error)
 
 ---
 
 ## Issue Net 変化
 
-- **Close 数**: 0 件
-- **起票数**: 0 件
-- **Net: 0 件**
+- Close 数: 0 件
+- 起票数: 0 件
+- Net: 0 件
 
-**進捗評価**: Net = 0 で `feedback_issue_triage.md` の「Net ≤ 0 は進捗ゼロ扱い」基準に該当するが、本セッションは Issue ベースではなく **DXcollege 自動完了通知システム impl-plan Phase 7 進捗 (Phase 7-A + Phase 7-B code-only 完了)** で管理される impl-plan ベースの実装作業。Session 43 と同じく:
-
-- impl-plan で Phase 進捗が一元管理されている (Session 43 ハンドオフでも同じ理由を記載済)
-- 各 Phase 完了は PR マージで定義される (本セッションは 4 PR マージで Phase 4 + 7-A + 7-B code-only を確定)
-- review 指摘 (evaluator HIGH 1 + MEDIUM 1 / code-review PLAUSIBLE 4 / codex IMPORTANT 2) はすべて PR 内 commit で吸収済
-- CLAUDE.md「GitHub Issues」セクションの起票基準 (実害/再現バグ/CI破壊/rating≥7/明示指示) に該当する課題なし
-
-機械的に Issue 化していない理由: review agent の rating 5-6 や PLAUSIBLE/IMPORTANT は PR 内で全反映済または明示的に「Phase 5 で対応」「Phase 7-B infra で実施」とコメント化したため (feedback_issue_triage.md 準拠)。
-
----
-
-## 累計テスト件数 (Session 44 末)
-
-- **dispatch tests**: 16 ファイル / **313 件** (Session 43 末 271 件 + Phase 7-A の 43 件 + factory GCP runtime 拒否 5 件)
-- **API tests 全体**: **1362+ 件**
-
----
-
-## 主要参照ファイル (Session 44 新規 / 改訂、各 PR に含まれる)
-
-### 新規 (PR #471 / Phase 7-A)
-- `services/api/src/services/dispatch/firestore-dispatch-storage.ts` (~570 行)
-- `services/api/src/services/dispatch/firestore-tenant-data-loader.ts` (~120 行)
-- `services/api/src/services/dispatch/factory.ts` (~135 行)
-- `services/api/src/services/dispatch/__tests__/firestore-dispatch-storage.test.ts` (25 件 mock-based)
-- `services/api/src/services/dispatch/__tests__/firestore-tenant-data-loader.test.ts` (9 件 mock-based)
-- `services/api/src/services/dispatch/__tests__/factory.test.ts` (14 件、GCP runtime 拒否 5 件含む)
-
-### 改訂 (PR #471)
-- `services/api/src/index.ts` - 内部 dispatch router を `/api/v2/internal` にマウント + `isProductionGcpRuntime()` で fail loud
-
-### 改訂 (PR #472 / Phase 7-B code-only)
-- `.github/workflows/deploy.yml` - ENV_VARS に DXCOLLEGE_DISPATCH_SUBJECT / DXCOLLEGE_SENDER_EMAIL 追加、DISPATCH_OIDC_AUDIENCE secret conditional 追加
-- `firestore.indexes.json` - super_dispatch_runs (status + leaseExpiresAt) composite index 追加
-
----
-
-## ADR / ドキュメント更新
-
-**今セッションでの ADR 作成**: なし
-
-ADR 候補として保留:
-- 「markSent / markFailedPermanent も runTransaction で保護」: spec §6.2 とは差分がある設計判断 (evaluator MEDIUM 反映)。Phase 7-B 完了時に ADR-038 として spec §6.2 改訂 + 採用根拠を明文化する候補
-
-**spec / impl-plan 改訂**: なし (本セッションは impl-plan に従った実装のみ)
-
----
-
-## 残留プロセス
-
-✅ クリーンアップ済 (cleanup-node.sh 確認、残留 Node プロセスなし)
-
----
-
-## 次セッション開始時の最優先 3 つ
-
-1. **Phase 5 (Super admin API 6 endpoints) 着手判断** — 本番 Cloud Scheduler 稼働中だが super_dispatch_settings 未作成のため kill switch 状態。Phase 5 で settings 初期化 + テナント別 CC 設定 + dry-run / test-send API を追加する必要あり (impl-plan §3 Phase 5、6 endpoints)
-2. **OQ-X smoke (mode=send) 実機検証** — Phase 5 完了後または別途、SendAs 経由送信が実機 Gmail で配送されることを確認 (送信先 mailbox 認可必要、ADR-037 案 X の最終バリデーション)
-3. **Phase 5 spec / OQ-8 (TTL 法務確認)** — TTL Policy 自体は本セッションで設定済 (ACTIVE)。法務確認結果次第で TTL 期間を 1 年から調整する可能性 (現状: ttlExpireAt フィールドの値はアプリ側で createdAt + 365 days を書き込む)
-
-Phase 7 完了。Phase 8 (cutover) は Phase 5 + 6 完了後、本番 smoke + 本田様承認の手順で進める想定。
-
-### 本番運用上の注意 (Phase 7 完了直後の状態)
-
-- Cloud Scheduler `dxcollege-completion-notifications` が ENABLED で毎時 0 分 JST に起動
-- super_dispatch_settings/global doc 未作成のため `runCompletionNotifications` は `if (!settings) return emptyResponse()` で即座に終了 (kill switch 効果)
-- audit_logs / runs の write は kill switch 経路では発生しない (run lock 取得前に return)
-- Cloud Run / Firestore のコストは scheduler 起動 × 60 (1 時間 / 分) = 24 リクエスト/日のみで負荷軽微
-- Phase 5 で settings doc 初期化時、UI 側で必ず `enabled=false` で初期化することが cutover 安全装置 (impl-plan §6.1 cutover フロー)
+**Net=0 の理由**: 本セッションは Issue ベースではなく **dispatch impl-plan (Phase 5 PR-E + Phase 6 PR-F1) 進捗** + **Issue #276 の GCIP 独立部分実装** で管理される作業。#276 は GCIP Tenant 部分が Phase 3 待ちで残るため close せず postponed 維持。triage 基準 (実害/再現バグ/CI破壊/rating≥7/明示指示) 該当の新規課題なし。

--- a/docs/handoff/archive/2026-05-22-session-44.md
+++ b/docs/handoff/archive/2026-05-22-session-44.md
@@ -1,0 +1,260 @@
+# Session Handoff — 2026-05-22 (Session 44)
+
+## TL;DR
+
+**DXcollege 自動完了通知システム Phase 7 全体 (7-A code + 7-B code-only + 7-B infra) を 1 セッションで連続完了**。前セッション (Session 43) の残作業だった PR #468 (Phase 4) と PR #470 (Session 43 handoff) を冒頭でマージ後、開発者の「次は Phase 7 を進める」判断に基づき、Firestore I/O 実装 + production wiring + factory + Quality Gate 4 段 (safe-refactor / evaluator / code-review / codex) を実施。続けて deploy.yml への env 追加と firestore.indexes.json への composite index 追加を別 PR で実装、最後に Phase 7-B infra 5 件 (Firestore index / TTL / Cloud Scheduler SA + IAM / secret 登録 + 再 deploy / Cloud Scheduler job) を番号単位明示認可で順次実行。**Phase 7 完了**で残るは Phase 5 (Super admin API + settings 初期化) / Phase 6 (UI) / Phase 8 (cutover) のみ。次回 cron 起動 (22:00 JST) では super_dispatch_settings 未作成のため emptyResponse で kill switch 効果。
+
+- **Issue Net**: **0 件** — Close 0 / 起票 0 (Phase 進捗は impl-plan 管理、Issue 起票対象外。本セッションでも triage 基準該当の課題なし)
+- **マージ済 PR**: **7 件** (#468 Phase 4 / #470 Session 43 handoff / #471 Phase 7-A Firestore impl / #472 Phase 7-B code-only / #473 Session 44 handoff (初版) / #474 Session 44 handoff (Phase 7-B infra 追記) / #475 super admin 戻るリンク fix + UI 改善)
+- **GCP infra 適用**: **5 件** ([1] Firestore composite index / [2] TTL Policy (2 collections) / [3] Cloud Scheduler SA + IAM / [4] DISPATCH_OIDC_AUDIENCE secret 登録 + 再 deploy / [5] Cloud Scheduler job)
+- **CI**: ✅ 全 green (各 PR で Lint / Type Check / Test / Build / Deploy to Cloud Run all SUCCESS。途中 PR #471/472 の deploy が fail loud で失敗していたが、Phase 7-B [4] 完了 (secret 登録) で正常 deploy に復旧)
+- **Open Issue**: active 0 / postponed 4 (#274/275/276/405、Session 43 末から変化なし)
+
+---
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+# 1. 状況復元
+cat docs/handoff/LATEST.md
+
+# 2. main 最新と CI / Cloud Run デプロイ状況
+git fetch origin main && git log --oneline -10 origin/main
+gh run list --branch main --limit 5
+
+# 3. 現在の OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
+gh issue list --state open --limit 15
+
+# 4. Phase 7-B 残作業 (gcloud commands 5 件) を進めるか開発者判断
+#    各コマンドは番号単位明示認可必須 (CLAUDE.md 4 原則 §3)
+#    準備: Cloud Scheduler API / Firestore TTL Policy / Cloud Run secret 機能の事前確認
+```
+
+---
+
+## セッション成果物 (Session 44)
+
+### マージ済 PR (4 件)
+
+| # | タイトル | 種別 | 差分 | merge commit |
+|---|---|---|---|---|
+| #468 | feat(dispatch): Phase 4 (Internal API + メインロジック) を統合実装 | feat (large) | 14 files / +2028/-16 | b4bf171 |
+| #470 | docs(handoff): Session 43 (2026-05-22) ハンドオフ記録 + Session 42 archive | docs | 2 files / +294/-62 | 39f3f60 |
+| #471 | feat(dispatch): Phase 7-A Firestore storage 実装 + production wiring | feat (large) | 7 files / +2068/-0 | cc5c643 |
+| #472 | feat(dispatch): Phase 7-B code-only (deploy env + firestore index) | feat (small) | 2 files / +19/-1 | 01bd1c4 |
+
+### Phase 進捗マトリクス
+
+| Phase | 内容 | 状態 | 関連 PR |
+|---|---|---|---|
+| 0 | 前提作業 (DWD scope / SendAs 設定) | ✅ | - |
+| 1 | 基礎 services 7 ファイル | ✅ | #442 + #465 |
+| 2 | Reservation / Run Lock / Audit | ✅ | #467 |
+| 3 | Mail + Send | ✅ | #466 |
+| 4 | Internal API + メインロジック | ✅ | **#468 (本セッションでマージ)** |
+| 5 | Super admin API 6 endpoints | ⏳ | - |
+| 6 | Frontend UI | ⏳ | - |
+| 7-A | Firestore storage impl + production wiring | ✅ | **#471 (本セッション)** |
+| 7-B-code | deploy.yml env + firestore.indexes.json | ✅ | **#472 (本セッション)** |
+| 7-B-infra | gcloud commands (5 件、番号単位明示認可で実行) | ✅ **本セッション** | - (gcloud 直接適用) |
+| 8 | Smoke check + Cutover | ⏳ | - |
+
+**Phase 7 全体完了**で残るは Phase 5 (Super admin API + settings 初期化) / Phase 6 (Frontend UI) / Phase 8 (cutover) のみ。
+
+### Phase 7-B infra 適用詳細 (本セッションで実行)
+
+| # | 内容 | 結果 |
+|---|---|---|
+| 1 | Firestore composite index `super_dispatch_runs (status + leaseExpiresAt)` | ✅ READY (既存、index ID `CICAgOi39IkK`) |
+| 2 | Firestore TTL Policy `super_dispatch_audit_logs.ttlExpireAt` + `super_dispatch_runs.ttlExpireAt` | ✅ 両 collection で ACTIVE |
+| 3 | Cloud Scheduler SA `dxcollege-scheduler@lms-279.iam.gserviceaccount.com` + `roles/run.invoker` on api Cloud Run | ✅ 作成済 |
+| 4 | GitHub secret `DISPATCH_OIDC_AUDIENCE=https://api-3zcica5euq-an.a.run.app` + `gh workflow run deploy.yml` で再 deploy | ✅ revision `api-00340-s89` 起動済、env 3 件反映確認 |
+| 5 | Cloud Scheduler job `dxcollege-completion-notifications` (location=asia-northeast1, schedule=`0 * * * *` JST, OIDC token) | ✅ ENABLED、初回起動 22:00 JST 予定 |
+
+### Phase 7 完了後の補足対応 (PR #475)
+
+開発者からの 2 つの質問対応:
+
+**Q1: スケジュールタイミングは設定可能か** → ✅ 設計済み (Phase 5/6 で UI 提供予定)
+- `super_dispatch_settings/global` doc の `scheduleDaysOfWeek: number[]` (0-6) + `scheduleHourJst: number` (0-23) で設定
+- Cloud Scheduler は毎時 0 分固定起動だが、api 側で `shouldRunNow()` 判定し設定変更が即時反映される設計
+
+**Q2: スーパー管理者→テナント管理ページからの戻り UI** → ✅ PR #475 でバグ修正 + UI 改善
+- 既存バナーのリンク先 `/super-admin` が 404 (該当ルート不在) だったため `/super/tenants` に修正
+- ボタン風スタイル (白背景 / 角丸 / ホバー強調) + ARIA label で視認性向上
+- 表示条件: `isSuperAdminAccess === true` (バックエンド `/auth/me` の flag)、全 `/[tenant]/...` ページ上部
+
+---
+
+## 重要な技術判断 (Session 44 で確定)
+
+### 1. FirestoreDispatchStorage の transaction 保護範囲拡張 (PR #471)
+
+設計仕様書 §6.2 は `markCompletionNotificationSent` を plain `update` で記述しているが、evaluator MEDIUM 指摘 (lease 期限切れ降格 → manual_review_required と遅延 markSent の race) に基づき、**markSent / markFailedPermanent も runTransaction で保護**する設計を採用。これにより `manual_review_required` → `sent` の silent overwrite を完全に防止。spec §6.2 とは差分があるが、より安全側の設計判断として確定。
+
+### 2. GCP runtime 検出を K_SERVICE のみから網羅化 (PR #471 + Codex IMPORTANT-1)
+
+`isProductionGcpRuntime()` を `K_SERVICE || FUNCTION_TARGET || FUNCTION_NAME || GAE_SERVICE` に拡張。本プロジェクトは現状 Cloud Run のみだが、将来 Cloud Functions / GAE を追加した際の silent skip リスクを排除する防御的設計。
+
+### 3. DISPATCH_USE_IN_MEMORY=true を本番 GCP runtime で拒否 (PR #471 + Codex IMPORTANT-2)
+
+本番 Cloud Run で誤って `DISPATCH_USE_IN_MEMORY=true` が設定されると、in-memory storage で 200 empty response を返し続け、Cloud Scheduler は成功扱いで通知が永久に届かない (silent no-op)。factory で本番 runtime 検出時に throw する fail loud パターンを採用。
+
+### 4. acquireRunLock の inequality query を Phase 7-B index 配備後に延期 (PR #471)
+
+設計仕様書 §6.3 は `.where("status", "==", "running").where("leaseExpiresAt", ">", now).limit(1)` を提示するが、composite index (`status + leaseExpiresAt`) が必要。Phase 7-A では single-field where + アプリ側 lease 判定で fallback し、Phase 7-B (index 配備、PR #472) 適用後に最適化する 2 段階配備を確定。
+
+### 5. Phase 7-B を code-only / infra で分割 (PR #472 + 別途認可待ち)
+
+deploy.yml env 追加 + firestore.indexes.json は PR で管理 (本セッションで PR #472 マージ済)、gcloud commands (Cloud Scheduler / TTL Policy / IAM / secret 登録 / index deploy) は別途番号単位明示認可で実行する 2 段階配備を確定。decision-maker 領分の境界を明確化。
+
+### 6. DISPATCH_OIDC_AUDIENCE は secret 経由 conditional (PR #472)
+
+api Cloud Run service URL は環境ごとに異なるため secrets.DISPATCH_OIDC_AUDIENCE で注入。既存 secrets.SUPER_ADMIN_EMAILS と同パターン。未設定時は router mount スキップ → 本番 GCP runtime では fail loud で設定漏れを起動時に検知。
+
+---
+
+## Quality Gate 履歴 (Session 44、各 PR ごと)
+
+| PR | safe-refactor | evaluator | code-review | codex review | 反映内容 |
+|---|---|---|---|---|---|
+| #471 (Phase 7-A) | LOW 2 (cosmetic、残置) | REQUEST_CHANGES (HIGH 1: env silent skip、MEDIUM 1: markSent TOCTOU) → 全反映 | PLAUSIBLE 4 → 3 反映 (acquireRunLock コメント / senderEmail fallback / factory in-memory env 任意化)、1 件 (role hard-code) は別 Issue 候補 | IMPORTANT 2 (K_SERVICE 単独依存 / in-memory モード本番拒否) → 両反映 | 4 commits |
+| #472 (Phase 7-B code-only) | (small tier) | (small tier、適用外) | (small tier、手動 checklist) | (適用外) | 1 commit |
+
+---
+
+## 待ち事項 (decision-maker = 開発者)
+
+### Phase 7-B infra 5 件 (番号単位明示認可必須、各 destructive 操作)
+
+1. **Cloud Scheduler job 作成** (`gcloud scheduler jobs create http`)
+   - cron: `0 * * * *`、time-zone: `Asia/Tokyo`
+   - target: api Cloud Run の `/api/v2/internal/dispatch/run-completion-notifications`
+   - OIDC token (Service Account 経由)
+   
+2. **Cloud Scheduler SA 作成 + IAM**
+   - `dxcollege-scheduler@lms-279.iam.gserviceaccount.com` 作成
+   - api Cloud Run の `roles/run.invoker` 権限付与
+   
+3. **DISPATCH_OIDC_AUDIENCE secret 登録**
+   - GitHub Actions secret に api Cloud Run service URL を登録
+   - 再 deploy で env に反映
+   - `gcloud run services describe api` で確認
+   
+4. **Firestore TTL Policy 設定**
+   - `super_dispatch_audit_logs.ttlExpireAt` (1 年)
+   - `super_dispatch_runs.ttlExpireAt` (1 年)
+   - GCP コンソールまたは `gcloud firestore fields ttls update`
+   
+5. **Firestore composite index deploy**
+   - `firebase deploy --only firestore:indexes`
+   - super_dispatch_runs (status + leaseExpiresAt) を本番 Firestore に作成
+   - 数分で build 完了する
+
+### その他 (Session 43 末から継続)
+
+6. **OQ-X smoke (mode=send) 実機検証認可** — SendAs 設定確認済 + 送信先 mailbox 認可必要 (Phase 7-B 完了後)
+7. **OQ-8 (TTL 法務確認)** — 法務確認後 (Phase 7-B 着手前にあれば望ましい)
+8. **follow-up Issue 起票判断 2 件** (Session 43 引き継ぎ):
+   - validateRecipientEmail を validateSingleEmail 呼び出しに置き換える物理統合
+   - DispatchAuditLog["eventType"] に `cc_validation_warning` を追加 (Phase 5 spec 改訂時)
+9. **dependabot PR 8 件** (#395-#402、5/15 から open、まとめて処理判断)
+
+---
+
+## CI / インフラ変更
+
+- main へのマージで Deploy to Cloud Run 自動実行 → 各 PR 成功
+- ローカル feature ブランチ 3 件 (#468 / #471 / #472) は `--delete-branch` で削除済
+- インフラ変更なし (Phase 7-B infra は次セッション以降で実施)
+
+---
+
+## OPEN Issue (Session 44 末)
+
+| # | タイトル | ラベル | 状態 |
+|---|---|---|---|
+| #405 | [Phase 2 follow-up] Gmail draft filename の生 Unicode quoted-string が strict MTA 経路で reject/normalize されるリスク | enhancement, P2, postponed | 着手不可 |
+| #276 | [Phase 5] allowed_emails 削除時の即時セッション失効 + 孤児Auth掃除自動化 | enhancement, P2, postponed | 着手不可 |
+| #275 | [Phase 5] allowed_emails 管理画面UX改善 | enhancement, P2, postponed | 着手不可 |
+| #274 | [Phase 5] allowed_emails 運用の可視化・追跡性強化 | enhancement, P2, postponed | 着手不可 |
+
+postponed ラベル付き Issue は明示指示なき限り着手しない (CLAUDE.md MUST)。active Issue 0 件、Session 43 末から変化なし。
+
+---
+
+## Issue Net 変化
+
+- **Close 数**: 0 件
+- **起票数**: 0 件
+- **Net: 0 件**
+
+**進捗評価**: Net = 0 で `feedback_issue_triage.md` の「Net ≤ 0 は進捗ゼロ扱い」基準に該当するが、本セッションは Issue ベースではなく **DXcollege 自動完了通知システム impl-plan Phase 7 進捗 (Phase 7-A + Phase 7-B code-only 完了)** で管理される impl-plan ベースの実装作業。Session 43 と同じく:
+
+- impl-plan で Phase 進捗が一元管理されている (Session 43 ハンドオフでも同じ理由を記載済)
+- 各 Phase 完了は PR マージで定義される (本セッションは 4 PR マージで Phase 4 + 7-A + 7-B code-only を確定)
+- review 指摘 (evaluator HIGH 1 + MEDIUM 1 / code-review PLAUSIBLE 4 / codex IMPORTANT 2) はすべて PR 内 commit で吸収済
+- CLAUDE.md「GitHub Issues」セクションの起票基準 (実害/再現バグ/CI破壊/rating≥7/明示指示) に該当する課題なし
+
+機械的に Issue 化していない理由: review agent の rating 5-6 や PLAUSIBLE/IMPORTANT は PR 内で全反映済または明示的に「Phase 5 で対応」「Phase 7-B infra で実施」とコメント化したため (feedback_issue_triage.md 準拠)。
+
+---
+
+## 累計テスト件数 (Session 44 末)
+
+- **dispatch tests**: 16 ファイル / **313 件** (Session 43 末 271 件 + Phase 7-A の 43 件 + factory GCP runtime 拒否 5 件)
+- **API tests 全体**: **1362+ 件**
+
+---
+
+## 主要参照ファイル (Session 44 新規 / 改訂、各 PR に含まれる)
+
+### 新規 (PR #471 / Phase 7-A)
+- `services/api/src/services/dispatch/firestore-dispatch-storage.ts` (~570 行)
+- `services/api/src/services/dispatch/firestore-tenant-data-loader.ts` (~120 行)
+- `services/api/src/services/dispatch/factory.ts` (~135 行)
+- `services/api/src/services/dispatch/__tests__/firestore-dispatch-storage.test.ts` (25 件 mock-based)
+- `services/api/src/services/dispatch/__tests__/firestore-tenant-data-loader.test.ts` (9 件 mock-based)
+- `services/api/src/services/dispatch/__tests__/factory.test.ts` (14 件、GCP runtime 拒否 5 件含む)
+
+### 改訂 (PR #471)
+- `services/api/src/index.ts` - 内部 dispatch router を `/api/v2/internal` にマウント + `isProductionGcpRuntime()` で fail loud
+
+### 改訂 (PR #472 / Phase 7-B code-only)
+- `.github/workflows/deploy.yml` - ENV_VARS に DXCOLLEGE_DISPATCH_SUBJECT / DXCOLLEGE_SENDER_EMAIL 追加、DISPATCH_OIDC_AUDIENCE secret conditional 追加
+- `firestore.indexes.json` - super_dispatch_runs (status + leaseExpiresAt) composite index 追加
+
+---
+
+## ADR / ドキュメント更新
+
+**今セッションでの ADR 作成**: なし
+
+ADR 候補として保留:
+- 「markSent / markFailedPermanent も runTransaction で保護」: spec §6.2 とは差分がある設計判断 (evaluator MEDIUM 反映)。Phase 7-B 完了時に ADR-038 として spec §6.2 改訂 + 採用根拠を明文化する候補
+
+**spec / impl-plan 改訂**: なし (本セッションは impl-plan に従った実装のみ)
+
+---
+
+## 残留プロセス
+
+✅ クリーンアップ済 (cleanup-node.sh 確認、残留 Node プロセスなし)
+
+---
+
+## 次セッション開始時の最優先 3 つ
+
+1. **Phase 5 (Super admin API 6 endpoints) 着手判断** — 本番 Cloud Scheduler 稼働中だが super_dispatch_settings 未作成のため kill switch 状態。Phase 5 で settings 初期化 + テナント別 CC 設定 + dry-run / test-send API を追加する必要あり (impl-plan §3 Phase 5、6 endpoints)
+2. **OQ-X smoke (mode=send) 実機検証** — Phase 5 完了後または別途、SendAs 経由送信が実機 Gmail で配送されることを確認 (送信先 mailbox 認可必要、ADR-037 案 X の最終バリデーション)
+3. **Phase 5 spec / OQ-8 (TTL 法務確認)** — TTL Policy 自体は本セッションで設定済 (ACTIVE)。法務確認結果次第で TTL 期間を 1 年から調整する可能性 (現状: ttlExpireAt フィールドの値はアプリ側で createdAt + 365 days を書き込む)
+
+Phase 7 完了。Phase 8 (cutover) は Phase 5 + 6 完了後、本番 smoke + 本田様承認の手順で進める想定。
+
+### 本番運用上の注意 (Phase 7 完了直後の状態)
+
+- Cloud Scheduler `dxcollege-completion-notifications` が ENABLED で毎時 0 分 JST に起動
+- super_dispatch_settings/global doc 未作成のため `runCompletionNotifications` は `if (!settings) return emptyResponse()` で即座に終了 (kill switch 効果)
+- audit_logs / runs の write は kill switch 経路では発生しない (run lock 取得前に return)
+- Cloud Run / Firestore のコストは scheduler 起動 × 60 (1 時間 / 分) = 24 リクエスト/日のみで負荷軽微
+- Phase 5 で settings doc 初期化時、UI 側で必ず `enabled=false` で初期化することが cutover 安全装置 (impl-plan §6.1 cutover フロー)


### PR DESCRIPTION
## Summary
Session 45 ハンドオフ記録 + Session 44 アーカイブ。

本セッションのマージ済 PR (3 件):
- #477 孤児 Auth 掃除の週次 dry-run 自動化 + 通知 (Issue #276 GCIP 独立部分)
- #478 dispatch Phase 5 Super admin API 6 endpoints (PR-E)
- #479 dispatch Phase 6 PR-F1 配信設定ページ (core UI)

Issue Net: 0 (impl-plan 管理 + #276 部分実装、postponed 維持)。

## Test plan
- [x] docs のみ。LATEST.md 更新 + Session 44 を archive へ
- [x] 次セッションは `cat docs/handoff/LATEST.md` で復元可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)