### PR TITLE
docs(handoff): Session 47 - PR #484 E2E spec 復旧 + workflow trigger 構造改善

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,19 +1,19 @@
-# Session Handoff — 2026-05-23 (Session 46)
+# Session Handoff — 2026-05-23 (Session 47)
 
 ## TL;DR
 
-**DXcollege 自動完了通知システム Phase 6 PR-F2 完了 (Frontend UI 全 component 揃った) + E2E spec 一時 skip hotfix**。2 PR を番号単位明示認可でマージ。
+**DXcollege 自動完了通知 dispatch-settings-api E2E spec の skip 解除 + in-memory wiring 追加 + E2E workflow trigger 構造改善**。PR #484 で復旧 + E2E Tests workflow を `pull_request` / `workflow_dispatch` trigger 対応にした。これにより、PR #481 で踏んで #482 で hotfix を出した「feature branch では E2E が走らず main マージ後に initial failure」の罠を構造的に断った。
 
-1. **PR #481** (Phase 6 PR-F2): スーパー管理者 `/super/dispatch-settings` ページに残 3 component と API smoke E2E を追加。**TenantCcEditor** (テナント別 CC chips、上限 10、CRLF/カンマ/制御文字拒否、case-insensitive 重複排除) + **AuditLogTable** (filter + cursor + requestId 方式 state race 対策) + **RunHistoryTable** (cursor + status badge)。新規 34 テスト、全 web 214 PASS。Codex セカンドオピニオン指摘 (state race 対策) + Evaluator 分離プロトコル (APPROVE 条件付き) + `/code-review high` PR inline 3 件指摘 (form/error 共存 / timezone label / regression test) を全反映。
-2. **PR #482** (hotfix): #481 マージ後に CI E2E が failure (dispatch factory 必須 env 未設定 / Firestore credential 無しで 500)。`e2e/tests/dispatch-settings-api.spec.ts` を `test.describe.fixme()` で一時 skip し復旧方針コメントを追記して CI を unblock。
+1. **PR #484** (medium, 6 files / +204 / -17): Phase 6 PR-F2 で `test.describe.fixme()` した dispatch-settings-api.spec を復旧。`InMemoryTenantCcConfigStore` 新設 + index.ts wiring (in-memory モードでのみ inject、本番は guard で拒否 + Firestore default 維持) + playwright.config.ts に `DISPATCH_USE_IN_MEMORY=true` 等の env 追加 + `parseSeedTenantIds` 純粋関数化で env パース層をテスト対象に + `.github/workflows/e2e.yml` に `pull_request` / `workflow_dispatch` trigger 追加。
+2. **E2E workflow trigger 改善**: PR の checks リストに `Playwright E2E` が表示されるようになり、merge 前に E2E 結果を構造的に確認できる状態に進化。LATEST.md L118-125 (Session 46) の教訓を技術的に解決。
 
-各 PR で番号単位明示認可を遵守 (`PR #番号 — タイトル (N files, +X/-Y)` 形式で要約)。
+番号単位明示認可 (`PR #484 — fix(e2e): dispatch-settings-api spec の skip 解除 + in-memory wiring 追加 (6 files, +204/-17)`) で squash merge。
 
-- **Issue Net**: **0 件** — Close 0 / 起票 0。dispatch Phase は impl-plan 管理 (Issue 起票対象外)。triage 基準該当の新規課題なし
-- **マージ済 PR**: **2 件** (#481 / #482)
-- **CI**: ✅ #481 マージ後 E2E failure → #482 マージで unblock (Build/Lint/Test/Type Check は green)
-- **Open Issue**: active 0 / postponed 4 (#274/275/276/405、変化なし)
-- **残留プロセス**: ✅ なし (ローカル vitest プロセス 1 つを handoff 時に kill)
+- **Issue Net**: **0 件** — Close 0 / 起票 0。dispatch impl-plan 内 follow-up (E2E 復旧) + CI 設定改善は triage 基準該当なし
+- **マージ済 PR**: **1 件** (#484)
+- **CI**: ✅ 全 5 jobs (Build / Lint / Test / Type Check / Playwright E2E) PASS
+- **Open Issue**: active 0 / postponed 4 (#274 / #275 / #276 / #405、変化なし)
+- **残留プロセス**: ✅ なし
 
 ---
 
@@ -33,14 +33,13 @@ gh issue list --state open --limit 15
 
 ---
 
-## セッション成果物 (Session 46)
+## セッション成果物 (Session 47)
 
-### マージ済 PR (2 件)
+### マージ済 PR (1 件)
 
 | # | タイトル | 種別 | 差分 | merge commit |
 |---|---|---|---|---|
-| #481 | feat(dispatch): Phase 6 PR-F2 完了通知 配信設定ページ 残コンポーネント | feat (large) | 10 files / +2027/-86 | 9e071fd |
-| #482 | fix(e2e): dispatch-settings-api.spec を describe.fixme で一時 skip | fix (small) | 1 file / +21/-2 | 8d191b0 |
+| #484 | fix(e2e): dispatch-settings-api spec の skip 解除 + in-memory wiring 追加 | fix (medium) | 6 files / +204/-17 | b9cc65a |
 
 ### Phase 進捗マトリクス (dispatch)
 
@@ -48,46 +47,35 @@ gh issue list --state open --limit 15
 |---|---|---|---|
 | 1-4 | 基礎 services / Reservation / Mail / Internal API | ✅ | #442/465/467/466/468 |
 | 5 | Super admin API 6 endpoints | ✅ | #478 |
-| 6 | Frontend UI | ✅ **完了 (本セッション)** | **#479 (F1) + #481 (F2)** |
+| 6 | Frontend UI | ✅ | #479 (F1) + #481 (F2) |
 | 7 | Infrastructure (Cloud Scheduler / TTL / env) | ✅ | #471/472 + gcloud |
-| 8 | Smoke check + Cutover | ⏳ **人手作業待ち** | - |
+| **8** | **Smoke check + Cutover** | ⏳ **人手作業待ち** | - |
+| Follow-up | **E2E spec 復旧 + workflow trigger 改善** | ✅ **完了 (本セッション)** | **#484** |
 
 ### Phase 8 cutover の前提 (人手作業待ち、decision-maker 領分)
 
-- **開発者の SendAs 登録**: `system@279279.net` の Gmail で `dxcollege@279279.net` を SendAs 追加 (ADR-037、これが無いと From 偽装不可)
+- **開発者の SendAs 登録**: `system@279279.net` の Gmail で `dxcollege@279279.net` を SendAs 追加 (ADR-037)
 - **dev/staging デプロイ + 目視確認**: super ページは Firebase user 必須でローカル dev (user=null) ではブラウザ表示不可。デプロイ後に `/super/dispatch-settings` の全 section (F1 + F2) を目視確認
 - cutover 手順: `super_dispatch_settings/global` を enabled=false で初期化 → SendAs send smoke → enabled=true 切替 (impl-plan Phase 8)
-
-### E2E 復旧 follow-up (PR #482 で一時 skip した範囲)
-
-`e2e/tests/dispatch-settings-api.spec.ts` を `test.describe.fixme()` で skip 中。復旧手順:
-
-1. `e2e/playwright.config.ts` の api webServer env に dispatch 関連 env 追加:
-   - `DISPATCH_USE_IN_MEMORY=true`
-   - `DXCOLLEGE_SENDER_EMAIL` / `DXCOLLEGE_DISPATCH_SUBJECT` / `DISPATCH_OIDC_AUDIENCE`
-2. `dispatch-super-router` の `ccStore` を in-memory モード時に `InMemoryTenantCcConfigStore` へ切り替える wiring 追加 (or Firestore emulator を CI で起動)
-3. spec の `test.describe.fixme()` を `test.describe()` に戻す
-
-Phase 8 cutover と並行検討。UI ロジックは component test 34 件、認可境界は middleware 単体テストでカバー済のため緊急性は低い。
 
 ---
 
 ## 重要な技術判断 (本セッション)
 
-### Phase 6 PR-F2 設計判断 (PR #481)
+### in-memory wiring の設計 (PR #484)
 
-- **state race 対策**: Codex セカンドオピニオン指摘で `requestIdRef` snapshot 方式採用。`AbortController` は React StrictMode の二重 effect と相性が悪く不採用。連打を許容しつつ最新 fetch のみ反映する設計
-- **F1/F2 独立ロード**: F2 component (TenantCcEditor / AuditLogTable / RunHistoryTable) は settings ロード状態と独立に常にマウント。settings ロード失敗時でも他 Section を閲覧可能
-- **早期 return 廃止 + form null 化**: page.tsx の `if (loading/error/!form) return ...` を条件 render に変更。code-review で「reload 失敗時に form と error が共存する race」が指摘され、loadSettings の catch で `setForm(null)` + `setSaveError(null)` + `setNotice(null)` 追加して解消 (regression test 追加)
-- **datetime-local の label 修正**: `new Date("YYYY-MM-DDTHH:mm")` は ES2017 仕様でブラウザ local time として解釈されるため、AuditLogTable の label「(JST)」→「(ローカル時刻)」に修正
-- **Radix Select の RTL テスト回避**: TenantCcEditor を `TenantCcEditor` (tenant 選択ラッパー) + `TenantCcForm` (CC 編集本体) の 2 export に分離、component test は Form に集中。Select interaction は実機目視で補う
-- **FE/BE validator divergence 回避**: `validateClientCcEmail` は BE `validateSingleEmail` と同じ正規表現を使用、`<>` 等の独自拡張は加えず BE 仕様にミラー
+- **二重防御で本番混入を遮断**:
+  1. `services/api/src/services/dispatch/factory.ts` の `isProductionGcpRuntime()` guard で `DISPATCH_USE_IN_MEMORY=true` を本番 GCP runtime (K_SERVICE / FUNCTION_TARGET / FUNCTION_NAME / GAE_SERVICE 検出) で throw → dispatchFactory build 失敗
+  2. `services/api/src/index.ts` の super dispatch router mount は `dispatchFactory.mode === "in-memory"` でのみ `InMemoryTenantCcConfigStore` を inject。firestore mode では `undefined` を渡し、router の `ccStore ?? new FirestoreTenantCcConfigStore()` で本番 wiring が維持される
+- **seed tenant は env で指定**: `DISPATCH_IN_MEMORY_SEED_TENANTS=demo` をカンマ区切りで指定。`parseSeedTenantIds` を純粋関数として export し、env パース層 (汚い入力: 空文字 / 空白 / 連続カンマ / 末尾カンマ) を unit test 7 件で押さえた
+- **operator UX**: in-memory モード起動時に `seedTenantIds` を `logger.info("Super dispatch router: in-memory ccStore seeded", { seedTenantIds })` で startup log に出す (env 誤設定で 404 が連続したときの原因切り分けを高速化)
 
-### E2E 復旧方針 (PR #482)
+### E2E workflow trigger 改善
 
-- 一時 skip + 復旧方針コメントを spec 冒頭に記録
-- CI を unblock することを最優先、品質は他レイヤー (component test 34 件 + middleware 単体テスト) でカバー
-- 復旧は Phase 8 cutover と並行検討 (BE wiring + E2E env 追加)
+- `.github/workflows/e2e.yml` に `pull_request: branches: [main]` + `workflow_dispatch` を追加
+- これまで `push: branches: [main]` のみで trigger されており、feature branch で E2E が走らず main マージ後に initial failure が発覚していた (Session 46 の #481 → #482 hotfix の経緯)
+- 本変更で PR の checks リストに `Playwright E2E` が表示され、merge 前に E2E 結果を構造的に確認可能に
+- untrusted input (issue title / PR body 等) は使用していないため command injection リスクなし
 
 ---
 
@@ -95,34 +83,46 @@ Phase 8 cutover と並行検討。UI ロジックは component test 34 件、認
 
 | ステップ | 結果 |
 |---|---|
-| `/brainstorm` | 不要 (既存 impl-plan の Phase 6 を継続) |
-| `/impl-plan` | サブ計画として plan file 作成 (Codex セカンドオピニオン取得後に承認) |
-| `/codex review` (impl-plan 段階) | state race 対策 (`requestId`) 指摘 → 実装に反映 |
-| `/safe-refactor` | HIGH 2 件 (DRY 違反、plan で意図的容認、follow-up 候補) |
-| `evaluator` 分離 (5+ ファイル) | **APPROVE 条件付き**。AC PASS、MEDIUM-2 (403 テスト欠落) を本 PR で反映 |
-| `/code-review high` (PR inline) | 3 件指摘を全反映 (form null 化 / timezone label / regression test) |
+| `/impl-plan` | サブ計画 (Phase 1-3) を作成、AC 4 件を定義 |
+| `/safe-refactor` | HIGH 0 / MEDIUM 0 / LOW 1 (env パース inline → 本 PR で純粋関数化済) |
+| `/code-review low` | findings なし (5 angles 精査済、致命的 bug なし) |
+| `/review-pr` (4 agent 並列) | Critical 0、Important 3 (rating 5-6)、cheap 2 件を本 PR で対応 |
+| api vitest | 1430 PASS (新規 12 件含む: InMemoryStore 5 + parseSeedTenantIds 7) |
+| web vitest | 214 PASS |
+| lint | 0 errors |
+| type-check | 全 workspace PASS |
+| curl smoke (port 8081) | 11 ケース全 PASS (port 8080 占有のため代替確認) |
+| **CI E2E (Playwright E2E)** | ✅ **PASS** (本 PR で trigger 追加し PR 内で確認できた、構造改善の成果) |
+
+---
+
+## Review Feedback 反映状況
+
+- **silent-failure-hunter LOW** (startup log): ✅ 反映済 (seedTenantIds を logger.info で出力)
+- **pr-test-analyzer rating 6** (env パース test 不在): ✅ 反映済 (`parseSeedTenantIds` 純粋関数化 + 7 件 unit test)
+- **pr-test-analyzer rating 5** (`InMemoryTenantCcConfigStore.updateTenantCcConfig` の ownerEmail 既存値ありでの保持 test): ⏳ Known limitation として PR description に記載、follow-up TODO。現在の API では seed 時に ownerEmail を null 以外で設定する経路がないため test 追加には API 拡張 (seedTenants で完全 config 受け入れ) が必要。実装は `prev?.ownerEmail ?? null` で正しく保持しており回帰リスクは低い
 
 ---
 
 ## 教訓 (CLAUDE.md feedback への追記候補)
 
-### ローカル E2E 起動確認のスキップが CI failure を顕在化
+### ローカル port 占有時の代替動作確認: curl smoke で API smoke を完全再現
 
-- 本 PR #481 では Playwright UI E2E を「super ページが Firebase user 必須で AUTH_MODE=dev では表示不可」を理由に API smoke のみに切り替えた。ただし、API smoke spec を **ローカルで実際に起動 (api + web webServer + Firestore emulator) して PASS 確認することなく** PR を出した
-- 結果として、CI E2E で dispatch factory の必須 env 未設定 + Firestore credential 無しで全テストが 500 を返し、main マージ後に発覚
-- これは既存 `feedback_integration_test_local_verify.md` の「module-level skip は『動作確認した』錯覚の罠」と同型のパターンで、新規 spec 追加時にも同じ罠が成立する
-- 対策: 新規 E2E spec を追加する PR では、**ローカルで webServer 起動 + spec PASS を必ず確認** してから push する。Firestore に依存する場合は Firestore emulator を立てる手順を spec 冒頭にコメントで明記する
+- ローカル port 8080 が別プロジェクト (Eclipse Spring Boot) に占有されており Playwright を直接走らせられない場面に遭遇
+- 代替手段として api server を port 8081 で起動し、spec が叩く endpoint と同じ HTTP request を curl で 11 ケース実行 → 401/403/200/400 全て期待通り
+- これにより spec が CI で PASS することの確度を高めた状態で push できた
+- 教訓: ローカル E2E 起動できない状況でも「同じプロセスで起動 + spec と同じ HTTP request を curl で再現」で動作確認の意義は果たせる
+- 既存 `feedback_integration_test_local_verify.md` の補強候補
 
-→ メモリ追記候補: `feedback_e2e_spec_local_verify_before_push.md` (`feedback_integration_test_local_verify.md` の関連) 
+→ メモリ追記候補: `feedback_local_e2e_alternative_curl_smoke.md`
 
-### CI 確認は jobs 全部を確認する (gh pr checks のリストが workflow 単位)
+### Workflow trigger は教訓ではなく構造で予防する
 
-- 本 PR で `gh pr checks 481` で 4 jobs (Build/Lint/Test/Type Check) が PASS と確認後、ユーザーの明示認可を受けて squash merge
-- しかし `Playwright E2E` job は別 workflow にあり、PR の checks リストに表示されなかった (push trigger workflow なので branch push 時に走るが、PR merge 前後で別 run)
-- 結果として E2E failure を merge 後に発覚
-- 対策: PR merge 前に `gh run list --branch <pr-branch>` で全 workflow run を確認する。または、deploy workflow が CI 通過に依存している場合、deploy 前の最終 gate として E2E 結果も確認する
+- Session 46 で「PR の checks リストに E2E が表示されない」教訓が言語化されたが、根本原因は `.github/workflows/e2e.yml` に `pull_request` trigger が無いという構造の問題だった
+- 本セッションで trigger を追加することで、教訓ではなく構造的に再発防止
+- 「workflow trigger 不足は教訓ではなく構造で解決する」が一般化可能な原則
 
-→ メモリ追記候補: 既存 `feedback_test_plan_execution.md` への補強
+→ メモリ追記候補: `feedback_workflow_trigger_structural_fix.md` (`feedback_test_plan_execution.md` の関連)
 
 ---
 
@@ -132,4 +132,4 @@ Phase 8 cutover と並行検討。UI ロジックは component test 34 件、認
 - 起票数: 0 件
 - Net: 0 件
 
-**Net=0 の理由**: 本セッションは Issue ベースではなく **dispatch impl-plan (Phase 6 PR-F2) 進捗** + **CI failure hotfix** で管理される作業。triage 基準 (実害/再現バグ/CI破壊/rating≥7/明示指示) 該当の新規課題なし。Phase 8 cutover 中の wiring follow-up (E2E 復旧) は impl-plan 管理内のため Issue 起票対象外。
+**Net=0 の理由**: 本セッションは dispatch impl-plan 内 follow-up (E2E 復旧) + CI 設定構造改善 (e2e.yml trigger 追加) で管理される作業。triage 基準 (実害/再現バグ/CI破壊/rating≥7/明示指示) 該当の新規課題なし。E2E workflow trigger 追加は構造的予防で、Issue 起票対象ではなく実装で解決済み。

--- a/docs/handoff/archive/2026-05-23-session-46.md
+++ b/docs/handoff/archive/2026-05-23-session-46.md
@@ -1,0 +1,135 @@
+# Session Handoff — 2026-05-23 (Session 46)
+
+## TL;DR
+
+**DXcollege 自動完了通知システム Phase 6 PR-F2 完了 (Frontend UI 全 component 揃った) + E2E spec 一時 skip hotfix**。2 PR を番号単位明示認可でマージ。
+
+1. **PR #481** (Phase 6 PR-F2): スーパー管理者 `/super/dispatch-settings` ページに残 3 component と API smoke E2E を追加。**TenantCcEditor** (テナント別 CC chips、上限 10、CRLF/カンマ/制御文字拒否、case-insensitive 重複排除) + **AuditLogTable** (filter + cursor + requestId 方式 state race 対策) + **RunHistoryTable** (cursor + status badge)。新規 34 テスト、全 web 214 PASS。Codex セカンドオピニオン指摘 (state race 対策) + Evaluator 分離プロトコル (APPROVE 条件付き) + `/code-review high` PR inline 3 件指摘 (form/error 共存 / timezone label / regression test) を全反映。
+2. **PR #482** (hotfix): #481 マージ後に CI E2E が failure (dispatch factory 必須 env 未設定 / Firestore credential 無しで 500)。`e2e/tests/dispatch-settings-api.spec.ts` を `test.describe.fixme()` で一時 skip し復旧方針コメントを追記して CI を unblock。
+
+各 PR で番号単位明示認可を遵守 (`PR #番号 — タイトル (N files, +X/-Y)` 形式で要約)。
+
+- **Issue Net**: **0 件** — Close 0 / 起票 0。dispatch Phase は impl-plan 管理 (Issue 起票対象外)。triage 基準該当の新規課題なし
+- **マージ済 PR**: **2 件** (#481 / #482)
+- **CI**: ✅ #481 マージ後 E2E failure → #482 マージで unblock (Build/Lint/Test/Type Check は green)
+- **Open Issue**: active 0 / postponed 4 (#274/275/276/405、変化なし)
+- **残留プロセス**: ✅ なし (ローカル vitest プロセス 1 つを handoff 時に kill)
+
+---
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+# 1. 状況復元
+cat docs/handoff/LATEST.md
+
+# 2. main 最新と CI
+git fetch origin main && git log --oneline -10 origin/main
+gh run list --branch main --limit 5
+
+# 3. OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
+gh issue list --state open --limit 15
+```
+
+---
+
+## セッション成果物 (Session 46)
+
+### マージ済 PR (2 件)
+
+| # | タイトル | 種別 | 差分 | merge commit |
+|---|---|---|---|---|
+| #481 | feat(dispatch): Phase 6 PR-F2 完了通知 配信設定ページ 残コンポーネント | feat (large) | 10 files / +2027/-86 | 9e071fd |
+| #482 | fix(e2e): dispatch-settings-api.spec を describe.fixme で一時 skip | fix (small) | 1 file / +21/-2 | 8d191b0 |
+
+### Phase 進捗マトリクス (dispatch)
+
+| Phase | 内容 | 状態 | 関連 PR |
+|---|---|---|---|
+| 1-4 | 基礎 services / Reservation / Mail / Internal API | ✅ | #442/465/467/466/468 |
+| 5 | Super admin API 6 endpoints | ✅ | #478 |
+| 6 | Frontend UI | ✅ **完了 (本セッション)** | **#479 (F1) + #481 (F2)** |
+| 7 | Infrastructure (Cloud Scheduler / TTL / env) | ✅ | #471/472 + gcloud |
+| 8 | Smoke check + Cutover | ⏳ **人手作業待ち** | - |
+
+### Phase 8 cutover の前提 (人手作業待ち、decision-maker 領分)
+
+- **開発者の SendAs 登録**: `system@279279.net` の Gmail で `dxcollege@279279.net` を SendAs 追加 (ADR-037、これが無いと From 偽装不可)
+- **dev/staging デプロイ + 目視確認**: super ページは Firebase user 必須でローカル dev (user=null) ではブラウザ表示不可。デプロイ後に `/super/dispatch-settings` の全 section (F1 + F2) を目視確認
+- cutover 手順: `super_dispatch_settings/global` を enabled=false で初期化 → SendAs send smoke → enabled=true 切替 (impl-plan Phase 8)
+
+### E2E 復旧 follow-up (PR #482 で一時 skip した範囲)
+
+`e2e/tests/dispatch-settings-api.spec.ts` を `test.describe.fixme()` で skip 中。復旧手順:
+
+1. `e2e/playwright.config.ts` の api webServer env に dispatch 関連 env 追加:
+   - `DISPATCH_USE_IN_MEMORY=true`
+   - `DXCOLLEGE_SENDER_EMAIL` / `DXCOLLEGE_DISPATCH_SUBJECT` / `DISPATCH_OIDC_AUDIENCE`
+2. `dispatch-super-router` の `ccStore` を in-memory モード時に `InMemoryTenantCcConfigStore` へ切り替える wiring 追加 (or Firestore emulator を CI で起動)
+3. spec の `test.describe.fixme()` を `test.describe()` に戻す
+
+Phase 8 cutover と並行検討。UI ロジックは component test 34 件、認可境界は middleware 単体テストでカバー済のため緊急性は低い。
+
+---
+
+## 重要な技術判断 (本セッション)
+
+### Phase 6 PR-F2 設計判断 (PR #481)
+
+- **state race 対策**: Codex セカンドオピニオン指摘で `requestIdRef` snapshot 方式採用。`AbortController` は React StrictMode の二重 effect と相性が悪く不採用。連打を許容しつつ最新 fetch のみ反映する設計
+- **F1/F2 独立ロード**: F2 component (TenantCcEditor / AuditLogTable / RunHistoryTable) は settings ロード状態と独立に常にマウント。settings ロード失敗時でも他 Section を閲覧可能
+- **早期 return 廃止 + form null 化**: page.tsx の `if (loading/error/!form) return ...` を条件 render に変更。code-review で「reload 失敗時に form と error が共存する race」が指摘され、loadSettings の catch で `setForm(null)` + `setSaveError(null)` + `setNotice(null)` 追加して解消 (regression test 追加)
+- **datetime-local の label 修正**: `new Date("YYYY-MM-DDTHH:mm")` は ES2017 仕様でブラウザ local time として解釈されるため、AuditLogTable の label「(JST)」→「(ローカル時刻)」に修正
+- **Radix Select の RTL テスト回避**: TenantCcEditor を `TenantCcEditor` (tenant 選択ラッパー) + `TenantCcForm` (CC 編集本体) の 2 export に分離、component test は Form に集中。Select interaction は実機目視で補う
+- **FE/BE validator divergence 回避**: `validateClientCcEmail` は BE `validateSingleEmail` と同じ正規表現を使用、`<>` 等の独自拡張は加えず BE 仕様にミラー
+
+### E2E 復旧方針 (PR #482)
+
+- 一時 skip + 復旧方針コメントを spec 冒頭に記録
+- CI を unblock することを最優先、品質は他レイヤー (component test 34 件 + middleware 単体テスト) でカバー
+- 復旧は Phase 8 cutover と並行検討 (BE wiring + E2E env 追加)
+
+---
+
+## Quality Gate (本セッション実施結果)
+
+| ステップ | 結果 |
+|---|---|
+| `/brainstorm` | 不要 (既存 impl-plan の Phase 6 を継続) |
+| `/impl-plan` | サブ計画として plan file 作成 (Codex セカンドオピニオン取得後に承認) |
+| `/codex review` (impl-plan 段階) | state race 対策 (`requestId`) 指摘 → 実装に反映 |
+| `/safe-refactor` | HIGH 2 件 (DRY 違反、plan で意図的容認、follow-up 候補) |
+| `evaluator` 分離 (5+ ファイル) | **APPROVE 条件付き**。AC PASS、MEDIUM-2 (403 テスト欠落) を本 PR で反映 |
+| `/code-review high` (PR inline) | 3 件指摘を全反映 (form null 化 / timezone label / regression test) |
+
+---
+
+## 教訓 (CLAUDE.md feedback への追記候補)
+
+### ローカル E2E 起動確認のスキップが CI failure を顕在化
+
+- 本 PR #481 では Playwright UI E2E を「super ページが Firebase user 必須で AUTH_MODE=dev では表示不可」を理由に API smoke のみに切り替えた。ただし、API smoke spec を **ローカルで実際に起動 (api + web webServer + Firestore emulator) して PASS 確認することなく** PR を出した
+- 結果として、CI E2E で dispatch factory の必須 env 未設定 + Firestore credential 無しで全テストが 500 を返し、main マージ後に発覚
+- これは既存 `feedback_integration_test_local_verify.md` の「module-level skip は『動作確認した』錯覚の罠」と同型のパターンで、新規 spec 追加時にも同じ罠が成立する
+- 対策: 新規 E2E spec を追加する PR では、**ローカルで webServer 起動 + spec PASS を必ず確認** してから push する。Firestore に依存する場合は Firestore emulator を立てる手順を spec 冒頭にコメントで明記する
+
+→ メモリ追記候補: `feedback_e2e_spec_local_verify_before_push.md` (`feedback_integration_test_local_verify.md` の関連) 
+
+### CI 確認は jobs 全部を確認する (gh pr checks のリストが workflow 単位)
+
+- 本 PR で `gh pr checks 481` で 4 jobs (Build/Lint/Test/Type Check) が PASS と確認後、ユーザーの明示認可を受けて squash merge
+- しかし `Playwright E2E` job は別 workflow にあり、PR の checks リストに表示されなかった (push trigger workflow なので branch push 時に走るが、PR merge 前後で別 run)
+- 結果として E2E failure を merge 後に発覚
+- 対策: PR merge 前に `gh run list --branch <pr-branch>` で全 workflow run を確認する。または、deploy workflow が CI 通過に依存している場合、deploy 前の最終 gate として E2E 結果も確認する
+
+→ メモリ追記候補: 既存 `feedback_test_plan_execution.md` への補強
+
+---
+
+## Issue Net 変化
+
+- Close 数: 0 件
+- 起票数: 0 件
+- Net: 0 件
+
+**Net=0 の理由**: 本セッションは Issue ベースではなく **dispatch impl-plan (Phase 6 PR-F2) 進捗** + **CI failure hotfix** で管理される作業。triage 基準 (実害/再現バグ/CI破壊/rating≥7/明示指示) 該当の新規課題なし。Phase 8 cutover 中の wiring follow-up (E2E 復旧) は impl-plan 管理内のため Issue 起票対象外。


### PR DESCRIPTION
## Summary

- Session 47 (本セッション) の handoff を新規 LATEST.md として作成
- Session 46 (前回) を `docs/handoff/archive/2026-05-23-session-46.md` に archive
- 本セッションの成果: PR #484 (dispatch-settings-api spec 復旧 + in-memory wiring) + e2e.yml に pull_request + workflow_dispatch trigger 追加で構造改善

## Issue Net 変化

- Close 数: 0 件
- 起票数: 0 件
- Net: 0 件

triage 基準 (実害/再現バグ/CI破壊/rating≥7/明示指示) 該当課題なし。dispatch impl-plan 内 follow-up + CI 設定構造改善。

## Test plan

- [x] LATEST.md サイズ 135 行 (500 行以下)
- [x] archive ファイル作成済 (`2026-05-23-session-46.md`)
- [ ] CI Lint (markdown 整合) PASS 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)