### PR TITLE
docs(handoff): Session 46 - Phase 6 PR-F2 完了 (#481) + E2E spec 一時 skip hotfix (#482)

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,19 +1,19 @@
-# Session Handoff — 2026-05-23 (Session 45)
+# Session Handoff — 2026-05-23 (Session 46)
 
 ## TL;DR
 
-**DXcollege 自動完了通知システム Phase 5 (Super admin API) + Phase 6 コア UI (PR-F1) を完了 + Issue #276 GCIP 独立部分を実装**。3 PR をすべて番号単位明示認可でマージ。
-1. **PR #477** (Issue #276 GCIP 独立部分): 孤児 Firebase Auth 掃除を GitHub Actions schedule で週次 dry-run 自動化 + 通知 (孤児検出時 job 失敗 → GitHub 標準メール、human-in-loop)。WIF external_account init 修正 + classifyUser 抽出 + ci.yml に test:scripts 追加。GCIP Tenant 掃除は **#272 Phase 3 (GCIP 移行本体) 未完了**のため継続 postponed (再開条件を「#272 close」→「Phase 3 close」に訂正)。
-2. **PR #478** (Phase 5 PR-E): Super admin API 6 endpoints (settings GET/PUT・tenant CC GET/PUT・audit-logs・runs・dry-run・test-send)。storage に updateDispatchSettings (version 楽観ロック) / listRuns 追加。新規 77 テスト、全 api 1417 PASS。
-3. **PR #479** (Phase 6 PR-F1): スーパー管理者 `/super/dispatch-settings` ページ (enabled Switch + ScheduleEditor + MessageBodyEditor + 保存(409 reload) + DryRunPanel + TestSendButton)。新規 16 テスト。
+**DXcollege 自動完了通知システム Phase 6 PR-F2 完了 (Frontend UI 全 component 揃った) + E2E spec 一時 skip hotfix**。2 PR を番号単位明示認可でマージ。
 
-各 PR で code-review + evaluator 分離を実施 (全 AC PASS / 指摘反映済)。
+1. **PR #481** (Phase 6 PR-F2): スーパー管理者 `/super/dispatch-settings` ページに残 3 component と API smoke E2E を追加。**TenantCcEditor** (テナント別 CC chips、上限 10、CRLF/カンマ/制御文字拒否、case-insensitive 重複排除) + **AuditLogTable** (filter + cursor + requestId 方式 state race 対策) + **RunHistoryTable** (cursor + status badge)。新規 34 テスト、全 web 214 PASS。Codex セカンドオピニオン指摘 (state race 対策) + Evaluator 分離プロトコル (APPROVE 条件付き) + `/code-review high` PR inline 3 件指摘 (form/error 共存 / timezone label / regression test) を全反映。
+2. **PR #482** (hotfix): #481 マージ後に CI E2E が failure (dispatch factory 必須 env 未設定 / Firestore credential 無しで 500)。`e2e/tests/dispatch-settings-api.spec.ts` を `test.describe.fixme()` で一時 skip し復旧方針コメントを追記して CI を unblock。
 
-- **Issue Net**: **0 件** — Close 0 / 起票 0。dispatch Phase は impl-plan 管理 (Issue 起票対象外)。#276 は GCIP 独立部分のみ実装し postponed 維持 (GCIP Tenant 部分が残るため close せず)。triage 基準該当の新規課題なし
-- **マージ済 PR**: **3 件** (#477 / #478 / #479)
-- **CI**: ✅ 全 green
+各 PR で番号単位明示認可を遵守 (`PR #番号 — タイトル (N files, +X/-Y)` 形式で要約)。
+
+- **Issue Net**: **0 件** — Close 0 / 起票 0。dispatch Phase は impl-plan 管理 (Issue 起票対象外)。triage 基準該当の新規課題なし
+- **マージ済 PR**: **2 件** (#481 / #482)
+- **CI**: ✅ #481 マージ後 E2E failure → #482 マージで unblock (Build/Lint/Test/Type Check は green)
 - **Open Issue**: active 0 / postponed 4 (#274/275/276/405、変化なし)
-- **残留プロセス**: ✅ なし (ローカル api smoke 後 kill 済)
+- **残留プロセス**: ✅ なし (ローカル vitest プロセス 1 つを handoff 時に kill)
 
 ---
 
@@ -33,53 +33,96 @@ gh issue list --state open --limit 15
 
 ---
 
-## セッション成果物 (Session 45)
+## セッション成果物 (Session 46)
 
-### マージ済 PR (3 件)
+### マージ済 PR (2 件)
 
 | # | タイトル | 種別 | 差分 | merge commit |
 |---|---|---|---|---|
-| #477 | feat(ops): 孤児 Auth 掃除の週次 dry-run 自動化 + 通知 (Issue #276 GCIP 独立部分) | feat | 4 files / +619/-117 | 33b8c34 |
-| #478 | feat(dispatch): Phase 5 Super admin API 6 endpoints (PR-E) | feat (large) | 23 files / +2212/-9 | e5cde89 |
-| #479 | feat(dispatch): Phase 6 PR-F1 完了通知 配信設定ページ (core UI) | feat (large) | 11 files / +990/-0 | d55cd2b |
+| #481 | feat(dispatch): Phase 6 PR-F2 完了通知 配信設定ページ 残コンポーネント | feat (large) | 10 files / +2027/-86 | 9e071fd |
+| #482 | fix(e2e): dispatch-settings-api.spec を describe.fixme で一時 skip | fix (small) | 1 file / +21/-2 | 8d191b0 |
 
 ### Phase 進捗マトリクス (dispatch)
 
 | Phase | 内容 | 状態 | 関連 PR |
 |---|---|---|---|
 | 1-4 | 基礎 services / Reservation / Mail / Internal API | ✅ | #442/465/467/466/468 |
-| 5 | Super admin API 6 endpoints | ✅ **本セッション** | **#478** |
-| 6 | Frontend UI | 🟡 **コア (F1) のみ完了** | **#479** |
+| 5 | Super admin API 6 endpoints | ✅ | #478 |
+| 6 | Frontend UI | ✅ **完了 (本セッション)** | **#479 (F1) + #481 (F2)** |
 | 7 | Infrastructure (Cloud Scheduler / TTL / env) | ✅ | #471/472 + gcloud |
-| 8 | Smoke check + Cutover | ⏳ | - |
+| 8 | Smoke check + Cutover | ⏳ **人手作業待ち** | - |
 
-### Phase 6 残作業 (PR-F2、次セッション候補)
-
-- テナント別 CC 編集 UI (EmailChipsInput chips、上限 10) — API は #478 で実装済 (`/super/tenants/:id/notification-cc-emails`)
-- 監査ログ / run 履歴テーブル (audit-logs / runs API は #478 実装済)
-- Playwright E2E (設定変更 → DB 反映 → audit_logs 記録)
-
-### Phase 8 cutover の前提 (人手作業待ち)
+### Phase 8 cutover の前提 (人手作業待ち、decision-maker 領分)
 
 - **開発者の SendAs 登録**: `system@279279.net` の Gmail で `dxcollege@279279.net` を SendAs 追加 (ADR-037、これが無いと From 偽装不可)
-- **デプロイ環境での画面目視**: super ページは Firebase user 必須でローカル dev (user=null) ではブラウザ表示不可。dev/staging デプロイ後に `/super/dispatch-settings` の保存・409・dry-run・test-send を目視確認
+- **dev/staging デプロイ + 目視確認**: super ページは Firebase user 必須でローカル dev (user=null) ではブラウザ表示不可。デプロイ後に `/super/dispatch-settings` の全 section (F1 + F2) を目視確認
 - cutover 手順: `super_dispatch_settings/global` を enabled=false で初期化 → SendAs send smoke → enabled=true 切替 (impl-plan Phase 8)
+
+### E2E 復旧 follow-up (PR #482 で一時 skip した範囲)
+
+`e2e/tests/dispatch-settings-api.spec.ts` を `test.describe.fixme()` で skip 中。復旧手順:
+
+1. `e2e/playwright.config.ts` の api webServer env に dispatch 関連 env 追加:
+   - `DISPATCH_USE_IN_MEMORY=true`
+   - `DXCOLLEGE_SENDER_EMAIL` / `DXCOLLEGE_DISPATCH_SUBJECT` / `DISPATCH_OIDC_AUDIENCE`
+2. `dispatch-super-router` の `ccStore` を in-memory モード時に `InMemoryTenantCcConfigStore` へ切り替える wiring 追加 (or Firestore emulator を CI で起動)
+3. spec の `test.describe.fixme()` を `test.describe()` に戻す
+
+Phase 8 cutover と並行検討。UI ロジックは component test 34 件、認可境界は middleware 単体テストでカバー済のため緊急性は低い。
 
 ---
 
 ## 重要な技術判断 (本セッション)
 
-### #276 再開条件の前提誤り訂正
-- 旧再開条件「#272 close で着手」は誤り。#272 は **緊急対応スコープ達成**で close されたが、**Phase 3 (GCIP 移行本体) は延期** (残事項 C、再評価 2026-10-24)。`useGcip` default=false の pre-canary 状態。よって GCIP Tenant 掃除は着手不可とし、GCIP 非依存の自動実行 + 通知のみ実装。#276 にこの経緯と訂正後再開条件 (Phase 3 close) をコメント済
+### Phase 6 PR-F2 設計判断 (PR #481)
 
-### Phase 5 設計判断 (PR-E)
-- settings GET は doc 未作成時 default (enabled=false/version=0) を返し初回 PUT で create。senderEmail は env overlay (NFR-8)
-- 409 は current (env overlay 済) を併せ返す。audit-logs/runs は全件取得 + in-memory paginate (小規模 + TTL 365d、composite index 不要)、存在しない cursor は終端扱い
-- dispatch super router は superAdminRouter の後に mount + 明示 auth (頻出パス二重 auth 回避)
+- **state race 対策**: Codex セカンドオピニオン指摘で `requestIdRef` snapshot 方式採用。`AbortController` は React StrictMode の二重 effect と相性が悪く不採用。連打を許容しつつ最新 fetch のみ反映する設計
+- **F1/F2 独立ロード**: F2 component (TenantCcEditor / AuditLogTable / RunHistoryTable) は settings ロード状態と独立に常にマウント。settings ロード失敗時でも他 Section を閲覧可能
+- **早期 return 廃止 + form null 化**: page.tsx の `if (loading/error/!form) return ...` を条件 render に変更。code-review で「reload 失敗時に form と error が共存する race」が指摘され、loadSettings の catch で `setForm(null)` + `setSaveError(null)` + `setNotice(null)` 追加して解消 (regression test 追加)
+- **datetime-local の label 修正**: `new Date("YYYY-MM-DDTHH:mm")` は ES2017 仕様でブラウザ local time として解釈されるため、AuditLogTable の label「(JST)」→「(ローカル時刻)」に修正
+- **Radix Select の RTL テスト回避**: TenantCcEditor を `TenantCcEditor` (tenant 選択ラッパー) + `TenantCcForm` (CC 編集本体) の 2 export に分離、component test は Form に集中。Select interaction は実機目視で補う
+- **FE/BE validator divergence 回避**: `validateClientCcEmail` は BE `validateSingleEmail` と同じ正規表現を使用、`<>` 等の独自拡張は加えず BE 仕様にミラー
 
-### Phase 6 設計判断 (PR-F1)
-- 全 super ページは Firebase user 必須 → ローカル dev (user=null) ではブラウザ表示不可。API ゴールデンパスは in-memory 実サーバー (curl) で疎通確認、UI ロジックは 16 component テストでカバー
-- 既存規約準拠 (useSuperAdminFetch / shadcn UI / 日本語固定 / inline error)
+### E2E 復旧方針 (PR #482)
+
+- 一時 skip + 復旧方針コメントを spec 冒頭に記録
+- CI を unblock することを最優先、品質は他レイヤー (component test 34 件 + middleware 単体テスト) でカバー
+- 復旧は Phase 8 cutover と並行検討 (BE wiring + E2E env 追加)
+
+---
+
+## Quality Gate (本セッション実施結果)
+
+| ステップ | 結果 |
+|---|---|
+| `/brainstorm` | 不要 (既存 impl-plan の Phase 6 を継続) |
+| `/impl-plan` | サブ計画として plan file 作成 (Codex セカンドオピニオン取得後に承認) |
+| `/codex review` (impl-plan 段階) | state race 対策 (`requestId`) 指摘 → 実装に反映 |
+| `/safe-refactor` | HIGH 2 件 (DRY 違反、plan で意図的容認、follow-up 候補) |
+| `evaluator` 分離 (5+ ファイル) | **APPROVE 条件付き**。AC PASS、MEDIUM-2 (403 テスト欠落) を本 PR で反映 |
+| `/code-review high` (PR inline) | 3 件指摘を全反映 (form null 化 / timezone label / regression test) |
+
+---
+
+## 教訓 (CLAUDE.md feedback への追記候補)
+
+### ローカル E2E 起動確認のスキップが CI failure を顕在化
+
+- 本 PR #481 では Playwright UI E2E を「super ページが Firebase user 必須で AUTH_MODE=dev では表示不可」を理由に API smoke のみに切り替えた。ただし、API smoke spec を **ローカルで実際に起動 (api + web webServer + Firestore emulator) して PASS 確認することなく** PR を出した
+- 結果として、CI E2E で dispatch factory の必須 env 未設定 + Firestore credential 無しで全テストが 500 を返し、main マージ後に発覚
+- これは既存 `feedback_integration_test_local_verify.md` の「module-level skip は『動作確認した』錯覚の罠」と同型のパターンで、新規 spec 追加時にも同じ罠が成立する
+- 対策: 新規 E2E spec を追加する PR では、**ローカルで webServer 起動 + spec PASS を必ず確認** してから push する。Firestore に依存する場合は Firestore emulator を立てる手順を spec 冒頭にコメントで明記する
+
+→ メモリ追記候補: `feedback_e2e_spec_local_verify_before_push.md` (`feedback_integration_test_local_verify.md` の関連) 
+
+### CI 確認は jobs 全部を確認する (gh pr checks のリストが workflow 単位)
+
+- 本 PR で `gh pr checks 481` で 4 jobs (Build/Lint/Test/Type Check) が PASS と確認後、ユーザーの明示認可を受けて squash merge
+- しかし `Playwright E2E` job は別 workflow にあり、PR の checks リストに表示されなかった (push trigger workflow なので branch push 時に走るが、PR merge 前後で別 run)
+- 結果として E2E failure を merge 後に発覚
+- 対策: PR merge 前に `gh run list --branch <pr-branch>` で全 workflow run を確認する。または、deploy workflow が CI 通過に依存している場合、deploy 前の最終 gate として E2E 結果も確認する
+
+→ メモリ追記候補: 既存 `feedback_test_plan_execution.md` への補強
 
 ---
 
@@ -89,4 +132,4 @@ gh issue list --state open --limit 15
 - 起票数: 0 件
 - Net: 0 件
 
-**Net=0 の理由**: 本セッションは Issue ベースではなく **dispatch impl-plan (Phase 5 PR-E + Phase 6 PR-F1) 進捗** + **Issue #276 の GCIP 独立部分実装** で管理される作業。#276 は GCIP Tenant 部分が Phase 3 待ちで残るため close せず postponed 維持。triage 基準 (実害/再現バグ/CI破壊/rating≥7/明示指示) 該当の新規課題なし。
+**Net=0 の理由**: 本セッションは Issue ベースではなく **dispatch impl-plan (Phase 6 PR-F2) 進捗** + **CI failure hotfix** で管理される作業。triage 基準 (実害/再現バグ/CI破壊/rating≥7/明示指示) 該当の新規課題なし。Phase 8 cutover 中の wiring follow-up (E2E 復旧) は impl-plan 管理内のため Issue 起票対象外。


### PR DESCRIPTION
## 概要

Session 46 (2026-05-23) のハンドオフ記録。本セッションで dispatch Phase 6 Frontend UI を完成させた。

## マージ済 PR (2 件)

| # | タイトル | 種別 | 差分 |
|---|---|---|---|
| #481 | feat(dispatch): Phase 6 PR-F2 完了通知 配信設定ページ 残コンポーネント | feat (large) | 10 files / +2027/-86 |
| #482 | fix(e2e): dispatch-settings-api.spec を describe.fixme で一時 skip | fix (small) | 1 file / +21/-2 |

## Issue Net 変化

- Close 数: 0 件
- 起票数: 0 件
- Net: 0 件

## 教訓 (新規 feedback 候補)

ローカル E2E 起動確認のスキップが CI failure を顕在化。\`feedback_integration_test_local_verify.md\` の「module-level skip は『動作確認した』錯覚の罠」と同型パターン。新規 E2E spec を push する前に必ずローカルで webServer 起動 + spec PASS を確認する原則を再確認。

## Test plan

- [x] handoff ファイル 92 行 → 209 行 (500 行制限以内)
- [ ] **次セッション**: \`cat docs/handoff/LATEST.md\` で復元できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)