### PR TITLE
feat(dispatch): Phase 6 PR-F2 完了通知 配信設定ページ 残コンポーネント (TenantCcEditor / AuditLogTable / RunHistoryTable)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
         AUTH_MODE: "dev",
         PORT: "8080",
         E2E_TEST_ENABLED: "true",
+        // dispatch-settings-api.spec で super-admin emulation を有効化
+        // (X-User-Email: admin@example.com を super として認識させる)
+        SUPER_ADMIN_EMAILS: "admin@example.com",
       },
     },
     {

--- a/e2e/tests/dispatch-settings-api.spec.ts
+++ b/e2e/tests/dispatch-settings-api.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * dispatch-settings (完了通知 配信設定) の API smoke E2E (Phase 6 PR-F2)。
+ *
+ * dispatch-settings ページは super 全体が Firebase user 必須で、AUTH_MODE=dev かつ
+ * user=null では web 側で表示されない (PR-F1 / handoff 既述)。よって本 E2E は UI 遷移を
+ * 含まず API 疎通 (`X-User-Email` での super-admin emulation) のみで impl-plan Phase 6
+ * 完了条件をカバーする。UI 操作の検証は component test 側で実施
+ * (`web/app/super/dispatch-settings/components/__tests__/`)。
+ *
+ * 確認内容:
+ *   - 認可境界: super なし 401 / 非 super 403 / super 200
+ *   - audit-logs / runs の正常応答
+ *   - tenant notification CC の GET/PUT、エラー応答 (CRLF / 11 件)
+ */
+
+import { test, expect } from "@playwright/test";
+
+const API = "http://localhost:8080";
+const SUPER_HEADERS = { "X-User-Email": "admin@example.com" };
+const NON_SUPER_HEADERS = { "X-User-Email": "user@example.com" };
+
+test.describe("dispatch super API 認可境界", () => {
+  test("X-User-Email 未指定は 401 (audit-logs)", async ({ request }) => {
+    const res = await request.get(`${API}/api/v2/super/dispatch/audit-logs`);
+    expect(res.status()).toBe(401);
+  });
+
+  test("非 super email は 403 (audit-logs)", async ({ request }) => {
+    const res = await request.get(`${API}/api/v2/super/dispatch/audit-logs`, {
+      headers: NON_SUPER_HEADERS,
+    });
+    expect(res.status()).toBe(403);
+  });
+
+  test("非 super email は 403 (runs)", async ({ request }) => {
+    const res = await request.get(`${API}/api/v2/super/dispatch/runs`, {
+      headers: NON_SUPER_HEADERS,
+    });
+    expect(res.status()).toBe(403);
+  });
+
+  test("super-admin emulation で audit-logs は 200", async ({ request }) => {
+    const res = await request.get(`${API}/api/v2/super/dispatch/audit-logs`, {
+      headers: SUPER_HEADERS,
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("logs");
+    expect(Array.isArray(body.logs)).toBe(true);
+    expect(body).toHaveProperty("nextCursor");
+  });
+
+  test("super-admin emulation で runs は 200", async ({ request }) => {
+    const res = await request.get(`${API}/api/v2/super/dispatch/runs`, {
+      headers: SUPER_HEADERS,
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("runs");
+    expect(Array.isArray(body.runs)).toBe(true);
+    expect(body).toHaveProperty("nextCursor");
+  });
+});
+
+test.describe("tenant notification CC API", () => {
+  test("non-super email でアクセスすると 403", async ({ request }) => {
+    const res = await request.get(
+      `${API}/api/v2/super/tenants/demo/notification-cc-emails`,
+      { headers: NON_SUPER_HEADERS },
+    );
+    expect(res.status()).toBe(403);
+  });
+
+  test("super-admin で demo tenant の CC 取得 → 200 + 期待スキーマ", async ({
+    request,
+  }) => {
+    const res = await request.get(
+      `${API}/api/v2/super/tenants/demo/notification-cc-emails`,
+      { headers: SUPER_HEADERS },
+    );
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("ownerEmail");
+    expect(body).toHaveProperty("notificationCcEmails");
+    expect(Array.isArray(body.notificationCcEmails)).toBe(true);
+    expect(body).toHaveProperty("completionNotificationEnabled");
+    expect(typeof body.completionNotificationEnabled).toBe("boolean");
+  });
+
+  test("PUT で CC 配列と enabled を更新できる (再 GET で反映確認)", async ({
+    request,
+  }) => {
+    const newEmails = [`cc-${Date.now()}@example.com`];
+    const putRes = await request.put(
+      `${API}/api/v2/super/tenants/demo/notification-cc-emails`,
+      {
+        headers: SUPER_HEADERS,
+        data: {
+          notificationCcEmails: newEmails,
+          completionNotificationEnabled: true,
+        },
+      },
+    );
+    expect(putRes.status()).toBe(200);
+    const updated = await putRes.json();
+    expect(updated.notificationCcEmails).toEqual(newEmails);
+    expect(updated.completionNotificationEnabled).toBe(true);
+
+    // 再 GET で反映確認
+    const getRes = await request.get(
+      `${API}/api/v2/super/tenants/demo/notification-cc-emails`,
+      { headers: SUPER_HEADERS },
+    );
+    expect(getRes.status()).toBe(200);
+    const reread = await getRes.json();
+    expect(reread.notificationCcEmails).toEqual(newEmails);
+  });
+
+  test("PUT で CRLF を含む CC は 400 invalid_cc_emails", async ({ request }) => {
+    const res = await request.put(
+      `${API}/api/v2/super/tenants/demo/notification-cc-emails`,
+      {
+        headers: SUPER_HEADERS,
+        data: {
+          notificationCcEmails: ["foo\r\nbar@example.com"],
+          completionNotificationEnabled: true,
+        },
+      },
+    );
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_cc_emails");
+  });
+
+  test("PUT で 11 件以上の CC は 400 cc_emails_too_many", async ({ request }) => {
+    const tooMany = Array.from(
+      { length: 11 },
+      (_, i) => `cc${i}@example.com`,
+    );
+    const res = await request.put(
+      `${API}/api/v2/super/tenants/demo/notification-cc-emails`,
+      {
+        headers: SUPER_HEADERS,
+        data: {
+          notificationCcEmails: tooMany,
+          completionNotificationEnabled: true,
+        },
+      },
+    );
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("cc_emails_too_many");
+  });
+});

--- a/web/app/super/dispatch-settings/__tests__/page.test.tsx
+++ b/web/app/super/dispatch-settings/__tests__/page.test.tsx
@@ -130,4 +130,27 @@ describe("DispatchSettingsPage", () => {
     expect(screen.getByTestId("audit-log-table")).toBeInTheDocument();
     expect(screen.getByTestId("run-history-table")).toBeInTheDocument();
   });
+
+  it("再読み込み失敗時 loadSettings は form を null 化する (regression: form/error 共存防止)", async () => {
+    // 初回 GET 失敗 → error 表示 + 再読み込みボタン
+    superFetchMock.mockRejectedValueOnce(
+      new ApiError(500, "internal", "初回失敗"),
+    );
+    render(<DispatchSettingsPage />);
+    await screen.findByText("初回失敗");
+    // form は表示されない
+    expect(
+      screen.queryByDisplayValue("DXcollege運営スタッフ"),
+    ).not.toBeInTheDocument();
+
+    // 再読み込み → 成功で form 表示
+    superFetchMock.mockResolvedValueOnce(baseSettings);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "再読み込み" }));
+    });
+    await screen.findByDisplayValue("DXcollege運営スタッフ");
+
+    // (本 PR 範囲外: 「再読み込み成功後にさらにエラー」を発火させる UI が現状無いため、
+    //  上記で「loadSettings catch で form null + error 表示」の正パスを保証する。)
+  });
 });

--- a/web/app/super/dispatch-settings/__tests__/page.test.tsx
+++ b/web/app/super/dispatch-settings/__tests__/page.test.tsx
@@ -1,8 +1,13 @@
 /**
- * DispatchSettingsPage (Phase 6 PR-F1) のテスト。
+ * DispatchSettingsPage (Phase 6 PR-F1 + PR-F2) のテスト。
  * - 初期 GET で値ロード + フォーム表示
  * - 保存で PUT 呼び出し + 成功表示
  * - 409 (version 競合) で再 GET + 警告表示 (AC-23)
+ * - F2 component (TenantCcEditor / AuditLogTable / RunHistoryTable) が常にマウントされる
+ *
+ * F2 component は本ページの settings ロード状態と独立に自分で fetch するため、
+ * page 単独の挙動を切り分けてテストする目的で stub 化する。内部の fetch / chips / cursor
+ * 等は各 component の専用テスト (../components/__tests__/) でカバー済。
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
@@ -13,6 +18,17 @@ import DispatchSettingsPage from "../page";
 const superFetchMock = vi.fn();
 vi.mock("@/lib/super-api", () => ({
   useSuperAdminFetch: () => ({ superFetch: superFetchMock }),
+}));
+
+// F2 component は内部で superFetch を呼ぶため、page 単独のテストでは stub 化する。
+vi.mock("../components/TenantCcEditor", () => ({
+  TenantCcEditor: () => <div data-testid="tenant-cc-editor" />,
+}));
+vi.mock("../components/AuditLogTable", () => ({
+  AuditLogTable: () => <div data-testid="audit-log-table" />,
+}));
+vi.mock("../components/RunHistoryTable", () => ({
+  RunHistoryTable: () => <div data-testid="run-history-table" />,
 }));
 
 const baseSettings: GetDispatchSettingsResponse = {
@@ -92,5 +108,26 @@ describe("DispatchSettingsPage", () => {
       await screen.findByText("この操作を行う権限がありません。"),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "再読み込み" })).toBeInTheDocument();
+  });
+
+  it("F2 component (CC / 監査ログ / Run 履歴) は settings ロード状態と独立に常にマウントされる", async () => {
+    // settings GET 失敗ケースでも F2 が表示されることを確認
+    superFetchMock.mockRejectedValueOnce(
+      new ApiError(500, "internal", "settings 失敗"),
+    );
+    render(<DispatchSettingsPage />);
+    await screen.findByText("settings 失敗");
+    expect(screen.getByTestId("tenant-cc-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("audit-log-table")).toBeInTheDocument();
+    expect(screen.getByTestId("run-history-table")).toBeInTheDocument();
+  });
+
+  it("F2 component は settings ロード成功時にも当然マウントされる", async () => {
+    superFetchMock.mockResolvedValueOnce(baseSettings);
+    render(<DispatchSettingsPage />);
+    await screen.findByDisplayValue("DXcollege運営スタッフ");
+    expect(screen.getByTestId("tenant-cc-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("audit-log-table")).toBeInTheDocument();
+    expect(screen.getByTestId("run-history-table")).toBeInTheDocument();
   });
 });

--- a/web/app/super/dispatch-settings/components/AuditLogTable.tsx
+++ b/web/app/super/dispatch-settings/components/AuditLogTable.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+/**
+ * 配信 監査ログ表示 (Phase 6 PR-F2)。
+ *
+ * GET /api/v2/super/dispatch/audit-logs?eventType=&tenantId=&userId=&from=&to=&limit=&cursor=
+ * を呼び、cursor paginate で累積 append。フィルタ変更時は結果配列リセット。
+ *
+ * State race 対策 (Codex 指摘):
+ *   フィルタ変更直後に古い fetch のレスポンスが着信して結果配列を上書きする/append する
+ *   race を防ぐため、`requestIdRef` で fetch ごとに採番。レスポンス着信時に最新と一致
+ *   しない場合は破棄する (AbortController は React StrictMode の二重 effect で扱いづらい
+ *   ため requestId 方式)。
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  DispatchAuditEventType,
+  DispatchAuditLog,
+  GetAuditLogsResponse,
+} from "@lms-279/shared-types";
+import { useSuperAdminFetch } from "@/lib/super-api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getDispatchErrorMessage } from "../errorMessage";
+
+/** Radix Select は value="" を許容しないので「すべて」用の sentinel を用意 */
+const ALL_EVENT_TYPES = "__all__" as const;
+
+type FilterEventType = typeof ALL_EVENT_TYPES | DispatchAuditEventType;
+
+const EVENT_TYPE_OPTIONS: { value: FilterEventType; label: string }[] = [
+  { value: ALL_EVENT_TYPES, label: "すべて" },
+  { value: "run_started", label: "Run 開始" },
+  { value: "run_completed", label: "Run 完了" },
+  { value: "run_aborted", label: "Run 中断" },
+  { value: "user_reserved", label: "ユーザー予約" },
+  { value: "user_notified", label: "ユーザー通知済" },
+  { value: "user_skipped", label: "ユーザー skip" },
+  { value: "user_failed_transient", label: "一時失敗" },
+  { value: "user_failed_permanent", label: "永続失敗" },
+  { value: "manual_review_required", label: "手動確認要" },
+  { value: "settings_updated", label: "設定更新" },
+  { value: "test_send", label: "テスト送信" },
+  { value: "dry_run", label: "ドライラン" },
+  { value: "orphan_send", label: "孤児送信" },
+];
+
+interface FilterState {
+  eventType: FilterEventType;
+  tenantId: string;
+  userId: string;
+  /** datetime-local の生値 (`YYYY-MM-DDTHH:mm`)、API には ISO 文字列化して渡す */
+  from: string;
+  to: string;
+}
+
+const EMPTY_FILTER: FilterState = {
+  eventType: ALL_EVENT_TYPES,
+  tenantId: "",
+  userId: "",
+  from: "",
+  to: "",
+};
+
+function buildQuery(filter: FilterState, cursor: string | null): string {
+  const params = new URLSearchParams();
+  if (filter.eventType !== ALL_EVENT_TYPES) {
+    params.set("eventType", filter.eventType);
+  }
+  if (filter.tenantId.trim()) params.set("tenantId", filter.tenantId.trim());
+  if (filter.userId.trim()) params.set("userId", filter.userId.trim());
+  if (filter.from.trim()) {
+    params.set("from", new Date(filter.from).toISOString());
+  }
+  if (filter.to.trim()) {
+    params.set("to", new Date(filter.to).toISOString());
+  }
+  if (cursor) params.set("cursor", cursor);
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString("ja-JP");
+}
+
+function truncate(text: string | null, max = 80): string {
+  if (!text) return "";
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+export function AuditLogTable() {
+  const { superFetch } = useSuperAdminFetch();
+  // 編集中フィルタ (Input/Select に bind) と適用済フィルタ (loadMore で使う) を分離する。
+  const [filter, setFilter] = useState<FilterState>(EMPTY_FILTER);
+  const [activeFilter, setActiveFilter] = useState<FilterState>(EMPTY_FILTER);
+  const [logs, setLogs] = useState<DispatchAuditLog[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+
+  const fetchLogs = useCallback(
+    async (
+      currentFilter: FilterState,
+      cursor: string | null,
+      mode: "replace" | "append",
+    ) => {
+      const myRequestId = ++requestIdRef.current;
+      setLoading(true);
+      setError(null);
+      try {
+        const q = buildQuery(currentFilter, cursor);
+        const data = await superFetch<GetAuditLogsResponse>(
+          `/api/v2/super/dispatch/audit-logs${q}`,
+        );
+        // state race: 最新 fetch でない場合は結果を捨てる (古い filter のレスポンスを破棄)
+        if (requestIdRef.current !== myRequestId) return;
+        setLogs((prev) =>
+          mode === "append" ? [...prev, ...data.logs] : data.logs,
+        );
+        setNextCursor(data.nextCursor);
+      } catch (e) {
+        if (requestIdRef.current !== myRequestId) return;
+        setError(getDispatchErrorMessage(e, "監査ログの取得に失敗しました"));
+      } finally {
+        if (requestIdRef.current === myRequestId) {
+          setLoading(false);
+        }
+      }
+    },
+    [superFetch],
+  );
+
+  // 初回マウント時のみ「フィルタなし」で取得
+  useEffect(() => {
+    fetchLogs(EMPTY_FILTER, null, "replace");
+  }, [fetchLogs]);
+
+  const handleApply = () => {
+    setActiveFilter(filter);
+    setLogs([]); // フィルタ変更時に結果配列リセット
+    setNextCursor(null);
+    fetchLogs(filter, null, "replace");
+  };
+
+  const handleLoadMore = () => {
+    if (!nextCursor || loading) return;
+    fetchLogs(activeFilter, nextCursor, "append");
+  };
+
+  const handleRetry = () => {
+    fetchLogs(activeFilter, null, "replace");
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="space-y-1">
+          <label className="text-xs">イベント</label>
+          <Select
+            value={filter.eventType}
+            onValueChange={(v) =>
+              setFilter({ ...filter, eventType: v as FilterEventType })
+            }
+          >
+            <SelectTrigger className="w-44" aria-label="イベント種別">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {EVENT_TYPE_OPTIONS.map((t) => (
+                <SelectItem key={t.value} value={t.value}>
+                  {t.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs">テナント ID</label>
+          <Input
+            className="w-32"
+            value={filter.tenantId}
+            onChange={(e) => setFilter({ ...filter, tenantId: e.target.value })}
+            placeholder="任意"
+            aria-label="テナント ID"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs">ユーザー ID</label>
+          <Input
+            className="w-32"
+            value={filter.userId}
+            onChange={(e) => setFilter({ ...filter, userId: e.target.value })}
+            placeholder="任意"
+            aria-label="ユーザー ID"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs">From (JST)</label>
+          <Input
+            type="datetime-local"
+            className="w-44"
+            value={filter.from}
+            onChange={(e) => setFilter({ ...filter, from: e.target.value })}
+            aria-label="From"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs">To (JST)</label>
+          <Input
+            type="datetime-local"
+            className="w-44"
+            value={filter.to}
+            onChange={(e) => setFilter({ ...filter, to: e.target.value })}
+            aria-label="To"
+          />
+        </div>
+        {/* disabled にしない: ユーザーが連打しても requestId 方式で古い fetch は破棄される */}
+        <Button variant="outline" onClick={handleApply}>
+          適用
+        </Button>
+      </div>
+
+      {error && (
+        <div className="space-y-2">
+          <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+            {error}
+          </div>
+          <Button variant="outline" onClick={handleRetry}>
+            再読み込み
+          </Button>
+        </div>
+      )}
+
+      {!error && logs.length === 0 && !loading ? (
+        <div className="rounded-md border p-4 text-sm text-muted-foreground text-center">
+          該当する監査ログはありません
+        </div>
+      ) : !error ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>発生時刻</TableHead>
+              <TableHead>イベント</TableHead>
+              <TableHead>テナント</TableHead>
+              <TableHead>ユーザー</TableHead>
+              <TableHead>エラー</TableHead>
+              <TableHead className="text-right">処理時間</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {logs.map((log) => (
+              <TableRow key={log.auditId}>
+                <TableCell className="whitespace-nowrap text-xs">
+                  {formatDateTime(log.createdAt)}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline" className="font-mono">
+                    {log.eventType}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-xs">{log.tenantId ?? "-"}</TableCell>
+                <TableCell className="text-xs">{log.userId ?? "-"}</TableCell>
+                <TableCell className="text-xs">
+                  {log.errorCode ? (
+                    <>
+                      <span className="font-mono">{log.errorCode}</span>
+                      {log.errorMessage && (
+                        <span className="text-muted-foreground">
+                          {" "}
+                          {truncate(log.errorMessage)}
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    "-"
+                  )}
+                </TableCell>
+                <TableCell className="text-right text-xs">
+                  {log.durationMs != null ? `${log.durationMs}ms` : "-"}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : null}
+
+      <div className="flex items-center gap-2">
+        {loading && (
+          <span className="text-xs text-muted-foreground">読み込み中...</span>
+        )}
+        {nextCursor && !loading && !error && (
+          <Button variant="outline" onClick={handleLoadMore}>
+            次の件を読み込む
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/app/super/dispatch-settings/components/AuditLogTable.tsx
+++ b/web/app/super/dispatch-settings/components/AuditLogTable.tsx
@@ -213,8 +213,15 @@ export function AuditLogTable() {
             aria-label="ユーザー ID"
           />
         </div>
+        {/*
+          datetime-local の値 ("YYYY-MM-DDTHH:mm") は `new Date()` でブラウザ local time
+          として解釈されるため、label を「(JST)」と固定せず「(ローカル時刻)」とする。
+          本プロダクトのユーザーは多くが JST 環境のためほぼ JST 入力になるが、海外出張中
+          等で異なる timezone のブラウザを使う場合は local time として送信される。
+          厳密な JST 強制が必要になった時点で +09:00 suffix の付与等を検討する。
+        */}
         <div className="space-y-1">
-          <label className="text-xs">From (JST)</label>
+          <label className="text-xs">From (ローカル時刻)</label>
           <Input
             type="datetime-local"
             className="w-44"
@@ -224,7 +231,7 @@ export function AuditLogTable() {
           />
         </div>
         <div className="space-y-1">
-          <label className="text-xs">To (JST)</label>
+          <label className="text-xs">To (ローカル時刻)</label>
           <Input
             type="datetime-local"
             className="w-44"

--- a/web/app/super/dispatch-settings/components/RunHistoryTable.tsx
+++ b/web/app/super/dispatch-settings/components/RunHistoryTable.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+/**
+ * 配信 Run 履歴表示 (Phase 6 PR-F2)。
+ *
+ * GET /api/v2/super/dispatch/runs?limit=&cursor= を呼び、cursor paginate で累積 append。
+ *
+ * State race 対策: AuditLogTable と同じく `requestIdRef` で fetch ごとに採番し、
+ * 古いレスポンスは破棄する (連打 / 連続再読み込み時の古い結果 append を防ぐ)。
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  DispatchRun,
+  DispatchRunStatus,
+  GetRunsResponse,
+} from "@lms-279/shared-types";
+import { useSuperAdminFetch } from "@/lib/super-api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getDispatchErrorMessage } from "../errorMessage";
+
+function statusBadgeVariant(
+  status: DispatchRunStatus,
+): "default" | "secondary" | "destructive" | "outline" {
+  switch (status) {
+    case "completed":
+      return "secondary"; // 緑系を tailwind class で別途付ける
+    case "running":
+    case "aborted":
+    case "timeout":
+      return "destructive";
+    default:
+      return "outline";
+  }
+}
+
+function statusBadgeClass(status: DispatchRunStatus): string {
+  if (status === "completed") {
+    return "bg-emerald-100 text-emerald-800 border-emerald-200";
+  }
+  return "";
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString("ja-JP");
+}
+
+function truncate(text: string | null, max = 60): string {
+  if (!text) return "-";
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+export function RunHistoryTable() {
+  const { superFetch } = useSuperAdminFetch();
+  const [runs, setRuns] = useState<DispatchRun[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+
+  const fetchRuns = useCallback(
+    async (cursor: string | null, mode: "replace" | "append") => {
+      const myRequestId = ++requestIdRef.current;
+      setLoading(true);
+      setError(null);
+      try {
+        const q = cursor ? `?cursor=${encodeURIComponent(cursor)}` : "";
+        const data = await superFetch<GetRunsResponse>(
+          `/api/v2/super/dispatch/runs${q}`,
+        );
+        // state race: 最新でない fetch のレスポンスは破棄
+        if (requestIdRef.current !== myRequestId) return;
+        setRuns((prev) =>
+          mode === "append" ? [...prev, ...data.runs] : data.runs,
+        );
+        setNextCursor(data.nextCursor);
+      } catch (e) {
+        if (requestIdRef.current !== myRequestId) return;
+        setError(getDispatchErrorMessage(e, "Run 履歴の取得に失敗しました"));
+      } finally {
+        if (requestIdRef.current === myRequestId) {
+          setLoading(false);
+        }
+      }
+    },
+    [superFetch],
+  );
+
+  useEffect(() => {
+    fetchRuns(null, "replace");
+  }, [fetchRuns]);
+
+  const handleLoadMore = () => {
+    if (!nextCursor || loading) return;
+    fetchRuns(nextCursor, "append");
+  };
+
+  const handleRetry = () => {
+    fetchRuns(null, "replace");
+  };
+
+  return (
+    <div className="space-y-3">
+      {error && (
+        <div className="space-y-2">
+          <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+            {error}
+          </div>
+          <Button variant="outline" onClick={handleRetry}>
+            再読み込み
+          </Button>
+        </div>
+      )}
+
+      {!error && runs.length === 0 && !loading ? (
+        <div className="rounded-md border p-4 text-sm text-muted-foreground text-center">
+          Run 履歴はありません
+        </div>
+      ) : !error ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Run ID</TableHead>
+              <TableHead>起動時刻</TableHead>
+              <TableHead>ステータス</TableHead>
+              <TableHead className="text-right">テナント</TableHead>
+              <TableHead className="text-right">送信</TableHead>
+              <TableHead className="text-right">スキップ</TableHead>
+              <TableHead className="text-right">失敗</TableHead>
+              <TableHead className="text-right">要確認</TableHead>
+              <TableHead>中断理由</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {runs.map((run) => (
+              <TableRow key={run.runId}>
+                <TableCell className="font-mono text-xs">{run.runId}</TableCell>
+                <TableCell className="whitespace-nowrap text-xs">
+                  {formatDateTime(run.triggeredAt)}
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant={statusBadgeVariant(run.status)}
+                    className={statusBadgeClass(run.status)}
+                  >
+                    {run.status}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-right text-xs">
+                  {run.processedTenants}
+                </TableCell>
+                <TableCell className="text-right text-xs">{run.sent}</TableCell>
+                <TableCell className="text-right text-xs">
+                  {run.skipped}
+                </TableCell>
+                <TableCell className="text-right text-xs">
+                  {run.failed}
+                </TableCell>
+                <TableCell className="text-right text-xs">
+                  {run.manualReviewRequired}
+                </TableCell>
+                <TableCell className="text-xs text-muted-foreground">
+                  {truncate(run.abortedReason)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : null}
+
+      <div className="flex items-center gap-2">
+        {loading && (
+          <span className="text-xs text-muted-foreground">読み込み中...</span>
+        )}
+        {nextCursor && !loading && !error && (
+          <Button variant="outline" onClick={handleLoadMore}>
+            次の件を読み込む
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/app/super/dispatch-settings/components/TenantCcEditor.tsx
+++ b/web/app/super/dispatch-settings/components/TenantCcEditor.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+/**
+ * テナント別 CC 設定エディタ (Phase 6 PR-F2)。
+ *
+ * - GET /api/v2/super/tenants で一覧を取得しテナント選択
+ * - GET /api/v2/super/tenants/:id/notification-cc-emails で現在の CC を取得
+ * - chips UI で CC を編集 (上限 10、CRLF/カンマ/制御文字/format 拒否、case-insensitive 重複排除)
+ * - completionNotificationEnabled Switch
+ * - PUT で保存 (差分があるときのみ有効)
+ *
+ * クライアント側バリデーションは BE `validateSingleEmail`
+ * (services/api/src/services/dispatch/cc-email-validator.ts) と同じロジックを軽量ミラー。
+ * 詳細は BE で再検証されるので、UI は「明らかに弾けるもの」のみ。BE と divergence させない。
+ *
+ * Radix-ui Select の RTL テストが煩雑なため、tenant 選択 UI (TenantCcEditor) と
+ * CC 編集本体 (TenantCcForm) を分離し、テストは TenantCcForm に集中する。
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import type {
+  GetTenantNotificationCcResponse,
+  PutTenantNotificationCcRequest,
+  SuperTenantListResponse,
+} from "@lms-279/shared-types";
+import { DISPATCH_CONSTRAINTS } from "@lms-279/shared-types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useSuperAdminFetch } from "@/lib/super-api";
+import { getDispatchErrorMessage } from "../errorMessage";
+
+const MAX_CC = DISPATCH_CONSTRAINTS.NOTIFICATION_CC_EMAILS_MAX;
+
+type SuperFetch = <T>(path: string, options?: RequestInit) => Promise<T>;
+
+type ClientValidationReason =
+  | "empty"
+  | "crlf"
+  | "comma"
+  | "control"
+  | "format"
+  | "duplicate";
+
+function reasonMessage(reason: ClientValidationReason): string {
+  switch (reason) {
+    case "empty":
+      return "メールアドレスを入力してください。";
+    case "crlf":
+      return "改行を含むメールアドレスは登録できません。";
+    case "comma":
+      return "カンマを含むメールアドレスは登録できません。";
+    case "control":
+      return "制御文字を含むメールアドレスは登録できません。";
+    case "format":
+      return "メールアドレスの形式が正しくありません。";
+    case "duplicate":
+      return "既に登録されているメールアドレスです。";
+  }
+}
+
+/**
+ * BE `validateSingleEmail` (cc-email-validator.ts) と同じロジック。
+ * 拒否条件: empty / CRLF / カンマ / C0+DEL 制御文字 / format regex 違反。
+ * 詳細は BE で再検証されるので UI 側は最低限の門前払いに留める。
+ */
+export function validateClientCcEmail(
+  input: string,
+): { ok: true; value: string } | { ok: false; reason: ClientValidationReason } {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return { ok: false, reason: "empty" };
+  if (/[\r\n]/.test(trimmed)) return { ok: false, reason: "crlf" };
+  if (/,/.test(trimmed)) return { ok: false, reason: "comma" };
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(trimmed)) return { ok: false, reason: "control" };
+  if (!/^[^\s@,]+@[^\s@,]+\.[^\s@,]+$/.test(trimmed)) {
+    return { ok: false, reason: "format" };
+  }
+  return { ok: true, value: trimmed };
+}
+
+/**
+ * CC 編集フォーム本体。tenantId を props で受け取り、自分で fetch + 編集 + 保存する。
+ * Radix Select の RTL テストを避けるため親 (TenantCcEditor) から分離。
+ */
+export function TenantCcForm({
+  tenantId,
+  superFetch,
+}: {
+  tenantId: string;
+  superFetch: SuperFetch;
+}) {
+  const [config, setConfig] = useState<GetTenantNotificationCcResponse | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [originalEmails, setOriginalEmails] = useState<string[]>([]);
+  const [originalEnabled, setOriginalEnabled] = useState<boolean>(true);
+  const [emails, setEmails] = useState<string[]>([]);
+  const [enabled, setEnabled] = useState<boolean>(true);
+
+  const [draft, setDraft] = useState("");
+  const [draftError, setDraftError] = useState<string | null>(null);
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const applyLoaded = (data: GetTenantNotificationCcResponse) => {
+    setConfig(data);
+    setOriginalEmails(data.notificationCcEmails);
+    setOriginalEnabled(data.completionNotificationEnabled);
+    setEmails(data.notificationCcEmails);
+    setEnabled(data.completionNotificationEnabled);
+    setDraft("");
+    setDraftError(null);
+  };
+
+  const loadConfig = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setSaveError(null);
+    setNotice(null);
+    try {
+      const data = await superFetch<GetTenantNotificationCcResponse>(
+        `/api/v2/super/tenants/${tenantId}/notification-cc-emails`,
+      );
+      applyLoaded(data);
+    } catch (e) {
+      setError(getDispatchErrorMessage(e, "CC 設定の取得に失敗しました"));
+      setConfig(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [tenantId, superFetch]);
+
+  useEffect(() => {
+    loadConfig();
+  }, [loadConfig]);
+
+  const handleAdd = () => {
+    setDraftError(null);
+    if (emails.length >= MAX_CC) {
+      setDraftError(`CC は最大 ${MAX_CC} 件までです。`);
+      return;
+    }
+    const result = validateClientCcEmail(draft);
+    if (!result.ok) {
+      // 既存 chips は不変 (無効入力でも emails は触らない)
+      setDraftError(reasonMessage(result.reason));
+      return;
+    }
+    // case-insensitive 重複排除
+    const lowerSet = new Set(emails.map((e) => e.toLowerCase()));
+    if (lowerSet.has(result.value.toLowerCase())) {
+      setDraftError(reasonMessage("duplicate"));
+      return;
+    }
+    setEmails((prev) => [...prev, result.value]);
+    setDraft("");
+  };
+
+  const handleRemove = (email: string) => {
+    setEmails((prev) => prev.filter((e) => e !== email));
+    setDraftError(null);
+  };
+
+  const isDirty =
+    enabled !== originalEnabled ||
+    emails.length !== originalEmails.length ||
+    emails.some((e, i) => originalEmails[i] !== e);
+
+  const handleSave = async () => {
+    if (!isDirty) return;
+    setSaving(true);
+    setSaveError(null);
+    setNotice(null);
+    const body: PutTenantNotificationCcRequest = {
+      notificationCcEmails: emails,
+      completionNotificationEnabled: enabled,
+    };
+    try {
+      const updated = await superFetch<GetTenantNotificationCcResponse>(
+        `/api/v2/super/tenants/${tenantId}/notification-cc-emails`,
+        { method: "PUT", body: JSON.stringify(body) },
+      );
+      applyLoaded(updated);
+      setNotice("保存しました。");
+    } catch (e) {
+      setSaveError(getDispatchErrorMessage(e, "保存に失敗しました"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="text-sm text-muted-foreground">CC 設定を読み込み中...</div>;
+  }
+  if (error) {
+    return (
+      <div className="space-y-2">
+        <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+          {error}
+        </div>
+        <Button variant="outline" onClick={loadConfig}>
+          再読み込み
+        </Button>
+      </div>
+    );
+  }
+  if (!config) return null;
+
+  return (
+    <div className="space-y-3">
+      <label className="flex items-center gap-3 text-sm">
+        <Switch
+          checked={enabled}
+          onCheckedChange={setEnabled}
+          disabled={saving}
+          aria-label="このテナントへの完了通知を有効化"
+        />
+        <span>
+          {enabled ? "このテナントへの配信 ON" : "このテナントへの配信 OFF"}
+        </span>
+      </label>
+
+      <p className="text-xs text-muted-foreground">
+        オーナー: <span className="font-mono">{config.ownerEmail ?? "(未設定)"}</span>{" "}
+        (read-only、テナント編集画面で変更)
+      </p>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium">
+          追加 CC ({emails.length} / {MAX_CC})
+        </label>
+        {emails.length === 0 ? (
+          <p className="text-xs text-muted-foreground">追加 CC は未登録です。</p>
+        ) : (
+          <div className="flex flex-wrap gap-1.5" data-testid="cc-chips">
+            {emails.map((e) => (
+              <Badge key={e} variant="secondary" className="gap-1">
+                {e}
+                <button
+                  type="button"
+                  className="ml-0.5 text-muted-foreground hover:text-destructive"
+                  onClick={() => handleRemove(e)}
+                  disabled={saving}
+                  aria-label={`${e} を削除`}
+                >
+                  ×
+                </button>
+              </Badge>
+            ))}
+          </div>
+        )}
+        <div className="flex items-center gap-2">
+          <Input
+            type="text"
+            inputMode="email"
+            autoComplete="off"
+            placeholder="cc@example.com"
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              if (draftError) setDraftError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleAdd();
+              }
+            }}
+            disabled={saving || emails.length >= MAX_CC}
+            aria-label="追加する CC メール"
+          />
+          <Button
+            variant="outline"
+            onClick={handleAdd}
+            disabled={
+              saving || emails.length >= MAX_CC || draft.trim().length === 0
+            }
+          >
+            追加
+          </Button>
+        </div>
+        {draftError && (
+          <p className="text-xs text-destructive" role="alert">
+            {draftError}
+          </p>
+        )}
+      </div>
+
+      {saveError && (
+        <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+          {saveError}
+        </div>
+      )}
+      {notice && (
+        <div className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300">
+          {notice}
+        </div>
+      )}
+      <div>
+        <Button onClick={handleSave} disabled={!isDirty || saving}>
+          {saving ? "保存中..." : "保存"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * tenant 一覧 + 選択 UI。本体の編集は TenantCcForm に委譲。
+ */
+export function TenantCcEditor() {
+  const { superFetch } = useSuperAdminFetch();
+  const [tenants, setTenants] = useState<SuperTenantListResponse["tenants"]>(
+    [],
+  );
+  const [tenantsLoading, setTenantsLoading] = useState(true);
+  const [tenantsError, setTenantsError] = useState<string | null>(null);
+  const [selectedTenantId, setSelectedTenantId] = useState<string | null>(null);
+
+  const loadTenants = useCallback(async () => {
+    setTenantsLoading(true);
+    setTenantsError(null);
+    try {
+      const data = await superFetch<SuperTenantListResponse>(
+        "/api/v2/super/tenants",
+      );
+      setTenants(data.tenants);
+    } catch (e) {
+      setTenantsError(
+        getDispatchErrorMessage(e, "テナント一覧の取得に失敗しました"),
+      );
+    } finally {
+      setTenantsLoading(false);
+    }
+  }, [superFetch]);
+
+  useEffect(() => {
+    loadTenants();
+  }, [loadTenants]);
+
+  if (tenantsLoading) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        テナント一覧を読み込み中...
+      </div>
+    );
+  }
+  if (tenantsError) {
+    return (
+      <div className="space-y-2">
+        <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+          {tenantsError}
+        </div>
+        <Button variant="outline" onClick={loadTenants}>
+          再読み込み
+        </Button>
+      </div>
+    );
+  }
+  if (tenants.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        テナントが存在しません。
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <label className="text-sm font-medium">対象テナント</label>
+        <Select
+          value={selectedTenantId ?? ""}
+          onValueChange={(v) => setSelectedTenantId(v)}
+        >
+          <SelectTrigger className="w-full" aria-label="対象テナント">
+            <SelectValue placeholder="テナントを選択..." />
+          </SelectTrigger>
+          <SelectContent>
+            {tenants.map((t) => (
+              <SelectItem key={t.id} value={t.id}>
+                {t.name} ({t.id})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {selectedTenantId && (
+        <TenantCcForm
+          key={selectedTenantId}
+          tenantId={selectedTenantId}
+          superFetch={superFetch}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/app/super/dispatch-settings/components/__tests__/AuditLogTable.test.tsx
+++ b/web/app/super/dispatch-settings/components/__tests__/AuditLogTable.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * AuditLogTable (Phase 6 PR-F2) のテスト。
+ * - 初回ロード成功 → table 表示
+ * - 適用ボタンでフィルタ反映 + 結果配列リセット
+ * - cursor 次ページ append
+ * - state race (古いレスポンスを破棄、requestId 方式)
+ * - 空状態 / API error
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import type {
+  DispatchAuditLog,
+  GetAuditLogsResponse,
+} from "@lms-279/shared-types";
+import { ApiError } from "@/lib/api";
+import { AuditLogTable } from "../AuditLogTable";
+
+const superFetchMock = vi.fn();
+vi.mock("@/lib/super-api", () => ({
+  useSuperAdminFetch: () => ({ superFetch: superFetchMock }),
+}));
+
+beforeEach(() => {
+  superFetchMock.mockReset();
+});
+
+function mkLog(
+  auditId: string,
+  overrides: Partial<DispatchAuditLog> = {},
+): DispatchAuditLog {
+  return {
+    auditId,
+    runId: "run-x",
+    runStartedAt: "2026-05-22T01:00:00.000Z",
+    eventType: "user_notified",
+    tenantId: "t1",
+    userId: "u1",
+    errorCode: null,
+    errorMessage: null,
+    durationMs: 12,
+    createdAt: "2026-05-22T01:00:00.000Z",
+    ttlExpireAt: "2027-05-22T01:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("AuditLogTable", () => {
+  it("初回 GET で監査ログテーブルを表示する", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      logs: [mkLog("a1"), mkLog("a2", { eventType: "run_started" })],
+      nextCursor: null,
+    } satisfies GetAuditLogsResponse);
+    render(<AuditLogTable />);
+    expect(await screen.findByText("user_notified")).toBeInTheDocument();
+    expect(screen.getByText("run_started")).toBeInTheDocument();
+    expect(superFetchMock).toHaveBeenCalledWith(
+      "/api/v2/super/dispatch/audit-logs",
+    );
+  });
+
+  it("空応答時は「該当する監査ログはありません」を表示", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      logs: [],
+      nextCursor: null,
+    } satisfies GetAuditLogsResponse);
+    render(<AuditLogTable />);
+    expect(
+      await screen.findByText("該当する監査ログはありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("API エラー時はエラー + 再読み込みボタン (空表示は出さない)", async () => {
+    superFetchMock.mockRejectedValueOnce(
+      new ApiError(500, "internal", "監査取得失敗"),
+    );
+    render(<AuditLogTable />);
+    expect(await screen.findByText("監査取得失敗")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "再読み込み" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("該当する監査ログはありません"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("適用ボタンで filter を URL クエリに反映し、結果配列をリセットする", async () => {
+    superFetchMock
+      .mockResolvedValueOnce({
+        logs: [mkLog("a1")],
+        nextCursor: null,
+      } satisfies GetAuditLogsResponse)
+      .mockResolvedValueOnce({
+        logs: [mkLog("a2", { eventType: "run_aborted" })],
+        nextCursor: null,
+      } satisfies GetAuditLogsResponse);
+
+    render(<AuditLogTable />);
+    await screen.findByText("user_notified");
+
+    fireEvent.change(screen.getByLabelText("テナント ID"), {
+      target: { value: "tenant-x" },
+    });
+    fireEvent.change(screen.getByLabelText("ユーザー ID"), {
+      target: { value: "user-y" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "適用" }));
+    });
+
+    await waitFor(() =>
+      expect(superFetchMock).toHaveBeenLastCalledWith(
+        expect.stringContaining("tenantId=tenant-x"),
+      ),
+    );
+    const lastUrl = superFetchMock.mock.calls.at(-1)![0] as string;
+    expect(lastUrl).toContain("userId=user-y");
+
+    // 結果配列は 2 回目だけになる (1 回目の a1 は消える)
+    expect(await screen.findByText("run_aborted")).toBeInTheDocument();
+    expect(screen.queryByText("user_notified")).not.toBeInTheDocument();
+  });
+
+  it("nextCursor があれば「次の件を読み込む」で append する", async () => {
+    superFetchMock
+      .mockResolvedValueOnce({
+        logs: [mkLog("a1")],
+        nextCursor: "cursor-2",
+      } satisfies GetAuditLogsResponse)
+      .mockResolvedValueOnce({
+        logs: [mkLog("a2", { eventType: "settings_updated" })],
+        nextCursor: null,
+      } satisfies GetAuditLogsResponse);
+
+    render(<AuditLogTable />);
+    await screen.findByText("user_notified");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "次の件を読み込む" }));
+    });
+
+    // append で両方表示される
+    expect(await screen.findByText("settings_updated")).toBeInTheDocument();
+    expect(screen.getByText("user_notified")).toBeInTheDocument();
+    // 2 回目の URL には cursor=cursor-2 が含まれる
+    const lastUrl = superFetchMock.mock.calls.at(-1)![0] as string;
+    expect(lastUrl).toContain("cursor=cursor-2");
+  });
+
+  it("state race: 古い fetch のレスポンスが後着しても結果に反映されない", async () => {
+    // 初回 fetch は即解決 (初期表示まで進める)
+    superFetchMock.mockResolvedValueOnce({
+      logs: [mkLog("init", { eventType: "user_notified" })],
+      nextCursor: null,
+    } satisfies GetAuditLogsResponse);
+    render(<AuditLogTable />);
+    await screen.findByText("user_notified");
+
+    // 2 回目 fetch を pending にする (slow fetch を模す)
+    let resolveSlow: (v: GetAuditLogsResponse) => void = () => {};
+    const slowPromise = new Promise<GetAuditLogsResponse>((r) => {
+      resolveSlow = r;
+    });
+    superFetchMock.mockImplementationOnce(() => slowPromise);
+    fireEvent.click(screen.getByRole("button", { name: "適用" }));
+
+    // 3 回目 fetch を即解決 (連打 = ユーザーが filter を変えて再適用したシナリオ)
+    superFetchMock.mockResolvedValueOnce({
+      logs: [mkLog("newest", { eventType: "settings_updated" })],
+      nextCursor: null,
+    } satisfies GetAuditLogsResponse);
+    fireEvent.click(screen.getByRole("button", { name: "適用" }));
+
+    // 3 回目の結果が最終的に表示される
+    await screen.findByText("settings_updated");
+
+    // 2 回目 fetch (slow) を後着で解決 → 古い requestId なので結果は破棄される
+    await act(async () => {
+      resolveSlow({
+        logs: [mkLog("stale", { eventType: "user_failed_permanent" })],
+        nextCursor: null,
+      });
+    });
+
+    expect(
+      screen.queryByText("user_failed_permanent"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("settings_updated")).toBeInTheDocument();
+  });
+
+  it("再読み込みボタンで activeFilter (最後に適用したもの) で再取得", async () => {
+    // 1 回目: 初回 fetch エラー
+    superFetchMock.mockRejectedValueOnce(
+      new ApiError(500, "internal", "失敗"),
+    );
+    render(<AuditLogTable />);
+    expect(await screen.findByText("失敗")).toBeInTheDocument();
+
+    // リトライ成功
+    superFetchMock.mockResolvedValueOnce({
+      logs: [mkLog("a1")],
+      nextCursor: null,
+    } satisfies GetAuditLogsResponse);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "再読み込み" }));
+    });
+    expect(await screen.findByText("user_notified")).toBeInTheDocument();
+  });
+});

--- a/web/app/super/dispatch-settings/components/__tests__/RunHistoryTable.test.tsx
+++ b/web/app/super/dispatch-settings/components/__tests__/RunHistoryTable.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * RunHistoryTable (Phase 6 PR-F2) のテスト。
+ * - 初回ロード → table + status badge
+ * - cursor 次ページ append
+ * - 空状態 / エラー
+ * - state race
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+} from "@testing-library/react";
+import type {
+  DispatchRun,
+  GetRunsResponse,
+} from "@lms-279/shared-types";
+import { ApiError } from "@/lib/api";
+import { RunHistoryTable } from "../RunHistoryTable";
+
+const superFetchMock = vi.fn();
+vi.mock("@/lib/super-api", () => ({
+  useSuperAdminFetch: () => ({ superFetch: superFetchMock }),
+}));
+
+beforeEach(() => {
+  superFetchMock.mockReset();
+});
+
+function mkRun(runId: string, overrides: Partial<DispatchRun> = {}): DispatchRun {
+  return {
+    runId,
+    triggeredAt: "2026-05-22T01:00:00.000Z",
+    status: "completed",
+    leaseExpiresAt: "2026-05-22T01:05:00.000Z",
+    processedTenants: 2,
+    sent: 3,
+    skipped: 1,
+    failed: 0,
+    manualReviewRequired: 0,
+    abortedReason: null,
+    ttlExpireAt: "2027-05-22T01:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("RunHistoryTable", () => {
+  it("初回 GET で run 履歴を表示する", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      runs: [
+        mkRun("run-1"),
+        mkRun("run-2", { status: "aborted", abortedReason: "scope_revoked" }),
+      ],
+      nextCursor: null,
+    } satisfies GetRunsResponse);
+    render(<RunHistoryTable />);
+    expect(await screen.findByText("run-1")).toBeInTheDocument();
+    expect(screen.getByText("run-2")).toBeInTheDocument();
+    // status badge
+    expect(screen.getByText("completed")).toBeInTheDocument();
+    expect(screen.getByText("aborted")).toBeInTheDocument();
+    // abortedReason
+    expect(screen.getByText("scope_revoked")).toBeInTheDocument();
+  });
+
+  it("空応答時は「Run 履歴はありません」を表示", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      runs: [],
+      nextCursor: null,
+    } satisfies GetRunsResponse);
+    render(<RunHistoryTable />);
+    expect(
+      await screen.findByText("Run 履歴はありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("API エラー時はエラー + 再読み込みボタン (空表示は出さない)", async () => {
+    superFetchMock.mockRejectedValueOnce(
+      new ApiError(500, "internal", "runs 取得失敗"),
+    );
+    render(<RunHistoryTable />);
+    expect(await screen.findByText("runs 取得失敗")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "再読み込み" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Run 履歴はありません"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("nextCursor で「次の件を読み込む」append", async () => {
+    superFetchMock
+      .mockResolvedValueOnce({
+        runs: [mkRun("run-1")],
+        nextCursor: "next-cursor",
+      } satisfies GetRunsResponse)
+      .mockResolvedValueOnce({
+        runs: [mkRun("run-2", { status: "running" })],
+        nextCursor: null,
+      } satisfies GetRunsResponse);
+
+    render(<RunHistoryTable />);
+    await screen.findByText("run-1");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "次の件を読み込む" }));
+    });
+
+    expect(await screen.findByText("run-2")).toBeInTheDocument();
+    expect(screen.getByText("run-1")).toBeInTheDocument();
+    expect(screen.getByText("running")).toBeInTheDocument();
+    const lastUrl = superFetchMock.mock.calls.at(-1)![0] as string;
+    expect(lastUrl).toContain("cursor=next-cursor");
+  });
+
+  it("再読み込みで初期化と同じ fetch を再実行", async () => {
+    superFetchMock.mockRejectedValueOnce(
+      new ApiError(500, "internal", "一時失敗"),
+    );
+    render(<RunHistoryTable />);
+    await screen.findByText("一時失敗");
+
+    superFetchMock.mockResolvedValueOnce({
+      runs: [mkRun("run-1")],
+      nextCursor: null,
+    } satisfies GetRunsResponse);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "再読み込み" }));
+    });
+
+    expect(await screen.findByText("run-1")).toBeInTheDocument();
+  });
+
+  it("pending な loadMore fetch が後で解決されると累積 append される", async () => {
+    // 初回 fetch
+    superFetchMock.mockResolvedValueOnce({
+      runs: [mkRun("init")],
+      nextCursor: "cursor-pending",
+    } satisfies GetRunsResponse);
+    render(<RunHistoryTable />);
+    await screen.findByText("init");
+
+    // loadMore を slow pending にする
+    let resolveSlow: (v: GetRunsResponse) => void = () => {};
+    superFetchMock.mockImplementationOnce(
+      () =>
+        new Promise<GetRunsResponse>((r) => {
+          resolveSlow = r;
+        }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "次の件を読み込む" }));
+
+    // 後着で解決 → 唯一の pending fetch なので requestId 一致で append される
+    await act(async () => {
+      resolveSlow({
+        runs: [mkRun("later", { status: "running" })],
+        nextCursor: null,
+      });
+    });
+
+    expect(await screen.findByText("later")).toBeInTheDocument();
+    expect(screen.getByText("init")).toBeInTheDocument();
+
+    // NOTE: RunHistoryTable は filter がなく、handleLoadMore も loading=true 中は no-op で
+    // ガードされているため、AuditLogTable で発生し得る「連打による race」を component test で
+    // 再現する手段がない。requestId ロジックの race 対策は AuditLogTable の state race テストで
+    // 共通実装を代表してカバーする。
+  });
+});

--- a/web/app/super/dispatch-settings/components/__tests__/TenantCcEditor.test.tsx
+++ b/web/app/super/dispatch-settings/components/__tests__/TenantCcEditor.test.tsx
@@ -1,0 +1,373 @@
+/**
+ * TenantCcEditor / TenantCcForm (Phase 6 PR-F2) のテスト。
+ *
+ * Radix-ui Select の interaction が RTL で煩雑なため、本テストは TenantCcForm
+ * (CC 編集本体) に集中する。TenantCcEditor (tenant 選択ラッパー) はロード/エラー/空の
+ * 表示分岐のみ確認する。
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import type {
+  GetTenantNotificationCcResponse,
+  SuperTenantListResponse,
+} from "@lms-279/shared-types";
+import { ApiError } from "@/lib/api";
+import {
+  TenantCcEditor,
+  TenantCcForm,
+  validateClientCcEmail,
+} from "../TenantCcEditor";
+
+const superFetchMock = vi.fn();
+vi.mock("@/lib/super-api", () => ({
+  useSuperAdminFetch: () => ({ superFetch: superFetchMock }),
+}));
+
+beforeEach(() => {
+  superFetchMock.mockReset();
+});
+
+const baseConfig: GetTenantNotificationCcResponse = {
+  ownerEmail: "owner@example.com",
+  notificationCcEmails: ["cc1@example.com", "cc2@example.com"],
+  completionNotificationEnabled: true,
+};
+
+describe("validateClientCcEmail", () => {
+  it("正常な email は ok=true", () => {
+    expect(validateClientCcEmail("a@example.com")).toEqual({
+      ok: true,
+      value: "a@example.com",
+    });
+  });
+
+  it("前後空白は trim される", () => {
+    expect(validateClientCcEmail("  a@example.com  ")).toEqual({
+      ok: true,
+      value: "a@example.com",
+    });
+  });
+
+  it("空文字 / 空白のみは empty", () => {
+    expect(validateClientCcEmail("")).toEqual({ ok: false, reason: "empty" });
+    expect(validateClientCcEmail("   ")).toEqual({ ok: false, reason: "empty" });
+  });
+
+  it("内部 CRLF を含むと crlf (末尾は trim() で消えるので OK 扱い、BE 仕様と一致)", () => {
+    expect(validateClientCcEmail("a@e.com\nfoo")).toEqual({
+      ok: false,
+      reason: "crlf",
+    });
+    expect(validateClientCcEmail("a@e.com\rfoo")).toEqual({
+      ok: false,
+      reason: "crlf",
+    });
+    // 末尾 \n は trim で消える → 通過 (BE validateSingleEmail と同じ挙動)
+    expect(validateClientCcEmail("a@e.com\n")).toEqual({
+      ok: true,
+      value: "a@e.com",
+    });
+  });
+
+  it("カンマを含むと comma", () => {
+    expect(validateClientCcEmail("a@e.com,b@e.com")).toEqual({
+      ok: false,
+      reason: "comma",
+    });
+  });
+
+  it("制御文字を含むと control", () => {
+    expect(validateClientCcEmail("a@e.com\x07")).toEqual({
+      ok: false,
+      reason: "control",
+    });
+    expect(validateClientCcEmail("a@e.com\x7f")).toEqual({
+      ok: false,
+      reason: "control",
+    });
+  });
+
+  it("形式違反は format", () => {
+    expect(validateClientCcEmail("plain")).toEqual({
+      ok: false,
+      reason: "format",
+    });
+    expect(validateClientCcEmail("a@b")).toEqual({
+      ok: false,
+      reason: "format",
+    });
+    expect(validateClientCcEmail("@example.com")).toEqual({
+      ok: false,
+      reason: "format",
+    });
+  });
+});
+
+describe("TenantCcForm", () => {
+  const renderForm = (tenantId = "t1") =>
+    render(<TenantCcForm tenantId={tenantId} superFetch={superFetchMock} />);
+
+  it("初期 GET で chips を表示する", async () => {
+    superFetchMock.mockResolvedValueOnce(baseConfig);
+    renderForm();
+    expect(await screen.findByText("cc1@example.com")).toBeInTheDocument();
+    expect(screen.getByText("cc2@example.com")).toBeInTheDocument();
+    expect(screen.getByText(/オーナー:/)).toHaveTextContent(
+      "owner@example.com",
+    );
+    expect(screen.getByText("追加 CC (2 / 10)")).toBeInTheDocument();
+  });
+
+  it("初期 GET 失敗時はエラー + 再読み込みボタン", async () => {
+    superFetchMock.mockRejectedValueOnce(
+      new ApiError(500, "internal", "ロード失敗"),
+    );
+    renderForm();
+    expect(await screen.findByText("ロード失敗")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "再読み込み" }),
+    ).toBeInTheDocument();
+  });
+
+  it("追加ボタンで新しい chip を追加する", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      ...baseConfig,
+      notificationCcEmails: [],
+    });
+    renderForm();
+    await screen.findByText("追加 CC (0 / 10)");
+
+    fireEvent.change(screen.getByLabelText("追加する CC メール"), {
+      target: { value: "new@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+
+    expect(await screen.findByText("new@example.com")).toBeInTheDocument();
+    expect(screen.getByText("追加 CC (1 / 10)")).toBeInTheDocument();
+  });
+
+  it("Enter キーでも追加できる", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      ...baseConfig,
+      notificationCcEmails: [],
+    });
+    renderForm();
+    await screen.findByText("追加 CC (0 / 10)");
+
+    const input = screen.getByLabelText(
+      "追加する CC メール",
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "new@example.com" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(await screen.findByText("new@example.com")).toBeInTheDocument();
+  });
+
+  // CRLF / 制御文字 / カンマの拒否は validateClientCcEmail の単体テストで網羅済み
+  // (jsdom の input 経由では改行や制御文字が strip されることがあり component test では再現困難)。
+  // 「無効入力時に既存 chips が壊れない」挙動は format / 重複 ケースで代表する。
+
+  it("無効入力 (format) でエラー、既存 chips が壊れない", async () => {
+    superFetchMock.mockResolvedValueOnce(baseConfig);
+    renderForm();
+    await screen.findByText("cc1@example.com");
+
+    fireEvent.change(screen.getByLabelText("追加する CC メール"), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+
+    expect(
+      await screen.findByText("メールアドレスの形式が正しくありません。"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("cc1@example.com")).toBeInTheDocument();
+  });
+
+  it("case-insensitive 重複はエラーで弾く", async () => {
+    superFetchMock.mockResolvedValueOnce(baseConfig);
+    renderForm();
+    await screen.findByText("cc1@example.com");
+
+    fireEvent.change(screen.getByLabelText("追加する CC メール"), {
+      target: { value: "CC1@Example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+
+    expect(
+      await screen.findByText("既に登録されているメールアドレスです。"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("追加 CC (2 / 10)")).toBeInTheDocument();
+  });
+
+  it("上限 10 件に達したら追加 input が disable", async () => {
+    const tenEmails = Array.from(
+      { length: 10 },
+      (_, i) => `cc${i}@example.com`,
+    );
+    superFetchMock.mockResolvedValueOnce({
+      ...baseConfig,
+      notificationCcEmails: tenEmails,
+    });
+    renderForm();
+    await screen.findByText("追加 CC (10 / 10)");
+
+    expect(screen.getByLabelText("追加する CC メール")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "追加" })).toBeDisabled();
+  });
+
+  it("削除後に同じ email を再追加できる", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      ...baseConfig,
+      notificationCcEmails: ["cc1@example.com"],
+    });
+    renderForm();
+    await screen.findByText("cc1@example.com");
+
+    // 削除
+    fireEvent.click(
+      screen.getByRole("button", { name: "cc1@example.com を削除" }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("cc1@example.com")).not.toBeInTheDocument(),
+    );
+
+    // 同じ email を再追加
+    fireEvent.change(screen.getByLabelText("追加する CC メール"), {
+      target: { value: "cc1@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+    expect(await screen.findByText("cc1@example.com")).toBeInTheDocument();
+  });
+
+  it("差分が無いと保存ボタンは disable、差分があると enable", async () => {
+    superFetchMock.mockResolvedValueOnce(baseConfig);
+    renderForm();
+    await screen.findByText("cc1@example.com");
+
+    expect(screen.getByRole("button", { name: "保存" })).toBeDisabled();
+
+    // 1 件削除で dirty
+    fireEvent.click(
+      screen.getByRole("button", { name: "cc2@example.com を削除" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "保存" })).toBeEnabled(),
+    );
+  });
+
+  it("保存で PUT を呼び成功メッセージを出す", async () => {
+    superFetchMock
+      .mockResolvedValueOnce(baseConfig) // GET
+      .mockResolvedValueOnce({
+        ...baseConfig,
+        notificationCcEmails: ["cc1@example.com"],
+      }); // PUT
+    renderForm();
+    await screen.findByText("cc2@example.com");
+
+    // 1 件削除して保存
+    fireEvent.click(
+      screen.getByRole("button", { name: "cc2@example.com を削除" }),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    });
+
+    await waitFor(() =>
+      expect(superFetchMock).toHaveBeenCalledWith(
+        "/api/v2/super/tenants/t1/notification-cc-emails",
+        expect.objectContaining({ method: "PUT" }),
+      ),
+    );
+    const putCall = superFetchMock.mock.calls.find(
+      (c) => c[1]?.method === "PUT",
+    );
+    expect(JSON.parse(putCall![1].body)).toEqual({
+      notificationCcEmails: ["cc1@example.com"],
+      completionNotificationEnabled: true,
+    });
+    expect(await screen.findByText("保存しました。")).toBeInTheDocument();
+    // 保存後は差分なし → 保存ボタン disable
+    expect(screen.getByRole("button", { name: "保存" })).toBeDisabled();
+  });
+
+  it("保存失敗時はエラー表示し chips state は維持", async () => {
+    superFetchMock
+      .mockResolvedValueOnce(baseConfig) // GET
+      .mockRejectedValueOnce(new ApiError(400, "bad_request", "保存失敗")); // PUT
+    renderForm();
+    await screen.findByText("cc1@example.com");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "cc2@example.com を削除" }),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    });
+
+    expect(await screen.findByText("保存失敗")).toBeInTheDocument();
+    // chips state は維持 (削除した cc2 はまだ表示されない)
+    expect(screen.queryByText("cc2@example.com")).not.toBeInTheDocument();
+    expect(screen.getByText("cc1@example.com")).toBeInTheDocument();
+  });
+});
+
+describe("TenantCcEditor (tenant 選択ラッパー)", () => {
+  const tenantsResponse: SuperTenantListResponse = {
+    tenants: [
+      {
+        id: "demo",
+        name: "デモテナント",
+        ownerEmail: "owner@demo.com",
+        status: "active",
+        userCount: 3,
+        gcipTenantId: null,
+        useGcip: false,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+  };
+
+  it("テナント一覧ロード成功で Select を表示する", async () => {
+    superFetchMock.mockResolvedValueOnce(tenantsResponse);
+    render(<TenantCcEditor />);
+    expect(await screen.findByLabelText("対象テナント")).toBeInTheDocument();
+  });
+
+  it("テナント一覧 0 件時は案内文を表示する", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      tenants: [],
+      pagination: { total: 0, limit: 50, offset: 0, hasMore: false },
+    } satisfies SuperTenantListResponse);
+    render(<TenantCcEditor />);
+    expect(
+      await screen.findByText("テナントが存在しません。"),
+    ).toBeInTheDocument();
+  });
+
+  it("テナント一覧ロード失敗時はエラー + 再読み込み", async () => {
+    superFetchMock.mockRejectedValueOnce(
+      new ApiError(500, "internal", "tenants エラー"),
+    );
+    render(<TenantCcEditor />);
+    expect(await screen.findByText("tenants エラー")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "再読み込み" }),
+    ).toBeInTheDocument();
+  });
+});
+
+// テストカバレッジ範囲外 (Radix Select の interaction は RTL で煩雑):
+// - Select で tenant を切り替えると TenantCcForm が再 mount される動線。
+//   key={selectedTenantId} を渡しているので React 側で確実に remount され、新 tenantId で
+//   loadConfig が走る。挙動は本テストの「初期 GET で chips を表示する」が tenantId="t1" 固定で
+//   保証している。
+//   Radix Select の click flow は実機 (Phase 8 cutover の dev/staging 目視確認) でカバー。

--- a/web/app/super/dispatch-settings/page.tsx
+++ b/web/app/super/dispatch-settings/page.tsx
@@ -1,14 +1,18 @@
 "use client";
 
 /**
- * スーパー管理者: 自動完了通知 配信設定ページ (Phase 6 PR-F1)。
+ * スーパー管理者: 自動完了通知 配信設定ページ (Phase 6 PR-F1 + PR-F2)。
  *
  * - GET /api/v2/super/dispatch/settings で初期値ロード (doc 未作成時は default)
  * - enabled (kill switch) / スケジュール / 署名・本文を編集し PUT で保存 (version 楽観ロック)
  * - 409 (version 競合) は最新値を再取得してフォームへ反映 + 警告 (AC-23)
  * - ドライラン / テスト送信を実行
+ * - テナント別 CC 設定 (PR-F2)
+ * - 監査ログ / run 履歴 (PR-F2)
  *
- * senderEmail は env 由来 (read-only)。テナント別 CC / 監査ログ / run 履歴は PR-F2。
+ * senderEmail は env 由来 (read-only)。F2 component (TenantCcEditor / AuditLogTable /
+ * RunHistoryTable) は本ページの settings ロード状態と独立に自分で fetch するため、
+ * settings ロード失敗時でも他 Section を閲覧できる。
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -24,6 +28,9 @@ import { ScheduleEditor } from "./components/ScheduleEditor";
 import { MessageBodyEditor } from "./components/MessageBodyEditor";
 import { DryRunPanel } from "./components/DryRunPanel";
 import { TestSendButton } from "./components/TestSendButton";
+import { TenantCcEditor } from "./components/TenantCcEditor";
+import { AuditLogTable } from "./components/AuditLogTable";
+import { RunHistoryTable } from "./components/RunHistoryTable";
 import { getDispatchErrorMessage } from "./errorMessage";
 
 interface FormState {
@@ -137,23 +144,6 @@ export default function DispatchSettingsPage() {
     }
   };
 
-  if (loading) {
-    return <div className="text-muted-foreground">読み込み中...</div>;
-  }
-  if (error) {
-    return (
-      <div className="space-y-3">
-        <div className="rounded-md bg-destructive/10 p-4 text-destructive text-sm">
-          {error}
-        </div>
-        <Button variant="outline" onClick={loadSettings}>
-          再読み込み
-        </Button>
-      </div>
-    );
-  }
-  if (!form) return null;
-
   return (
     <div className="space-y-4">
       <div>
@@ -163,84 +153,125 @@ export default function DispatchSettingsPage() {
         </p>
       </div>
 
-      <Section
-        title="配信の有効化"
-        description="無効にすると次回 cron 起動時に即座に配信が停止します (kill switch)。"
-      >
-        <label className="flex items-center gap-3 text-sm">
-          <Switch
-            checked={form.enabled}
-            onCheckedChange={(v) => setForm({ ...form, enabled: v })}
-            disabled={saving}
-            aria-label="配信を有効化"
-          />
-          <span>{form.enabled ? "配信 ON" : "配信 OFF"}</span>
-        </label>
-        <p className="text-xs text-muted-foreground">
-          送信元: <span className="font-mono">{form.senderEmail}</span> (環境設定、変更不可)
-        </p>
-      </Section>
-
-      <Section title="配信スケジュール">
-        <ScheduleEditor
-          daysOfWeek={form.scheduleDaysOfWeek}
-          hourJst={form.scheduleHourJst}
-          onChange={(next) =>
-            setForm({
-              ...form,
-              scheduleDaysOfWeek: next.daysOfWeek,
-              scheduleHourJst: next.hourJst,
-            })
-          }
-          disabled={saving}
-        />
-      </Section>
-
-      <Section title="メール署名・本文">
-        <MessageBodyEditor
-          signatureName={form.signatureName}
-          completionMessageBody={form.completionMessageBody}
-          onChange={(next) =>
-            setForm({
-              ...form,
-              signatureName: next.signatureName,
-              completionMessageBody: next.completionMessageBody,
-            })
-          }
-          disabled={saving}
-        />
-      </Section>
-
-      {saveError && (
-        <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
-          {saveError}
-        </div>
+      {/* F1: settings (ロード/エラー時は他 Section と独立に inline 表示) */}
+      {loading && (
+        <div className="text-muted-foreground">読み込み中...</div>
       )}
-      {notice && (
-        <div className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300">
-          {notice}
+      {error && (
+        <div className="space-y-3">
+          <div className="rounded-md bg-destructive/10 p-4 text-destructive text-sm">
+            {error}
+          </div>
+          <Button variant="outline" onClick={loadSettings}>
+            再読み込み
+          </Button>
         </div>
       )}
 
-      <div className="flex items-center gap-3">
-        <Button onClick={handleSave} disabled={saving}>
-          {saving ? "保存中..." : "保存"}
-        </Button>
-        <span className="text-xs text-muted-foreground">version {form.version}</span>
-      </div>
+      {form && (
+        <>
+          <Section
+            title="配信の有効化"
+            description="無効にすると次回 cron 起動時に即座に配信が停止します (kill switch)。"
+          >
+            <label className="flex items-center gap-3 text-sm">
+              <Switch
+                checked={form.enabled}
+                onCheckedChange={(v) => setForm({ ...form, enabled: v })}
+                disabled={saving}
+                aria-label="配信を有効化"
+              />
+              <span>{form.enabled ? "配信 ON" : "配信 OFF"}</span>
+            </label>
+            <p className="text-xs text-muted-foreground">
+              送信元: <span className="font-mono">{form.senderEmail}</span> (環境設定、変更不可)
+            </p>
+          </Section>
 
+          <Section title="配信スケジュール">
+            <ScheduleEditor
+              daysOfWeek={form.scheduleDaysOfWeek}
+              hourJst={form.scheduleHourJst}
+              onChange={(next) =>
+                setForm({
+                  ...form,
+                  scheduleDaysOfWeek: next.daysOfWeek,
+                  scheduleHourJst: next.hourJst,
+                })
+              }
+              disabled={saving}
+            />
+          </Section>
+
+          <Section title="メール署名・本文">
+            <MessageBodyEditor
+              signatureName={form.signatureName}
+              completionMessageBody={form.completionMessageBody}
+              onChange={(next) =>
+                setForm({
+                  ...form,
+                  signatureName: next.signatureName,
+                  completionMessageBody: next.completionMessageBody,
+                })
+              }
+              disabled={saving}
+            />
+          </Section>
+
+          {saveError && (
+            <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+              {saveError}
+            </div>
+          )}
+          {notice && (
+            <div className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300">
+              {notice}
+            </div>
+          )}
+
+          <div className="flex items-center gap-3">
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? "保存中..." : "保存"}
+            </Button>
+            <span className="text-xs text-muted-foreground">version {form.version}</span>
+          </div>
+
+          <Section
+            title="ドライラン"
+            description="次回配信される対象を送信せずに確認します。"
+          >
+            <DryRunPanel />
+          </Section>
+
+          <Section
+            title="テスト送信"
+            description="設定中の送信経路を、自分宛の固定ダミーメールで確認します。"
+          >
+            <TestSendButton />
+          </Section>
+        </>
+      )}
+
+      {/* F2: settings の loading/error と独立に表示。1 つの Section の取得失敗が他に波及しない */}
       <Section
-        title="ドライラン"
-        description="次回配信される対象を送信せずに確認します。"
+        title="テナント別 CC 設定"
+        description="完了通知メールに CC として追加するメールアドレスをテナントごとに設定します (上限 10 件)。"
       >
-        <DryRunPanel />
+        <TenantCcEditor />
       </Section>
 
       <Section
-        title="テスト送信"
-        description="設定中の送信経路を、自分宛の固定ダミーメールで確認します。"
+        title="監査ログ"
+        description="配信に関する各種イベントの履歴 (TTL 365 日)。"
       >
-        <TestSendButton />
+        <AuditLogTable />
+      </Section>
+
+      <Section
+        title="Run 履歴"
+        description="Cloud Scheduler 起動ごとの実行結果 (TTL 365 日)。"
+      >
+        <RunHistoryTable />
       </Section>
     </div>
   );

--- a/web/app/super/dispatch-settings/page.tsx
+++ b/web/app/super/dispatch-settings/page.tsx
@@ -92,12 +92,19 @@ export default function DispatchSettingsPage() {
   const loadSettings = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setSaveError(null); // 前回の保存エラーを持ち越さない
+    setNotice(null);
     try {
       const data = await superFetchRef.current<GetDispatchSettingsResponse>(
         "/api/v2/super/dispatch/settings",
       );
       setForm(toFormState(data));
     } catch (e) {
+      // 早期 return を廃止し条件 render に変更したので、form を null 化しないと
+      // 前回成功時の値が残ったまま error と同時表示される。AC-23 の 409 reload は
+      // 409 を catch する前に loadSettings の try ブロックに入るため、新値を取得して
+      // setForm が成功すれば form は最新値で上書きされる。
+      setForm(null);
       setError(getDispatchErrorMessage(e, "設定の取得に失敗しました"));
     } finally {
       setLoading(false);


### PR DESCRIPTION
## 概要

PR-F1 (#479) に続き、`/super/dispatch-settings` ページに残る 3 component と API smoke E2E を追加して **impl-plan Phase 6 Frontend UI** を完了させる。

## 変更内容

| 区分 | ファイル | 用途 |
|---|---|---|
| 新規 component | `TenantCcEditor.tsx` | テナント別 CC chips UI (上限 10、CRLF/カンマ/制御文字拒否、case-insensitive 重複排除) + `completionNotificationEnabled` Switch。Radix Select の testability から `TenantCcEditor` (tenant 選択ラッパー) と `TenantCcForm` (CC 編集本体) を 1 ファイル 2 export で分離 |
| 新規 component | `AuditLogTable.tsx` | 監査ログ表示。フィルタ (eventType / tenantId / userId / from / to) + cursor paginate |
| 新規 component | `RunHistoryTable.tsx` | Run 履歴表示。status Badge 色分け (completed=緑 / running・aborted・timeout=赤) + cursor paginate |
| 変更 | `page.tsx` | F2 component を Section で追加マウント。F2 は settings ロード状態と**独立に常に表示** (settings 失敗時でも閲覧可能) |
| 変更 | `__tests__/page.test.tsx` | F2 を `vi.mock` で stub 化、F2 が settings 失敗時にもマウントされるテストを追加 |
| 新規 test | TenantCcEditor (21) / AuditLogTable (7) / RunHistoryTable (6) | 計 34 件 |
| 新規 E2E | `dispatch-settings-api.spec.ts` | API smoke (audit-logs / runs / tenant CC GET/PUT + 認可境界 401/403/200 + バリデーション 400) |
| 変更 | `e2e/playwright.config.ts` | api webServer env に `SUPER_ADMIN_EMAILS=admin@example.com` 追加 |

## 設計判断

### state race 対策 (Codex セカンドオピニオン指摘反映)

filter 変更直後に古い fetch のレスポンスが後着して結果配列を上書きする race を防ぐため、`requestIdRef` で fetch ごとに採番する snapshot 方式を採用。`AbortController` は React StrictMode の二重 effect で扱いづらいため不採用。AuditLogTable のテストで「slow pending → 後着 → 破棄」シナリオを実証。

「適用」ボタンは `disabled={loading}` にしない (連打を許容)。requestId 方式が古い fetch を破棄するため。

### Playwright UI E2E スキップ

super ページは Firebase user 必須で `AUTH_MODE=dev` + `user=null` ではブラウザ表示不可 (PR-F1 で確立した方針)。代わりに API smoke で疎通を取り、UI ロジックは component test 34 件でカバー。E2E spec 冒頭にスキップ理由を明文化。

### FE/BE validator divergence 回避

`validateClientCcEmail` (FE) は BE の `validateSingleEmail` と同じ正規表現を使用。`<>` 等の独自拡張は加えず BE 仕様にミラー。詳細は BE で再検証する前提のため UI は「明らかに弾けるもの」のみ。共通モジュール化は follow-up Issue 候補。

### F1/F2 独立ロード

`<TenantCcEditor />` / `<AuditLogTable />` / `<RunHistoryTable />` は内部で fetch するため、settings ロード失敗時でも閲覧可能。Section ごとに loading / error / empty が独立。

## Test plan

- [x] `npm run type-check -w @lms-279/web`: PASS
- [x] `npm run lint`: 0 errors (warning 1 件は本 PR 範囲外)
- [x] `npm test -w @lms-279/web`: **213/213 PASS** (新規 34 件: TenantCcEditor 21 + AuditLogTable 7 + RunHistoryTable 6 + page.test.tsx 6)
- [x] `cd e2e && npx tsc --noEmit` for dispatch-settings-api.spec.ts: PASS (既存 attendance-api.spec.ts のエラーは本 PR 範囲外)
- [ ] **CI**: api smoke E2E がデプロイ前環境で PASS することを確認
- [ ] **Phase 8 Smoke (本 PR 範囲外、人手作業)**: dev/staging デプロイ後に `/super/dispatch-settings` ページの目視確認
  - TenantCcEditor: テナント選択 → chips 編集 → 保存 → 再 GET で反映
  - AuditLogTable: フィルタ適用 → cursor paginate
  - RunHistoryTable: cursor paginate

## Quality Gate

| ステップ | 結果 |
|---|---|
| `safe-refactor` | HIGH 2 件 (DRY 違反、plan で意図的容認、follow-up 候補)、SAFE 全項目クリア |
| `evaluator` 分離 (5+ ファイル) | **APPROVE 条件付き**。全 AC PASS。MEDIUM-2 (audit-logs/runs の 403 テスト欠落) を本 PR で反映済 |
| `code-review` | (PR 作成後 inline 投稿予定) |
| `codex review` セカンドオピニオン | impl-plan 段階で実施済 (state race 対策の指摘を反映) |

### Evaluator 指摘の未対応箇所

- **MEDIUM-1 (audit_logs 記録の E2E 未検証)**: BE 側で tenant CC PUT / dispatch settings PUT の audit_logs 書き込みが未実装。impl-plan Phase 6 完了条件「設定変更 → DB 反映 → audit_logs 記録」の audit_logs 部分は **Phase 8 Smoke で確認**する方針に変更。
- **LOW-1 (`isDirty` 順序依存)**: 現状 BE が入力順を保持する想定で実害なし。将来 BE が順序正規化する場合に `Set` 比較へ変更。
- **LOW-2 (datetime-local の自動補正)**: ブラウザの input type=datetime-local が仕様上補正する範囲なので問題なし。

## Refs

- Phase 6 PR-F1: #479 (Section / DryRunPanel / TestSendButton / ScheduleEditor / MessageBodyEditor / page core)
- impl-plan: `docs/specs/2026-05-20-completion-notification-impl-plan.md` Phase 6 完了条件 (Playwright E2E 行 228) は **Phase 8 Smoke へ移管** (本 PR 範囲外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)