### PR TITLE
feat(dispatch-settings): テナント代表メール note の「テナント管理」を直リンク化

### DIFF
--- a/web/app/super/dispatch-settings/components/TenantCcEditor.tsx
+++ b/web/app/super/dispatch-settings/components/TenantCcEditor.tsx
@@ -17,6 +17,7 @@
  * CC 編集本体 (TenantCcForm) を分離し、テストは TenantCcForm に集中する。
  */
 
+import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import type {
   GetTenantNotificationCcResponse,
@@ -236,7 +237,15 @@ export function TenantCcForm({
 
       <p className="text-xs text-muted-foreground">
         テナント代表メール: <span className="font-mono">{config.ownerEmail ?? "（未設定）"}</span>{" "}
-        （変更は「テナント管理」画面から）
+        （変更は
+        <Link
+          href="/super/tenants"
+          className="underline underline-offset-2 hover:text-foreground focus-visible:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2"
+          aria-label="テナント管理画面を開く（代表メールはこの画面から変更）"
+        >
+          「テナント管理」画面
+        </Link>
+        から）
       </p>
 
       <div className="space-y-2">


### PR DESCRIPTION
## Summary

- `/super/dispatch-settings` の **TenantCcEditor** 内、テナント代表メール下の note「（変更は「テナント管理」画面から）」の「テナント管理」を `next/link` で `/super/tenants` への直リンクにする。
- スーパー管理者 (非エンジニア) が CC 確認中にテナント代表メールを変更したくなった時、ワンクリックで「テナント管理」画面へ遷移できるよう UX 改善。
- 1 ファイル変更 (`web/app/super/dispatch-settings/components/TenantCcEditor.tsx`)、+10/-1。
- a11y: `aria-label` でリンク意図明示、`focus-visible` スタイル付与。

## 背景

Phase 8 cutover 進行中、開発者 (本田様) が `/super/tenants` でテナント編集ダイアログを開いて owner を確認する作業が発生 (3 テナント分)。今後も CC 設定確認や代表メール変更時に「テナント管理」画面への遷移が繰り返し発生するため、`/super/dispatch-settings` 上で直リンク化しておく。

## Test plan

- [x] type-check (`npx tsc --noEmit`) PASS
- [x] eslint (`npx eslint web/app/super/dispatch-settings/components/TenantCcEditor.tsx`) PASS
- [x] vitest (`TenantCcEditor.test.tsx` 21 件) PASS
- [ ] (マージ後) 本番反映確認: `/super/dispatch-settings` で「テナント別 CC 設定」セクションを開き、「テナント管理」の文字がリンク (青下線) として表示され、クリックで `/super/tenants` に遷移すること

## 関連

- Phase 8 cutover: Step 6 (対象一覧 + テナント設定レビュー) で本田様作業を効率化
- 設計仕様書: `docs/specs/2026-05-20-completion-notification-design.md` (変更なし)
- 前 PR #492: 文言平易化 + ヘルプページ追加 (同 UX 改善ライン)

🤖 Generated with [Claude Code](https://claude.com/claude-code)