### PR TITLE
fix(auth): /auth/me response に isSuperAdminAccess を含める (super admin バナー消失修正)

### DIFF
--- a/services/api/src/routes/shared/users.ts
+++ b/services/api/src/routes/shared/users.ts
@@ -33,6 +33,7 @@ router.get("/auth/me", requireUser, async (req: Request, res: Response) => {
 
   res.json({
     user: req.user,
+    isSuperAdminAccess: req.isSuperAdminAccess ?? false,
     ...(tenantName && { tenantName }),
   });
 });


### PR DESCRIPTION
## Summary

スーパー管理者がテナント管理画面 (`/[tenant]/admin/*`) に遷移しても、ヘッダー上部に出るはずの **「スーパー管理者としてアクセス中 + ← スーパー管理者ページに戻る」赤バナー** が表示されない問題を修正。

原因: `web/app/[tenant]/layout.tsx` line 92, 100-101 は `/auth/me` の response から `isSuperAdminAccess` を読んで条件分岐するが、API 側 (`services/api/src/routes/shared/users.ts:34-37`) が response に `isSuperAdminAccess` を含めていなかった (フィールド自体が無いため常に undefined → `?? false` で false)。

## 修正内容

```diff
   res.json({
     user: req.user,
+    isSuperAdminAccess: req.isSuperAdminAccess ?? false,
     ...(tenantName && { tenantName }),
   });
```

1 file / +1/-0 / extra small。

## 構造的妥当性

middleware 順序 (`services/api/src/index.ts:239-247`):

```
/api/v2/:tenant → tenantMiddleware → demoAuthMiddleware
                → tenantAwareAuthMiddleware  ← req.isSuperAdminAccess を立てる
                → demoReadOnlyMiddleware
                → createSharedRouter()  ← /auth/me ルート
```

`tenantAwareAuthMiddleware` (`services/api/src/middleware/tenant-auth.ts:297-299`) で super admin の場合 `req.isSuperAdminAccess = true` がセットされ、handler 到達時点で読める状態。

## Test plan

- [x] `npx tsc --noEmit` (services/api) PASS
- [x] `npx eslint src/routes/shared/users.ts` PASS
- [x] `npx vitest run` (services/api) PASS — **1421/1421 tests pass, 90 files**
- [x] Web 側コード変更不要を確認 (`data.isSuperAdminAccess ?? false` は既存)
- [ ] (マージ後 + デプロイ後) `system@279279.net` でテナント管理画面 (`/atali82i/admin` 等) にアクセスして、ヘッダー上部に赤バナー「スーパー管理者としてアクセス中 + ← スーパー管理者ページに戻る」が表示されることをブラウザで確認
- [ ] (マージ後) 一般テナント管理者でアクセスすると赤バナーが出ないことを確認 (ノイズ防止)

## 関連

- 既存実装 (`web/app/[tenant]/layout.tsx:113-127`): バナー UI + リンク
- middleware 実装 (`services/api/src/middleware/tenant-auth.ts:297-299`): `req.isSuperAdminAccess` セット
- middleware 実装 (`services/api/src/middleware/auth.ts:39`): `requireAdmin` 内で `req.isSuperAdminAccess` を log 用に読む既存箇所
- 既存テスト (`services/api/src/middleware/__tests__/tenant-auth-allowlist-recheck.test.ts`): `isSuperAdminAccess` が response field である前提のテストハンドラあり (test 用 mount で別 route、本 PR の users.ts には触れていなかったため通っていた)

## 影響範囲

- `/auth/me` の response に新フィールド `isSuperAdminAccess: boolean` が追加される
- 既存 consumer (`web/app/[tenant]/layout.tsx` + `web/app/[tenant]/admin/layout.tsx`) は元々このフィールドを読む前提のコード → 修正で初めて意図通り動く
- 新しいフィールドを ignore する consumer には影響なし
- API contract への追加変更で破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)