### PR TITLE
feat(phase-3d): progressReportEnabled tenant opt-in + dispatch UI

### DIFF
--- a/services/api/src/routes/super/__tests__/tenant-notification-cc.test.ts
+++ b/services/api/src/routes/super/__tests__/tenant-notification-cc.test.ts
@@ -19,8 +19,13 @@ import {
 
 class FakeStore implements TenantCcConfigStore {
   configs = new Map<string, TenantNotificationCcConfig>();
-  updates: { tenantId: string; notificationCcEmails: string[]; enabled: boolean }[] =
-    [];
+  updates: {
+    tenantId: string;
+    notificationCcEmails: string[];
+    enabled: boolean;
+    /** Phase 3 (ADR-039 D-6): undefined = 未送信 (patch semantics で既存値保持) */
+    progressReportEnabled?: boolean;
+  }[] = [];
 
   async getTenantCcConfig(
     tenantId: string,
@@ -29,18 +34,28 @@ class FakeStore implements TenantCcConfigStore {
   }
   async updateTenantCcConfig(
     tenantId: string,
-    input: { notificationCcEmails: string[]; completionNotificationEnabled: boolean },
+    input: {
+      notificationCcEmails: string[];
+      completionNotificationEnabled: boolean;
+      progressReportEnabled?: boolean;
+    },
   ): Promise<void> {
     this.updates.push({
       tenantId,
       notificationCcEmails: input.notificationCcEmails,
       enabled: input.completionNotificationEnabled,
+      progressReportEnabled: input.progressReportEnabled,
     });
     const prev = this.configs.get(tenantId);
     this.configs.set(tenantId, {
       ownerEmail: prev?.ownerEmail ?? null,
       notificationCcEmails: input.notificationCcEmails,
       completionNotificationEnabled: input.completionNotificationEnabled,
+      // patch semantics: undefined のとき既存値保持 (default false)
+      progressReportEnabled:
+        input.progressReportEnabled !== undefined
+          ? input.progressReportEnabled
+          : (prev?.progressReportEnabled ?? false),
     });
   }
 }
@@ -69,6 +84,7 @@ describe("GET /super/tenants/:tenantId/notification-cc-emails", () => {
       ownerEmail: "owner@example.com",
       notificationCcEmails: ["cc1@example.com"],
       completionNotificationEnabled: true,
+      progressReportEnabled: true,
     });
     const res = await request(makeApp(store)).get(
       "/api/v2/super/tenants/atali82i/notification-cc-emails",
@@ -78,6 +94,7 @@ describe("GET /super/tenants/:tenantId/notification-cc-emails", () => {
       ownerEmail: "owner@example.com",
       notificationCcEmails: ["cc1@example.com"],
       completionNotificationEnabled: true,
+      progressReportEnabled: true,
     });
   });
 
@@ -106,10 +123,11 @@ describe("PUT /super/tenants/:tenantId/notification-cc-emails", () => {
       ownerEmail: "owner@example.com",
       notificationCcEmails: [],
       completionNotificationEnabled: true,
+      progressReportEnabled: false,
     });
   });
 
-  it("CC を更新し、ownerEmail を保持して返す", async () => {
+  it("CC を更新し、ownerEmail を保持して返す (progressReportEnabled は既存値継承)", async () => {
     const res = await request(makeApp(store))
       .put("/api/v2/super/tenants/atali82i/notification-cc-emails")
       .send({
@@ -121,8 +139,12 @@ describe("PUT /super/tenants/:tenantId/notification-cc-emails", () => {
       ownerEmail: "owner@example.com",
       notificationCcEmails: ["a@example.com", "b@example.com"],
       completionNotificationEnabled: false,
+      // 旧 UI 由来の PUT (progressReportEnabled 未送信) で既存値 false を保持
+      progressReportEnabled: false,
     });
     expect(store.updates).toHaveLength(1);
+    // store には未送信 (undefined) で patch される (Firestore merge で既存値保持される)
+    expect(store.updates[0]!.progressReportEnabled).toBeUndefined();
   });
 
   it("AC-24: 11 件以上は 400 cc_emails_too_many", async () => {
@@ -194,10 +216,87 @@ describe("PUT /super/tenants/:tenantId/notification-cc-emails", () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("bad_request");
   });
+
+  // ============================================================
+  // Phase 3 ADR-039 D-6: progressReportEnabled patch semantics
+  // ============================================================
+
+  it("progressReportEnabled を含めて PUT すると保存され、response にも含まれる", async () => {
+    const res = await request(makeApp(store))
+      .put("/api/v2/super/tenants/atali82i/notification-cc-emails")
+      .send({
+        notificationCcEmails: [],
+        completionNotificationEnabled: true,
+        progressReportEnabled: true,
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.progressReportEnabled).toBe(true);
+    expect(store.updates[0]!.progressReportEnabled).toBe(true);
+  });
+
+  it("progressReportEnabled=true 既存テナントに対し未送信 PUT で既存値 true を保持する (AC-PR-19)", async () => {
+    // 事前に true を保存
+    await request(makeApp(store))
+      .put("/api/v2/super/tenants/atali82i/notification-cc-emails")
+      .send({
+        notificationCcEmails: [],
+        completionNotificationEnabled: true,
+        progressReportEnabled: true,
+      });
+    // 旧 UI 由来の PUT (progressReportEnabled なし)
+    const res = await request(makeApp(store))
+      .put("/api/v2/super/tenants/atali82i/notification-cc-emails")
+      .send({
+        notificationCcEmails: ["cc@example.com"],
+        completionNotificationEnabled: false,
+      });
+    expect(res.status).toBe(200);
+    // 完了通知 OFF は反映されるが、進捗レポート ON は既存値保持
+    expect(res.body.completionNotificationEnabled).toBe(false);
+    expect(res.body.progressReportEnabled).toBe(true);
+  });
+
+  it("progressReportEnabled が boolean でないと 400 bad_request", async () => {
+    const res = await request(makeApp(store))
+      .put("/api/v2/super/tenants/atali82i/notification-cc-emails")
+      .send({
+        notificationCcEmails: [],
+        completionNotificationEnabled: true,
+        progressReportEnabled: "yes",
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("bad_request");
+  });
+
+  // Codex セカンドオピニオン LOW 指摘: 既存 true を明示 false で OFF にする境界テスト。
+  // 将来 `...(body.progressReportEnabled && ...)` のような truthy 判定退行を検知するため。
+  it("既存 progressReportEnabled=true を明示 false で送信すると false に更新される (truthy 退行防止)", async () => {
+    // 事前に true を保存
+    await request(makeApp(store))
+      .put("/api/v2/super/tenants/atali82i/notification-cc-emails")
+      .send({
+        notificationCcEmails: [],
+        completionNotificationEnabled: true,
+        progressReportEnabled: true,
+      });
+    // 明示 false で OFF
+    const res = await request(makeApp(store))
+      .put("/api/v2/super/tenants/atali82i/notification-cc-emails")
+      .send({
+        notificationCcEmails: [],
+        completionNotificationEnabled: true,
+        progressReportEnabled: false,
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.progressReportEnabled).toBe(false);
+    // store にも false が伝播 (truthy 判定退行なら undefined になり既存値 true が保持されてしまう)
+    const lastUpdate = store.updates[store.updates.length - 1]!;
+    expect(lastUpdate.progressReportEnabled).toBe(false);
+  });
 });
 
 describe("InMemoryTenantCcConfigStore", () => {
-  it("seedTenantIds で指定したテナントは default config で初期化される", async () => {
+  it("seedTenantIds で指定したテナントは default config で初期化される (progressReportEnabled=false)", async () => {
     const store = new InMemoryTenantCcConfigStore({
       seedTenantIds: ["demo", "tenant-a"],
     });
@@ -205,11 +304,14 @@ describe("InMemoryTenantCcConfigStore", () => {
       ownerEmail: null,
       notificationCcEmails: [],
       completionNotificationEnabled: true,
+      // Phase 3 (ADR-039 D-6): default false (opt-in)
+      progressReportEnabled: false,
     });
     expect(await store.getTenantCcConfig("tenant-a")).toEqual({
       ownerEmail: null,
       notificationCcEmails: [],
       completionNotificationEnabled: true,
+      progressReportEnabled: false,
     });
   });
 
@@ -223,7 +325,7 @@ describe("InMemoryTenantCcConfigStore", () => {
     expect(await store.getTenantCcConfig("demo")).toBeNull();
   });
 
-  it("updateTenantCcConfig で notificationCcEmails / enabled が反映される", async () => {
+  it("updateTenantCcConfig で notificationCcEmails / enabled が反映される (progressReportEnabled は未送信で既存値保持)", async () => {
     const store = new InMemoryTenantCcConfigStore({ seedTenantIds: ["demo"] });
     await store.updateTenantCcConfig("demo", {
       notificationCcEmails: ["cc1@example.com", "cc2@example.com"],
@@ -233,10 +335,12 @@ describe("InMemoryTenantCcConfigStore", () => {
       ownerEmail: null,
       notificationCcEmails: ["cc1@example.com", "cc2@example.com"],
       completionNotificationEnabled: false,
+      // seed の default false がそのまま保たれる
+      progressReportEnabled: false,
     });
   });
 
-  it("seed していない tenant への update は新規 config を作る", async () => {
+  it("seed していない tenant への update は新規 config を作る (progressReportEnabled は default false)", async () => {
     const store = new InMemoryTenantCcConfigStore();
     await store.updateTenantCcConfig("new-tenant", {
       notificationCcEmails: ["cc@example.com"],
@@ -246,7 +350,40 @@ describe("InMemoryTenantCcConfigStore", () => {
       ownerEmail: null,
       notificationCcEmails: ["cc@example.com"],
       completionNotificationEnabled: true,
+      progressReportEnabled: false,
     });
+  });
+
+  // ============================================================
+  // Phase 3 ADR-039 D-6: InMemoryTenantCcConfigStore patch semantics
+  // ============================================================
+
+  it("updateTenantCcConfig で progressReportEnabled を true に切替できる", async () => {
+    const store = new InMemoryTenantCcConfigStore({ seedTenantIds: ["demo"] });
+    await store.updateTenantCcConfig("demo", {
+      notificationCcEmails: [],
+      completionNotificationEnabled: true,
+      progressReportEnabled: true,
+    });
+    const config = await store.getTenantCcConfig("demo");
+    expect(config?.progressReportEnabled).toBe(true);
+  });
+
+  it("progressReportEnabled=true 保存後に未送信 update を呼ぶと true を保持する (patch semantics)", async () => {
+    const store = new InMemoryTenantCcConfigStore({ seedTenantIds: ["demo"] });
+    await store.updateTenantCcConfig("demo", {
+      notificationCcEmails: [],
+      completionNotificationEnabled: true,
+      progressReportEnabled: true,
+    });
+    await store.updateTenantCcConfig("demo", {
+      notificationCcEmails: ["cc@example.com"],
+      completionNotificationEnabled: false,
+      // progressReportEnabled 未送信
+    });
+    const config = await store.getTenantCcConfig("demo");
+    expect(config?.completionNotificationEnabled).toBe(false);
+    expect(config?.progressReportEnabled).toBe(true);
   });
 });
 

--- a/services/api/src/routes/super/__tests__/tenant-notification-cc.test.ts
+++ b/services/api/src/routes/super/__tests__/tenant-notification-cc.test.ts
@@ -23,7 +23,7 @@ class FakeStore implements TenantCcConfigStore {
     tenantId: string;
     notificationCcEmails: string[];
     enabled: boolean;
-    /** Phase 3 (ADR-039 D-6): undefined = 未送信 (patch semantics で既存値保持) */
+    /** ADR-039 D-6: undefined = 未送信 (patch semantics で既存値保持) */
     progressReportEnabled?: boolean;
   }[] = [];
 
@@ -218,7 +218,7 @@ describe("PUT /super/tenants/:tenantId/notification-cc-emails", () => {
   });
 
   // ============================================================
-  // Phase 3 ADR-039 D-6: progressReportEnabled patch semantics
+  // ADR-039 D-6: progressReportEnabled patch semantics
   // ============================================================
 
   it("progressReportEnabled を含めて PUT すると保存され、response にも含まれる", async () => {
@@ -234,7 +234,7 @@ describe("PUT /super/tenants/:tenantId/notification-cc-emails", () => {
     expect(store.updates[0]!.progressReportEnabled).toBe(true);
   });
 
-  it("progressReportEnabled=true 既存テナントに対し未送信 PUT で既存値 true を保持する (AC-PR-19)", async () => {
+  it("progressReportEnabled=true 既存テナントに対し未送信 PUT で既存値 true を保持する (AC-PR-18 tenant 拡張)", async () => {
     // 事前に true を保存
     await request(makeApp(store))
       .put("/api/v2/super/tenants/atali82i/notification-cc-emails")
@@ -268,8 +268,53 @@ describe("PUT /super/tenants/:tenantId/notification-cc-emails", () => {
     expect(res.body.error).toBe("bad_request");
   });
 
-  // Codex セカンドオピニオン LOW 指摘: 既存 true を明示 false で OFF にする境界テスト。
-  // 将来 `...(body.progressReportEnabled && ...)` のような truthy 判定退行を検知するため。
+  // `null` は `typeof null === "object"` で undefined と異なる。`??` を使った patch
+  // 簡略化リファクタで `null` が「未送信」扱いされる退行を防ぐ境界テスト。
+  it("progressReportEnabled=null は 400 bad_request (undefined と等価扱いにしない)", async () => {
+    const res = await request(makeApp(store))
+      .put("/api/v2/super/tenants/atali82i/notification-cc-emails")
+      .send({
+        notificationCcEmails: [],
+        completionNotificationEnabled: true,
+        progressReportEnabled: null,
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("bad_request");
+  });
+
+  // 完了通知 OFF + 進捗レポート ON の独立組合せ。AC-PR-11 (両レーン独立性 - 設定) と
+  // AC-PR-19 (テナント独立性) の中核ケース。2 つの boolean が混同される実装ミス
+  // (例: enabled = completion || progress) を防ぐ。
+  it("完了通知 OFF + 進捗レポート ON を独立に保存できる (AC-PR-11 / AC-PR-19 直交性)", async () => {
+    const res = await request(makeApp(store))
+      .put("/api/v2/super/tenants/atali82i/notification-cc-emails")
+      .send({
+        notificationCcEmails: ["cc@example.com"],
+        completionNotificationEnabled: false,
+        progressReportEnabled: true,
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.completionNotificationEnabled).toBe(false);
+    expect(res.body.progressReportEnabled).toBe(true);
+  });
+
+  // 逆組合せ (完了通知 ON + 進捗レポート OFF) も同時保存できることの対称性確認
+  it("完了通知 ON + 進捗レポート OFF を独立に保存できる (AC-PR-11 / AC-PR-19 直交性、逆)", async () => {
+    const res = await request(makeApp(store))
+      .put("/api/v2/super/tenants/atali82i/notification-cc-emails")
+      .send({
+        notificationCcEmails: ["cc@example.com"],
+        completionNotificationEnabled: true,
+        progressReportEnabled: false,
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.completionNotificationEnabled).toBe(true);
+    expect(res.body.progressReportEnabled).toBe(false);
+  });
+
+  // 既存 true を明示 false で OFF にできることを検証
+  // (`...(body.progressReportEnabled && ...)` 等の truthy 判定への退行で false 更新だけが
+  // 静かに無視されるリグレッションを検知するため)
   it("既存 progressReportEnabled=true を明示 false で送信すると false に更新される (truthy 退行防止)", async () => {
     // 事前に true を保存
     await request(makeApp(store))
@@ -304,7 +349,7 @@ describe("InMemoryTenantCcConfigStore", () => {
       ownerEmail: null,
       notificationCcEmails: [],
       completionNotificationEnabled: true,
-      // Phase 3 (ADR-039 D-6): default false (opt-in)
+      // ADR-039 D-6: default false (opt-in)
       progressReportEnabled: false,
     });
     expect(await store.getTenantCcConfig("tenant-a")).toEqual({
@@ -355,7 +400,7 @@ describe("InMemoryTenantCcConfigStore", () => {
   });
 
   // ============================================================
-  // Phase 3 ADR-039 D-6: InMemoryTenantCcConfigStore patch semantics
+  // ADR-039 D-6: InMemoryTenantCcConfigStore patch semantics
   // ============================================================
 
   it("updateTenantCcConfig で progressReportEnabled を true に切替できる", async () => {

--- a/services/api/src/routes/super/tenant-notification-cc.ts
+++ b/services/api/src/routes/super/tenant-notification-cc.ts
@@ -30,18 +30,25 @@ const TENANT_ID_REGEX = /^[a-zA-Z0-9_-]{1,128}$/;
 
 /**
  * tenant CC config の I/O 抽象。production は Firestore、test は in-memory fake。
+ *
+ * `progressReportEnabled` は Phase 3 (ADR-039 D-6) で追加。undefined を渡したときは
+ * 既存値を保持 (patch semantics)、boolean を渡したときのみ書き換える。完了通知 OFF と
+ * 進捗レポート OFF は独立に決裁したいテナント運用 (例: 完了通知のみ運用 / 進捗のみ運用)
+ * に対応するため。
  */
 export interface TenantCcConfigStore {
   /** tenant doc の CC config を取得。tenant doc 不在なら null */
   getTenantCcConfig(
     tenantId: string,
   ): Promise<TenantNotificationCcConfig | null>;
-  /** notificationCcEmails / completionNotificationEnabled を更新 (merge) */
+  /** notificationCcEmails / completionNotificationEnabled / progressReportEnabled を更新 (merge) */
   updateTenantCcConfig(
     tenantId: string,
     input: {
       notificationCcEmails: string[];
       completionNotificationEnabled: boolean;
+      /** Phase 3 (ADR-039 D-6): undefined のとき既存値保持 (patch semantics) */
+      progressReportEnabled?: boolean;
     },
   ): Promise<void>;
 }
@@ -85,6 +92,8 @@ export class InMemoryTenantCcConfigStore implements TenantCcConfigStore {
         ownerEmail: null,
         notificationCcEmails: [],
         completionNotificationEnabled: true,
+        // Phase 3 (ADR-039 D-6): default false (opt-in)
+        progressReportEnabled: false,
       });
     }
   }
@@ -100,6 +109,7 @@ export class InMemoryTenantCcConfigStore implements TenantCcConfigStore {
     input: {
       notificationCcEmails: string[];
       completionNotificationEnabled: boolean;
+      progressReportEnabled?: boolean;
     },
   ): Promise<void> {
     const prev = this.configs.get(tenantId);
@@ -107,6 +117,11 @@ export class InMemoryTenantCcConfigStore implements TenantCcConfigStore {
       ownerEmail: prev?.ownerEmail ?? null,
       notificationCcEmails: input.notificationCcEmails,
       completionNotificationEnabled: input.completionNotificationEnabled,
+      // patch semantics: undefined のとき既存値保持 (default false)
+      progressReportEnabled:
+        input.progressReportEnabled !== undefined
+          ? input.progressReportEnabled
+          : (prev?.progressReportEnabled ?? false),
     });
   }
 }
@@ -125,6 +140,9 @@ export class FirestoreTenantCcConfigStore implements TenantCcConfigStore {
       // 既存テナント後方互換: 未設定は default true (loader と整合)
       completionNotificationEnabled:
         (data.completionNotificationEnabled as boolean | undefined) ?? true,
+      // Phase 3 (ADR-039 D-6): 既存テナントは default false (opt-in)
+      progressReportEnabled:
+        (data.progressReportEnabled as boolean | undefined) ?? false,
     };
   }
 
@@ -133,9 +151,12 @@ export class FirestoreTenantCcConfigStore implements TenantCcConfigStore {
     input: {
       notificationCcEmails: string[];
       completionNotificationEnabled: boolean;
+      progressReportEnabled?: boolean;
     },
   ): Promise<void> {
-    // merge: 他の tenant フィールドを保護。両値とも常に定義済 (undefined 混入なし)。
+    // merge: 他の tenant フィールドを保護。
+    // progressReportEnabled は undefined のとき payload に含めず既存値保持
+    // (rules/production-data-safety.md §1)。route handler の同パターン spread と統一。
     await getFirestore()
       .collection("tenants")
       .doc(tenantId)
@@ -143,6 +164,9 @@ export class FirestoreTenantCcConfigStore implements TenantCcConfigStore {
         {
           notificationCcEmails: input.notificationCcEmails,
           completionNotificationEnabled: input.completionNotificationEnabled,
+          ...(input.progressReportEnabled !== undefined && {
+            progressReportEnabled: input.progressReportEnabled,
+          }),
         },
         { merge: true },
       );
@@ -214,6 +238,19 @@ export function createTenantNotificationCcRouter(
         });
         return;
       }
+      // Phase 3 (ADR-039 D-6): progressReportEnabled は optional。送信時のみ
+      // type を検証し、未送信なら storage 層で既存値保持 (patch semantics)。
+      // 旧 UI 由来の PUT は progressReportEnabled を含まないため、既存値が消えない。
+      if (
+        body.progressReportEnabled !== undefined &&
+        typeof body.progressReportEnabled !== "boolean"
+      ) {
+        res.status(400).json({
+          error: "bad_request",
+          message: "progressReportEnabled は boolean が必要です。",
+        });
+        return;
+      }
       if (!Array.isArray(body.notificationCcEmails)) {
         res.status(400).json({
           error: "invalid_cc_emails",
@@ -257,12 +294,22 @@ export function createTenantNotificationCcRouter(
       await deps.store.updateTenantCcConfig(tenantId, {
         notificationCcEmails: deduped,
         completionNotificationEnabled: body.completionNotificationEnabled,
+        // 未送信なら storage 層で既存値保持 (patch semantics、ADR-039 D-6)
+        ...(body.progressReportEnabled !== undefined && {
+          progressReportEnabled: body.progressReportEnabled,
+        }),
       });
 
+      // 応答は更新後の整合値: 送信されたら採用、未送信なら既存値を引き継ぐ
+      const effectiveProgressReportEnabled =
+        body.progressReportEnabled !== undefined
+          ? body.progressReportEnabled
+          : (existing.progressReportEnabled ?? false);
       const response: GetTenantNotificationCcResponse = {
         ownerEmail: existing.ownerEmail,
         notificationCcEmails: deduped,
         completionNotificationEnabled: body.completionNotificationEnabled,
+        progressReportEnabled: effectiveProgressReportEnabled,
       };
       res.json(response);
     },

--- a/services/api/src/routes/super/tenant-notification-cc.ts
+++ b/services/api/src/routes/super/tenant-notification-cc.ts
@@ -31,7 +31,7 @@ const TENANT_ID_REGEX = /^[a-zA-Z0-9_-]{1,128}$/;
 /**
  * tenant CC config の I/O 抽象。production は Firestore、test は in-memory fake。
  *
- * `progressReportEnabled` は Phase 3 (ADR-039 D-6) で追加。undefined を渡したときは
+ * `progressReportEnabled` は ADR-039 D-6 で追加。undefined を渡したときは
  * 既存値を保持 (patch semantics)、boolean を渡したときのみ書き換える。完了通知 OFF と
  * 進捗レポート OFF は独立に決裁したいテナント運用 (例: 完了通知のみ運用 / 進捗のみ運用)
  * に対応するため。
@@ -47,7 +47,7 @@ export interface TenantCcConfigStore {
     input: {
       notificationCcEmails: string[];
       completionNotificationEnabled: boolean;
-      /** Phase 3 (ADR-039 D-6): undefined のとき既存値保持 (patch semantics) */
+      /** ADR-039 D-6: undefined のとき既存値保持 (patch semantics) */
       progressReportEnabled?: boolean;
     },
   ): Promise<void>;
@@ -92,7 +92,7 @@ export class InMemoryTenantCcConfigStore implements TenantCcConfigStore {
         ownerEmail: null,
         notificationCcEmails: [],
         completionNotificationEnabled: true,
-        // Phase 3 (ADR-039 D-6): default false (opt-in)
+        // ADR-039 D-6: default false (opt-in)
         progressReportEnabled: false,
       });
     }
@@ -140,7 +140,7 @@ export class FirestoreTenantCcConfigStore implements TenantCcConfigStore {
       // 既存テナント後方互換: 未設定は default true (loader と整合)
       completionNotificationEnabled:
         (data.completionNotificationEnabled as boolean | undefined) ?? true,
-      // Phase 3 (ADR-039 D-6): 既存テナントは default false (opt-in)
+      // ADR-039 D-6: 既存テナントは default false (opt-in)
       progressReportEnabled:
         (data.progressReportEnabled as boolean | undefined) ?? false,
     };
@@ -238,7 +238,7 @@ export function createTenantNotificationCcRouter(
         });
         return;
       }
-      // Phase 3 (ADR-039 D-6): progressReportEnabled は optional。送信時のみ
+      // ADR-039 D-6: progressReportEnabled は optional。送信時のみ
       // type を検証し、未送信なら storage 層で既存値保持 (patch semantics)。
       // 旧 UI 由来の PUT は progressReportEnabled を含まないため、既存値が消えない。
       if (

--- a/web/app/super/dispatch-settings/__tests__/page.test.tsx
+++ b/web/app/super/dispatch-settings/__tests__/page.test.tsx
@@ -131,6 +131,98 @@ describe("DispatchSettingsPage", () => {
     expect(screen.getByTestId("run-history-table")).toBeInTheDocument();
   });
 
+  // ============================================================
+  // Phase 3 PR 3d (ADR-039 D-1): progressReport セクション
+  // ============================================================
+
+  it("progressReport セクションが表示される (旧 doc で progressReport 欠落でも default を表示)", async () => {
+    superFetchMock.mockResolvedValueOnce(baseSettings); // progressReport なし
+    render(<DispatchSettingsPage />);
+    await screen.findByDisplayValue("DXcollege運営スタッフ");
+    expect(
+      screen.getByRole("switch", {
+        name: "進捗レポート定期配信を有効化",
+      }),
+    ).toBeInTheDocument();
+    // default OFF 表示
+    expect(
+      screen.getByText("進捗レポート配信 OFF"),
+    ).toBeInTheDocument();
+  });
+
+  it("既存 progressReport ON を読み込み、ON ラベルを表示する", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      ...baseSettings,
+      progressReport: {
+        enabled: true,
+        scheduleDaysOfWeek: [2, 5],
+        scheduleHourJst: 11,
+      },
+    });
+    render(<DispatchSettingsPage />);
+    await screen.findByDisplayValue("DXcollege運営スタッフ");
+    expect(screen.getByText("進捗レポート配信 ON")).toBeInTheDocument();
+  });
+
+  it("保存時に progressReport を含めて PUT する (always-send-all)", async () => {
+    superFetchMock
+      .mockResolvedValueOnce({
+        ...baseSettings,
+        progressReport: {
+          enabled: true,
+          scheduleDaysOfWeek: [3],
+          scheduleHourJst: 8,
+        },
+      })
+      .mockResolvedValueOnce({ ...baseSettings, version: 4 });
+    render(<DispatchSettingsPage />);
+    await screen.findByDisplayValue("DXcollege運営スタッフ");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    });
+
+    await waitFor(() =>
+      expect(superFetchMock).toHaveBeenCalledWith(
+        "/api/v2/super/dispatch/settings",
+        expect.objectContaining({ method: "PUT" }),
+      ),
+    );
+    const putCall = superFetchMock.mock.calls.find((c) => c[1]?.method === "PUT");
+    const sentBody = JSON.parse(putCall![1].body);
+    expect(sentBody.progressReport).toEqual({
+      enabled: true,
+      scheduleDaysOfWeek: [3],
+      scheduleHourJst: 8,
+    });
+  });
+
+  it("旧 doc (progressReport なし) を保存すると default の OFF/空配列/0時を送信する", async () => {
+    superFetchMock
+      .mockResolvedValueOnce(baseSettings) // progressReport なし
+      .mockResolvedValueOnce({ ...baseSettings, version: 4 });
+    render(<DispatchSettingsPage />);
+    await screen.findByDisplayValue("DXcollege運営スタッフ");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    });
+
+    await waitFor(() =>
+      expect(superFetchMock).toHaveBeenCalledWith(
+        "/api/v2/super/dispatch/settings",
+        expect.objectContaining({ method: "PUT" }),
+      ),
+    );
+    const putCall = superFetchMock.mock.calls.find((c) => c[1]?.method === "PUT");
+    const sentBody = JSON.parse(putCall![1].body);
+    expect(sentBody.progressReport).toEqual({
+      enabled: false,
+      scheduleDaysOfWeek: [],
+      scheduleHourJst: 0,
+    });
+  });
+
   it("再読み込み失敗時 loadSettings は form を null 化する (regression: form/error 共存防止)", async () => {
     // 初回 GET 失敗 → error 表示 + 再読み込みボタン
     superFetchMock.mockRejectedValueOnce(

--- a/web/app/super/dispatch-settings/__tests__/page.test.tsx
+++ b/web/app/super/dispatch-settings/__tests__/page.test.tsx
@@ -132,7 +132,7 @@ describe("DispatchSettingsPage", () => {
   });
 
   // ============================================================
-  // Phase 3 PR 3d (ADR-039 D-1): progressReport セクション
+  // ADR-039 D-1: progressReport セクション
   // ============================================================
 
   it("progressReport セクションが表示される (旧 doc で progressReport 欠落でも default を表示)", async () => {

--- a/web/app/super/dispatch-settings/components/TenantCcEditor.tsx
+++ b/web/app/super/dispatch-settings/components/TenantCcEditor.tsx
@@ -108,7 +108,7 @@ export function TenantCcForm({
 
   const [originalEmails, setOriginalEmails] = useState<string[]>([]);
   const [originalEnabled, setOriginalEnabled] = useState<boolean>(true);
-  // Phase 3 (ADR-039 D-6): progressReport テナント opt-in を CC 編集と同一画面に統合
+  // ADR-039 D-6: progressReport テナント opt-in を CC 編集と同一画面に統合
   const [originalProgressReportEnabled, setOriginalProgressReportEnabled] =
     useState<boolean>(false);
   const [emails, setEmails] = useState<string[]>([]);

--- a/web/app/super/dispatch-settings/components/TenantCcEditor.tsx
+++ b/web/app/super/dispatch-settings/components/TenantCcEditor.tsx
@@ -108,8 +108,13 @@ export function TenantCcForm({
 
   const [originalEmails, setOriginalEmails] = useState<string[]>([]);
   const [originalEnabled, setOriginalEnabled] = useState<boolean>(true);
+  // Phase 3 (ADR-039 D-6): progressReport テナント opt-in を CC 編集と同一画面に統合
+  const [originalProgressReportEnabled, setOriginalProgressReportEnabled] =
+    useState<boolean>(false);
   const [emails, setEmails] = useState<string[]>([]);
   const [enabled, setEnabled] = useState<boolean>(true);
+  const [progressReportEnabled, setProgressReportEnabled] =
+    useState<boolean>(false);
 
   const [draft, setDraft] = useState("");
   const [draftError, setDraftError] = useState<string | null>(null);
@@ -122,8 +127,12 @@ export function TenantCcForm({
     setConfig(data);
     setOriginalEmails(data.notificationCcEmails);
     setOriginalEnabled(data.completionNotificationEnabled);
+    // 旧テナント (progressReportEnabled 欠落) は default false で初期化
+    const progressReport = data.progressReportEnabled ?? false;
+    setOriginalProgressReportEnabled(progressReport);
     setEmails(data.notificationCcEmails);
     setEnabled(data.completionNotificationEnabled);
+    setProgressReportEnabled(progressReport);
     setDraft("");
     setDraftError(null);
   };
@@ -179,6 +188,7 @@ export function TenantCcForm({
 
   const isDirty =
     enabled !== originalEnabled ||
+    progressReportEnabled !== originalProgressReportEnabled ||
     emails.length !== originalEmails.length ||
     emails.some((e, i) => originalEmails[i] !== e);
 
@@ -190,6 +200,8 @@ export function TenantCcForm({
     const body: PutTenantNotificationCcRequest = {
       notificationCcEmails: emails,
       completionNotificationEnabled: enabled,
+      // 当画面で常に値が確定するので always-send-all (旧 UI の patch 保護は BE 側)
+      progressReportEnabled,
     };
     try {
       const updated = await superFetch<GetTenantNotificationCcResponse>(
@@ -232,7 +244,23 @@ export function TenantCcForm({
           aria-label="このテナントへの完了通知を有効化"
         />
         <span>
-          {enabled ? "このテナントへの配信 ON" : "このテナントへの配信 OFF"}
+          {enabled
+            ? "このテナントへの完了通知 配信 ON"
+            : "このテナントへの完了通知 配信 OFF"}
+        </span>
+      </label>
+
+      <label className="flex items-center gap-3 text-sm">
+        <Switch
+          checked={progressReportEnabled}
+          onCheckedChange={setProgressReportEnabled}
+          disabled={saving}
+          aria-label="このテナントへの進捗レポート定期配信を有効化"
+        />
+        <span>
+          {progressReportEnabled
+            ? "このテナントへの進捗レポート定期配信 ON"
+            : "このテナントへの進捗レポート定期配信 OFF"}
         </span>
       </label>
 

--- a/web/app/super/dispatch-settings/components/__tests__/TenantCcEditor.test.tsx
+++ b/web/app/super/dispatch-settings/components/__tests__/TenantCcEditor.test.tsx
@@ -288,13 +288,107 @@ describe("TenantCcForm", () => {
     const putCall = superFetchMock.mock.calls.find(
       (c) => c[1]?.method === "PUT",
     );
+    // Phase 3 PR 3d: progressReportEnabled は always-send-all で常に送信
     expect(JSON.parse(putCall![1].body)).toEqual({
       notificationCcEmails: ["cc1@example.com"],
       completionNotificationEnabled: true,
+      progressReportEnabled: false,
     });
     expect(await screen.findByText("保存しました。")).toBeInTheDocument();
     // 保存後は差分なし → 保存ボタン disable
     expect(screen.getByRole("button", { name: "保存" })).toBeDisabled();
+  });
+
+  // ============================================================
+  // Phase 3 PR 3d (ADR-039 D-6): progressReportEnabled テナント opt-in
+  // ============================================================
+
+  it("progressReportEnabled トグルが表示され、既存値を反映する", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      ...baseConfig,
+      progressReportEnabled: true,
+    });
+    renderForm();
+    await screen.findByText("cc1@example.com");
+    expect(
+      screen.getByRole("switch", {
+        name: "このテナントへの進捗レポート定期配信を有効化",
+      }),
+    ).toBeChecked();
+    expect(
+      screen.getByText("このテナントへの進捗レポート定期配信 ON"),
+    ).toBeInTheDocument();
+  });
+
+  it("旧テナント (progressReportEnabled 欠落) は default OFF を表示する", async () => {
+    superFetchMock.mockResolvedValueOnce(baseConfig); // progressReportEnabled なし
+    renderForm();
+    await screen.findByText("cc1@example.com");
+    expect(
+      screen.getByRole("switch", {
+        name: "このテナントへの進捗レポート定期配信を有効化",
+      }),
+    ).not.toBeChecked();
+    expect(
+      screen.getByText("このテナントへの進捗レポート定期配信 OFF"),
+    ).toBeInTheDocument();
+  });
+
+  it("progressReportEnabled のみ変更でも dirty 扱いとなり保存ボタン enable", async () => {
+    superFetchMock.mockResolvedValueOnce(baseConfig);
+    renderForm();
+    await screen.findByText("cc1@example.com");
+
+    expect(screen.getByRole("button", { name: "保存" })).toBeDisabled();
+
+    // 進捗レポート OFF → ON に切替で dirty
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "このテナントへの進捗レポート定期配信を有効化",
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "保存" })).toBeEnabled(),
+    );
+  });
+
+  it("保存時に progressReportEnabled を含めて PUT する (always-send-all)", async () => {
+    superFetchMock
+      .mockResolvedValueOnce(baseConfig) // GET
+      .mockResolvedValueOnce({
+        ...baseConfig,
+        progressReportEnabled: true,
+      }); // PUT
+    renderForm();
+    await screen.findByText("cc1@example.com");
+
+    // 進捗レポート ON に切替
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "このテナントへの進捗レポート定期配信を有効化",
+      }),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    });
+
+    await waitFor(() =>
+      expect(superFetchMock).toHaveBeenCalledWith(
+        "/api/v2/super/tenants/t1/notification-cc-emails",
+        expect.objectContaining({ method: "PUT" }),
+      ),
+    );
+    const putCall = superFetchMock.mock.calls.find(
+      (c) => c[1]?.method === "PUT",
+    );
+    const sentBody = JSON.parse(putCall![1].body);
+    expect(sentBody.progressReportEnabled).toBe(true);
+    // 既存の CC / 完了通知の field も常に送信されている (always-send-all)
+    expect(sentBody.completionNotificationEnabled).toBe(true);
+    expect(sentBody.notificationCcEmails).toEqual([
+      "cc1@example.com",
+      "cc2@example.com",
+    ]);
   });
 
   it("保存失敗時はエラー表示し chips state は維持", async () => {

--- a/web/app/super/dispatch-settings/components/__tests__/TenantCcEditor.test.tsx
+++ b/web/app/super/dispatch-settings/components/__tests__/TenantCcEditor.test.tsx
@@ -288,7 +288,7 @@ describe("TenantCcForm", () => {
     const putCall = superFetchMock.mock.calls.find(
       (c) => c[1]?.method === "PUT",
     );
-    // Phase 3 PR 3d: progressReportEnabled は always-send-all で常に送信
+    // ADR-039 D-6: progressReportEnabled は always-send-all で常に送信
     expect(JSON.parse(putCall![1].body)).toEqual({
       notificationCcEmails: ["cc1@example.com"],
       completionNotificationEnabled: true,
@@ -300,7 +300,7 @@ describe("TenantCcForm", () => {
   });
 
   // ============================================================
-  // Phase 3 PR 3d (ADR-039 D-6): progressReportEnabled テナント opt-in
+  // ADR-039 D-6: progressReportEnabled テナント opt-in
   // ============================================================
 
   it("progressReportEnabled トグルが表示され、既存値を反映する", async () => {

--- a/web/app/super/dispatch-settings/page.tsx
+++ b/web/app/super/dispatch-settings/page.tsx
@@ -18,6 +18,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   GetDispatchSettingsResponse,
+  ProgressReportSettings,
   PutDispatchSettingsRequest,
 } from "@lms-279/shared-types";
 import { ApiError } from "@/lib/api";
@@ -42,9 +43,22 @@ interface FormState {
   scheduleHourJst: number;
   signatureName: string;
   completionMessageBody: string;
+  /**
+   * Phase 3 (ADR-039 D-1): 進捗レポート定期配信の設定。
+   * undefined のとき UI は default (enabled=false / scheduleDaysOfWeek=[] / scheduleHourJst=0) を表示する。
+   * 保存時は当画面で常に値が確定するため、PUT body には常に含めて送信する (always-send-all)。
+   */
+  progressReport: ProgressReportSettings;
   version: number;
   senderEmail: string;
 }
+
+/** progressReport 欠落時 (旧 doc) の default 値 */
+const DEFAULT_PROGRESS_REPORT: ProgressReportSettings = {
+  enabled: false,
+  scheduleDaysOfWeek: [],
+  scheduleHourJst: 0,
+};
 
 function toFormState(s: GetDispatchSettingsResponse): FormState {
   return {
@@ -53,6 +67,7 @@ function toFormState(s: GetDispatchSettingsResponse): FormState {
     scheduleHourJst: s.scheduleHourJst,
     signatureName: s.signatureName,
     completionMessageBody: s.completionMessageBody,
+    progressReport: s.progressReport ?? DEFAULT_PROGRESS_REPORT,
     version: s.version,
     senderEmail: s.senderEmail,
   };
@@ -144,6 +159,9 @@ export default function DispatchSettingsPage() {
       scheduleHourJst: form.scheduleHourJst,
       signatureName: form.signatureName,
       completionMessageBody: form.completionMessageBody,
+      // Phase 3 (ADR-039 D-1): 当画面が進捗レポート設定の真実の入り口なので
+      // always-send-all 戦略で常に送信。patch semantics は別 UI 経由の保護用。
+      progressReport: form.progressReport,
       version: form.version,
     };
     try {
@@ -172,9 +190,9 @@ export default function DispatchSettingsPage() {
   return (
     <div className="space-y-4">
       <div>
-        <h1 className="text-xl font-bold">完了通知 配信設定</h1>
+        <h1 className="text-xl font-bold">完了通知・進捗レポート 配信設定</h1>
         <p className="text-sm text-muted-foreground">
-          全コース 100% 完了した受講者へ自動送信する完了通知の設定です。
+          全コース 100% 完了した受講者へ送る完了通知と、受講中の方へ送る進捗レポート（PDF 添付）の定期配信を、それぞれ独立に設定します。
         </p>
       </div>
 
@@ -244,6 +262,46 @@ export default function DispatchSettingsPage() {
                   ...form,
                   signatureName: next.signatureName,
                   completionMessageBody: next.completionMessageBody,
+                })
+              }
+              disabled={saving}
+            />
+          </Section>
+
+          <Section
+            title="進捗レポート 定期配信"
+            description="受講中の方へ、現在の進捗をまとめた PDF を添付したメールを定期的に自動送信する設定です（完了通知とは別のレーンで動きます）。"
+            hint="完了通知レーンとは独立したスケジュールで動きます。OFF にすると次の自動チェック（最大 60 分以内）から進捗レポートのみ停止し、完了通知への影響はありません。テナント単位の opt-in が別途必要です（「テナントごとの CC 追加設定」内のトグル）。"
+          >
+            <label className="flex items-center gap-3 text-sm">
+              <Switch
+                checked={form.progressReport.enabled}
+                onCheckedChange={(v) =>
+                  setForm({
+                    ...form,
+                    progressReport: { ...form.progressReport, enabled: v },
+                  })
+                }
+                disabled={saving}
+                aria-label="進捗レポート定期配信を有効化"
+              />
+              <span>
+                {form.progressReport.enabled
+                  ? "進捗レポート配信 ON"
+                  : "進捗レポート配信 OFF"}
+              </span>
+            </label>
+            <ScheduleEditor
+              daysOfWeek={form.progressReport.scheduleDaysOfWeek}
+              hourJst={form.progressReport.scheduleHourJst}
+              onChange={(next) =>
+                setForm({
+                  ...form,
+                  progressReport: {
+                    ...form.progressReport,
+                    scheduleDaysOfWeek: next.daysOfWeek,
+                    scheduleHourJst: next.hourJst,
+                  },
                 })
               }
               disabled={saving}

--- a/web/app/super/dispatch-settings/page.tsx
+++ b/web/app/super/dispatch-settings/page.tsx
@@ -44,7 +44,7 @@ interface FormState {
   signatureName: string;
   completionMessageBody: string;
   /**
-   * Phase 3 (ADR-039 D-1): 進捗レポート定期配信の設定。
+   * ADR-039 D-1: 進捗レポート定期配信の設定。
    * undefined のとき UI は default (enabled=false / scheduleDaysOfWeek=[] / scheduleHourJst=0) を表示する。
    * 保存時は当画面で常に値が確定するため、PUT body には常に含めて送信する (always-send-all)。
    */
@@ -159,8 +159,8 @@ export default function DispatchSettingsPage() {
       scheduleHourJst: form.scheduleHourJst,
       signatureName: form.signatureName,
       completionMessageBody: form.completionMessageBody,
-      // Phase 3 (ADR-039 D-1): 当画面が進捗レポート設定の真実の入り口なので
-      // always-send-all 戦略で常に送信。patch semantics は別 UI 経由の保護用。
+      // ADR-039 D-1: 当画面が進捗レポート設定の真実の入り口なので always-send-all 戦略で
+      // 常に送信。patch semantics は他経路 (CLI / 旧 UI) からの PUT 保護用。
       progressReport: form.progressReport,
       version: form.version,
     };


### PR DESCRIPTION
Phase 3 PR 3d: super-admin の進捗レポート定期配信 UI 完成 (impl-plan §PR 3d)。

## Summary

- BE: `tenant-notification-cc.ts` の `TenantCcConfigStore` に `progressReportEnabled` 拡張 (patch semantics、InMemory + Firestore 両実装、PUT validation、response 拡張)
- FE: `dispatch-settings/page.tsx` に「進捗レポート 定期配信」セクション追加 (既存 `ScheduleEditor` 流用、always-send-all 戦略)
- FE: `TenantCcEditor.tsx` にテナント opt-in トグル UI 追加 (always-send-all、dirty 判定拡張)
- AC-PR-04 / AC-PR-05 / AC-PR-11 / AC-PR-18 / AC-PR-19 / AC-PR-22 を満たす実装

## 変更ファイル (6 files, +468/-12)

| File | Lines |
|---|---|
| `services/api/src/routes/super/tenant-notification-cc.ts` | +51 / -12 |
| `services/api/src/routes/super/__tests__/tenant-notification-cc.test.ts` | +151 |
| `web/app/super/dispatch-settings/page.tsx` | +62 |
| `web/app/super/dispatch-settings/components/TenantCcEditor.tsx` | +30 |
| `web/app/super/dispatch-settings/__tests__/page.test.tsx` | +92 |
| `web/app/super/dispatch-settings/components/__tests__/TenantCcEditor.test.tsx` | +94 |

## Quality Gate 4 段階完全実施

| 段階 | 結果 | 反映 |
|---|---|---|
| `/safe-refactor` | 問題なし | — |
| `/code-review high` (7 angles × 1-vote verify) | 採用 fix 1 件 | Firestore payload spread 表現を route handler と統一 |
| Evaluator 分離 (5+ ファイル + 新機能) | APPROVE | AC 全 PASS、HIGH なし |
| Codex セカンドオピニオン (3+ ファイル / 200+ 行) | LOW 1 件反映 | true→false 明示 OFF テスト追加 |

## Phase 4 OQ 候補 (本 PR スコープ外、既存設計問題)

**OQ #8**: tenant CC API の always-send-all 戦略は version 管理なしのため lost update リスク
- 現状 `completionNotificationEnabled` も同じ、運用上は限定された super-admin 同時編集で稀
- Codex MEDIUM 1。修正案: dirty 判定で patch semantics 化、または version 列追加

**OQ #9**: tenant-notification-cc PUT response が `existing` 由来で構築、Firestore 並行更新時に stale 値返却
- 現状 `completionNotificationEnabled` も同じパターン
- Codex MEDIUM 2。修正案: update 後 re-read、または store の update を returning 風に再設計

## Test plan

- [x] `npm run type-check -w @lms-279/shared-types -w @lms-279/api -w @lms-279/web` → 全 PASS
- [x] `npm run test -w @lms-279/api` → 1589 / 1589 PASS (PR 3d 新規 6 件含む)
- [x] `npm run test -w @lms-279/web` → 216 / 216 PASS (PR 3d 新規 8 件含む)
- [x] `npm run lint` → 既存 warning 1 件のみ (本 PR 起因なし)
- [ ] (cutover 時) Firestore 実環境で「旧 doc → progressReportEnabled 書込 → 再読込で永続化確認」
- [ ] (cutover 時) Playwright MCP で「FE 進捗レポート ON → 保存 → リロード → 状態保持」

## 関連

- ADR-039 D-1 (progressReport sub-object) / D-6 (tenant opt-in default false)
- impl-plan: `docs/specs/2026-06-01-progress-report-dispatch-impl-plan.md` §PR 3d
- 前 PR: #512 (PR 3c run-progress-reports state machine)
- 次 PR: 3e (Cloud Scheduler + TTL Policy + dry-run + runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)