### PR TITLE
fix(deploy): CORS_ORIGIN に Cloud Run 新形式 URL を追加 (Phase 8 Web UI 動作復旧)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,12 +98,23 @@ jobs:
           #   api Cloud Run service URL と一致させる必要があるため secret 経由 (環境ごとに異なる)。
           #   未設定なら mount スキップ (services/api/src/index.ts の isProductionGcpRuntime で
           #   fail loud → 設定漏れを起動時に検知)。
-          ENV_VARS="NODE_ENV=production,DEMO_ENABLED=true,AUTH_MODE=firebase,CORS_ORIGIN=https://web-3zcica5euq-an.a.run.app,GOOGLE_WORKSPACE_ADMIN_EMAIL=system@279279.net,SESSION_DURATION_MS=10800000,GCS_RESOURCE_BUCKET=lms-279-resources,DXCOLLEGE_DISPATCH_SUBJECT=system@279279.net,DXCOLLEGE_SENDER_EMAIL=dxcollege@279279.net"
+          # NOTE: gcloud `--set-env-vars` のデフォルト区切り文字はカンマ `,` だが、
+          # CORS_ORIGIN は複数 origin をカンマ区切りで保持する (services/api/src/index.ts
+          # の split(",") を参照) ため env_var 区切りと衝突する。
+          # 解決: gcloud の custom delimiter syntax `^|^...` で env_var 区切りを `|` に変更し、
+          # CORS_ORIGIN 内で `,` を安全に使えるようにする。
+          # `|` は URL / email / プロジェクト名いずれにも通常出現しないため安全。
+          #
+          # CORS_ORIGIN: Cloud Run は同じ web service に対して旧形式
+          # (web-3zcica5euq-an.a.run.app) と新形式 (web-1034821634012.asia-northeast1.run.app)
+          # の 2 種類の URL を並列提供している。どちらの origin からアクセスされても
+          # CORS preflight が通るよう両方を許可する (2026-05-23 Phase 8 cutover で発覚)。
+          ENV_VARS="^|^NODE_ENV=production|DEMO_ENABLED=true|AUTH_MODE=firebase|CORS_ORIGIN=https://web-3zcica5euq-an.a.run.app,https://web-1034821634012.asia-northeast1.run.app|GOOGLE_WORKSPACE_ADMIN_EMAIL=system@279279.net|SESSION_DURATION_MS=10800000|GCS_RESOURCE_BUCKET=lms-279-resources|DXCOLLEGE_DISPATCH_SUBJECT=system@279279.net|DXCOLLEGE_SENDER_EMAIL=dxcollege@279279.net"
           if [ -n "${{ secrets.SUPER_ADMIN_EMAILS }}" ]; then
-            ENV_VARS="${ENV_VARS},SUPER_ADMIN_EMAILS=${{ secrets.SUPER_ADMIN_EMAILS }}"
+            ENV_VARS="${ENV_VARS}|SUPER_ADMIN_EMAILS=${{ secrets.SUPER_ADMIN_EMAILS }}"
           fi
           if [ -n "${{ secrets.DISPATCH_OIDC_AUDIENCE }}" ]; then
-            ENV_VARS="${ENV_VARS},DISPATCH_OIDC_AUDIENCE=${{ secrets.DISPATCH_OIDC_AUDIENCE }}"
+            ENV_VARS="${ENV_VARS}|DISPATCH_OIDC_AUDIENCE=${{ secrets.DISPATCH_OIDC_AUDIENCE }}"
           fi
           gcloud run deploy api \
             --image=${{ env.ARTIFACT_REGISTRY }}/api:${{ github.sha }} \


### PR DESCRIPTION
## Summary

Phase 8 cutover Step 1 (dispatch-settings 初期化) 進行時、web service の新形式 URL からのアクセスで API への全 fetch が CORS preflight で blocked される事象が発覚。

```
Access to fetch at 'https://api-3zcica5euq-an.a.run.app/api/v2/super/dispatch/settings'
from origin 'https://web-1034821634012.asia-northeast1.run.app'
has been blocked by CORS policy: ...No 'Access-Control-Allow-Origin' header...
```

Cloud Run は同 web service に対し **2 種類の URL を並列提供** しているが、`deploy.yml` の `ENV_VARS` は旧形式のみを `CORS_ORIGIN` に含めていた:

| URL 形式 | 例 | CORS_ORIGIN 旧設定 |
|---------|----|------------------|
| 旧形式 | `https://web-3zcica5euq-an.a.run.app` | ✅ 含まれる |
| 新形式 | `https://web-1034821634012.asia-northeast1.run.app` | ❌ **含まれない** |

→ 開発者が新形式 URL でアクセスすると CORS preflight で全 API blocked。

## 修正内容

| 変更点 | 内容 |
|--------|------|
| `ENV_VARS` 区切り文字 | `,` → `\|` (gcloud `--set-env-vars` の `^\|^...` custom delimiter syntax) |
| `CORS_ORIGIN` の値 | 旧形式のみ → **旧+新両形式を許可** |
| 他の env 値 | 変更なし |

### delimiter に `\|` を選んだ理由

URL / email / プロジェクト名 / SUPER_ADMIN_EMAILS / DISPATCH_OIDC_AUDIENCE の値に通常 `\|` は出現しないため、conditional 追加含め全 env_var で安全に使える。

## 影響範囲

- 変更ファイル: `.github/workflows/deploy.yml` 1 ファイルのみ
- 副作用: merge → deploy.yml 自動実行 → api service が新 revision で再起動 (約 1 分のローリングデプロイ、ゼロダウンタイム)
- ロールバック: gcloud で旧 env 値に戻すか、本 commit を revert

## Test plan

- [x] yaml syntax (git diff で構文確認、`gcloud --set-env-vars` の custom delimiter は公式 syntax)

deploy 後検証 (merge 後に実施):

- [ ] 新形式 URL `https://web-1034821634012.asia-northeast1.run.app/super/dispatch-settings` → 完了通知設定タブで API 呼び出しが 200 で返る
- [ ] 旧形式 URL `https://web-3zcica5euq-an.a.run.app/super/dispatch-settings` も引き続き動作 (両方許可)
- [ ] Cloud Run api service の env を確認: `gcloud run services describe api --format="value(spec.template.spec.containers[].env)"` で `CORS_ORIGIN=https://web-3zcica5euq-an.a.run.app,https://web-1034821634012.asia-northeast1.run.app` を確認
- [ ] Phase 8 Step 1 (dispatch-settings/global doc 初期化) を再試行 → 成功

## 関連

- Phase 8 cutover playbook: `docs/runbook/dxcollege-completion-notification-cutover.md`
- 直近 PR #486 (Phase 8 cutover 事前準備)
- 発覚タイミング: 2026-05-23 Phase 8 Step 1 進行時

🤖 Generated with [Claude Code](https://claude.com/claude-code)