### PR TITLE
feat(dispatch): dispatch-dry-run admin SDK CLI + workflow (Phase 8 Step 5 代替)

### DIFF
--- a/.github/workflows/dispatch-dry-run.yml
+++ b/.github/workflows/dispatch-dry-run.yml
@@ -1,0 +1,123 @@
+name: Dispatch Dry Run
+
+# DXcollege 自動完了通知 dry-run admin SDK CLI workflow (Phase 8 Step 5 代替)。
+#
+# 目的:
+#   `/super/dispatch-settings` UI の「ドライラン」ボタン (撤廃予定) を経由せず、
+#   workflow_dispatch + Firestore admin SDK で次回 cron 配信対象 + MIME プレビューを取得する。
+#
+# 安全性:
+#   - 完全 read-only (Gmail 送信なし、Firestore write なし)
+#   - 既存 services/api/src/services/dispatch/{firestore-tenant-data-loader,firestore-dispatch-storage}
+#     を直接利用するため本番 logic と query 構造が完全一致
+#
+# 出力:
+#   - workflow log (stdout): 結果 JSON 全文
+#   - artifact: dispatch-dry-run-result-*.json (30 日保持)
+#   - $GITHUB_STEP_SUMMARY: 対象件数サマリ
+#
+# セキュリティ: workflow_dispatch 入力は本 workflow では受け取らない (固定動作)。
+# 参考: https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+#
+# 関連:
+#   - 設計仕様書: docs/specs/2026-05-20-completion-notification-design.md §8 / AC-8
+#   - playbook: docs/runbook/dxcollege-completion-notification-cutover.md Step 5
+#   - スクリプト: scripts/dispatch-dry-run-cli.ts
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  dry-run:
+    name: Dispatch Dry Run
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      FIREBASE_PROJECT_ID: lms-279
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared-types
+        # scripts/dispatch-dry-run-cli.ts は @lms-279/shared-types から DispatchSettings を
+        # import するため build 必須 (package.json main が dist/index.js を指す)。
+        run: npm run build -w @lms-279/shared-types
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/1034821634012/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-actions@lms-279.iam.gserviceaccount.com
+
+      - name: Run dispatch dry-run CLI
+        env:
+          GOOGLE_CLOUD_PROJECT: lms-279
+          DXCOLLEGE_SENDER_EMAIL: dxcollege@279279.net
+        run: |
+          set -euo pipefail
+          npx tsx scripts/dispatch-dry-run-cli.ts
+
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dispatch-dry-run-${{ github.run_id }}
+          path: dispatch-dry-run-result-*.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Summarize result
+        if: always()
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          result_files=(dispatch-dry-run-result-*.json)
+          RESULT_FILE="${result_files[0]:-}"
+          if [ -z "$RESULT_FILE" ]; then
+            {
+              echo "## Dispatch Dry Run"
+              echo ""
+              echo "結果 JSON が見つかりません。スクリプトが異常終了した可能性があります。"
+              echo "Run ステップの実行ログで原因を確認してください。"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          EVALUATED_AT=$(jq -r '.evaluatedAt' "$RESULT_FILE")
+          SETTINGS_LOADED=$(jq -r '.settingsLoaded' "$RESULT_FILE")
+          TENANTS_SCANNED=$(jq -r '.tenantsScanned' "$RESULT_FILE")
+          WOULD_NOTIFY_COUNT=$(jq -r '.wouldNotifyCount' "$RESULT_FILE")
+          ENABLED=$(jq -r '.settingsSnapshot.enabled // "null"' "$RESULT_FILE")
+          DOW=$(jq -rc '.settingsSnapshot.scheduleDaysOfWeek // "null"' "$RESULT_FILE")
+          HOUR=$(jq -r '.settingsSnapshot.scheduleHourJst // "null"' "$RESULT_FILE")
+          {
+            echo "## Dispatch Dry Run"
+            echo ""
+            echo "| 項目 | 値 |"
+            echo "|---|---|"
+            echo "| evaluatedAt | $EVALUATED_AT |"
+            echo "| settingsLoaded | $SETTINGS_LOADED |"
+            echo "| settings.enabled | $ENABLED |"
+            echo "| settings.scheduleDaysOfWeek | $DOW |"
+            echo "| settings.scheduleHourJst | $HOUR |"
+            echo "| tenantsScanned | $TENANTS_SCANNED |"
+            echo "| **wouldNotifyCount** | **$WOULD_NOTIFY_COUNT** |"
+            echo ""
+            if [ "$WOULD_NOTIFY_COUNT" -gt 0 ]; then
+              echo "### 対象一覧 (上位 10 件)"
+              echo ""
+              jq -r '.wouldNotify | .[0:10] | .[] | "- \(.tenantId) / \(.userId) / \(.userEmail) (\(.userName))"' "$RESULT_FILE" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "次回 cron で送信される対象はありません。"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/__tests__/dispatch-dry-run-cli.smoke.ts
+++ b/scripts/__tests__/dispatch-dry-run-cli.smoke.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env npx tsx
+/**
+ * `scripts/dispatch-dry-run-cli.ts` の module-load + 型 sanity smoke test。
+ *
+ * 位置づけ:
+ *   - scripts/ 配下は vitest workspace 対象外のため、node:assert で最低限の回帰検知。
+ *   - 本 CLI は Firestore 統合 (副作用) が中心のため Unit Test は最小に留め、
+ *     実機検証は workflow_dispatch + dry-run 出力 JSON で行う方針。
+ *   - test 経由の import で main() が走らないこと (isMainEntry guard) が回帰時に
+ *     最も発覚しやすいバグなので、import 自体が副作用を起こさないことを確認する。
+ *
+ * 実行方法:
+ *   npx tsx scripts/__tests__/dispatch-dry-run-cli.smoke.ts
+ */
+
+import assert from "node:assert/strict";
+
+import {
+  runDryRunCli,
+  type DryRunMimePreview,
+  type DryRunResultCli,
+  type DryRunTargetCli,
+  type DryRunTenantSummary,
+} from "../dispatch-dry-run-cli.ts";
+
+// --- export sanity: runDryRunCli が関数として import できる ---
+{
+  assert.equal(typeof runDryRunCli, "function", "runDryRunCli must be a function");
+  assert.equal(
+    runDryRunCli.length,
+    1,
+    "runDryRunCli should take a single Firestore arg",
+  );
+}
+
+// --- 型 sanity: 公開された型が DTO として構築可能 ---
+{
+  const preview: DryRunMimePreview = {
+    from: "DXcollege運営スタッフ <dxcollege@279279.net>",
+    to: "user@example.com",
+    cc: ["owner@tenant.example"],
+    subject: "【DXcollege】受講修了のお知らせ",
+    body: "山田太郎 様\n\n受講お疲れ様でした。\n\n---\nDXcollege運営スタッフ\n",
+  };
+  const target: DryRunTargetCli = {
+    tenantId: "tenant-a",
+    userId: "user-1",
+    userEmail: "user@example.com",
+    userName: "山田太郎",
+    courseIdsSnapshot: ["c1", "c2"],
+    mimePreview: preview,
+  };
+  const summary: DryRunTenantSummary = {
+    tenantId: "tenant-a",
+    skipped: false,
+    usersScanned: 10,
+    eligibleCount: 1,
+  };
+  const result: DryRunResultCli = {
+    evaluatedAt: "2026-05-23T12:00:00.000Z",
+    settingsLoaded: true,
+    settingsSnapshot: {
+      enabled: false,
+      scheduleDaysOfWeek: [1],
+      scheduleHourJst: 9,
+      signatureName: "DXcollege運営スタッフ",
+      completionMessageBodyLength: 50,
+    },
+    tenantsScanned: 1,
+    tenantsSummary: [summary],
+    wouldNotifyCount: 1,
+    wouldNotify: [target],
+  };
+
+  // 構造 invariants
+  assert.equal(result.wouldNotifyCount, result.wouldNotify.length);
+  assert.ok(result.tenantsSummary.every((s) => s.eligibleCount >= 0));
+  assert.match(target.mimePreview.from, /<.*@.*>$/, "from header MUST contain angle-bracketed email");
+}
+
+// --- skipReason の lifecycle: skipped=true の時のみ意味を持つ ---
+{
+  const skipped: DryRunTenantSummary = {
+    tenantId: "tenant-b",
+    skipped: true,
+    skipReason: "tenant_completion_notification_disabled",
+    usersScanned: 0,
+    eligibleCount: 0,
+  };
+  assert.equal(skipped.usersScanned, 0, "skipped tenant has 0 users scanned");
+  assert.equal(skipped.eligibleCount, 0, "skipped tenant has 0 eligible");
+}
+
+// --- 副作用なし import sanity: 本 file 読込時点で initFirestore() / main() が呼ばれていないこと ---
+// → main() が走っていれば firebase-admin の initializeApp が走り、credentials 不足で throw する。
+// 本テストがここまで例外なく到達できているということは、isMainEntry guard が機能している証拠。
+// (assert は不要、ここまで到達できたこと自体が test の合格条件)
+
+console.log("dispatch-dry-run-cli.smoke.ts: all structural assertions passed");

--- a/scripts/dispatch-dry-run-cli.ts
+++ b/scripts/dispatch-dry-run-cli.ts
@@ -52,7 +52,10 @@ import { getFirestore, type Firestore } from "firebase-admin/firestore";
 import { FirestoreDispatchStorage } from "../services/api/src/services/dispatch/firestore-dispatch-storage.js";
 import { FirestoreTenantDataLoader } from "../services/api/src/services/dispatch/firestore-tenant-data-loader.js";
 import { evaluateCompletionEligibility } from "../services/api/src/services/dispatch/completion-eligibility.js";
-import { validateSingleEmail } from "../services/api/src/services/dispatch/cc-email-validator.js";
+import {
+  validateAndDedupeCcEmails,
+  validateSingleEmail,
+} from "../services/api/src/services/dispatch/cc-email-validator.js";
 import { buildCompletionMail } from "../services/api/src/services/dispatch/completion-notification-mail.js";
 import { sanitizeErrorForAudit } from "../services/api/src/services/dispatch/dispatch-error-sanitizer.js";
 import type { DispatchSettings } from "@lms-279/shared-types";
@@ -155,14 +158,12 @@ export async function runDryRunCli(db: Firestore): Promise<DryRunResultCli> {
   const storage = new FirestoreDispatchStorage(db);
   const loader = new FirestoreTenantDataLoader(db);
 
-  // ① settings 読み取り (なければ default を使い、preview のみ提供)
-  let settings: DispatchSettings | null = null;
-  try {
-    settings = await storage.getDispatchSettings();
-  } catch (err) {
-    // settings 読み取り失敗は致命ではない (preview なら default で進行)
-    console.error(`WARN: getDispatchSettings failed: ${sanitizeErrorForAudit(err)}`);
-  }
+  // ① settings 読み取り
+  // doc missing (storage.getDispatchSettings が null 返却) は許容: 初期化前の cutover
+  // リハーサル想定で default 文言を埋めて preview を返す。
+  // read/parse error (throw) は cutover 判断材料の整合性に直結するため致命扱いし、
+  // workflow を失敗させる (codex review 2026-05-24 PR #488 Low-1 反映)。
+  const settings: DispatchSettings | null = await storage.getDispatchSettings();
 
   const signature = settings?.signatureName ?? DEFAULT_SIGNATURE;
   const messageBody = settings?.completionMessageBody ?? DEFAULT_BODY;
@@ -223,11 +224,15 @@ export async function runDryRunCli(db: Firestore): Promise<DryRunResultCli> {
         signatureName: signature,
       });
 
-      const ccList: string[] = [];
-      if (ccConfig.ownerEmail) ccList.push(ccConfig.ownerEmail);
-      for (const cc of ccConfig.notificationCcEmails ?? []) {
-        if (cc && !ccList.includes(cc)) ccList.push(cc);
-      }
+      // CC 組立は本番送信側 (run-completion-notifications.ts) と完全同期させるため、
+      // validateAndDedupeCcEmails を使う (trim / 形式検証 / CRLF・カンマ排除 /
+      // case-insensitive dedupe を実施)。codex review (2026-05-24 PR #488 Medium-1) で
+      // 本番ロジック (gmail-dwd-send.ts) との preview ドリフトを指摘されたため反映。
+      const ccResult = validateAndDedupeCcEmails(
+        ccConfig.notificationCcEmails ?? [],
+        ccConfig.ownerEmail,
+      );
+      const ccList = ccResult.validCcEmails;
 
       wouldNotify.push({
         tenantId,

--- a/scripts/dispatch-dry-run-cli.ts
+++ b/scripts/dispatch-dry-run-cli.ts
@@ -1,0 +1,320 @@
+#!/usr/bin/env npx tsx
+/**
+ * DXcollege 自動完了通知 dry-run admin SDK CLI (Phase 8 Step 5 代替)。
+ *
+ * 目的:
+ *   `/super/dispatch-settings` UI の「ドライラン」ボタン (`/api/v2/super/dispatch/dry-run`)
+ *   を経由せず、Firestore admin SDK で直接対象一覧 + MIME プレビューを取得する。
+ *   既存 UI / API endpoint は撤廃予定 (PR-B) のため、本 CLI が cutover 検証手段。
+ *
+ *   完全 read-only:
+ *     - Gmail 送信なし
+ *     - Firestore write なし (settings / dispatch_runs / completion_notifications いずれも write しない)
+ *     - 既存 `services/api/src/services/dispatch/{firestore-tenant-data-loader,firestore-dispatch-storage}`
+ *       を直接利用するため本番ロジックと query 構造が完全一致 (重複再実装によるドリフトを回避)。
+ *
+ * 動作:
+ *   1. super_dispatch_settings/global 読み取り (default にフォールバック)
+ *   2. tenants 一覧取得 → 各 tenant について completionNotificationEnabled チェック
+ *   3. published courses + users を走査
+ *   4. evaluateCompletionEligibility で 100% 完了判定
+ *   5. completion_notifications/{userId} 存在チェック (既送信は除外)
+ *   6. 各 user 向け MIME プレビュー (件名/本文/署名/CC) を組み立て
+ *   7. 結果を JSON で stdout + `dispatch-dry-run-result-<ts>.json` に出力
+ *
+ * 使用方法:
+ *   # ローカル (ADC 経由)
+ *   GOOGLE_APPLICATION_CREDENTIALS=path/to/key.json \
+ *   GOOGLE_CLOUD_PROJECT=lms-279 \
+ *   npx tsx scripts/dispatch-dry-run-cli.ts
+ *
+ *   # workflow_dispatch (WIF 認証)
+ *   GitHub Actions UI > Dispatch Dry Run > Run workflow
+ *
+ * 関連:
+ *   - 設計仕様書 §8 (Phase 8 cutover) / AC-8 (dry-run は read-only)
+ *   - playbook: docs/runbook/dxcollege-completion-notification-cutover.md Step 5
+ *   - 既存 API endpoint (撤廃予定): services/api/src/routes/super/dispatch-dry-run.ts
+ */
+
+import { pathToFileURL } from "node:url";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  applicationDefault,
+  cert,
+  initializeApp,
+  type ServiceAccount,
+} from "firebase-admin/app";
+import { getFirestore, type Firestore } from "firebase-admin/firestore";
+
+import { FirestoreDispatchStorage } from "../services/api/src/services/dispatch/firestore-dispatch-storage.js";
+import { FirestoreTenantDataLoader } from "../services/api/src/services/dispatch/firestore-tenant-data-loader.js";
+import { evaluateCompletionEligibility } from "../services/api/src/services/dispatch/completion-eligibility.js";
+import { validateSingleEmail } from "../services/api/src/services/dispatch/cc-email-validator.js";
+import { buildCompletionMail } from "../services/api/src/services/dispatch/completion-notification-mail.js";
+import { sanitizeErrorForAudit } from "../services/api/src/services/dispatch/dispatch-error-sanitizer.js";
+import type { DispatchSettings } from "@lms-279/shared-types";
+
+// ============================================================
+// 型定義 (CLI 出力 JSON shape)
+// ============================================================
+
+export interface DryRunMimePreview {
+  from: string;
+  to: string;
+  cc: string[];
+  subject: string;
+  body: string;
+}
+
+export interface DryRunTargetCli {
+  tenantId: string;
+  userId: string;
+  userEmail: string;
+  userName: string;
+  courseIdsSnapshot: string[];
+  mimePreview: DryRunMimePreview;
+}
+
+export interface DryRunTenantSummary {
+  tenantId: string;
+  skipped: boolean;
+  skipReason?: string;
+  usersScanned: number;
+  eligibleCount: number;
+}
+
+export interface DryRunResultCli {
+  evaluatedAt: string;
+  settingsLoaded: boolean;
+  settingsSnapshot: {
+    enabled: boolean;
+    scheduleDaysOfWeek: number[];
+    scheduleHourJst: number;
+    signatureName: string;
+    completionMessageBodyLength: number;
+  } | null;
+  tenantsScanned: number;
+  tenantsSummary: DryRunTenantSummary[];
+  wouldNotifyCount: number;
+  wouldNotify: DryRunTargetCli[];
+}
+
+// ============================================================
+// 環境変数 / 定数
+// ============================================================
+
+const GCP_PROJECT_ID =
+  process.env.GOOGLE_CLOUD_PROJECT ?? process.env.FIREBASE_PROJECT_ID ?? "lms-279";
+const SENDER_EMAIL = process.env.DXCOLLEGE_SENDER_EMAIL ?? "dxcollege@279279.net";
+
+// settings 未保存テナント / フォールバック時の default 値 (本番では doc 必須だが、初期化前
+// の cutover リハーサルでも対象一覧プレビューを返せるようにする)。
+const DEFAULT_SIGNATURE = "DXcollege運営スタッフ";
+const DEFAULT_BODY = "(本文未設定 — super_dispatch_settings/global.completionMessageBody を保存してください)";
+
+// ============================================================
+// Firebase Admin SDK 初期化
+// ============================================================
+
+function initFirestore(): Firestore {
+  // 認証経路の分岐 (cleanup-orphan-auth-users.ts と同じパターン):
+  //   1. type=service_account の JSON (ローカル SA key) → cert() で初期化
+  //   2. type=external_account の JSON (GitHub Actions WIF 経由) → applicationDefault() で ADC 委譲
+  //   3. GOOGLE_APPLICATION_CREDENTIALS 未設定 → applicationDefault() (Cloud Run ADC 等)
+  // type を読まずに cert() を使うと WIF JSON で project_id property 不在エラーになる。
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (credPath) {
+    const jsonPath = resolve(process.cwd(), credPath);
+    const credJson = JSON.parse(readFileSync(jsonPath, "utf-8")) as {
+      type?: string;
+    };
+    if (credJson.type === "service_account") {
+      initializeApp({ credential: cert(credJson as ServiceAccount) });
+      console.error(`[init] 認証: サービスアカウント JSON (${jsonPath})`);
+    } else {
+      initializeApp({ credential: applicationDefault() });
+      console.error(
+        `[init] 認証: ADC (cred file type=${credJson.type ?? "unknown"}, WIF 想定)`,
+      );
+    }
+  } else {
+    initializeApp({ credential: applicationDefault() });
+    console.error("[init] 認証: Application Default Credentials");
+  }
+  return getFirestore();
+}
+
+// ============================================================
+// メイン dry-run ロジック
+// ============================================================
+
+export async function runDryRunCli(db: Firestore): Promise<DryRunResultCli> {
+  const storage = new FirestoreDispatchStorage(db);
+  const loader = new FirestoreTenantDataLoader(db);
+
+  // ① settings 読み取り (なければ default を使い、preview のみ提供)
+  let settings: DispatchSettings | null = null;
+  try {
+    settings = await storage.getDispatchSettings();
+  } catch (err) {
+    // settings 読み取り失敗は致命ではない (preview なら default で進行)
+    console.error(`WARN: getDispatchSettings failed: ${sanitizeErrorForAudit(err)}`);
+  }
+
+  const signature = settings?.signatureName ?? DEFAULT_SIGNATURE;
+  const messageBody = settings?.completionMessageBody ?? DEFAULT_BODY;
+
+  // ② tenants 走査
+  const tenantIds = await loader.listAllTenantIds();
+  const tenantsSummary: DryRunTenantSummary[] = [];
+  const wouldNotify: DryRunTargetCli[] = [];
+
+  for (const tenantId of tenantIds) {
+    const ccConfig = await loader.getTenantCcConfig(tenantId);
+
+    // テナント単位 disable は対象外 (本番 dispatch-dry-run.ts の logic と整合)
+    if (!ccConfig?.completionNotificationEnabled) {
+      tenantsSummary.push({
+        tenantId,
+        skipped: true,
+        skipReason: "tenant_completion_notification_disabled",
+        usersScanned: 0,
+        eligibleCount: 0,
+      });
+      continue;
+    }
+
+    const dataView = loader.getTenantDataView(tenantId);
+    const publishedCourses = await dataView.listPublishedCourses();
+    if (publishedCourses.length === 0) {
+      tenantsSummary.push({
+        tenantId,
+        skipped: true,
+        skipReason: "no_published_courses",
+        usersScanned: 0,
+        eligibleCount: 0,
+      });
+      continue;
+    }
+
+    const users = await dataView.listNotificationTargetUsers();
+    let eligibleCount = 0;
+
+    for (const user of users) {
+      // email 無効はどのみち送信されない (AC-19)
+      const emailV = validateSingleEmail(user.email);
+      if (!emailV.ok) continue;
+
+      const progresses = await dataView.listCourseProgressForUser(user.id);
+      const eligibility = evaluateCompletionEligibility(publishedCourses, progresses);
+      if (!eligibility.eligible) continue;
+
+      // 既存 notification (sent/reserved/failed/manual) は再送されない
+      const existing = await storage.getCompletionNotification(tenantId, user.id);
+      if (existing) continue;
+
+      // MIME プレビュー組立
+      const built = buildCompletionMail({
+        userName: user.name,
+        completionMessageBody: messageBody,
+        signatureName: signature,
+      });
+
+      const ccList: string[] = [];
+      if (ccConfig.ownerEmail) ccList.push(ccConfig.ownerEmail);
+      for (const cc of ccConfig.notificationCcEmails ?? []) {
+        if (cc && !ccList.includes(cc)) ccList.push(cc);
+      }
+
+      wouldNotify.push({
+        tenantId,
+        userId: user.id,
+        userEmail: emailV.value,
+        userName: user.name ?? "",
+        courseIdsSnapshot: eligibility.courseIdsSnapshot,
+        mimePreview: {
+          from: `${signature} <${SENDER_EMAIL}>`,
+          to: emailV.value,
+          cc: ccList,
+          subject: built.subject,
+          body: built.body,
+        },
+      });
+      eligibleCount++;
+    }
+
+    tenantsSummary.push({
+      tenantId,
+      skipped: false,
+      usersScanned: users.length,
+      eligibleCount,
+    });
+  }
+
+  const result: DryRunResultCli = {
+    evaluatedAt: new Date().toISOString(),
+    settingsLoaded: settings !== null,
+    settingsSnapshot: settings
+      ? {
+          enabled: settings.enabled,
+          scheduleDaysOfWeek: settings.scheduleDaysOfWeek,
+          scheduleHourJst: settings.scheduleHourJst,
+          signatureName: settings.signatureName,
+          completionMessageBodyLength: settings.completionMessageBody.length,
+        }
+      : null,
+    tenantsScanned: tenantIds.length,
+    tenantsSummary,
+    wouldNotifyCount: wouldNotify.length,
+    wouldNotify,
+  };
+  return result;
+}
+
+// ============================================================
+// CLI エントリポイント
+// ============================================================
+
+async function main(): Promise<void> {
+  console.error("[dispatch-dry-run-cli] start");
+  console.error(`  project: ${GCP_PROJECT_ID}`);
+  console.error(`  sender:  ${SENDER_EMAIL}`);
+  console.error("");
+
+  const db = initFirestore();
+  const result = await runDryRunCli(db);
+
+  // stdout に JSON 出力 (workflow log でも見える)
+  process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+
+  // artifact 用のファイル出力 (workflow から upload-artifact で吸い上げる)
+  const ts = result.evaluatedAt.replace(/[:.]/g, "-");
+  const outFile = `dispatch-dry-run-result-${ts}.json`;
+  writeFileSync(outFile, JSON.stringify(result, null, 2), "utf-8");
+  console.error(`[dispatch-dry-run-cli] result written: ${outFile}`);
+  console.error(
+    `[dispatch-dry-run-cli] summary: ${result.wouldNotifyCount} target(s), ` +
+      `${result.tenantsScanned} tenant(s) scanned`,
+  );
+}
+
+// テスト import 時に main() が走らないようにエントリポイント判定する。
+// `pathToFileURL` で URL encode 差 (空白 / 非 ASCII path) を吸収する。
+const isMainEntry =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMainEntry) {
+  main().catch((err) => {
+    process.exitCode = 1;
+    process.stderr.write("\n=== dispatch-dry-run-cli FAILED ===\n");
+    process.stderr.write(`Error: ${sanitizeErrorForAudit(err)}\n`);
+    if (err instanceof Error && err.stack) {
+      // stack は workflow log で開発者にのみ見える (Cloud Build 等で漏洩しない構成前提)
+      process.stderr.write(`Stack: ${err.stack}\n`);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Phase 8 Step 5 (dry-run) を `/super/dispatch-settings` UI ボタン経由ではなく、admin SDK workflow_dispatch から実行するための CLI を新規追加。

**設計判断**: 既存 UI / API endpoint (`services/api/src/routes/super/dispatch-dry-run.ts`) は **後続 PR-B で撤廃予定** (スーパー管理者の運用判断「むだな UI は増やさない」)。本 PR はその移行ステップとして、独立した admin SDK 経路を整備する。

## 設計方針

| 観点 | 内容 |
|------|------|
| **完全 read-only** | Gmail 送信なし / Firestore write なし |
| **本番ロジック再利用** | `FirestoreDispatchStorage` / `FirestoreTenantDataLoader` を直接 import、`evaluateCompletionEligibility` / `validateSingleEmail` / `buildCompletionMail` を流用。重複再実装によるドリフトを防ぐ |
| **WIF 対応** | `cleanup-orphan-auth-users.ts` の credential type 分岐パターンを踏襲 (type=service_account → `cert()`, type=external_account → `applicationDefault()`) |
| **isMainEntry guard** | `pathToFileURL` で test import 時に main 非起動 |
| **安全機構** | workflow_dispatch 入力ゼロ / WIF + CI SA / sanitizeErrorForAudit で PII 除去 |

## 出力形式

```jsonc
{
  "evaluatedAt": "2026-05-24T...",
  "settingsLoaded": true,
  "settingsSnapshot": { "enabled": false, "scheduleDaysOfWeek": [...], "scheduleHourJst": 9, "signatureName": "...", "completionMessageBodyLength": 50 },
  "tenantsScanned": 2,
  "tenantsSummary": [{ "tenantId": "...", "skipped": false, "usersScanned": 10, "eligibleCount": 1 }],
  "wouldNotifyCount": 1,
  "wouldNotify": [{
    "tenantId": "...", "userId": "...", "userEmail": "...", "userName": "...",
    "courseIdsSnapshot": [...],
    "mimePreview": { "from": "DXcollege運営スタッフ <dxcollege@279279.net>", "to": "...", "cc": [...], "subject": "【DXcollege】受講修了のお知らせ", "body": "..." }
  }]
}
```

stdout + artifact (`dispatch-dry-run-result-*.json`、30 日保持) + `$GITHUB_STEP_SUMMARY` に出力。

## 変更ファイル (3 / +542 lines)

| ファイル | 種別 | 規模 |
|---------|------|------|
| `scripts/dispatch-dry-run-cli.ts` | new | 320 lines |
| `scripts/__tests__/dispatch-dry-run-cli.smoke.ts` | new | 99 lines |
| `.github/workflows/dispatch-dry-run.yml` | new | 123 lines |

## Test plan

実行済み:

- [x] type-check 全 workspace PASS
- [x] lint 0 errors (1 warning は既存、本 PR 影響外)
- [x] test:scripts 全 PASS (新規 `dispatch-dry-run-cli.smoke.ts` 含む)
- [x] api vitest 1430 PASS (regression なし、既存 dispatch-dry-run.ts に変更なし)
- [x] workflow yml: workflow_dispatch 入力ゼロ (injection 経路なし) / env 経由 / `${{ github.run_id }}` のみ補間 (数値 ID、injection 不可能)

実行予定 (本 PR マージ後):

- [ ] `gh workflow run dispatch-dry-run.yml` → workflow run 起動
- [ ] result JSON の `wouldNotifyCount` + `wouldNotify[]` を取得
- [ ] スーパー管理者目視確認: 対象一覧 + 各受講者向け MIME プレビュー
- [ ] Phase 8 Step 6 (対象一覧レビュー) → Step 7 (認可) → Step 8 (enabled=true) へ進行

## 関連

- Phase 8 cutover playbook: `docs/runbook/dxcollege-completion-notification-cutover.md`
- 直近 PR #486 (Phase 8 cutover 事前準備) / #487 (CORS 修正)
- **後続 PR-B**: UI/API/設計仕様書から test-send + dry-run 機能を削除予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)