### PR TITLE
fix(e2e): dispatch-settings-api spec の skip 解除 + in-memory wiring 追加

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,9 @@ name: E2E Tests
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   e2e:

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -25,6 +25,15 @@ export default defineConfig({
         // dispatch-settings-api.spec で super-admin emulation を有効化
         // (X-User-Email: admin@example.com を super として認識させる)
         SUPER_ADMIN_EMAILS: "admin@example.com",
+        // dispatch factory を in-memory モードで mount し、CI で Firestore credential 不要にする。
+        // 本番 GCP runtime (K_SERVICE 等) では factory が throw して silent fallback を防ぐ。
+        DISPATCH_USE_IN_MEMORY: "true",
+        // in-memory モード時の env (factory.ts IN_MEMORY_DEFAULTS と整合、実送信は発生しない)
+        DXCOLLEGE_SENDER_EMAIL: "in-memory-from@example.invalid",
+        DXCOLLEGE_DISPATCH_SUBJECT: "in-memory-subject@example.invalid",
+        DISPATCH_OIDC_AUDIENCE: "https://in-memory.example.invalid",
+        // dispatch-settings-api.spec が demo tenant の CC 取得を期待するため seed する
+        DISPATCH_IN_MEMORY_SEED_TENANTS: "demo",
       },
     },
     {

--- a/e2e/tests/dispatch-settings-api.spec.ts
+++ b/e2e/tests/dispatch-settings-api.spec.ts
@@ -13,22 +13,14 @@
  *   - tenant notification CC の GET/PUT、エラー応答 (CRLF / 11 件)
  *
  * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- * 一時 skip (PR #481 マージ後の CI E2E failure 対応、2026-05-23):
+ * E2E wiring 復旧 (PR #482 の一時 skip を解除、2026-05-23):
  *
- * CI E2E 環境では `DISPATCH_USE_IN_MEMORY` / `DXCOLLEGE_SENDER_EMAIL` 等の
- * dispatch factory 必須 env が未設定で、Firestore credential も無いため:
- *   - DISPATCH_USE_IN_MEMORY 未設定 → factory が requireEnv で throw → dispatch-super-router
- *     mount スキップ → audit-logs / runs / settings 等 dispatch 配下 endpoint は 404
- *   - `FirestoreTenantCcConfigStore` は Firestore-only wiring のため、CI で 500
- *
- * 復旧方針 (follow-up、Phase 8 cutover タスクに含める):
- *   1. `e2e/playwright.config.ts` の api webServer env に `DISPATCH_USE_IN_MEMORY=true`
- *      `DXCOLLEGE_SENDER_EMAIL`, `DXCOLLEGE_DISPATCH_SUBJECT`, `DISPATCH_OIDC_AUDIENCE` を追加
- *   2. `dispatch-super-router` の `ccStore` を in-memory モード時に `InMemoryTenantCcConfigStore`
- *      へ切り替える wiring を追加 (or Firestore emulator を CI で起動)
- *
- * UI ロジックは component test 34 件 (web/...components/__tests__/) でカバー済みなので
- * UI/ロジック保証はそのまま。本 spec の再有効化は wiring 修正と同時に follow-up PR で実施。
+ * `e2e/playwright.config.ts` で `DISPATCH_USE_IN_MEMORY=true` +
+ * `DISPATCH_IN_MEMORY_SEED_TENANTS=demo` 等を inject し、CI でも Firestore
+ * credential なしで dispatch-super-router を mount + demo tenant の CC を
+ * read/write できる状態にした。`index.ts` 側で in-memory モード時のみ
+ * `InMemoryTenantCcConfigStore` を ccStore として inject している
+ * (本番 GCP runtime では factory が throw して silent fallback を防ぐ)。
  * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  */
 
@@ -38,7 +30,7 @@ const API = "http://localhost:8080";
 const SUPER_HEADERS = { "X-User-Email": "admin@example.com" };
 const NON_SUPER_HEADERS = { "X-User-Email": "user@example.com" };
 
-test.describe.fixme("dispatch super API 認可境界", () => {
+test.describe("dispatch super API 認可境界", () => {
   test("X-User-Email 未指定は 401 (audit-logs)", async ({ request }) => {
     const res = await request.get(`${API}/api/v2/super/dispatch/audit-logs`);
     expect(res.status()).toBe(401);
@@ -81,7 +73,7 @@ test.describe.fixme("dispatch super API 認可境界", () => {
   });
 });
 
-test.describe.fixme("tenant notification CC API", () => {
+test.describe("tenant notification CC API", () => {
   test("non-super email でアクセスすると 403", async ({ request }) => {
     const res = await request.get(
       `${API}/api/v2/super/tenants/demo/notification-cc-emails`,

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -19,7 +19,10 @@ import { helpRoleRouter } from "./routes/help-role.js";
 import { publicRouter } from "./routes/public.js";
 import { createInternalDispatchRouter } from "./routes/internal/dispatch.js";
 import { createDispatchSuperRouter } from "./routes/super/dispatch-super-router.js";
-import { InMemoryTenantCcConfigStore } from "./routes/super/tenant-notification-cc.js";
+import {
+  InMemoryTenantCcConfigStore,
+  parseSeedTenantIds,
+} from "./routes/super/tenant-notification-cc.js";
 import { superAdminAuthMiddleware } from "./middleware/super-admin.js";
 import { buildDispatchFactory } from "./services/dispatch/factory.js";
 import { logger } from "./utils/logger.js";
@@ -204,15 +207,19 @@ if (dispatchFactory) {
   // (FirestoreTenantCcConfigStore は Firestore credential 必須で CI / dev で 500)。
   // seed tenant は env DISPATCH_IN_MEMORY_SEED_TENANTS (カンマ区切り) で指定。
   // 本番 (firestore mode) では undefined を渡し、router default の Firestore wiring を使う。
-  const inMemoryCcStore =
-    dispatchFactory.mode === "in-memory"
-      ? new InMemoryTenantCcConfigStore({
-          seedTenantIds: (process.env.DISPATCH_IN_MEMORY_SEED_TENANTS ?? "")
-            .split(",")
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0),
-        })
-      : undefined;
+  let inMemoryCcStore: InMemoryTenantCcConfigStore | undefined;
+  if (dispatchFactory.mode === "in-memory") {
+    const seedTenantIds = parseSeedTenantIds(
+      process.env.DISPATCH_IN_MEMORY_SEED_TENANTS,
+    );
+    inMemoryCcStore = new InMemoryTenantCcConfigStore({ seedTenantIds });
+    // operator UX: env 未設定 / 誤設定で seedTenantIds が空のまま起動すると
+    // GET /tenants/:id/notification-cc-emails が常に 404 になり原因切り分けが
+    // 遅れるため、採用値を startup log に明示する (review feedback 反映)。
+    logger.info("Super dispatch router: in-memory ccStore seeded", {
+      seedTenantIds,
+    });
+  }
 
   app.use(
     "/api/v2/super",

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -19,6 +19,7 @@ import { helpRoleRouter } from "./routes/help-role.js";
 import { publicRouter } from "./routes/public.js";
 import { createInternalDispatchRouter } from "./routes/internal/dispatch.js";
 import { createDispatchSuperRouter } from "./routes/super/dispatch-super-router.js";
+import { InMemoryTenantCcConfigStore } from "./routes/super/tenant-notification-cc.js";
 import { superAdminAuthMiddleware } from "./middleware/super-admin.js";
 import { buildDispatchFactory } from "./services/dispatch/factory.js";
 import { logger } from "./utils/logger.js";
@@ -199,6 +200,20 @@ app.use("/api/v2/super", superAdminRouter);
 // 明示的に superAdminAuthMiddleware を適用し、auth 依存を self-contained にする
 // (本番 GCP で factory build 失敗時は dispatchFactory=null となり mount をスキップ)。
 if (dispatchFactory) {
+  // in-memory モード時のみ、ccStore も in-memory に差し替える
+  // (FirestoreTenantCcConfigStore は Firestore credential 必須で CI / dev で 500)。
+  // seed tenant は env DISPATCH_IN_MEMORY_SEED_TENANTS (カンマ区切り) で指定。
+  // 本番 (firestore mode) では undefined を渡し、router default の Firestore wiring を使う。
+  const inMemoryCcStore =
+    dispatchFactory.mode === "in-memory"
+      ? new InMemoryTenantCcConfigStore({
+          seedTenantIds: (process.env.DISPATCH_IN_MEMORY_SEED_TENANTS ?? "")
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0),
+        })
+      : undefined;
+
   app.use(
     "/api/v2/super",
     superAdminAuthMiddleware,
@@ -206,6 +221,7 @@ if (dispatchFactory) {
       storage: dispatchFactory.storage,
       loader: dispatchFactory.loader,
       env: dispatchFactory.env,
+      ccStore: inMemoryCcStore,
     }),
   );
   logger.info("Super dispatch router mounted", { mode: dispatchFactory.mode });

--- a/services/api/src/routes/super/__tests__/tenant-notification-cc.test.ts
+++ b/services/api/src/routes/super/__tests__/tenant-notification-cc.test.ts
@@ -12,6 +12,7 @@ import request from "supertest";
 import type { TenantNotificationCcConfig } from "@lms-279/shared-types";
 import {
   createTenantNotificationCcRouter,
+  InMemoryTenantCcConfigStore,
   type TenantCcConfigStore,
 } from "../tenant-notification-cc.js";
 
@@ -191,5 +192,59 @@ describe("PUT /super/tenants/:tenantId/notification-cc-emails", () => {
       .send({ notificationCcEmails: [], completionNotificationEnabled: "yes" });
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("bad_request");
+  });
+});
+
+describe("InMemoryTenantCcConfigStore", () => {
+  it("seedTenantIds で指定したテナントは default config で初期化される", async () => {
+    const store = new InMemoryTenantCcConfigStore({
+      seedTenantIds: ["demo", "tenant-a"],
+    });
+    expect(await store.getTenantCcConfig("demo")).toEqual({
+      ownerEmail: null,
+      notificationCcEmails: [],
+      completionNotificationEnabled: true,
+    });
+    expect(await store.getTenantCcConfig("tenant-a")).toEqual({
+      ownerEmail: null,
+      notificationCcEmails: [],
+      completionNotificationEnabled: true,
+    });
+  });
+
+  it("seed していないテナントは null を返す", async () => {
+    const store = new InMemoryTenantCcConfigStore({ seedTenantIds: ["demo"] });
+    expect(await store.getTenantCcConfig("missing")).toBeNull();
+  });
+
+  it("オプション省略時は空 (どの tenant も null)", async () => {
+    const store = new InMemoryTenantCcConfigStore();
+    expect(await store.getTenantCcConfig("demo")).toBeNull();
+  });
+
+  it("updateTenantCcConfig で notificationCcEmails / enabled が反映される", async () => {
+    const store = new InMemoryTenantCcConfigStore({ seedTenantIds: ["demo"] });
+    await store.updateTenantCcConfig("demo", {
+      notificationCcEmails: ["cc1@example.com", "cc2@example.com"],
+      completionNotificationEnabled: false,
+    });
+    expect(await store.getTenantCcConfig("demo")).toEqual({
+      ownerEmail: null,
+      notificationCcEmails: ["cc1@example.com", "cc2@example.com"],
+      completionNotificationEnabled: false,
+    });
+  });
+
+  it("seed していない tenant への update は新規 config を作る", async () => {
+    const store = new InMemoryTenantCcConfigStore();
+    await store.updateTenantCcConfig("new-tenant", {
+      notificationCcEmails: ["cc@example.com"],
+      completionNotificationEnabled: true,
+    });
+    expect(await store.getTenantCcConfig("new-tenant")).toEqual({
+      ownerEmail: null,
+      notificationCcEmails: ["cc@example.com"],
+      completionNotificationEnabled: true,
+    });
   });
 });

--- a/services/api/src/routes/super/__tests__/tenant-notification-cc.test.ts
+++ b/services/api/src/routes/super/__tests__/tenant-notification-cc.test.ts
@@ -13,6 +13,7 @@ import type { TenantNotificationCcConfig } from "@lms-279/shared-types";
 import {
   createTenantNotificationCcRouter,
   InMemoryTenantCcConfigStore,
+  parseSeedTenantIds,
   type TenantCcConfigStore,
 } from "../tenant-notification-cc.js";
 
@@ -246,5 +247,44 @@ describe("InMemoryTenantCcConfigStore", () => {
       notificationCcEmails: ["cc@example.com"],
       completionNotificationEnabled: true,
     });
+  });
+});
+
+describe("parseSeedTenantIds (env パース)", () => {
+  it("undefined → 空配列", () => {
+    expect(parseSeedTenantIds(undefined)).toEqual([]);
+  });
+
+  it("空文字 → 空配列", () => {
+    expect(parseSeedTenantIds("")).toEqual([]);
+  });
+
+  it("単一値", () => {
+    expect(parseSeedTenantIds("demo")).toEqual(["demo"]);
+  });
+
+  it("カンマ区切り複数値", () => {
+    expect(parseSeedTenantIds("demo,tenant-a")).toEqual(["demo", "tenant-a"]);
+  });
+
+  it("各要素を trim する", () => {
+    expect(parseSeedTenantIds(" demo , tenant-a ")).toEqual([
+      "demo",
+      "tenant-a",
+    ]);
+  });
+
+  it("空文字エントリ (連続カンマ・末尾カンマ) を除去する", () => {
+    expect(parseSeedTenantIds(",,demo,,tenant-a,")).toEqual([
+      "demo",
+      "tenant-a",
+    ]);
+  });
+
+  it("空白のみのエントリも除去する", () => {
+    expect(parseSeedTenantIds("demo,   ,tenant-a")).toEqual([
+      "demo",
+      "tenant-a",
+    ]);
   });
 });

--- a/services/api/src/routes/super/tenant-notification-cc.ts
+++ b/services/api/src/routes/super/tenant-notification-cc.ts
@@ -46,6 +46,53 @@ export interface TenantCcConfigStore {
   ): Promise<void>;
 }
 
+/**
+ * test / E2E / local dev 用の InMemory 実装。
+ *
+ * production wiring (`FirestoreTenantCcConfigStore`) は Firestore credential 必須のため、
+ * CI E2E / Firebase emulator 無し dev では使えない。本クラスは `DISPATCH_USE_IN_MEMORY=true`
+ * のとき index.ts wiring で inject される。
+ *
+ * `seedTenantIds` で初期 tenant を登録 (default config: ownerEmail=null /
+ * notificationCcEmails=[] / completionNotificationEnabled=true)。E2E spec で
+ * `/super/tenants/demo/notification-cc-emails` を呼ぶ場合は env
+ * `DISPATCH_IN_MEMORY_SEED_TENANTS=demo` で seed する。
+ */
+export class InMemoryTenantCcConfigStore implements TenantCcConfigStore {
+  private readonly configs = new Map<string, TenantNotificationCcConfig>();
+
+  constructor(options: { seedTenantIds?: string[] } = {}) {
+    for (const tenantId of options.seedTenantIds ?? []) {
+      this.configs.set(tenantId, {
+        ownerEmail: null,
+        notificationCcEmails: [],
+        completionNotificationEnabled: true,
+      });
+    }
+  }
+
+  async getTenantCcConfig(
+    tenantId: string,
+  ): Promise<TenantNotificationCcConfig | null> {
+    return this.configs.get(tenantId) ?? null;
+  }
+
+  async updateTenantCcConfig(
+    tenantId: string,
+    input: {
+      notificationCcEmails: string[];
+      completionNotificationEnabled: boolean;
+    },
+  ): Promise<void> {
+    const prev = this.configs.get(tenantId);
+    this.configs.set(tenantId, {
+      ownerEmail: prev?.ownerEmail ?? null,
+      notificationCcEmails: input.notificationCcEmails,
+      completionNotificationEnabled: input.completionNotificationEnabled,
+    });
+  }
+}
+
 /** production wiring: tenants/{tenantId} doc を直接読み書き */
 export class FirestoreTenantCcConfigStore implements TenantCcConfigStore {
   async getTenantCcConfig(

--- a/services/api/src/routes/super/tenant-notification-cc.ts
+++ b/services/api/src/routes/super/tenant-notification-cc.ts
@@ -47,6 +47,24 @@ export interface TenantCcConfigStore {
 }
 
 /**
+ * env value (カンマ区切り文字列) を `seedTenantIds` 配列に変換する純粋関数。
+ *
+ * 仕様 (汚い入力に対する正規化):
+ *   - undefined / "" → `[]` (env 未設定)
+ *   - 各要素を trim、空文字エントリは除去 ("a,,b" → ["a","b"], " a " → ["a"])
+ *   - 重複は除去せず保持 (constructor 側で重複 seed は冪等、上書きされるだけ)
+ *
+ * index.ts wiring (`InMemoryTenantCcConfigStore` への inject) と本ファイル test の
+ * 両方で共通利用。env パース層の回帰を unit test で押さえる目的で独立 export。
+ */
+export function parseSeedTenantIds(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
  * test / E2E / local dev 用の InMemory 実装。
  *
  * production wiring (`FirestoreTenantCcConfigStore`) は Firestore credential 必須のため、


### PR DESCRIPTION
## Summary

PR #482 で一時 skip した `e2e/tests/dispatch-settings-api.spec.ts` (`test.describe.fixme()`) を復旧する。CI E2E 環境で Firestore credential なしでも dispatch-super-router を mount + demo tenant の CC を read/write できる wiring を追加。

- `InMemoryTenantCcConfigStore` を `tenant-notification-cc.ts` に追加 (seedTenantIds で初期 tenant を空 config で登録)
- `parseSeedTenantIds` を純粋関数として export し env パース層を test 対象化
- `index.ts` で dispatch factory が in-memory モード時のみ ccStore に InMemory 実装を inject (firestore mode では undefined で router default の Firestore wiring 維持)
- in-memory モード時の seedTenantIds を startup log に明示 (operator UX)
- E2E config に dispatch 必須 env + `DISPATCH_IN_MEMORY_SEED_TENANTS=demo` を追加

## 本番安全性

本番 GCP runtime では `factory.ts` の `isProductionGcpRuntime()` guard で in-memory モード採用を拒否 (silent no-op 防止、Codex Important 反映済)。本 PR の wiring は `dispatchFactory.mode === "in-memory"` 条件下のみで作動するため、本番 wiring は不変 (`FirestoreTenantCcConfigStore` がデフォルト)。

## 動作確認

ローカル port 8080 が別プロジェクト (Eclipse Spring Boot) に占有されており Playwright を直接走らせられないため、代替手段として api server を port 8081 で起動して **curl smoke 11 ケース** で動作確認した:

| # | endpoint | header | 期待 | 結果 |
|---|---|---|---|---|
| 1 | GET /dispatch/audit-logs | (なし) | 401 | ✅ 401 |
| 2 | GET /dispatch/audit-logs | user@example.com | 403 | ✅ 403 |
| 3 | GET /dispatch/audit-logs | admin@example.com | 200 + logs/nextCursor | ✅ 200 |
| 4 | GET /dispatch/runs | admin@example.com | 200 + runs/nextCursor | ✅ 200 |
| 5 | GET /dispatch/runs | user@example.com | 403 | ✅ 403 |
| 6 | GET /tenants/demo/notification-cc-emails | admin@example.com | 200 + schema | ✅ 200 |
| 7 | GET /tenants/demo/notification-cc-emails | user@example.com | 403 | ✅ 403 |
| 8 | PUT /tenants/demo/notification-cc-emails | admin@example.com | 200 + 反映 | ✅ 200 |
| 9 | GET 再取得 (反映確認) | admin@example.com | 200 + PUT 値 | ✅ 200 |
| 10 | PUT CRLF 含む | admin@example.com | 400 invalid_cc_emails | ✅ 400 |
| 11 | PUT 11 件 | admin@example.com | 400 cc_emails_too_many | ✅ 400 |

server log で `Super dispatch router mounted mode:"in-memory"` を確認。

## Quality Gate

| ステップ | 結果 |
|---|---|
| `/impl-plan` | サブ計画 (Phase 1-3) を作成、AC 4 件を定義 |
| `/safe-refactor` | HIGH 0 / MEDIUM 0 / LOW 1 (env パース inline → 本 PR でリファクタ済) |
| `/code-review low` | findings なし (5 angles 精査済、致命的 bug なし) |
| `/review-pr` (4 agent 並列) | Critical 0、Important 3 (rating 5-6)、cheap 2 件を本 PR で対応 |
| api vitest | 1430 PASS (新規 12 件含む) |
| web vitest | 214 PASS |
| lint | 0 errors |
| type-check | 全 workspace PASS |

## Review Feedback 反映

- **silent-failure-hunter LOW**: in-memory モード時の `seedTenantIds` を startup log に明示
- **pr-test-analyzer rating 6** (env パース test 不在): `parseSeedTenantIds` 純粋関数化 + unit test 7 件追加 (undefined / 空文字 / 単一値 / カンマ区切り / trim / 連続カンマ除去 / 空白のみ除去)

## Known Limitations (follow-up TODO)

- **pr-test-analyzer rating 5** (`InMemoryTenantCcConfigStore.updateTenantCcConfig` の ownerEmail 既存値ありでの保持 test): 現在の API では seed 時に ownerEmail を null 以外で設定する経路がないため test 追加には API 拡張 (seedTenants で完全 config 受け入れ) が必要。実装は `prev?.ownerEmail ?? null` で正しく保持しており回帰リスクは低い。次回 dispatch 周辺改修時の TODO

## Test plan

- [x] api vitest 1430 PASS
- [x] web vitest 214 PASS
- [x] lint 0 errors
- [x] type-check 全 workspace PASS
- [x] curl smoke 11 ケース全 PASS (port 8081 代替確認)
- [x] `/review-pr` 4 agent 並列レビュー、Critical 0
- [ ] CI E2E (`dispatch-settings-api.spec`) で全 10 test PASS、skip 0 (merge 前確認)
- [ ] CI Build/Lint/Test/Type Check も全 PASS (merge 前確認)

## 関連

- 復旧対象: PR #482 (hotfix で test.describe.fixme で一時 skip)
- 復旧手順元: `docs/handoff/LATEST.md` L61-71
- 教訓反映: LATEST.md L110-114「ローカル E2E 起動 + PASS 確認を push 前に必須化」→ 本 PR では port 占有のため curl smoke で代替確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)