### PR TITLE
docs(phase-3): ADR-039 + 設計仕様書 - 進捗レポート 定期自動配信

### DIFF
--- a/docs/adr/ADR-039-phase3-progress-report-dispatch.md
+++ b/docs/adr/ADR-039-phase3-progress-report-dispatch.md
@@ -1,0 +1,206 @@
+# ADR-039: 進捗レポート 定期自動配信 (Phase 3) のレーン分離・冪等設計・テナント opt-out 分離
+
+- Status: **Accepted**
+- Date: 2026-06-01
+- Deciders: 開発者, system-279
+- 関連: ADR-032 (super-admin 進捗 PDF), ADR-034 (Phase 2 Gmail draft), ADR-037 (完了通知 sender impersonation), 設計仕様書 `docs/specs/2026-06-01-progress-report-dispatch-design.md`, Issue #346 (Phase 3 候補先送り記録), Session 52 ハンドオフ (`docs/handoff/archive/2026-06-01-session-52.md`)
+
+## Context
+
+Session 52 で業務スーパー管理者から受領したフィードバックで、業務スーパー管理者が期待する「自動配信」(受講中の全ユーザーへ進捗レポートを定期配信) と、既存の自動配信レーン (完了通知 = 100% 完了者のみ・1 度きり) との認識ずれが判明した。
+
+時系列:
+- ADR-032 (2026-05-13): 進捗 PDF を 2 Phase 分割、「将来テナント管理者へ自動送信する余地を残す」と記載
+- Issue #346 (起票時): Phase 2 は手動ボタン押下→確認モーダル承認、末尾に「**スコープ外 (将来 Phase 3 候補): 定期自動送信 (Cloud Scheduler)**」と明記
+- ADR-033 (Rejected): SMTP relay 自動送信案 → Gmail API 一択を維持
+- ADR-034 (2026-05-14): Phase 2 を手動 Gmail 下書きに再定義 (= Image #4)
+- 完了通知 spec (2026-05-20): 自動配信レーンは「全コース 100% 完了者のみ・1 度だけ」と明確にスコープ
+- Session 52 (2026-06-01): 業務スーパー管理者フィードバックで認識ずれ判明、Phase 3 として実装を**開発者判断で決定**
+
+Phase 3 設計では複数の設計判断が必要で、Plan stage で Codex セカンドオピニオン (CRITICAL 4 件 / HIGH 5 件) を取得して反映した。本 ADR はその判断記録を残す。
+
+### Plan stage で取得した Codex セカンドオピニオンの要点
+
+| 観点 | Codex 指摘 |
+|---|---|
+| CRITICAL-1 | `runId=randomUUID()` では Cloud Scheduler at-least-once delivery の retry を冪等化できない |
+| CRITICAL-2 | `tx.create()` のみでは PDF 生成中・Gmail 送信直後の crash で「sent か未送信か判定不能」な orphan が残る |
+| CRITICAL-3 | run-lock に `laneId` 条件を追加するだけでは既存 query→set の best-effort race を解消できない |
+| CRITICAL-4 | 同期一括処理 + 280s lease は受講者数次第で timeout する。最大規模の確定が必要 |
+| HIGH-1 | `listNotificationTargetUsers` の `role=student` フィルタだけでは退会・期限切れ・未着手 0% が混入する |
+| HIGH-2 | テナント単位 opt-out を完了通知と共有すると「完了通知だけ止めたい」「進捗だけ止めたい」が UI で表現できない |
+| HIGH-3 | Gmail API quota より Workspace 送信上限 2,000 msg/day/user (rolling 24h) が先に効く |
+| HIGH-4 | settings 全体上書き PUT で、PR 3a→3d の間に旧 UI 経由で `progressReport` が消える可能性 |
+| HIGH-5 | MIME 添付の filename dual-form 標準は RFC 5987 (HTTP header 用) ではなく RFC 2231 |
+
+## Decision
+
+進捗レポート 定期自動配信を **完了通知レーンと並走する別レーン** として実装する。以下の 8 つの設計判断を採用する。
+
+### D-1. レーン分離 (別 endpoint + 別 Cloud Scheduler job)
+
+- 新規 endpoint: `POST /api/v2/internal/dispatch/run-progress-reports`
+- 新規 Cloud Scheduler job: `dxcollege-progress-reports` (完了通知 job と **30 分ずらす**)
+- 完了通知 (`run-completion-notifications.ts`) のロジックは変更せず、Phase 3 用に新規ファイル `run-progress-reports.ts` を作成
+- 共通ヘルパー (OIDC verify / schedule-matcher / CC validator / completion-eligibility / progress-pdf 集約・PDF・メールテンプレ) は完全流用
+
+**採用理由**: 障害切り分けが独立 (一方の不具合が他方に波及しない)、スケジュール独立、kill switch 独立、監査ログでの区別が明確、Codex 推奨。
+
+**不採用案**: 同一 endpoint 拡張 (run-completion-notifications.ts に進捗レポート処理を追加)。理由: 障害切り分けが難化、片方の修正で両方をテストする必要が出る、設計対称性が崩れる。
+
+### D-2. 冪等性キーは `occurrenceId` を分離 (Cloud Scheduler at-least-once 対応)
+
+- `occurrenceId` = sha256(`laneId` + `X-CloudScheduler-ScheduleTime`) を first-class identifier として扱う
+- `runId` (UUID) は HTTP attempt 単位の監査用に限定
+- recipient claim の doc ID = `{occurrenceId}__{userId}`
+- Cloud Scheduler が同 scheduled execution を retry すると同 occurrenceId が来るため、recipient claim で天然に重複拒否される
+
+**採用理由**: Cloud Scheduler は at-least-once delivery で、同 scheduled execution が retry されると現行設計 (`runId=randomUUID()`) では新 UUID が発行されて重複送信される (Codex CRITICAL-1)。Cloud Scheduler は `X-CloudScheduler-ScheduleTime` ヘッダを RFC3339 で付与するため、これを first-class identifier として使うのが堅牢。
+
+**不採用案**: `runId` だけで claim キーにする (現行 plan の旧案)。理由: Scheduler retry で重複送信が起きる、手動再実行の意味論も曖昧。
+
+### D-3. Recipient state machine: pending → sent/failed/manual_review_required
+
+- claim 時点で `status=pending` doc を create (lease 10 min、ttlExpireAt も同時設定)
+- 既存 doc 不在: pending claim
+- 既存 pending + lease 有効: 他 worker 処理中 → skip
+- 既存 pending + lease 切れ: `manual_review_required` に降格 + skip (自動再送せず)
+- 既存 sent / failed: skip
+- Gmail 受理 → `markProgressRecipientSent` で finalize
+- permanent error → `markProgressRecipientFailed` で finalize
+
+**採用理由**: `tx.create()` のみでは PDF 生成中・Gmail 送信直後の crash で「sent か未送信か判定不能」な orphan が残る (Codex CRITICAL-2)。pending state を持たせて lease + finalize モデルにすることで、crash 後に自動再送しない (manual_review_required) 安全策が取れる。Gmail 送信と Firestore finalize は atomic にできないため、orphan_send (Gmail 受理済だが finalize 失敗) は audit で運用検出する設計とする。
+
+**不採用案**: append-only (sent/failed のみ)。理由: claim 直後の crash 後に「未送信」判定で次 retry が重複送信する。
+
+### D-4. Lane lock を `super_dispatch_lane_locks/{laneId}` 別 doc + transactional 取得
+
+- 新規 collection `super_dispatch_lane_locks/{laneId}` (laneId 別 doc)
+- 取得経路: Firestore transaction で `tx.get(lockRef)` → lease 判定 → `tx.set(lockRef)`
+- `super_dispatch_runs/{runId}` は監査用に runId / laneId / occurrenceId を記録
+- 既存 `super_dispatch_runs` doc に `laneId` フィールドを追加 (欠落時は `"completion"` 扱いで後方互換)
+- 完了通知レーンの既存 `run-lock.ts` は Phase 3 で破壊せず、Phase 4 で lane-lock に統合検討
+
+**採用理由**: 既存 run-lock の query→set は best-effort で race を完全排除できない (Codex CRITICAL-3)。lane 別 lock doc + transaction で取り直すことで Firestore レベルの排他保証が得られる。将来 lane が N 個に増えても lock doc 追加だけで済む拡張性も得られる。
+
+**不採用案**: 既存 `run-lock.ts` に `laneId` 引数を追加するだけ。理由: query→set best-effort のため同 lane 並行 request の race が残る。
+
+### D-5. 受講中フィルタは厳密 (active student + enrollment + 不退会 + 期限内 + 1% 以上進捗)
+
+- 新規関数 `listProgressReportTargetUsers()` を `tenant-data-loader.ts` に追加
+- フィルタ条件: tenant が active + role=student + enrollment 存在 + 退会・無効化なし + videoAccessUntil 期限内 + 進捗 1% 以上
+- claim 直前と send 直前の active 再確認も実施 (削除直前 race 対策)
+
+**採用理由**: 既存 `listNotificationTargetUsers()` は `role=student` のみで、退会・テスト用ユーザー・期限切れ・未着手 0% を全て含む (Codex HIGH-1)。期限切れユーザーに「進捗を上げてください」レポートを送る ROI ナシ、未着手 0% は「とりあえず送って何も進捗ないレポート」を避ける運用判断。受講者最大規模 (D-7) と組み合わせて Workspace 上限を緩和する効果もある。
+
+**確定済 OQ**: §確定済 OQ #7 (decision-maker 承認済) で「厳密」を選択。
+
+### D-6. テナント単位 opt-out を分離 (`progressReportEnabled` 新規フィールド)
+
+- 新規フィールド `tenants/{tid}.progressReportEnabled?: boolean` (default false、optional)
+- 既存 `tenants/{tid}.completionNotificationEnabled` とは独立
+- Phase 3a で migration なし (optional、既存テナントは undefined のまま動く)
+- 親スイッチ (`dispatchEnabled`) は導入せず、将来必要になったら追加
+
+**採用理由**: 共有だと「完了通知だけ止めたい」「進捗レポートだけ止めたい」が UI で表現できない (Codex HIGH-2)。最初から分離する方が将来 migration コストよりも安い。default false (opt-in) にすることで、業務スーパー管理者がテナントごとに決裁・設定するプロセスを runbook で明示できる。
+
+**不採用案**: `completionNotificationEnabled` 共有。理由: 上記 HIGH-2 のとおり、後付け migration コストが高い。
+
+### D-7. 受講者最大規模 < 500 名前提で同期バッチ維持
+
+- Phase 3 着手時点での想定: 全テナント合計 < 500 名
+- 同期一括処理 (Cloud Run endpoint で tenant 走査 + user 並列度 8) を採用
+- 280s timeout に収まる規模を runbook で監視
+- scale trigger: 全テナント合計 300 名超で Cloud Tasks 移行を Phase 4 OQ として登録
+
+**採用理由**: Cloud Tasks 採用は初期実装コスト +30% で、< 500 名規模ではメリットが小さい (Codex CRITICAL-4 緩和)。Workspace 送信上限 2,000 msg/day/user (rolling 24h) に対しても、500 名 × CC 1 名 = 1,000 件/週 で余裕 (Codex HIGH-3)。完了通知 sender (`system@279279.net`、ADR-037) と進捗レポート sender が同一の場合は両レーン合計を 2,000 で抑える必要があるため、cron を 30 分ずらす対策と合わせて運用する。
+
+**確定済 OQ**: §確定済 OQ #8 (decision-maker 承認済) で「< 500 名 / 同期バッチ」を選択。
+
+**再評価条件**: 全テナント合計 300 名超 (runbook 監視) または Workspace 送信上限抵触で Cloud Tasks 移行を検討。
+
+### D-8. RFC 2231 filename dual-form (RFC 5987 ではない)
+
+- 添付ファイル名 (進捗 PDF は日本語含む) の MIME header は **RFC 2231** に準拠
+- `Content-Disposition: attachment; filename="..."; filename*=UTF-8''<percent-encoded>` の dual-form
+- 既存 `gmail-draft.ts:buildFilenameParam` のロジックを参考に `gmail-dwd-send.ts` 内でローカル実装 (Phase 4 で `mime-utils.ts` 共通化を検討)
+- Phase 3e smoke で Gmail / Outlook365 / Apple Mail での実デコード確認
+
+**採用理由**: RFC 5987 は HTTP header の標準で、メール MIME attachment parameter の根拠ではない (Codex HIGH-5)。spec / コード / コメントで RFC 2231 と記載することで、将来「規格根拠を確認したい」となった際の調査ミスを防ぐ。
+
+### Settings PUT を patch semantics に変更 (Codex HIGH-4)
+
+D-1〜D-8 の前提として、`DispatchSettings` PUT を **patch semantics** に変更する (in-memory / firestore 両実装で対応)。storage 層で undefined フィールドを既存値で保持し、FE は always-send-all 戦略。これにより PR 3a→3d の間に旧 UI 経由で `progressReport` が消失する事故を防ぐ。
+
+### 不採用案 (横断)
+
+#### 案 A: 完了通知の reservation モデル流用
+
+`completion_notifications/{userId}` (userId 単位・永続) を進捗レポートにも流用する案。
+
+- **不採用理由**: 完了通知は「1 人 1 回限り」、進捗レポートは「定期的に毎回送る」で意味論が真逆。流用すると全ユーザーの再送が永続ブロックされる。
+
+#### 案 B: append-only collection (pending state なし)
+
+`progress_report_sends/{occurrenceId}__{userId}` に status を持たせず sent/failed のみ。
+
+- **不採用理由**: Codex CRITICAL-2 のとおり crash 後 orphan を扱えない。pending state は Phase 3 の最小限の安全策。
+
+#### 案 C: Cloud Tasks による recipient 分割
+
+各 recipient を Cloud Tasks の単位に分割して並列処理する案。
+
+- **不採用理由**: 受講者 < 500 名規模で同期バッチが timeout しないため初期実装コスト ROI ナシ。300 名超で再評価する。
+
+#### 案 D: 完了通知レーン本体の改造 (`100% フィルタを外す`)
+
+`run-completion-notifications.ts` の 100% フィルタを外して進捗レポートも兼ねる案。
+
+- **不採用理由**: 完了通知の reservation モデル (1 人 1 回) と進捗レポートの定期送信が両立しない。両レーン独立の D-1 と矛盾。
+
+## Consequences
+
+### 良い影響
+
+- 完了通知レーンと進捗レポートレーンが完全独立化 → 障害・設定・監査の切り分けが明確
+- Cloud Scheduler at-least-once delivery + crash シナリオの両方に対して堅牢な冪等性 (D-2 + D-3)
+- Firestore レベルの transactional lane lock で race condition を構造的に排除 (D-4)
+- 受講中フィルタ厳密化により「期限切れに進捗レポート」「未着手 0% に進捗レポート」の運用事故を防ぐ (D-5)
+- テナント単位 opt-out が分離されているため、業務的に「完了通知だけ ON / 進捗レポートだけ ON」が表現できる (D-6)
+- patch semantics 化で旧 UI 経由の設定消失事故を防ぐ
+- 既存 `progress-pdf.ts` / `ProgressPdfDocument` / `buildMailTemplate` が完全流用できるため、進捗レポートの中身は手動レーン (ADR-034) と同一体験
+
+### 受容するトレードオフ
+
+- ADR-034 (Phase 2 手動 Gmail 下書き) と Phase 3 (定期自動配信) で「同じ進捗レポートを送る経路が 2 つある」状態。混乱を runbook で明示する必要あり。
+- `system@279279.net` (ADR-037) の Workspace 送信上限 2,000 msg/day を完了通知と進捗レポートの両レーンで共有。受講者数規模に応じた監視が必要 (300 名超で再評価)。
+- pending state machine + transactional lane lock の導入で Phase 3c の Integration テストが大規模 (25 シナリオ)。Evaluator 分離プロトコル + Codex review のセカンドオピニオン併用が必須。
+- 旧 `run-lock.ts` と新 `lane-lock.ts` の 2 機構が並存する期間が発生 (Phase 4 で統合検討)。
+- テナント単位 `progressReportEnabled=true` の設定が opt-in (default false) のため、業務スーパー管理者が各テナントについて決裁・設定する作業が発生する (runbook で cutover step として明示)。
+
+### 既存実装への影響
+
+- `dispatch-storage.ts` interface 拡張 + in-memory / firestore 両実装に 7 メソッド追加 → Phase 3a で破壊的変更ナシで対応 (新規メソッド追加のみ)
+- `gmail-dwd-send.ts` に `buildMessageMime` 新 export + 既存 `buildCompletionMime` を薄い wrapper にリファクタ → byte-for-byte 回帰テストで後方互換保証
+- `DispatchSettings` PUT を patch semantics に変更 → Phase 3a で既存 PUT 経路の挙動を保ったまま実装 (旧 UI でフィールド全件送信されている挙動も維持)
+- `super_dispatch_runs/{runId}` の `laneId` フィールド追加 → 既存 doc は欠落時 `"completion"` 扱いで後方互換
+- `tenants/{tid}.progressReportEnabled?: boolean` 追加 → optional でマイグレーション不要
+
+### 再評価条件 / 将来 OQ
+
+- 全テナント合計 300 名超: Cloud Tasks 移行を検討 (D-7 再評価)
+- Workspace 送信上限抵触: 30 分ずらした cron でも足りなければ Cloud Tasks 必須
+- 完了通知 + 進捗レポートの両方を一括 ON/OFF したい運用要件: 親スイッチ `dispatchEnabled` 追加を検討
+- 進捗レポートの件名・本文をテナント単位に変更したい要件: 設定 UI 拡張 + DispatchSettings に template フィールド追加
+- pending lease 切れの `manual_review_required` 件数が多い (Cloud Run 不安定): heartbeat lease 更新 / Cloud Tasks 移行
+
+## References
+
+- 設計仕様書: `docs/specs/2026-06-01-progress-report-dispatch-design.md`
+- 実装計画: `docs/specs/2026-06-01-progress-report-dispatch-impl-plan.md`
+- フロー図: `docs/specs/2026-06-01-progress-report-dispatch-flow.mmd`
+- Plan ファイル (Plan stage 議論記録): `~/.claude/plans/eager-jumping-hoare.md`
+- Codex セカンドオピニオン thread ID: `019e82e8-4228-79c1-a63a-d3c4e7359731` (Plan stage 取得、PR 3c で継続利用)
+- Cloud Scheduler at-least-once delivery: https://docs.cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs
+- Gmail Workspace 送信上限: https://support.google.com/a/answer/166852
+- RFC 2231 (MIME parameter value extensions): https://www.rfc-editor.org/rfc/rfc2231

--- a/docs/specs/2026-06-01-progress-report-dispatch-design.md
+++ b/docs/specs/2026-06-01-progress-report-dispatch-design.md
@@ -1,0 +1,257 @@
+# 進捗レポート 定期自動配信 (Phase 3) 設計仕様書
+
+| 項目 | 値 |
+|---|---|
+| 起票日 | 2026-06-01 |
+| 起票者 | 開発者 (要件) / system-279 (設計) |
+| 関連 ADR | ADR-032 (super-admin 進捗 PDF) / ADR-034 (Phase 2 Gmail 下書き) / ADR-037 (sender impersonation) / **ADR-039 (Phase 3 進捗レポート 定期自動配信、本仕様の判断記録)** |
+| 関連 spec | `2026-05-20-completion-notification-design.md` (完了通知レーン、本仕様の対称設計参考) |
+| 関連 Issue | #346 (Phase 2 起票時に Phase 3 候補として先送り記録) |
+| 関連 PR | #434 (Phase 2 Gmail 下書き、本仕様と独立) |
+| Plan stage 議論記録 | `~/.claude/plans/eager-jumping-hoare.md` |
+| Codex セカンドオピニオン | thread `019e82e8-4228-79c1-a63a-d3c4e7359731` |
+| 処理フロー図 | [`2026-06-01-progress-report-dispatch-flow.mmd`](./2026-06-01-progress-report-dispatch-flow.mmd) |
+| 実装計画 | [`2026-06-01-progress-report-dispatch-impl-plan.md`](./2026-06-01-progress-report-dispatch-impl-plan.md) |
+
+---
+
+## 1. 概要 / 動機
+
+### 1.1 背景
+
+業務スーパー管理者からのオーダー: 受講中の全ユーザーに進捗レポートメール (PDF 添付) を曜日・時刻スケジュールで自動配信したい。Session 52 で判明したのは、業務スーパー管理者が期待する「自動配信」と既存の自動配信レーン (完了通知 = 100% 完了者のみ・1 度きり) との認識ずれ。途中経過の進捗レポートの定期自動配信は Issue #346 で「Phase 3 候補」として明示的に先送りされていた機能。
+
+詳細な経緯は ADR-039 §Context を参照。
+
+### 1.2 目的
+
+既存の完了通知レーン (`run-completion-notifications.ts`) を変更せず、並走する別レーンとして「**進捗レポート 定期自動配信**」を新設する。受講中の active 受講者に、手動レーン (ADR-034 / Image #4) と同等の進捗レポートメール (件名・本文・PDF 添付) を、受講者本人 (To) + テナント担当者 (CC) へ自動送信する。
+
+### 1.3 既存機能との関係
+
+```
+[既存 Phase 2] スーパー管理者が画面でボタン → Gmail 下書き (個人 OAuth, gmail.compose)  ← 維持
+[既存 完了通知] Cloud Scheduler → 100% 完了者のみ・1 回限り (修了メール、PDF 添付なし)  ← 維持
+[新規 Phase 3] Cloud Scheduler → active 受講者の定期配信 (進捗レポート、PDF 添付あり) ← 追加
+```
+
+3 機構は全て独立。一方の不具合が他方に波及しない設計とする。
+
+---
+
+## 2. 用語
+
+| 用語 | 定義 |
+|---|---|
+| 進捗レポート | 受講者の進捗率・受講期限・推奨ペースを記載したメール本文 + PDF 添付 (ADR-034 と同じ中身) |
+| 配信レーン | Cloud Scheduler → endpoint → 受信者群へメール送信 の 1 系統 |
+| 完了通知レーン | 既存。`run-completion-notifications.ts` 経由、100% 完了者・1 回限り |
+| 進捗レポートレーン | 新規。`run-progress-reports.ts` 経由、active 受講者・定期送信 |
+| occurrenceId | 1 回の scheduled execution を識別する key。`sha256(laneId + X-CloudScheduler-ScheduleTime)`。冪等性キーとして使用 |
+| runId | 1 回の HTTP attempt を識別する UUID。監査用 |
+| pending | recipient claim 直後の状態。lease 10 min + ttlExpireAt 設定 |
+| manual_review_required | pending lease 切れの降格状態。自動再送せず手動確認 |
+
+---
+
+## 3. 機能要件 / 確定済 OQ
+
+| # | 項目 | 決定 | 根拠 |
+|---|---|---|---|
+| 1 | 配信頻度・スケジュール | 完了通知と同一構造 (`scheduleDaysOfWeek[]` + `scheduleHourJst`、独立設定) | decision-maker 承認 |
+| 2 | PDF 添付 | あり (手動レーンと同等。multipart/mixed に拡張) | decision-maker 承認 |
+| 3 | 実行レーン | 別 endpoint + 別 Cloud Scheduler ジョブ | ADR-039 D-1 |
+| 4 | 100% 完了者の扱い | 除外 (`skipCompletedUsers=true` 固定、設定 UI で切替不可) | decision-maker 承認 |
+| 5 | PR 分割粒度 | 5 PR (3a / 3b / 3c / 3d / 3e) | decision-maker 承認 |
+| 6 | Firestore TTL | 90 日 | decision-maker 承認 |
+| 7 | 「受講中」定義 | 厳密: active student + enrollment 有 + 不退会 + 期限内 + 1% 以上進捗 | ADR-039 D-5 |
+| 8 | 受講者最大規模 | < 500 名 / 全テナント合計 (同期バッチ維持) | ADR-039 D-7 |
+| 9 | テナント単位 opt-out | 分離: `tenants/{tid}.progressReportEnabled?: boolean` 新規 (default false) | ADR-039 D-6 |
+
+---
+
+## 4. アーキテクチャ
+
+詳細は [`2026-06-01-progress-report-dispatch-flow.mmd`](./2026-06-01-progress-report-dispatch-flow.mmd) 参照。
+
+### 4.1 構成
+
+```
+Cloud Scheduler (新規 job: dxcollege-progress-reports, cron 完了通知と 30 分ずらし, tz=Asia/Tokyo)
+  ↓ OIDC ID Token + X-CloudScheduler-ScheduleTime ヘッダ
+POST /api/v2/internal/dispatch/run-progress-reports (services/api)
+  → oidc-verify → occurrenceId 算出 → runId 採番
+  → acquireLaneLock (lane_locks/progress, transactional)
+  → schedule-matcher (progressReport sub-schedule)
+  → tenant 直列走査 (active + progressReportEnabled=true)
+  → user 並列度 8 (listProgressReportTargetUsers)
+    eligibility 判定: 100% 完了 → skip
+    tryClaimProgressRecipient(occurrenceId, userId) → pending claim
+    buildProgressPdfData → ProgressPdfDocument → renderToBuffer (PDF 5MB 上限)
+    buildMailTemplate (件名・本文) + validateAndDedupeCcEmails
+    sendProgressMail (multipart/mixed, RFC 2231 filename) via Gmail DWD SendAs
+    markProgressRecipientSent / Failed (finalize)
+  → completeLaneLock / abortLaneLock
+```
+
+### 4.2 主要設計判断 (ADR-039 サマリ)
+
+- **D-1**: レーン分離 (別 endpoint + 別 Cloud Scheduler job)
+- **D-2**: 冪等性キー `occurrenceId` を分離 (Cloud Scheduler at-least-once 対応)
+- **D-3**: Recipient state machine `pending → sent / failed / manual_review_required`
+- **D-4**: Lane lock を別 doc + transactional 取得
+- **D-5**: 受講中フィルタ厳密化
+- **D-6**: テナント単位 opt-out を分離 (`progressReportEnabled`)
+- **D-7**: < 500 名前提で同期バッチ維持
+- **D-8**: RFC 2231 filename dual-form
+
+---
+
+## 5. データモデル
+
+### 5.1 新規 Firestore collections
+
+**`super_dispatch_lane_locks/{laneId}`** (lane 別排他)
+```typescript
+{
+  laneId: "completion" | "progress";
+  ownerRunId: string;
+  occurrenceId: string;
+  leaseExpiresAt: Timestamp;
+  acquiredAt: Timestamp;
+  updatedAt: Timestamp;
+}
+```
+
+**`tenants/{tenantId}/progress_report_sends/{occurrenceId}__{userId}`** (recipient state)
+```typescript
+{
+  occurrenceId: string;
+  runId: string;
+  userId: string;
+  status: "pending" | "sent" | "failed" | "manual_review_required";
+  claimedAt: Timestamp;
+  leaseExpiresAt: Timestamp;     // pending 時のみ
+  sentAt: Timestamp | null;      // sent 時のみ
+  messageId: string | null;
+  pdfSizeBytes: number | null;
+  failedAt: Timestamp | null;    // failed 時のみ
+  errorCode: string | null;      // sanitized
+  errorMessage: string | null;   // sanitized
+  promotedAt: Timestamp | null;  // manual_review 時のみ
+  recipientToHash: string;       // sha256 (PII 最小化)
+  recipientCcHashes: string[];
+  ttlExpireAt: Timestamp;        // claim 時に claimedAt + 90 days
+}
+```
+
+### 5.2 既存 Firestore コレクション拡張
+
+**`super_dispatch_runs/{runId}`** (既存): `laneId` / `occurrenceId` フィールド追加。既存 doc は `laneId` 欠落時 `"completion"` 扱い (後方互換)。
+
+**`tenants/{tenantId}`** (既存): `progressReportEnabled?: boolean` 追加 (default false、optional)。
+
+### 5.3 DTO 拡張 (`packages/shared-types/src/dispatch.ts`)
+
+```typescript
+export interface ProgressReportSettings {
+  enabled: boolean;
+  scheduleDaysOfWeek: number[];  // 0-6
+  scheduleHourJst: number;       // 0-23
+}
+
+export interface DispatchSettings {
+  // ... 既存 fields
+  progressReport?: ProgressReportSettings;  // optional, undefined で disable と同等
+}
+
+export interface RunProgressReportsResponse {
+  runId: string;
+  occurrenceId: string;
+  processedTenants: number;
+  sent: number;
+  skipped: number;
+  failed: number;
+  pendingPromotedToManualReview: number;
+  laneLockContention: boolean;
+}
+```
+
+**Settings PUT は patch semantics**: storage 層で undefined フィールドを既存値で保持 (Codex HIGH-4 反映)。FE は always-send-all 戦略。
+
+---
+
+## 6. 既存コードからの再利用
+
+### 6.1 完全流用 (変更なし)
+
+| 機構 | パス |
+|---|---|
+| OIDC 検証 | `services/api/src/services/dispatch/oidc-verify.ts` |
+| schedule 判定 | `services/api/src/services/dispatch/schedule-matcher.ts` |
+| CC validator | `services/api/src/services/dispatch/cc-email-validator.ts` |
+| 100% 判定 (除外フィルタ用) | `services/api/src/services/dispatch/completion-eligibility.ts` |
+| 進捗データ集約 | `services/api/src/services/progress-pdf.ts` (`buildProgressPdfData`) |
+| メール件名・本文 | `services/api/src/services/progress-pdf-mail-template.ts` (`buildMailTemplate`) |
+| PDF 生成 | `services/api/src/services/progress-pdf-document.tsx` (`ProgressPdfDocument`) |
+
+### 6.2 拡張 / 新規
+
+| 区分 | パス | 内容 |
+|---|---|---|
+| 新規 | `services/api/src/services/dispatch/lane-lock.ts` | transactional 取得、laneId 別 doc |
+| 新規 | `services/api/src/services/dispatch/run-progress-reports.ts` | メインフロー |
+| 新規 | `services/api/src/services/dispatch/progress-report-recipient.ts` | state machine |
+| 新規 | `services/api/src/services/dispatch/progress-mime-builder.ts` | multipart/mixed 組立 |
+| 新規 | `services/api/src/routes/internal/progress-reports.ts` | endpoint |
+| 拡張 | `services/api/src/services/dispatch/gmail-dwd-send.ts` | 新 export `buildMessageMime`、既存 `buildCompletionMime` を wrapper にリファクタ |
+| 拡張 | `services/api/src/services/dispatch/dispatch-storage.ts` + 両実装 | 7 メソッド追加、settings patch semantics |
+| 拡張 | `services/api/src/services/dispatch/tenant-data-loader.ts` | `listProgressReportTargetUsers()` + `getTenantInfo()` |
+| 拡張 | `services/api/src/services/dispatch/dispatch-audit.ts` | eventType 9 種追加 |
+| 拡張 | `packages/shared-types/src/dispatch.ts` + `tenant.ts` | DTO 拡張 |
+| 拡張 | `web/app/super/dispatch-settings/page.tsx` | 新セクション + テナント opt-in トグル |
+
+---
+
+## 7. セキュリティ / 認可
+
+- 内部 endpoint (`/api/v2/internal/dispatch/run-progress-reports`) は OIDC 検証必須 (Cloud Scheduler の SA トークン以外は 401)
+- super-admin 設定 endpoint (`/api/v2/super/dispatch-settings`、`/api/v2/super/tenants/{tid}`) は既存の super-admin middleware で保護
+- recipient sub-collection は生 email を保存せず sha256 hash のみ (PII 最小化、NFR 準拠)
+- audit log の error message は sanitize (token, email, PII の除去)
+- Gmail DWD 送信は ADR-037 採用方式 (`subject=system@279279.net` + SendAs で `From: dxcollege@279279.net`)
+
+---
+
+## 8. 運用 (cutover / kill switch / 再評価)
+
+詳細は実装計画 [`2026-06-01-progress-report-dispatch-impl-plan.md`](./2026-06-01-progress-report-dispatch-impl-plan.md) §運用 を参照。
+
+主要ポイント:
+- cutover step 1: 各テナント `progressReportEnabled=true` を業務スーパー管理者が決裁・設定 (default false 前提)
+- kill switch: `progressReport.enabled=false` で即時停止 (完了通知への影響なし)
+- 受講者規模監視: 全テナント合計 300 名超で Cloud Tasks 移行検討 (Phase 4 OQ)
+- Workspace 送信上限監視: `system@279279.net` の rolling 24h 2,000 件を完了通知 + 進捗レポートで共有
+
+---
+
+## 9. Open Questions (Phase 3 中・終了後の再評価)
+
+| OQ | 内容 | 再評価条件 |
+|---|---|---|
+| OQ-1 | 受講者規模拡大 | 全テナント合計 300 名超 |
+| OQ-2 | 親スイッチ `dispatchEnabled` | 完了通知 + 進捗の一括 ON/OFF 要望 |
+| OQ-3 | 件名・本文テナント別カスタマイズ | テナント別文面要望 |
+| OQ-4 | heartbeat lease 更新 / Cloud Tasks | pending lease 切れ多発 |
+| OQ-5 | `mime-utils.ts` 共通化 | Phase 4 リファクタ |
+
+---
+
+## 10. 参考
+
+- 完了通知 spec (対称設計参考): `docs/specs/2026-05-20-completion-notification-design.md`
+- 手動進捗レポート: `services/api/src/routes/super/progress-pdf-draft.ts` (ADR-034)
+- Plan stage 議論記録: `~/.claude/plans/eager-jumping-hoare.md`
+- Cloud Scheduler at-least-once delivery: https://docs.cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs
+- Workspace Gmail 送信上限: https://support.google.com/a/answer/166852
+- RFC 2231 (MIME parameter value extensions): https://www.rfc-editor.org/rfc/rfc2231

--- a/docs/specs/2026-06-01-progress-report-dispatch-flow.mmd
+++ b/docs/specs/2026-06-01-progress-report-dispatch-flow.mmd
@@ -1,0 +1,60 @@
+%% 進捗レポート 定期自動配信 (Phase 3) 処理フロー
+%% 関連: docs/specs/2026-06-01-progress-report-dispatch-design.md / docs/adr/ADR-039
+flowchart TD
+  start([Cloud Scheduler<br/>dxcollege-progress-reports<br/>cron JST]) --> oidc{OIDC verify<br/>token, audience}
+  oidc -- "fail" --> resp401[401 Unauthorized]
+  oidc -- "ok" --> occurrence[occurrenceId 算出<br/>sha256 laneId + ScheduleTime]
+  occurrence --> run[runId 採番 UUID<br/>HTTP attempt 監査用]
+  run --> lock{acquireLaneLock<br/>tx.get + tx.set<br/>laneId=progress}
+  lock -- "contention" --> respLock[200 empty<br/>laneLockContention=true]
+  lock -- "acquired" --> schedule{shouldRunNow<br/>progressReport sub-schedule}
+  schedule -- "not now" --> respSched[200 empty]
+  schedule -- "match" --> tenantLoop[tenant 直列走査]
+  tenantLoop --> tenantFilter{tenant active<br/>+ progressReportEnabled=true}
+  tenantFilter -- "no" --> nextTenant[次 tenant]
+  tenantFilter -- "yes" --> userList[listProgressReportTargetUsers<br/>active + enrollment + 不退会<br/>+ 期限内 + 1%以上]
+  userList --> userParallel[user 並列度 8]
+  userParallel --> eligibility{eligibility 判定<br/>100% 完了?}
+  eligibility -- "yes" --> skipCompleted[skip + audit<br/>user_skipped_completed]
+  eligibility -- "no" --> claim{tryClaimProgressRecipient<br/>doc id occurrenceId__userId}
+  claim -- "既存 sent/failed" --> skipSent[skip]
+  claim -- "既存 pending lease 有効" --> skipPending[skip<br/>他 worker 処理中]
+  claim -- "既存 pending lease 切れ" --> promote[promotePendingToManualReview<br/>status=manual_review_required]
+  promote --> skipPromoted[skip]
+  claim -- "新規 create" --> pending[status=pending<br/>lease 10min<br/>ttlExpireAt=claimedAt+90d]
+  pending --> buildData[buildProgressPdfData<br/>進捗集約]
+  buildData --> renderPdf[ProgressPdfDocument<br/>renderToBuffer]
+  renderPdf --> sizeCheck{PDF size <= 5MB}
+  sizeCheck -- "超過" --> pdfTooLarge[skip + audit<br/>pdf_too_large<br/>専用 counter]
+  sizeCheck -- "ok" --> buildMail[buildMailTemplate<br/>件名・本文]
+  buildMail --> ccValidate[validateAndDedupeCcEmails]
+  ccValidate --> buildMime[buildMessageMime<br/>multipart/mixed<br/>RFC 2231 filename]
+  buildMime --> gmail{Gmail DWD SendAs<br/>From=dxcollege@279279.net}
+  gmail -- "429 retry x3 fail" --> markFailed[markProgressRecipientFailed<br/>status=failed]
+  gmail -- "403 scope_revoked" --> abort[RunAbortError<br/>laneLock abort]
+  gmail -- "400 permanent" --> markFailed
+  gmail -- "受理" --> markSent[markProgressRecipientSent<br/>status=sent<br/>messageId, pdfSizeBytes]
+  markSent --> nextUser[次 user]
+  markFailed --> nextUser
+  pdfTooLarge --> nextUser
+  skipCompleted --> nextUser
+  skipSent --> nextUser
+  skipPending --> nextUser
+  skipPromoted --> nextUser
+  nextUser --> userParallel
+  userParallel -- "tenant 完了" --> nextTenant
+  nextTenant --> tenantLoop
+  tenantLoop -- "全 tenant 完了" --> complete[completeLaneLock<br/>audit progress_report_run_completed]
+  complete --> respOk[200 RunProgressReportsResponse<br/>processed, sent, skipped, failed,<br/>pendingPromotedToManualReview]
+  abort --> abortLock[abortLaneLock]
+  abortLock --> respAbort[200 with abort reason]
+
+  classDef skipNode fill:#fef3c7,stroke:#f59e0b
+  classDef errorNode fill:#fee2e2,stroke:#dc2626
+  classDef successNode fill:#d1fae5,stroke:#059669
+  classDef decisionNode fill:#dbeafe,stroke:#2563eb
+
+  class skipCompleted,skipSent,skipPending,skipPromoted,pdfTooLarge skipNode
+  class resp401,markFailed,abort,abortLock,respAbort errorNode
+  class markSent,complete,respOk successNode
+  class oidc,lock,schedule,tenantFilter,eligibility,claim,sizeCheck,gmail decisionNode

--- a/docs/specs/2026-06-01-progress-report-dispatch-impl-plan.md
+++ b/docs/specs/2026-06-01-progress-report-dispatch-impl-plan.md
@@ -1,0 +1,183 @@
+# 進捗レポート 定期自動配信 (Phase 3) 実装計画
+
+| 項目 | 値 |
+|---|---|
+| 起票日 | 2026-06-01 |
+| 設計仕様書 | [`2026-06-01-progress-report-dispatch-design.md`](./2026-06-01-progress-report-dispatch-design.md) |
+| 関連 ADR | ADR-039 |
+| 関連 PR | (3a / 3b / 3c / 3d / 3e + 設計 PR 本 PR) |
+
+---
+
+## 1. PR 分割 (5 PR + 1 設計 PR)
+
+### Phase 3-design (本 PR): ADR-039 + 3 spec
+- `docs/adr/ADR-039-phase3-progress-report-dispatch.md`
+- `docs/specs/2026-06-01-progress-report-dispatch-design.md`
+- `docs/specs/2026-06-01-progress-report-dispatch-impl-plan.md`
+- `docs/specs/2026-06-01-progress-report-dispatch-flow.mmd`
+
+### PR 3a: shared-types + storage interface 拡張 (~1000 LOC)
+- `packages/shared-types/src/dispatch.ts` / `tenant.ts` DTO 拡張
+- `services/api/src/services/dispatch/dispatch-storage.ts` interface に 7 メソッド追加
+- `services/api/src/services/dispatch/lane-lock.ts` 新規 (transactional 取得、firestore 実装)
+- `in-memory-dispatch-storage.ts` / `firestore-dispatch-storage.ts` 実装
+- settings PUT を patch semantics に変更 (両実装)
+- `tenant-data-loader.ts` に `listProgressReportTargetUsers()` + `getTenantInfo()` 追加
+- 単体テスト: claim 重複 reject、pending lease 切れ降格、transactional lane lock 並行 reject、settings patch、受講中フィルタ境界
+
+### PR 3b: gmail-dwd-send.ts multipart/mixed 添付対応 (~450 LOC)
+- 新 export `buildMessageMime`
+- 既存 `buildCompletionMime` を wrapper にリファクタ
+- byte-for-byte 回帰テスト
+- RFC 2231 dual-form filename
+- 単体テスト: boundary、base64 76char wrap、日本語ファイル名、CR/LF reject、後方互換
+
+### PR 3c: run-progress-reports + state machine + endpoint + Integration (~1700 LOC、**Evaluator 分離発動**)
+- 新規 4 ファイル: `run-progress-reports.ts` / `progress-report-recipient.ts` / `progress-mime-builder.ts` / `routes/internal/progress-reports.ts`
+- Integration テスト 25 シナリオ (InMemoryDispatchStorage 中心):
+  - 基本配信 / 100% 完了除外 / 受講中フィルタ境界 / progressReportEnabled=false テナント skip
+  - occurrenceId 冪等 (Scheduler retry で重複なし)
+  - pending lease 切れ → manual_review_required
+  - crash シナリオ (pending claim 後の Gmail 失敗 / markSent 失敗 → orphan_send audit)
+  - lane lock transactional 排他
+  - 別 occurrenceId で再送
+  - 両レーン独立性 (障害・設定)
+  - Gmail 429 retry × 3、403 scope_revoked、400 permanent
+  - PDF 5MB 超 → `pdf_too_large` skip
+  - PII sha256
+  - TTL: pending claim 時点で `ttlExpireAt` 設定
+- **Evaluator 分離プロトコル発動** (5 ファイル以上 + 新機能)
+- **Codex review セカンドオピニオン併用** (Plan stage thread `019e82e8-4228-79c1-a63a-d3c4e7359731` 継続)
+
+### PR 3d: super-admin API バリデーション + FE 設定 UI (~550 LOC)
+- `routes/super/dispatch-settings.ts` PUT バリデーション拡張 (patch semantics 検証含む)
+- `routes/super/tenant-settings.ts` に `progressReportEnabled` 追加
+- `web/app/super/dispatch-settings/page.tsx` に「進捗レポート 定期配信」セクション追加
+- `ScheduleEditor` 流用、always-send-all 戦略
+- テナント opt-in トグル UI
+- FE テスト: セクション表示、PUT 時 `progressReport` 送信、409 reload、patch semantics 動作確認
+
+### PR 3e: Cloud Scheduler + TTL Policy + dry-run + runbook (~250 LOC + infra)
+- Cloud Scheduler 新規 job: `dxcollege-progress-reports` (完了通知と 30 分ずらす)
+- Firestore TTL Policy: `progress_report_sends.ttlExpireAt` で 90 日
+- `scripts/progress-report-dry-run-cli.ts` + `.github/workflows/progress-report-dry-run.yml`
+- `docs/runbook/dxcollege-progress-report-cutover.md` 新規
+- scale trigger 300 名超 明記
+
+---
+
+## 2. Acceptance Criteria (AC-PR-01〜22)
+
+### 機能要件
+- **AC-PR-01** 基本配信: 設定 ON + schedule 一致 + active 受講者有 → 受講者 (To) + テナント担当者 (CC) に進捗レポート (PDF 添付) 送信
+- **AC-PR-02** 100% 完了者除外 → skip + `user_skipped_completed` audit
+- **AC-PR-03** 受講中フィルタ: 退会 / 期限切れ / 0% / 非 student / 非 active tenant 全 skip
+- **AC-PR-04** `progressReportEnabled=false` テナント全件 skip
+- **AC-PR-05** `progressReport.enabled=false` → no-op
+
+### 冪等性 (CRITICAL 反映)
+- **AC-PR-06** occurrenceId 冪等: Scheduler 同 scheduled execution の retry で重複送信なし
+- **AC-PR-07** pending claim 後 crash → 次 retry で manual_review_required 降格、自動再送なし
+- **AC-PR-08** 別 occurrenceId (翌週) で同 user 再送 (新 doc create)
+- **AC-PR-09** lane lock transactional: 同 lane 並行 request の 2 番目 reject
+- **AC-PR-10** 両レーン独立性 (障害): 完了通知 abort 中でも進捗 run 通常完了
+- **AC-PR-11** 両レーン独立性 (設定): 完了通知 enabled=true / 進捗 enabled=false → 完了通知のみ送信
+
+### MIME / 添付
+- **AC-PR-12** MIME 構造: multipart/mixed、text/plain + application/pdf、RFC 2231 filename dual-form
+- **AC-PR-13** PDF 5MB 超 → `pdf_too_large` skip (failed カウンタ不変、専用 counter)
+- **AC-PR-14** 既存 `buildCompletionMime` 出力 byte-for-byte 不変 (後方互換)
+
+### セキュリティ / 運用
+- **AC-PR-15** PII 最小化: sub-collection に sha256 のみ
+- **AC-PR-16** OIDC 認証: token なし or audience 不一致 → 401、settings 読み取りも発生せず
+- **AC-PR-17** TTL: pending claim 時点で `ttlExpireAt = claimedAt + 90 days` 設定
+- **AC-PR-18** settings patch semantics: 旧 PUT (progressReport 未送信) で既存 `progressReport` 不変
+- **AC-PR-19** Tenant `progressReportEnabled` のみ OFF → 完了通知影響なし
+- **AC-PR-20** retry & rate limit: Gmail 429 × 2 → 3 回目成功 → sent +1、`Retry-After` 尊重
+- **AC-PR-21** audit: laneId / occurrenceId / claimed / pendingExpired / orphanSend / rateLimited / pdfGenerationFailed / duration を記録
+- **AC-PR-22** kill switch 即時性: `progressReport.enabled=false` → 次回 cron で進捗のみ no-op、完了通知影響なし
+
+---
+
+## 3. 検証 (end-to-end)
+
+### 各 PR で
+```bash
+npm run lint -w @lms-279/shared-types -w @lms-279/api -w @lms-279/web
+npm run type-check -w @lms-279/shared-types -w @lms-279/api -w @lms-279/web
+npm run test -w @lms-279/api
+npm run test -w @lms-279/web
+```
+
+### PR 3c マージ前 (Evaluator 分離プロトコル)
+- 別コンテキストで evaluator agent 起動
+- 入力: AC-PR-01〜22 + git diff --name-only
+- 評価: PASS / FAIL / UNTESTABLE 判定 + 設計妥当性 + 見落としエッジケース
+
+### PR 3e マージ後 (dry-run smoke + 実 MIME 確認)
+```bash
+# dry-run: Gmail 送信せず、対象人数 + 推定通数 + CC 数 + PDF サイズ + 処理時間予測を出力
+gh workflow run progress-report-dry-run.yml \
+  -f tenant_ids=t_xxx -f tenant_emails=eval-only@example.com
+
+# 実 MIME smoke: Gmail / Outlook365 / Apple Mail で日本語ファイル名デコード確認
+gh workflow run progress-report-smoke.yml \
+  -f tenant_id=t_xxx -f recipient_email=qa-only@example.com
+```
+
+### 本番有効化 (業務スーパー管理者作業、runbook 準拠)
+1. Tenant `progressReportEnabled=true` 設定 (テナント単位 opt-in)
+2. dispatch-settings UI で `progressReport.enabled=true`、曜日・時刻設定
+3. 次回 cron 起動 → 受信確認
+4. NG なら `progressReport.enabled=false` (kill switch、完了通知影響なし)
+
+---
+
+## 4. 運用 (cutover / kill switch / 監視)
+
+### 4.1 cutover step (業務スーパー管理者作業)
+1. テナント単位の `progressReportEnabled` 決裁
+2. 各テナントの `progressReportEnabled=true` 設定
+3. dispatch-settings UI で曜日・時刻設定、`progressReport.enabled=true`
+4. dry-run workflow で対象人数・推定処理時間を確認
+5. 本番 cron 起動 → 受信確認 → 業務スーパー管理者へ報告
+
+### 4.2 kill switch
+- 即時停止: `progressReport.enabled=false` (UI 操作で完了通知影響なし)
+- テナント単位停止: `tenants/{tid}.progressReportEnabled=false`
+
+### 4.3 監視
+| 監視対象 | 閾値 | アクション |
+|---|---|---|
+| 全テナント合計受講者数 | 300 名超 | Cloud Tasks 移行を Phase 4 OQ として検討 |
+| Workspace `system@279279.net` 送信上限 | rolling 24h で 1,800 件超 (90%) | cron ずらし強化 or Cloud Tasks 移行 |
+| pending lease 切れ件数 | 1 run で 5 件超 | Cloud Run 安定性調査、heartbeat lease 更新検討 |
+| orphan_send audit | 1 件でも発生 | Gmail 送信ログ突合、手動確認 |
+
+---
+
+## 5. リスク
+
+| リスク | 緩和策 |
+|---|---|
+| 受講者数 500 名超に拡大 | runbook scale trigger 明記、Phase 4 OQ 登録 |
+| Cloud Run 280s timeout | AC-PR-09 lane lock + AC-PR-07 pending lease 切れで自動 manual_review 降格 |
+| PDF メモリ消費 (並列 8 × 数 MB) | Font.register cache、Phase 3e ベンチ |
+| 両 cron 同時起動で 429 蓄積 | Phase 3e で初期から 30 分ずらす |
+| 削除直前ユーザー race | claim 直前 / send 直前の active 再確認 |
+| テナント opt-in 後付け忘れ | runbook cutover step で明示 |
+| RFC 2231 filename MUA 互換性 | Phase 3e smoke で Gmail / Outlook365 / Apple Mail 実デコード確認 |
+
+---
+
+## 6. 関連リソース
+
+- ADR-039: `docs/adr/ADR-039-phase3-progress-report-dispatch.md`
+- 設計仕様書: `docs/specs/2026-06-01-progress-report-dispatch-design.md`
+- フロー図: `docs/specs/2026-06-01-progress-report-dispatch-flow.mmd`
+- Plan stage 議論: `~/.claude/plans/eager-jumping-hoare.md`
+- Codex セカンドオピニオン thread: `019e82e8-4228-79c1-a63a-d3c4e7359731`
+- 完了通知 spec (対称設計): `docs/specs/2026-05-20-completion-notification-design.md`
+- 完了通知 cutover runbook (mirror 対象): `docs/runbook/dxcollege-completion-notification-cutover.md`


### PR DESCRIPTION
## Summary

Session 52 で決定された Phase 3「進捗レポート 定期自動配信」を正式化する設計 PR。Plan stage で Codex セカンドオピニオン (CRITICAL 4 件 / HIGH 5 件) を取得して反映済。完了通知レーンと並走する別レーンとして、受講中の active 受講者へ進捗レポートメール+PDF を曜日・時刻スケジュールで自動配信する設計を ADR-039 と 3 spec に正式化する。

### 主要設計判断 (ADR-039 D-1〜D-8)
- **D-1** レーン分離 (別 endpoint + 別 Cloud Scheduler job)
- **D-2** 冪等性キー `occurrenceId` 分離 (Cloud Scheduler at-least-once 対応)
- **D-3** Recipient state machine `pending → sent / failed / manual_review_required`
- **D-4** Lane lock 別 doc + transactional 取得
- **D-5** 受講中フィルタ厳密化 (active + enrollment + 不退会 + 期限内 + 1% 以上)
- **D-6** テナント opt-out 分離 (`progressReportEnabled` 新規)
- **D-7** < 500 名前提で同期バッチ維持 (300 名超で Cloud Tasks 移行 OQ)
- **D-8** RFC 2231 filename dual-form (5987 ではない)

### 確定済 OQ (decision-maker 承認済)
本 PR 着手前に decision-maker と Plan stage で 9 件の OQ を全て確定済 (詳細は ADR-039 §確定済 OQ / spec design §3)。

### 成果物
- `docs/adr/ADR-039-phase3-progress-report-dispatch.md` (判断記録)
- `docs/specs/2026-06-01-progress-report-dispatch-design.md` (設計仕様書)
- `docs/specs/2026-06-01-progress-report-dispatch-impl-plan.md` (実装計画、AC-PR-01〜22)
- `docs/specs/2026-06-01-progress-report-dispatch-flow.mmd` (処理フロー図)

### 次の PR (本 PR マージ後)
- PR 3a: shared-types + storage interface 拡張 (~1000 LOC)
- PR 3b: gmail-dwd-send.ts multipart/mixed 添付対応 (~450 LOC)
- PR 3c: run-progress-reports + state machine + endpoint + Integration (~1700 LOC、Evaluator 分離プロトコル発動)
- PR 3d: super-admin API バリデーション + FE 設定 UI (~550 LOC)
- PR 3e: Cloud Scheduler + TTL Policy + dry-run + runbook (~250 LOC + infra)

## Test plan

ドキュメントのみの PR のため、構文検証 + 次セッションでの参照確認で完了 (CLAUDE.md「設定/ドキュメントのみのPRでは、構文検証+次セッション確認で可」準拠)。

- [x] ADR / spec の markdown 構文確認 (本セッション内目視)
- [x] Mermaid flow 図 (`.mmd`) の構文確認 (classDef / arrow 構造)
- [x] 関連ファイル間の相互リンク整合性確認 (ADR-039 ↔ spec design ↔ spec impl-plan ↔ flow.mmd)
- [ ] 次セッションで draw.io MCP 経由で flow.mmd を視覚確認
- [ ] 次セッションで PR 3a 着手時に spec の DTO 拡張部分を参照

## 関連

- Closes: なし (Issue #346 は Phase 2 完了で close 済、本 PR は Phase 3 着手宣言)
- Refs: #346 (Phase 3 候補として先送り記録)
- ハンドオフ: `docs/handoff/LATEST.md` (Session 52、本 PR の Context 元)
- Codex セカンドオピニオン thread: `019e82e8-4228-79c1-a63a-d3c4e7359731` (PR 3c で継続利用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)