### PR TITLE
feat(dispatch-settings): 保存/エラー通知を InlineFeedback で刷新

### DIFF
--- a/web/app/super/dispatch-settings/components/InlineFeedback.tsx
+++ b/web/app/super/dispatch-settings/components/InlineFeedback.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { AlertCircle, CheckCircle2, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Tone = "success" | "error";
+
+interface InlineFeedbackProps {
+  tone: Tone;
+  children: React.ReactNode;
+  onDismiss?: () => void;
+  /** ms。指定なしの場合 success=5000 / error=未自動消去 */
+  autoDismissMs?: number;
+}
+
+const toneClasses: Record<Tone, string> = {
+  success:
+    "border-l-emerald-500 bg-emerald-50 text-emerald-900 dark:border-l-emerald-400 dark:bg-emerald-950/60 dark:text-emerald-100",
+  error:
+    "border-l-rose-500 bg-rose-50 text-rose-900 dark:border-l-rose-400 dark:bg-rose-950/60 dark:text-rose-100",
+};
+
+const toneIcon: Record<Tone, React.ReactNode> = {
+  success: <CheckCircle2 className="size-4 shrink-0 mt-0.5" aria-hidden />,
+  error: <AlertCircle className="size-4 shrink-0 mt-0.5" aria-hidden />,
+};
+
+export function InlineFeedback({
+  tone,
+  children,
+  onDismiss,
+  autoDismissMs,
+}: InlineFeedbackProps) {
+  const effectiveAutoDismissMs = autoDismissMs ?? (tone === "success" ? 5000 : undefined);
+
+  // 親が onDismiss を inline arrow で渡しても auto-dismiss タイマーが
+  // 親 re-render の度に reset されないよう、最新の onDismiss は ref で参照する。
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+  const hasDismiss = onDismiss !== undefined;
+
+  useEffect(() => {
+    if (!effectiveAutoDismissMs || !hasDismiss) return;
+    const t = window.setTimeout(() => onDismissRef.current?.(), effectiveAutoDismissMs);
+    return () => window.clearTimeout(t);
+  }, [effectiveAutoDismissMs, hasDismiss]);
+
+  return (
+    <div
+      role="status"
+      aria-live={tone === "error" ? "assertive" : "polite"}
+      className={cn(
+        "flex max-w-md items-start gap-2.5 rounded-md border border-l-4 px-3 py-2.5 text-sm shadow-sm",
+        "animate-in fade-in slide-in-from-top-1 duration-200",
+        toneClasses[tone],
+      )}
+    >
+      {toneIcon[tone]}
+      <div className="flex-1 leading-snug">{children}</div>
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="閉じる"
+          className="-m-0.5 rounded p-0.5 opacity-60 transition hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1"
+        >
+          <X className="size-4" aria-hidden />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/app/super/dispatch-settings/components/TenantCcEditor.tsx
+++ b/web/app/super/dispatch-settings/components/TenantCcEditor.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/components/ui/select";
 import { useSuperAdminFetch } from "@/lib/super-api";
 import { getDispatchErrorMessage } from "../errorMessage";
+import { InlineFeedback } from "./InlineFeedback";
 
 const MAX_CC = DISPATCH_CONSTRAINTS.NOTIFICATION_CC_EMAILS_MAX;
 
@@ -310,14 +311,14 @@ export function TenantCcForm({
       </div>
 
       {saveError && (
-        <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+        <InlineFeedback tone="error" onDismiss={() => setSaveError(null)}>
           {saveError}
-        </div>
+        </InlineFeedback>
       )}
       {notice && (
-        <div className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300">
+        <InlineFeedback tone="success" onDismiss={() => setNotice(null)}>
           {notice}
-        </div>
+        </InlineFeedback>
       )}
       <div>
         <Button onClick={handleSave} disabled={!isDirty || saving}>

--- a/web/app/super/dispatch-settings/page.tsx
+++ b/web/app/super/dispatch-settings/page.tsx
@@ -33,6 +33,7 @@ import { MessageBodyEditor } from "./components/MessageBodyEditor";
 import { TenantCcEditor } from "./components/TenantCcEditor";
 import { AuditLogTable } from "./components/AuditLogTable";
 import { RunHistoryTable } from "./components/RunHistoryTable";
+import { InlineFeedback } from "./components/InlineFeedback";
 import { getDispatchErrorMessage } from "./errorMessage";
 
 interface FormState {
@@ -250,14 +251,14 @@ export default function DispatchSettingsPage() {
           </Section>
 
           {saveError && (
-            <div className="rounded-md bg-destructive/10 p-3 text-destructive text-sm">
+            <InlineFeedback tone="error" onDismiss={() => setSaveError(null)}>
               {saveError}
-            </div>
+            </InlineFeedback>
           )}
           {notice && (
-            <div className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300">
+            <InlineFeedback tone="success" onDismiss={() => setNotice(null)}>
               {notice}
-            </div>
+            </InlineFeedback>
           )}
 
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

`/super/dispatch-settings` の inline 通知 (success「保存しました。」/ error) が横一杯のべた塗りブロックで視認性が低かったため、専用 component `InlineFeedback` を新設して 4 箇所 (page.tsx + TenantCcEditor.tsx の notice/saveError) を置換。`/fd` skill による design proposal + safe-refactor + code-review low の Quality Gate を一通り通過済。

## 主な改善

- **視認性**: icon (lucide CheckCircle2 / AlertCircle) + 左 4px accent border (success=emerald-500 / error=rose-500) + `max-w-md` で横に伸びすぎない
- **一時性**: success は 5 秒で auto-dismiss、error は明示 dismiss (×ボタン) のみ (誤って読み飛ばし防止)
- **a11y**: `aria-live=polite/assertive` + `role=status`、`aria-label="閉じる"`、`focus-visible:outline`、`aria-hidden` on icon
- **アニメーション**: `animate-in fade-in slide-in-from-top-1 duration-200` (既存 popover/dialog と同じ語彙、依存追加なし)
- **dark mode**: emerald/rose の各 -950/60 bg + -100 text
- **timer 安定化**: `onDismiss` は `useRef` で参照、useEffect deps から外す。caller が inline arrow (`onDismiss={() => setSaveError(null)}`) を渡しても、親 re-render で auto-dismiss タイマーが reset されない (code-review low 反映)

## 変更

| ファイル | 変更 |
|---|---|
| 新規 `web/app/super/dispatch-settings/components/InlineFeedback.tsx` | success/error 一時通知 component (72 行) |
| `web/app/super/dispatch-settings/page.tsx` | import 1 + notice/saveError 2 箇所置換 |
| `web/app/super/dispatch-settings/components/TenantCcEditor.tsx` | import 1 + notice/saveError 2 箇所置換 |

3 files, +83/-8。

## Quality Gate

- [x] `/fd` skill による design proposal (sidebar accent + iconified pattern、refined editorial tone)
- [x] `npx tsc --noEmit` PASS
- [x] `npx eslint` PASS (新規 + 変更ファイル)
- [x] `npx vitest run app/super/dispatch-settings` 47/47 PASS (既存テスト互換、`findByText("保存しました。")` も維持)
- [x] `/safe-refactor` 反映: LOW 1 件 (変数名 `effective` → `effectiveAutoDismissMs`)
- [x] `/code-review low` 反映: HIGH 1 件 (useEffect deps の `onDismiss` を `useRef` 化、auto-dismiss reset バグの予防)
- [x] スコープ限定: dispatch-settings 配下のみ、他画面の `bg-destructive/10` パターン (多数) には触れず

## Test plan

- [x] type-check / lint / vitest ローカル PASS
- [ ] (マージ後) 本番 `/super/dispatch-settings` で「保存」して "保存しました。" 通知の見た目 (icon / accent / max-w / fade) を確認
- [ ] (マージ後) 何かを保存して 5 秒経過で success が自動消去されること、× ボタンで即時消えることを確認
- [ ] (マージ後) error 系を意図的に出して × ボタンでのみ消えること (auto-dismiss されないこと) を確認

## 関連

- 前 PR #494: 「テナント管理」直リンク化 (同 UX 改善ライン)
- 前 PR #492: 文言平易化 + ヘルプページ追加
- Phase 8 cutover との関係: 本 PR は cutover 本流とは独立。マージ前 / マージ後どちらでも Step 8 (`enabled=true`) 切替可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)