### PR TITLE
Phase 4 α-7-BE: dispatch dry-run UI 両レーン化 BE 実装 + Quality Gate 段階 1-4 反映

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,26 +1,24 @@
-# Session Handoff — 2026-06-04 (Session 58)
+# Session Handoff — 2026-06-04 (Session 59)
 
 ## TL;DR
 
-Phase 4 α-7 (dry-run UI 両レーン化) **採用決定 + impl-plan 起票 + BE 実装完了**。同時に進捗レポート定期配信 cutover **Step 0a/0b/0c 完了** (Cloud Scheduler + Firestore TTL Policy + WIF 確認)。α-7-BE は 7 タスク全完了で 1 commit (`234c4e1`、16 files、+3,070/-472)。Quality Gate 5 段階は次セッションで実施 → PR 作成 → merge → α-7-FE 着手の流れ。
+Phase 4 α-7-BE の **Quality Gate 段階 1-3 完了** (`/safe-refactor` + `/code-review high` + Evaluator)。code-review で 10 finding 抽出 (F1〜F9) のうち 8 件 fix + 2 件 documented behavior、Evaluator は **READY-WITH-NOTES** 判定で追加フォロー 2 件 (AC-α7-05 403 / 限ter 両 lane 合算 budget) を同 PR 内で消化。本セッションで 2 commit 追加 (refactor + feat、計 12 files、+570/-265)、tests 1643 → **1649 PASS**。ネットワーク不可で段階 4-5 (`/codex review` / push + `gh pr create` / `/review-pr`) は未実施 → 次セッションでネット復旧後に実施。
 
 | 主要成果 | 結果 |
 |---|---|
-| Cutover Step 0a (Cloud Scheduler `dxcollege-progress-reports`) | ✅ 作成、毎時 30 分起動、初回 JST 21:30 |
-| Cutover Step 0b (Firestore TTL Policy `progress_report_sends.ttlExpireAt`) | ✅ state=ACTIVE、90 日保持 |
-| Cutover Step 0c (WIF 確認、read-only) | ✅ `github-actions@` SA バインド済 |
-| Phase 4 OQ 整理 spec | ✅ `docs/specs/2026-06-03-phase-4-progress-report-followups.md` (15 + #16 = 16 件) |
-| OQ #16 採用決定 (dry-run UI 両レーン化) | ✅ HIGH 採用、Codex セカンドオピニオン経由 |
-| α-7-BE impl-plan 起票 | ✅ `docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md` (Codex 反映 + PR #490 撤廃理由解消) |
-| α-7-BE 実装完了 (7 タスク) | ✅ commit `234c4e1`、type-check + 1643 tests + 両 smoke PASS |
-| 業務スーパー管理者連絡文案 | ✅ 作成済、送信判断は開発者領分 |
+| 段階 1 `/safe-refactor` | M1 (CLI init helper 抽出) + M2 (test fixture 集約)、-205 行重複削減 |
+| 段階 2 `/code-review high` | 7 angle × 約 42 候補 → dedup → 10 findings (F1〜F9)、8 件 fix + 2 件 documented |
+| 段階 3 Evaluator (別コンテキスト) | 5 BE-scope AC 評価 (3 PASS / 1 PARTIAL / 1 UNTESTABLE)、**READY-WITH-NOTES** |
+| Evaluator フォロー 2 件 | AC-α7-05 403 直接 assert + 限ter 両 lane 合算 budget test pin |
+| Test count | 1643 → **1649 PASS** (+6 regression test) |
+| type-check / Lint | 全 PASS / 0 errors |
+| 未 push commit | 3 件 (`41ac184` Session 58 handoff、`fe9b429` refactor、`260790d` feat、加えて本 handoff commit が今追加) |
 
 - **Issue Net**: 0 件 (Close 0 / 起票 0)
-- **マージ済 PR**: 0 件 (本セッションは α-7-BE 実装 commit のみ、PR 作成は次セッション)
-- **CI / Deploy**: ⏭️ α-7-BE commit は未 push、Quality Gate 完了後に PR 作成予定
-- **Open Issue**: active 0 / postponed 4 (#274 / #275 / #276 / #405、変化なし)
+- **マージ済 PR**: 0 件 (α-7-BE PR は未作成、push 段階で停止中)
+- **CI / Deploy**: ⏭️ commit は未 push、ネット復旧後に push + PR 作成予定
+- **Open Issue**: ⚠️ gh CLI ネット不通で確認不可、Session 58 baseline は active 0 / postponed 4 (#274 / #275 / #276 / #405)
 - **残留プロセス**: ✅ なし
-- **未 push commit**: 1 件 (`234c4e1` on `feat/phase-4-pr-alpha-7-be-dry-run-ui`)
 
 ---
 
@@ -30,133 +28,119 @@ Phase 4 α-7 (dry-run UI 両レーン化) **採用決定 + impl-plan 起票 + BE
 # 1. 状況復元
 cat docs/handoff/LATEST.md
 
-# 2. main 最新と CI
+# 2. ネットワーク確認 (本セッション時点で gh / GCP OAuth ともに不通)
+curl -s --max-time 5 -o /dev/null -w "%{http_code}" https://api.github.com
+curl -s --max-time 5 -o /dev/null -w "%{http_code}" https://oauth2.googleapis.com
+
+# 3. ネット OK の場合
 git fetch origin main && git log --oneline -5 origin/main
 gh run list --branch main --limit 5
+gh issue list --state open --limit 15
 
-# 3. α-7-BE feature ブランチに切替 (本セッションで未 push の commit あり)
+# 4. α-7-BE feature ブランチ確認 (未 push commit 3 件あり)
 git checkout feat/phase-4-pr-alpha-7-be-dry-run-ui
-git log --oneline -3
+git log --oneline -5
 
-# 4. cutover 状態確認
+# 5. Quality Gate 段階 4-5 をネット復旧後に
+#    a. /codex review (3+ files / 200+ 行 PR 該当、CLAUDE.md 必須)
+#    b. git push -u origin feat/phase-4-pr-alpha-7-be-dry-run-ui
+#    c. gh pr create --title "..." --body "..."
+#    d. /review-pr (6 エージェント並列)
+#    e. quality gate pass → merge
+
+# 6. cutover 状態確認 (Session 58 から変化なし想定)
 gcloud scheduler jobs describe dxcollege-progress-reports --location=asia-northeast1 --project=lms-279 --format="value(state,schedule)"
 gcloud firestore fields ttls list --project=lms-279 --database='(default)' --filter="name~progress_report_sends" --format="value(name,ttlConfig.state)"
 
-# 5. OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
-gh issue list --state open --limit 15
-
-# 6. 次の最有力候補 (開発者判断)
-#    A. α-7-BE の Quality Gate 5 段階 (/safe-refactor → /code-review high → Evaluator → Codex → review-pr 5 agents)
-#    B. 上記合格後 → α-7-BE PR 作成 → merge
-#    C. α-7-FE 着手 (FE viewer + 統合 + Playwright + runbook 更新)
-#    D. 業務スーパー管理者連絡文案の送付判断
-#    E. cutover Step 1-2 (テナント opt-in + 配信曜日/時刻初期化、業務スーパー管理者 UI 操作)
-#    F. 別タスク (開発者からの新規指示)
+# 7. 次の最有力候補 (開発者判断)
+#    A. Quality Gate 段階 4-5 + PR 作成 → merge (最優先、ネット復旧後)
+#    B. α-7-FE 着手 (FE viewer + 統合 + Playwright + runbook 更新、cutover Step 6 前完了必須)
+#    C. 業務スーパー管理者連絡文案の送付判断 (decision-maker 領分、Session 52 から継続)
+#    D. cutover Step 1-2 (テナント opt-in + 配信曜日/時刻初期化、業務スーパー管理者 UI 操作)
+#    E. Phase 4 OQ #17 起票 (Evaluator エッジ-2/3 + F10 expired reserved promote、開発者明示指示前提)
+#    F. `Cleanup Orphan Auth Users` workflow_dispatch 手動実行 (Session 57 から継続)
 ```
 
-**次セッションの最初の一手**: Quality Gate 5 段階を fresh context で実施 (推奨)。これが完了するまで PR 作成は時期尚早。
+**次セッションの最初の一手**: ネット復旧確認 → 段階 4 (`/codex review`) → push + PR 作成 → 段階 5 (`/review-pr`)。
 
 ---
 
 ## 重要な作業内容 (本セッション)
 
-### 1. Session 57 ハンドオフ受領 + 優先順着手
+### 1. Quality Gate 段階 1: `/safe-refactor`
 
-Session 57 handoff の「次のアクション」(A/B/C/D) を優先順で受領し着手:
-1. ✅ A cutover Step 0a/0b 認可要請 → 開発者番号単位認可 → 実行 → Step 0c 確認
-2. ✅ B Phase 4 OQ 整理 spec 作成 → OQ #16 (dry-run UI) 採用決定
-3. ✅ C 業務スーパー管理者連絡文案 (3 回の改訂、専門用語削除 + 自律性反映 + 安全機能追加 cutover 遅延反映)
-4. ⏸️ D (別タスク) は未発生
+α-7-BE 14 production/test ファイルを分析し以下を抽出:
 
-### 2. Cutover Step 0a/0b/0c (Cloud Scheduler + TTL + WIF)
+- **M1**: scripts/dispatch-dry-run-cli.ts と scripts/progress-report-dry-run-cli.ts に完全重複していた Firebase Admin SDK 初期化 (約 22 行 × 2) を `scripts/lib/init-firebase-admin.ts` に集約
+- **M2**: 3 つの dry-run test ファイル (`progress-report-dry-run.test.ts` / `completion-notification-dry-run.test.ts` / `dispatch-dry-run.test.ts`) に重複していた `makeSettings` / `makeFixture` / `partialProgress` / `completedProgress` (各 40-50 行) を `services/api/src/services/dispatch/dry-run/__tests__/dry-run-fixtures.ts` に集約
+- **L1** (skip-branch repetition): readability 維持判断で保留 (decision-maker 判断不要、L1 ペースで follow-up)
 
-- **Step 0a**: `gcloud scheduler jobs create http dxcollege-progress-reports`
-  - schedule `30 * * * *` (JST、完了通知と 30 分ずらし)
-  - target `/api/v2/internal/dispatch/run-progress-reports`
-  - OIDC SA: `dxcollege-scheduler@lms-279.iam.gserviceaccount.com` (完了通知レーンと共用)
-  - `--max-retry-attempts=0` (AC-PR-06 occurrenceId 冪等化)
-- **Step 0b**: `gcloud firestore fields ttls update ttlExpireAt --collection-group=progress_report_sends --enable-ttl`
-  - state=ACTIVE、90 日保持 (AC-PR-17)
-  - Phase 4 OQ #13 注記クリア (フィールド名一致 `ttlExpireAt` 確認済)
-- **Step 0c**: WIF 確認 (read-only) — `github-actions@` SA に `roles/iam.workloadIdentityUser` 付与済
+結果: 1643 tests PASS 維持、-205 行 重複削減 + 170 行 helper 追加 = 純減 -35 行。
 
-### 3. Phase 4 OQ 整理 spec + OQ #16 採用決定
+### 2. Quality Gate 段階 2: `/code-review high`
 
-- `docs/specs/2026-06-03-phase-4-progress-report-followups.md` 新規作成
-- 15 件 (Phase 3 PR 3c-3e 由来) + **#16 (本セッション開発者指摘由来、dry-run UI 両レーン化)** = 16 件
-- 優先度試案: HIGH 3 (#10, #13, **#16 採用決定**) / MEDIUM 10 / LOW 3
-- 着手戦略試案: 8 PR 集約 (α-1〜α-7、α-7 最優先 + cutover Step 6 前完了必須)
-- **OQ #16 採用理由**: 「安全性が重要、寄与できる内容なら積極的に導入」(2026-06-03 開発者決裁)
-  - スコープ B: 進捗 + 完了通知の両レーン同時 UI 化 (UX 統一性)
-  - cutover Step 4-5 を画面化、業務スーパー管理者の自律的運用を実現
+7 angle (line-by-line / removed-behavior / cross-file / reuse / simplification / efficiency / altitude) × 約 42 候補を並列 finder で抽出、dedup + verify で 10 finding に絞り込み:
 
-### 4. α-7 impl-plan 起票 + Codex セカンドオピニオン反映
-
-- `docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md` 新規作成
-- タスク分解: A1+A2+B+C1+C2+C3+A3 (BE) + D1+D2+D3+E1+E2 (FE) = 12 タスク (BE 7 / FE 5)
-- **Codex セカンドオピニオン (thread `019e8fc7-...`)** で High 3 / Medium 3 / Low 1 件指摘
-  - High: discriminated union 厳密化 / DoS 対策 (専用 limiter + single-flight) / 完了通知 regression (service-level test)
-  - Medium: 規模見積もり ~1,500-2,000 LOC / AC-α7-09-13 追加 (a11y / responsive / empty / request control / data freshness) / 性能 AC を flaky 化しない形に
-  - Low: 旧 router/page コメント更新
-- **PR #490 撤廃理由の解消セクション新設**: 過去 6 撤廃理由 × 解消方針を 1:1 マッピング、test-send 機能の永久撤廃方針を維持
-
-### 5. α-7-BE 実装完了 (7 タスク、commit 234c4e1)
-
-| # | タスク | 結果 |
+| Finding | severity | 対応 |
 |---|---|---|
-| A1 | progress-report 共有 module 化 | service module + 17 unit tests PASS |
-| A2 | completion-notification 共有 module 化 | service module + 14 unit tests PASS (Codex 強化 5 パス) |
-| B | shared-types DTO discriminated union 追加 | `DispatchDryRunResult` + 9 関連型、shared-types build PASS |
-| C1 | BE endpoint + 専用 limiter + single-flight | 3 新規 file (route + middleware + service)、5 single-flight tests PASS |
-| C2 | dispatch-super-router.ts に dry-run router mount | DispatchSuperRouterDeps に loader 復活 (PR #490 削除分)、コメント更新 |
-| C3 | BE integration test + 完了通知 service-level regression | 15 tests PASS (200/500/limiter/独立 lane/完了通知 5 パス/PR #490 撤廃確認) |
-| A3 | CLI 2 本を薄 wrapper 化 + smoke 維持 | 出力 JSON 構造を `lane` field 除外で旧互換、両 smoke PASS |
+| F1 progress dry-run の eligibility.reason 非分岐 (overestimate) | HIGH | fix 済、`ineligibleCount` 新カウンタ追加 + 本番 processProgressUser:439-468 と一致 |
+| F2 shouldRunProgressReportNow check 欠落 | MEDIUM | follow-up (dry-run semantics は decision-maker 領分) |
+| F3 completionMessageBodyLength undefined throw | HIGH | fix 済、null fallback + DTO `number \| null` 拡張 |
+| F4 HTTP route logger NOOP silent fail | HIGH | fix 済、`createStructuredProgressDryRunLogger` 経由で `utils/logger.ts` を inject |
+| F5 両 lane 共有 limiter (10/min 全体) | MEDIUM | documented (route deps コメント、現実装は仕様通り) |
+| F6 limiter IP fallback collapse self-DoS | MEDIUM | fix 済、sentinel `ip:anonymous-no-ip` に変更 |
+| F7 single-flight cross-caller fail-fast | MEDIUM | documented (route deps コメントで意図明示) |
+| F8 completion lane `invalidEmailCount` 欠落 | MEDIUM | fix 済、DTO 拡張 + 進捗レーンと対称化 |
+| F9 storage 型レベル read-only 担保 (Pick narrow) | LOW-MEDIUM | fix 済、`Pick<DispatchStorage, "getDispatchSettings" \| "getCompletionNotification">` |
+| F10 completion existing notification expired reserved promote 欠落 | MEDIUM | Phase 4 OQ #17 候補 (DTO 拡張 + FE 連動が必要) |
 
-**最終検証**:
-- type-check 全 PASS
-- services/api 全 test **1643 PASS** (dry-run 関連 51 件追加、regression なし、flaky 1 件は外部要因)
-- progress-report-dry-run-cli + dispatch-dry-run-cli smoke 両方 PASS
+P0 (F3 / F4) + P1 (F1 / F6 / F8 / F9) = 6 件 fix + F5 / F7 documented を本 PR 内で完了。F2 / F10 は follow-up (OQ #17 候補)。
 
-### 6. 業務スーパー管理者連絡文案 (3 回改訂)
+### 3. Quality Gate 段階 3: Evaluator (別コンテキスト)
 
-- 初版: 専門用語 (Phase 3 / Cloud Scheduler / TTL / kill switch 等) 多用 → 開発者指摘
-- 改訂 2: 専門用語削除、業務語に置換 → 「ご相談したい」項目は画面で完結すべきと開発者指摘
-- 改訂 3: 「すべて管理画面でご操作いただけます」を明示 + 安全機能追加開発中 (cutover 遅延) を反映
-- **送信判断・送信操作は decision-maker 領分** (執筆完了、送信は開発者承認待ち)
+`rules/quality-gate.md` 発動条件 (5 ファイル以上 + 新機能) 該当のため `evaluator` subagent_type で AC-α7-05 / 06 / 07 / 08 / 12 を独立評価:
+
+| AC | 判定 | 根拠 |
+|---|---|---|
+| AC-α7-05 (super-admin 403) | **PARTIAL** | route test に 403 直接 assert 不在 → 本 PR 内で追加 fix 済 |
+| AC-α7-06 (read-only / test-send 不在 / dispatch-settings 不影響) | **PASS** | Pick narrow + 404 test + grep 検証で test-send 経路ゼロ確認 |
+| AC-α7-07 (CLI 互換 + 完了通知 5 パス regression) | **PASS** | service + route 双方 test で全パス確認 |
+| AC-α7-08 (Performance p95 5 秒以内) | **UNTESTABLE** | impl-plan 注記通り BE benchmark integration なし、InMemory で μs オーダー |
+| AC-α7-12 (limiter + single-flight) | **PASS** | limiter 429 + single-flight 5 unit test + route 429 確認 |
+
+**総合: READY-WITH-NOTES**。Evaluator 指摘 2 件 (AC-α7-05 403 / 限ter 両 lane 合算 budget) を本 PR 内で追加 test 化、エッジケース残 3 件は documented behavior or follow-up に分類。
+
+### 4. 2 commit に分割
+
+| commit | 内容 | 統計 |
+|---|---|---|
+| `fe9b429` refactor | safe-refactor M1/M2 (CLI init helper + test fixture file 新設) | 4 files, +193/-88 |
+| `260790d` feat | code-review F1-F9 反映 + Evaluator フォロー (限ter 両 lane / AC-α7-05 403) | 8 files, +377/-177 |
+
+`safe-refactor` M2 の test ファイル import 置換は feat commit に集約 (test に新 it block と混在するため file 単位で feat に含めた)。
+
+### 5. 業務スーパー管理者連絡 (Session 52 から継続)
+
+Session 58 で作成した連絡文案 (3 回改訂) に変化なし。送信判断・送信操作は decision-maker 領分。本セッションで追加対応なし。
 
 ---
 
-## Phase 4 OQ 累計 16 件 (本セッションで #16 採用決定)
+## DTO 拡張 (shared-types)
 
-詳細: `docs/specs/2026-06-03-phase-4-progress-report-followups.md`
+本セッションで `packages/shared-types/src/dispatch.ts` に追加:
 
-| 優先度 | 件数 | 主な内容 |
-|---|---|---|
-| HIGH | 3 | #10 (PUT silent fail) / #13 (TTL silent fail) / **#16 (dry-run UI 両レーン化、採用決定済)** |
-| MEDIUM | 10 | DRY 集約 / 並行更新 / 型整合 / 仕様拡張 (Retry-After) / 業務自律性 |
-| LOW | 3 | 命名 / 集約 / データ品質 |
+```ts
+// F1 反映
+ProgressDryRunTenantSummary.ineligibleCount: number
 
-**着手戦略試案 (8 PR 集約)**: α-1 (HIGH 集約) → **α-7 (dry-run UI、採用決定、最優先 + cutover Step 6 前完了必須)** → α-2 (設計品質集約) → α-3 (MIME 分離) → α-4 (AC 拡張) → α-5 (dispatch-settings 整合性) → α-6 (CLI 可観測性)
+// F3 反映
+CompletionDryRunResult.settingsSnapshot.completionMessageBodyLength: number | null
 
----
+// F8 反映
+CompletionDryRunTenantSummary.invalidEmailCount: number
+```
 
-## α-7-BE 実装統計
-
-- production code: 約 +830 (削除分込み、CLI wrapper 化で実質減)
-  - service module: progress 271 + completion 196 = 467
-  - shared-types DTO: +133
-  - middleware (limiter): 38
-  - service (single-flight): 57
-  - route (dispatch-dry-run): 83
-  - super-router edit: +25
-  - index.ts: +1
-- test code: 約 1,312
-  - progress-report unit: 385
-  - completion-notification unit: 382
-  - single-flight unit: 95
-  - dispatch-dry-run integration: 450
-- 合計: ~2,142 LOC (impl-plan 見積もり ~1,500-2,000 と概ね合致、test 多め)
-- commit: 16 files changed, +3,070 / -472
+**α-7-FE 着手前に `/impact-analysis` 実施推奨**: shared-types DTO 拡張 (3 件) で FE 連動が必要。FE viewer の skip 内訳表示 (AC-α7-04) で `ineligibleCount` / `invalidEmailCount` の UI 表現を要設計。
 
 ---
 
@@ -168,30 +152,51 @@ Session 57 handoff の「次のアクション」(A/B/C/D) を優先順で受領
 
 **Net=0 の理由言語化** (`feedback_issue_triage.md` 準拠):
 
-本セッションは Phase 4 α-7-BE 実装 (commit 234c4e1) + cutover Step 0a/0b/0c 完了 + impl-plan / OQ spec 起票が中心。triage 基準 (実害 / 再現バグ / CI 破壊 / rating ≥ 7 / ユーザー明示指示) を満たす個別タスク発生なし。
+本セッションは Phase 4 α-7-BE の Quality Gate 段階 1-3 完了 (refactor commit `fe9b429` + feat commit `260790d`) が中心。triage 基準 (実害 / 再現バグ / CI 破壊 / rating ≥ 7 / ユーザー明示指示) を満たす個別タスク発生なし。
 
-Codex セカンドオピニオン指摘 (High 3 / Medium 3 / Low 1) は本 PR 内で全反映、または impl-plan 内に明示記録のため Issue 化不要。Phase 4 OQ 16 件は spec ファイル (`docs/specs/2026-06-03-phase-4-progress-report-followups.md`) に集約管理しており、Issue 重複起票しない方針 (Session 56/57 と同パターン継続)。
+`/code-review high` で抽出した 10 finding (F1〜F9) のうち F1 (HIGH) / F3 (HIGH) / F4 (HIGH) / F6 (MEDIUM) / F8 (MEDIUM) / F9 (LOW-MEDIUM) は本 PR 内で全 fix。F5 / F7 は documented behavior として route deps コメントに明示 (現実装が仕様通り、test で granularity pin)。F2 (shouldRunProgressReportNow check) / F10 (expired reserved promote) は Phase 4 OQ #17 候補だが、起票には開発者明示指示が必要 (decision-maker 領分)。
 
-Net = 0 は本セッションの場合「α-7-BE 7 タスク完了 + cutover Step 0 完了 + 2 spec ファイル起票」を進捗として加味すべきで、`feedback_issue_triage.md` の「Net ≤ 0 は進捗ゼロ扱い」は新規スコープ追加時の警告であり、計画通りの実装完了フェーズでは適用外と判断。
+Evaluator の見落としエッジ 3 件のうち 2 件 (AC-α7-05 403 / 限ter 両 lane 合算) は本 PR 内で追加 test 化。残 1 件 (evaluateCompletionEligibility reason 新規追加時 auto-coverage exhaust check 不在) は defensive default (`reason !== "not_completed"` で skip 側に寄せる安全側設計) で future-proof のため Issue 化不要。
+
+ネットワーク不通で `gh issue list` 不可、Session 58 baseline (active 0 / postponed 4) からの変化未確認だが、本セッションで新規 Issue 起票なし + close なしのため Net=0 は確定。
+
+---
+
+## 構造的整合性チェック
+
+| 観点 | 該当 | 状態 |
+|---|---|---|
+| `/impact-analysis` (型・共有ロジック・設定ファイル) | ✅ 該当 (shared-types DTO 3 件拡張) | ⚠️ 未実施 (α-7-FE 着手前に推奨) |
+| `/new-resource` (新規テーブル/API) | ❌ 該当なし (前 commit で対応済) | ⏭️ スキップ |
+| `/trace-dataflow` (データフロー実装) | ❌ 該当なし (FE 不在、α-7-FE で実施) | ⏭️ スキップ |
+
+DTO 拡張は本 PR (BE のみ) に閉じるが、`ineligibleCount` / `invalidEmailCount` / `completionMessageBodyLength: number \| null` を FE viewer がどう表示するかは α-7-FE 設計時に impact-analysis で全 consumer を洗い出すべき。
+
+---
+
+## グローバル memory scope チェック
+
+本セッションで `memory/feedback_*.md` / `memory/reference_*.md` / `memory/MEMORY.md` への変更なし → **該当なし、スキップ**。
 
 ---
 
 ## 残課題 (開発者領分、AI 着手不可)
 
-1. **業務スーパー管理者への返信送付** — Session 52 から継続。本セッションで Phase 3 完結 + 安全機能追加開発中 + cutover 遅延を反映した文案 (3 回改訂) を作成済、送信判断 + 内容承認を待つ
-2. **α-7-BE Quality Gate 5 段階** — 次セッションで実施 (/safe-refactor → /code-review high → Evaluator → Codex → review-pr 5 agents)
-3. **α-7-BE PR 作成 → merge** — Quality Gate 合格後
-4. **α-7-FE 着手** — α-7-BE merge 後 (cutover Step 6 前完了必須)
-5. **cutover Step 1-2** (業務スーパー管理者 UI 操作) — テナント opt-in + 配信曜日/時刻初期化、α-7-BE/FE と並行可
-6. **`Cleanup Orphan Auth Users` workflow_dispatch 手動実行** (孤児 Auth 3 件掃除、Session 57 から継続)
+1. **業務スーパー管理者への返信送付** — Session 52 から継続、Session 58 文案 (3 回改訂、安全機能追加 + cutover 遅延反映) を送信判断待ち
+2. **α-7-BE Quality Gate 段階 4-5** — ネット復旧後に実施 (`/codex review` + push + PR 作成 + `/review-pr`)
+3. **α-7-BE PR 作成 → merge** — 段階 4-5 合格後
+4. **α-7-FE 着手** — α-7-BE merge 後、`/impact-analysis` で DTO 拡張の FE 影響洗い出し + Playwright + runbook 更新
+5. **cutover Step 1-2** — テナント opt-in + 配信曜日/時刻初期化、業務スーパー管理者 UI 操作
+6. **Phase 4 OQ #17 起票判断** — F2 (shouldRunProgressReportNow check) / F10 (expired reserved promote) を OQ spec に追記するか開発者判断
+7. **`Cleanup Orphan Auth Users` workflow_dispatch 手動実行** — Session 57 から継続、孤児 Auth 3 件掃除
 
 ---
 
 ## 次のアクション
 
-1. 開発者の指示に応じて A (Quality Gate) / B (PR 作成 merge) / C (α-7-FE 着手) / D (業務スーパー管理者連絡送付) / E (cutover Step 1-2) / F (別タスク) のいずれか
-2. Quality Gate 着手時は fresh context で /safe-refactor から順次
-3. PR 作成時は本 handoff commit を含めた状態で `gh pr create`、Test plan に dry-run endpoint 動作確認を必須化
+1. ネット復旧 → `git push -u origin feat/phase-4-pr-alpha-7-be-dry-run-ui` + `/codex review` + `gh pr create` + `/review-pr`
+2. PR 作成時は本 handoff commit を含めた 3 commits (`41ac184` Session 58 handoff + `fe9b429` refactor + `260790d` feat) + 本 handoff commit を含む
+3. Test plan には dry-run endpoint 動作確認 + AC-α7-05〜08 / 12 の BE 側担保項目を明記
 4. postponed Issue 4 件 (#274 / #275 / #276 / #405) は明示指示なき限り着手不可
 
-Phase 4 α-7 は本セッションで BE 7 タスク完了 + impl-plan + Codex 反映 + PR #490 撤廃理由解消まで進めた。次セッションは Quality Gate → PR merge → FE 着手のフェーズに入る。
+Phase 4 α-7-BE は本セッションで Quality Gate 段階 1-3 まで進めた。次セッションは段階 4-5 + PR merge → α-7-FE 着手のフェーズに入る。

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,23 +1,26 @@
-# Session Handoff — 2026-06-03 (Session 57)
+# Session Handoff — 2026-06-04 (Session 58)
 
 ## TL;DR
 
-Phase 3「進捗レポート 定期自動配信」の **PR 3d (#514) + PR 3e (#515) を本セッションで連続完成 → 両 PR merged**。これにより **Phase 3 全体が 5/5 完了で完結**。両 PR とも `/safe-refactor` → `/code-review` → Evaluator (PR 3d のみ、5+ ファイル + 新機能) → Codex セカンドオピニオン → `/pr-review-toolkit:review-pr` (5 specialized agents 並列) の **Quality Gate 5 段階完全実施**。指摘合計 80+ 件のうち、Critical / Important / 確認価値のあるものを本 PR 内で反映し、その他は **Phase 4 OQ 通算 15 件** (#1-7 前セッション、#8-9 PR 3d、#10-12 PR 3d review-pr、#13-15 PR 3e review-pr) として commit message + PR コメントに記録。
+Phase 4 α-7 (dry-run UI 両レーン化) **採用決定 + impl-plan 起票 + BE 実装完了**。同時に進捗レポート定期配信 cutover **Step 0a/0b/0c 完了** (Cloud Scheduler + Firestore TTL Policy + WIF 確認)。α-7-BE は 7 タスク全完了で 1 commit (`234c4e1`、16 files、+3,070/-472)。Quality Gate 5 段階は次セッションで実施 → PR 作成 → merge → α-7-FE 着手の流れ。
 
 | 主要成果 | 結果 |
 |---|---|
-| PR 3d 完成 + merged | ✅ PR #514 (squash `ce3285b`、6 files、+513/-12) |
-| PR 3e 完成 + merged | ✅ PR #515 (squash `f12a32e`、4 files、+1110/-0) |
-| Quality Gate 5 段階 × 2 PR | ✅ safe-refactor / code-review / Evaluator (3d のみ) / Codex / review-pr 5 agents |
-| review-pr 反映 commit | ✅ PR 3d f46449d (+64/-19)、PR 3e 958d5ad (+51/-21) |
-| Phase 3 完結 | ✅ 5/5 完了 (3-design / 3a / 3b / 3c / 3d / 3e すべて main 反映) |
-| Phase 4 OQ 累計 15 件記録 | ✅ #1-15、本ハンドオフ §Phase 4 OQ に列挙 |
+| Cutover Step 0a (Cloud Scheduler `dxcollege-progress-reports`) | ✅ 作成、毎時 30 分起動、初回 JST 21:30 |
+| Cutover Step 0b (Firestore TTL Policy `progress_report_sends.ttlExpireAt`) | ✅ state=ACTIVE、90 日保持 |
+| Cutover Step 0c (WIF 確認、read-only) | ✅ `github-actions@` SA バインド済 |
+| Phase 4 OQ 整理 spec | ✅ `docs/specs/2026-06-03-phase-4-progress-report-followups.md` (15 + #16 = 16 件) |
+| OQ #16 採用決定 (dry-run UI 両レーン化) | ✅ HIGH 採用、Codex セカンドオピニオン経由 |
+| α-7-BE impl-plan 起票 | ✅ `docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md` (Codex 反映 + PR #490 撤廃理由解消) |
+| α-7-BE 実装完了 (7 タスク) | ✅ commit `234c4e1`、type-check + 1643 tests + 両 smoke PASS |
+| 業務スーパー管理者連絡文案 | ✅ 作成済、送信判断は開発者領分 |
 
-- **Issue Net**: 0 件 (Close 0 / 起票 0、triage 基準を満たす個別タスク発生なし)
-- **マージ済 PR**: 2 件 (#514 / #515、本セッション handoff PR を除く)
-- **CI / Deploy**: ✅ 通常 CI 全 pass、`Deploy to Cloud Run` (PR #515 merge 後 in_progress、handoff 時点 52s 経過、本セッション handoff 時点で未完了 — 開発者領分)
+- **Issue Net**: 0 件 (Close 0 / 起票 0)
+- **マージ済 PR**: 0 件 (本セッションは α-7-BE 実装 commit のみ、PR 作成は次セッション)
+- **CI / Deploy**: ⏭️ α-7-BE commit は未 push、Quality Gate 完了後に PR 作成予定
 - **Open Issue**: active 0 / postponed 4 (#274 / #275 / #276 / #405、変化なし)
 - **残留プロセス**: ✅ なし
+- **未 push commit**: 1 件 (`234c4e1` on `feat/phase-4-pr-alpha-7-be-dry-run-ui`)
 
 ---
 
@@ -31,156 +34,164 @@ cat docs/handoff/LATEST.md
 git fetch origin main && git log --oneline -5 origin/main
 gh run list --branch main --limit 5
 
-# 3. Phase 3 完結状態の確認 (PR 3d/3e merged)
-gh pr view 514 --json state,mergedAt
-gh pr view 515 --json state,mergedAt
+# 3. α-7-BE feature ブランチに切替 (本セッションで未 push の commit あり)
+git checkout feat/phase-4-pr-alpha-7-be-dry-run-ui
+git log --oneline -3
 
-# 4. OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
+# 4. cutover 状態確認
+gcloud scheduler jobs describe dxcollege-progress-reports --location=asia-northeast1 --project=lms-279 --format="value(state,schedule)"
+gcloud firestore fields ttls list --project=lms-279 --database='(default)' --filter="name~progress_report_sends" --format="value(name,ttlConfig.state)"
+
+# 5. OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
 gh issue list --state open --limit 15
 
-# 5. 次の最有力候補 (開発者判断)
-#    A. cutover 開始: docs/runbook/dxcollege-progress-report-cutover.md Step 0a/0b の Cloud Scheduler + TTL Policy 作成認可
-#    B. Phase 4 OQ 15 件の impl-plan 整理 (#1-15 列挙は本ハンドオフ §Phase 4 OQ 参照)
-#    C. 業務スーパー管理者への Phase 3 完了 + テナント opt-in 説明
-#    D. 別タスク (開発者からの新規指示)
+# 6. 次の最有力候補 (開発者判断)
+#    A. α-7-BE の Quality Gate 5 段階 (/safe-refactor → /code-review high → Evaluator → Codex → review-pr 5 agents)
+#    B. 上記合格後 → α-7-BE PR 作成 → merge
+#    C. α-7-FE 着手 (FE viewer + 統合 + Playwright + runbook 更新)
+#    D. 業務スーパー管理者連絡文案の送付判断
+#    E. cutover Step 1-2 (テナント opt-in + 配信曜日/時刻初期化、業務スーパー管理者 UI 操作)
+#    F. 別タスク (開発者からの新規指示)
 ```
 
-**次セッションの最初の一手**: 開発者の指示に応じて A-D のいずれか。AI 単独で着手判断する経路はなし (cutover は番号単位明示認可必須、Phase 4 OQ は impl-plan 段階の設計判断要、業務スーパー管理者連絡は decision-maker 領分)。
+**次セッションの最初の一手**: Quality Gate 5 段階を fresh context で実施 (推奨)。これが完了するまで PR 作成は時期尚早。
 
 ---
 
 ## 重要な作業内容 (本セッション)
 
-### 1. Session 56 ハンドオフ受領 + 優先順着手
+### 1. Session 57 ハンドオフ受領 + 優先順着手
 
-Session 56 handoff の「次のアクション」(優先順) を受領し優先順に着手:
-1. ✅ Phase 3 PR 3d (super-admin API バリデーション + FE 設定 UI) 着手 → #514 merged
-2. ✅ Phase 3 PR 3e (Cloud Scheduler + TTL Policy + dry-run + runbook) 着手 → #515 merged
-3. (postponed Issue 4 件は着手不可、変化なし)
+Session 57 handoff の「次のアクション」(A/B/C/D) を優先順で受領し着手:
+1. ✅ A cutover Step 0a/0b 認可要請 → 開発者番号単位認可 → 実行 → Step 0c 確認
+2. ✅ B Phase 4 OQ 整理 spec 作成 → OQ #16 (dry-run UI) 採用決定
+3. ✅ C 業務スーパー管理者連絡文案 (3 回の改訂、専門用語削除 + 自律性反映 + 安全機能追加 cutover 遅延反映)
+4. ⏸️ D (別タスク) は未発生
 
-### 2. PR 3d 完成 + merged (#514、6 files、+513/-12)
+### 2. Cutover Step 0a/0b/0c (Cloud Scheduler + TTL + WIF)
 
-**スコープ**: super-admin の進捗レポート定期配信 UI 完成 (impl-plan §PR 3d)
-- BE `tenant-notification-cc.ts` に `progressReportEnabled` patch semantics 拡張 (InMemory + Firestore 両 store + PUT validation + response 拡張)
-- FE `dispatch-settings/page.tsx` に「進捗レポート 定期配信」セクション追加 (既存 `ScheduleEditor` 流用、always-send-all 戦略)
-- FE `TenantCcEditor.tsx` にテナント opt-in トグル UI 追加 (always-send-all、dirty 判定拡張)
-- AC-PR-04 / 05 / 11 / 18 / 19 / 22 を満たす実装
+- **Step 0a**: `gcloud scheduler jobs create http dxcollege-progress-reports`
+  - schedule `30 * * * *` (JST、完了通知と 30 分ずらし)
+  - target `/api/v2/internal/dispatch/run-progress-reports`
+  - OIDC SA: `dxcollege-scheduler@lms-279.iam.gserviceaccount.com` (完了通知レーンと共用)
+  - `--max-retry-attempts=0` (AC-PR-06 occurrenceId 冪等化)
+- **Step 0b**: `gcloud firestore fields ttls update ttlExpireAt --collection-group=progress_report_sends --enable-ttl`
+  - state=ACTIVE、90 日保持 (AC-PR-17)
+  - Phase 4 OQ #13 注記クリア (フィールド名一致 `ttlExpireAt` 確認済)
+- **Step 0c**: WIF 確認 (read-only) — `github-actions@` SA に `roles/iam.workloadIdentityUser` 付与済
 
-**Quality Gate 5 段階**:
-1. `/safe-refactor` → 問題なし
-2. `/code-review high` (7 angles × 1-vote verify) → 採用 fix 1 件 (Firestore payload spread 統一)
-3. Evaluator 分離 (5+ ファイル + 新機能、発動条件) → APPROVE
-4. Codex セカンドオピニオン → LOW 1 件反映 (true→false 明示 OFF テスト、truthy 退行防止)
-5. `/pr-review-toolkit:review-pr` (5 agents 並列) → Critical 3 + Important 2 件反映 (Phase 3 prefix 削除 + Codex 言及削除 + AC 番号修正 + 直交性テスト 2 件 + null 境界テスト追加)
+### 3. Phase 4 OQ 整理 spec + OQ #16 採用決定
 
-→ commit ce2184e (初版) + f46449d (review-pr 反映) → squash merged
+- `docs/specs/2026-06-03-phase-4-progress-report-followups.md` 新規作成
+- 15 件 (Phase 3 PR 3c-3e 由来) + **#16 (本セッション開発者指摘由来、dry-run UI 両レーン化)** = 16 件
+- 優先度試案: HIGH 3 (#10, #13, **#16 採用決定**) / MEDIUM 10 / LOW 3
+- 着手戦略試案: 8 PR 集約 (α-1〜α-7、α-7 最優先 + cutover Step 6 前完了必須)
+- **OQ #16 採用理由**: 「安全性が重要、寄与できる内容なら積極的に導入」(2026-06-03 開発者決裁)
+  - スコープ B: 進捗 + 完了通知の両レーン同時 UI 化 (UX 統一性)
+  - cutover Step 4-5 を画面化、業務スーパー管理者の自律的運用を実現
 
-### 3. PR 3e 完成 + merged (#515、4 files、+1110/-21)
+### 4. α-7 impl-plan 起票 + Codex セカンドオピニオン反映
 
-**スコープ**: 進捗レポート定期自動配信の cutover 支援 infrastructure (impl-plan §PR 3e)
-- `scripts/progress-report-dry-run-cli.ts` (406 行): read-only dry-run CLI (Gmail/PDF/Firestore write なし、対象人数 + 規模試算 + scale trigger 検知)
-- `scripts/__tests__/progress-report-dry-run-cli.smoke.ts` (125 行): node:assert smoke (型 sanity + 内訳保証 invariant)
-- `.github/workflows/progress-report-dry-run.yml` (141 行): workflow_dispatch + WIF + artifact + step summary
-- `docs/runbook/dxcollege-progress-report-cutover.md` (438 行): Step 0-8 段階 cutover、完了通知 cutover mirror
+- `docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md` 新規作成
+- タスク分解: A1+A2+B+C1+C2+C3+A3 (BE) + D1+D2+D3+E1+E2 (FE) = 12 タスク (BE 7 / FE 5)
+- **Codex セカンドオピニオン (thread `019e8fc7-...`)** で High 3 / Medium 3 / Low 1 件指摘
+  - High: discriminated union 厳密化 / DoS 対策 (専用 limiter + single-flight) / 完了通知 regression (service-level test)
+  - Medium: 規模見積もり ~1,500-2,000 LOC / AC-α7-09-13 追加 (a11y / responsive / empty / request control / data freshness) / 性能 AC を flaky 化しない形に
+  - Low: 旧 router/page コメント更新
+- **PR #490 撤廃理由の解消セクション新設**: 過去 6 撤廃理由 × 解消方針を 1:1 マッピング、test-send 機能の永久撤廃方針を維持
 
-**Quality Gate 5 段階**:
-1. `/safe-refactor` → 問題なし
-2. `/code-review medium` → Important 1 + Suggestion 1 反映 (jq null fallback、skipReason 型コメント整合)
-3. Evaluator → 該当 (新機能ではない infra 中心)、本 PR ではスキップ
-4. Codex セカンドオピニオン → High 1 + Medium 2 + Low 1 すべて反映
-   - **High**: cron URI 修正 (`/internal/dispatch/progress-reports` → `/api/v2/internal/dispatch/run-progress-reports`、404 silent fail 回避)
-   - **Medium 1**: SA 名統一 (`dispatch-scheduler` → `dxcollege-scheduler@lms-279.iam.gserviceaccount.com`、完了通知レーン共用)
-   - **Medium 2**: candidateCount 集計位置 + invalidEmailCount 追加 (dry-run skip 規模取りこぼし防止)
-   - **Low**: scale trigger 楽観性緩和 (>300 名は原則 Step 6 保留 + 3 選択肢明文化)
-5. `/pr-review-toolkit:review-pr` (5 agents 並列) → Critical 5 + Important 1 件反映
-   - comment-analyzer Critical 3 (AI レビュワー言及削除 + impl-plan § anchor 削除 → ADR-039 統一)
-   - silent-failure-hunter Critical 2 (workflow exit 0 → exit 1 + tenant_doc_not_found stderr WARN)
-   - code-reviewer + silent-failure-hunter (重複) Important (runbook L207 旧 SA 名残置 → 置換)
-   - type-design-analyzer Important (`skipReason: string` → `DryRunSkipReason` union literal)
+### 5. α-7-BE 実装完了 (7 タスク、commit 234c4e1)
 
-→ commit 0d1f248 (初版) + 958d5ad (review-pr 反映) → squash merged
+| # | タスク | 結果 |
+|---|---|---|
+| A1 | progress-report 共有 module 化 | service module + 17 unit tests PASS |
+| A2 | completion-notification 共有 module 化 | service module + 14 unit tests PASS (Codex 強化 5 パス) |
+| B | shared-types DTO discriminated union 追加 | `DispatchDryRunResult` + 9 関連型、shared-types build PASS |
+| C1 | BE endpoint + 専用 limiter + single-flight | 3 新規 file (route + middleware + service)、5 single-flight tests PASS |
+| C2 | dispatch-super-router.ts に dry-run router mount | DispatchSuperRouterDeps に loader 復活 (PR #490 削除分)、コメント更新 |
+| C3 | BE integration test + 完了通知 service-level regression | 15 tests PASS (200/500/limiter/独立 lane/完了通知 5 パス/PR #490 撤廃確認) |
+| A3 | CLI 2 本を薄 wrapper 化 + smoke 維持 | 出力 JSON 構造を `lane` field 除外で旧互換、両 smoke PASS |
 
-### 4. CI / Deploy
+**最終検証**:
+- type-check 全 PASS
+- services/api 全 test **1643 PASS** (dry-run 関連 51 件追加、regression なし、flaky 1 件は外部要因)
+- progress-report-dry-run-cli + dispatch-dry-run-cli smoke 両方 PASS
 
-- 通常 CI 全 pass (Build / Lint / Test / Type Check / Playwright E2E)
-- `Deploy to Cloud Run` workflow が PR #515 merge 後 in_progress (handoff 時点 52s 経過、本セッション handoff 時点で未完了 — 開発者領分)
+### 6. 業務スーパー管理者連絡文案 (3 回改訂)
 
----
-
-## Quality Gate 5 段階完全実施プロトコル (本セッションで確立)
-
-PR #514 / #515 両方で実施した順序を Phase 3 標準として記録:
-
-| 段階 | スキル / ツール | 目的 | 本セッション実績 |
-|---|---|---|---|
-| 1 | `/safe-refactor` | DRY / 未使用 / 複雑度 / 命名 / 型安全性 / エラー処理 簡易チェック | 両 PR とも問題なし |
-| 2 | `/code-review [effort]` | correctness bug 検出 (7 angles × 1-vote verify、high で再現性) | PR 3d high (採用 1)、PR 3e medium (採用 2) |
-| 3 | Evaluator 分離 (5+ ファイル + 新機能) | AC ベース PASS/FAIL/UNTESTABLE 判定 + 設計妥当性 + 見落としエッジケース | PR 3d 該当 → APPROVE、PR 3e 非該当 |
-| 4 | Codex セカンドオピニオン (3+ ファイル / 200+ 行) | 別 LLM の独立観点 | PR 3d LOW 1 件、PR 3e High 1 + Med 2 + Low 1 |
-| 5 | `/pr-review-toolkit:review-pr` (5 agents 並列) | code-reviewer / pr-test-analyzer / comment-analyzer / silent-failure-hunter / type-design-analyzer | PR 3d Critical 3 + Important 2、PR 3e Critical 5 + Important 1 |
-
-**確立した教訓**:
-- Quality Gate 4 段階だけでは comment-analyzer / silent-failure-hunter / type-design-analyzer の指摘 (PR 3d で Critical 3、PR 3e で Critical 5) を捕捉できない → **review-pr 5 agents を Phase 3 PR の標準として導入**
-- AI レビュワー言及 (`Codex MEDIUM 反映` 等) は CLAUDE.md 「現タスク参照禁止」違反として 2 PR 連続で同じ Critical を踏んだ → 次セッション以降コメント追記時に意識する
+- 初版: 専門用語 (Phase 3 / Cloud Scheduler / TTL / kill switch 等) 多用 → 開発者指摘
+- 改訂 2: 専門用語削除、業務語に置換 → 「ご相談したい」項目は画面で完結すべきと開発者指摘
+- 改訂 3: 「すべて管理画面でご操作いただけます」を明示 + 安全機能追加開発中 (cutover 遅延) を反映
+- **送信判断・送信操作は decision-maker 領分** (執筆完了、送信は開発者承認待ち)
 
 ---
 
-## Phase 4 OQ 累計 15 件 (次セッション以降の impl-plan 候補)
+## Phase 4 OQ 累計 16 件 (本セッションで #16 採用決定)
 
-前 Session 56 で #1-7 記録済、本セッションで #8-15 追加。すべて commit message + PR コメントに source 記載済。
+詳細: `docs/specs/2026-06-03-phase-4-progress-report-followups.md`
 
-### Session 56 由来 (#1-7)
-詳細: `docs/handoff/archive/2026-06-03-session-56.md` §Phase 4 OQ
+| 優先度 | 件数 | 主な内容 |
+|---|---|---|
+| HIGH | 3 | #10 (PUT silent fail) / #13 (TTL silent fail) / **#16 (dry-run UI 両レーン化、採用決定済)** |
+| MEDIUM | 10 | DRY 集約 / 並行更新 / 型整合 / 仕様拡張 (Retry-After) / 業務自律性 |
+| LOW | 3 | 命名 / 集約 / データ品質 |
 
-### PR 3d 由来 (#8-9、Codex MEDIUM)
-- **#8**: tenant CC API の always-send-all 戦略は version 管理なしで lost update リスク (現状 `completionNotificationEnabled` も同じ既存設計問題)
-- **#9**: tenant-notification-cc PUT response が `existing` 由来で構築、並行更新時に stale 値返却
+**着手戦略試案 (8 PR 集約)**: α-1 (HIGH 集約) → **α-7 (dry-run UI、採用決定、最優先 + cutover Step 6 前完了必須)** → α-2 (設計品質集約) → α-3 (MIME 分離) → α-4 (AC 拡張) → α-5 (dispatch-settings 整合性) → α-6 (CLI 可観測性)
 
-### PR 3d review-pr 由来 (#10-12)
-- **#10** (silent-failure-hunter C-1): PUT handler try-catch 欠落 + global error handler shape 不一致 (silent fail 経路)
-- **#11** (silent-failure-hunter I-3): `progressReport.enabled=true` + `scheduleDaysOfWeek=[]` の矛盾状態が save 可能で inline warning なし
-- **#12** (type-design-analyzer Critical): 型設計の 3 役兼任 (`TenantNotificationCcConfig` が storage / wire response / wire request) + `progressReportEnabled?` の 2 義性 (省略=保持 / 明示=置換)
+---
 
-### PR 3e 由来 + review-pr 由来 (#13-15)
-- **#13** (silent-failure-hunter I-2): Firestore TTL Policy `already exists` skip がフィールド名不一致を hide (`ttlExpireAt` 以外の名前で既存 TTL 登録 → 90 日保持 AC-PR-17 破綻リスク)
-- **#14** (silent-failure-hunter I-5): CLI tenant 走査の per-tenant error が全 tenant fail-stop + 失敗痕跡が tenantsSummary に残らないため debug 困難
-- **#15** (type-design-analyzer Important 集約): producer-side breakdown invariant assertion 不在 + `settingsLoaded` + `settingsSnapshot` redundant pair + `scaleTriggerExceeded` derived の同期問題 + PDF range ordering の型保証不在
+## α-7-BE 実装統計
 
-**OQ 整理の次セッション以降の進め方**:
-- 15 件を impl-plan の Phase 4 セクション (`docs/specs/2026-06-01-progress-report-dispatch-impl-plan.md` 既存 or 新規 `phase-4-*.md`) に転記
-- 優先度 (Critical / High / Medium / Low) を AI が試案 → 開発者が決裁
-- 1 OQ 1 PR の方針で順次着手 (Phase 3 PR のような 5 段階 Quality Gate を継続)
+- production code: 約 +830 (削除分込み、CLI wrapper 化で実質減)
+  - service module: progress 271 + completion 196 = 467
+  - shared-types DTO: +133
+  - middleware (limiter): 38
+  - service (single-flight): 57
+  - route (dispatch-dry-run): 83
+  - super-router edit: +25
+  - index.ts: +1
+- test code: 約 1,312
+  - progress-report unit: 385
+  - completion-notification unit: 382
+  - single-flight unit: 95
+  - dispatch-dry-run integration: 450
+- 合計: ~2,142 LOC (impl-plan 見積もり ~1,500-2,000 と概ね合致、test 多め)
+- commit: 16 files changed, +3,070 / -472
 
 ---
 
 ## Issue Net 変化
 
-- Close 数: 0 件
-- 起票数: 0 件
-- Net: 0 件
+- **Close 数**: 0 件
+- **起票数**: 0 件
+- **Net**: 0 件
 
-**理由**: 本セッションは Phase 3 PR 3d/3e の実装 + merge + Quality Gate 5 段階完全実施が中心。triage 基準 (実害 / 再現バグ / CI 破壊 / rating ≥7 / ユーザー明示指示) を満たす個別タスク発生なし。review-pr 由来の指摘は本 PR 内で対応 (Critical) または Phase 4 OQ として commit message + PR コメントに記録 (Important / Suggestion) で、Issue 起票不要。Phase 4 OQ #8-15 は **次セッションで impl-plan として整理する設計**、現時点で Issue 化するのは時期尚早 (rating 5-6 の review agent 提案を機械的 Issue 化しない方針、`feedback_issue_triage.md` 基準準拠)。
+**Net=0 の理由言語化** (`feedback_issue_triage.md` 準拠):
 
-Net = 0 は本セッションの場合「実装 PR 2 件 merge + Phase 3 完結」を進捗として加味すべきで、`feedback_issue_triage.md` の「Net ≤ 0 は進捗ゼロ扱い」は **新規スコープ追加時の警告** であり、計画通りの実装完了 fase では適用外と判断。
+本セッションは Phase 4 α-7-BE 実装 (commit 234c4e1) + cutover Step 0a/0b/0c 完了 + impl-plan / OQ spec 起票が中心。triage 基準 (実害 / 再現バグ / CI 破壊 / rating ≥ 7 / ユーザー明示指示) を満たす個別タスク発生なし。
+
+Codex セカンドオピニオン指摘 (High 3 / Medium 3 / Low 1) は本 PR 内で全反映、または impl-plan 内に明示記録のため Issue 化不要。Phase 4 OQ 16 件は spec ファイル (`docs/specs/2026-06-03-phase-4-progress-report-followups.md`) に集約管理しており、Issue 重複起票しない方針 (Session 56/57 と同パターン継続)。
+
+Net = 0 は本セッションの場合「α-7-BE 7 タスク完了 + cutover Step 0 完了 + 2 spec ファイル起票」を進捗として加味すべきで、`feedback_issue_triage.md` の「Net ≤ 0 は進捗ゼロ扱い」は新規スコープ追加時の警告であり、計画通りの実装完了フェーズでは適用外と判断。
 
 ---
 
 ## 残課題 (開発者領分、AI 着手不可)
 
-1. **業務スーパー管理者への返信送付** (Session 52 から継続中) — Phase 3 完結を共有し、cutover 開始の判断材料を提供
-2. **`Cleanup Orphan Auth Users` workflow_dispatch 手動実行** (孤児 Auth 3 件掃除、番号単位認可必要)
-3. **`Deploy to Cloud Run` 状況確認** (PR #515 merge 後 in_progress で離脱、本セッション handoff 時点未完了)
-4. **PR 3e cutover 開始判断** — `docs/runbook/dxcollege-progress-report-cutover.md` Step 0a/0b の Cloud Scheduler + TTL Policy 作成認可
-5. **Phase 4 OQ 15 件の impl-plan 反映可否判断** — `docs/specs/` 配下に Phase 4 spec 起票、優先度設定、着手順
-6. **AC-PR-20 Retry-After 対応方針** (本 PR 内 / Phase 4 / 仕様改訂、Session 56 から継続)
+1. **業務スーパー管理者への返信送付** — Session 52 から継続。本セッションで Phase 3 完結 + 安全機能追加開発中 + cutover 遅延を反映した文案 (3 回改訂) を作成済、送信判断 + 内容承認を待つ
+2. **α-7-BE Quality Gate 5 段階** — 次セッションで実施 (/safe-refactor → /code-review high → Evaluator → Codex → review-pr 5 agents)
+3. **α-7-BE PR 作成 → merge** — Quality Gate 合格後
+4. **α-7-FE 着手** — α-7-BE merge 後 (cutover Step 6 前完了必須)
+5. **cutover Step 1-2** (業務スーパー管理者 UI 操作) — テナント opt-in + 配信曜日/時刻初期化、α-7-BE/FE と並行可
+6. **`Cleanup Orphan Auth Users` workflow_dispatch 手動実行** (孤児 Auth 3 件掃除、Session 57 から継続)
 
 ---
 
 ## 次のアクション
 
-1. 開発者の指示に応じて A (cutover 開始認可) / B (Phase 4 OQ 整理着手) / C (業務スーパー管理者連絡) / D (別タスク) のいずれか
-2. cutover 着手時は runbook §Step 0a → 番号単位明示認可 → gcloud コマンド実行
-3. Phase 4 OQ 着手時は #1-15 から優先度判定 → 1 OQ 1 PR の方針で順次
+1. 開発者の指示に応じて A (Quality Gate) / B (PR 作成 merge) / C (α-7-FE 着手) / D (業務スーパー管理者連絡送付) / E (cutover Step 1-2) / F (別タスク) のいずれか
+2. Quality Gate 着手時は fresh context で /safe-refactor から順次
+3. PR 作成時は本 handoff commit を含めた状態で `gh pr create`、Test plan に dry-run endpoint 動作確認を必須化
 4. postponed Issue 4 件 (#274 / #275 / #276 / #405) は明示指示なき限り着手不可
 
-Phase 3 (進捗レポート定期自動配信) は本セッションで実装計画通り完結。次セッションは Phase 4 着手判断 or cutover 支援 or 別フェーズ着手のいずれか。
+Phase 4 α-7 は本セッションで BE 7 タスク完了 + impl-plan + Codex 反映 + PR #490 撤廃理由解消まで進めた。次セッションは Quality Gate → PR merge → FE 着手のフェーズに入る。

--- a/docs/handoff/archive/2026-06-03-session-57.md
+++ b/docs/handoff/archive/2026-06-03-session-57.md
@@ -1,0 +1,186 @@
+# Session Handoff — 2026-06-03 (Session 57)
+
+## TL;DR
+
+Phase 3「進捗レポート 定期自動配信」の **PR 3d (#514) + PR 3e (#515) を本セッションで連続完成 → 両 PR merged**。これにより **Phase 3 全体が 5/5 完了で完結**。両 PR とも `/safe-refactor` → `/code-review` → Evaluator (PR 3d のみ、5+ ファイル + 新機能) → Codex セカンドオピニオン → `/pr-review-toolkit:review-pr` (5 specialized agents 並列) の **Quality Gate 5 段階完全実施**。指摘合計 80+ 件のうち、Critical / Important / 確認価値のあるものを本 PR 内で反映し、その他は **Phase 4 OQ 通算 15 件** (#1-7 前セッション、#8-9 PR 3d、#10-12 PR 3d review-pr、#13-15 PR 3e review-pr) として commit message + PR コメントに記録。
+
+| 主要成果 | 結果 |
+|---|---|
+| PR 3d 完成 + merged | ✅ PR #514 (squash `ce3285b`、6 files、+513/-12) |
+| PR 3e 完成 + merged | ✅ PR #515 (squash `f12a32e`、4 files、+1110/-0) |
+| Quality Gate 5 段階 × 2 PR | ✅ safe-refactor / code-review / Evaluator (3d のみ) / Codex / review-pr 5 agents |
+| review-pr 反映 commit | ✅ PR 3d f46449d (+64/-19)、PR 3e 958d5ad (+51/-21) |
+| Phase 3 完結 | ✅ 5/5 完了 (3-design / 3a / 3b / 3c / 3d / 3e すべて main 反映) |
+| Phase 4 OQ 累計 15 件記録 | ✅ #1-15、本ハンドオフ §Phase 4 OQ に列挙 |
+
+- **Issue Net**: 0 件 (Close 0 / 起票 0、triage 基準を満たす個別タスク発生なし)
+- **マージ済 PR**: 2 件 (#514 / #515、本セッション handoff PR を除く)
+- **CI / Deploy**: ✅ 通常 CI 全 pass、`Deploy to Cloud Run` (PR #515 merge 後 in_progress、handoff 時点 52s 経過、本セッション handoff 時点で未完了 — 開発者領分)
+- **Open Issue**: active 0 / postponed 4 (#274 / #275 / #276 / #405、変化なし)
+- **残留プロセス**: ✅ なし
+
+---
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+# 1. 状況復元
+cat docs/handoff/LATEST.md
+
+# 2. main 最新と CI
+git fetch origin main && git log --oneline -5 origin/main
+gh run list --branch main --limit 5
+
+# 3. Phase 3 完結状態の確認 (PR 3d/3e merged)
+gh pr view 514 --json state,mergedAt
+gh pr view 515 --json state,mergedAt
+
+# 4. OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
+gh issue list --state open --limit 15
+
+# 5. 次の最有力候補 (開発者判断)
+#    A. cutover 開始: docs/runbook/dxcollege-progress-report-cutover.md Step 0a/0b の Cloud Scheduler + TTL Policy 作成認可
+#    B. Phase 4 OQ 15 件の impl-plan 整理 (#1-15 列挙は本ハンドオフ §Phase 4 OQ 参照)
+#    C. 業務スーパー管理者への Phase 3 完了 + テナント opt-in 説明
+#    D. 別タスク (開発者からの新規指示)
+```
+
+**次セッションの最初の一手**: 開発者の指示に応じて A-D のいずれか。AI 単独で着手判断する経路はなし (cutover は番号単位明示認可必須、Phase 4 OQ は impl-plan 段階の設計判断要、業務スーパー管理者連絡は decision-maker 領分)。
+
+---
+
+## 重要な作業内容 (本セッション)
+
+### 1. Session 56 ハンドオフ受領 + 優先順着手
+
+Session 56 handoff の「次のアクション」(優先順) を受領し優先順に着手:
+1. ✅ Phase 3 PR 3d (super-admin API バリデーション + FE 設定 UI) 着手 → #514 merged
+2. ✅ Phase 3 PR 3e (Cloud Scheduler + TTL Policy + dry-run + runbook) 着手 → #515 merged
+3. (postponed Issue 4 件は着手不可、変化なし)
+
+### 2. PR 3d 完成 + merged (#514、6 files、+513/-12)
+
+**スコープ**: super-admin の進捗レポート定期配信 UI 完成 (impl-plan §PR 3d)
+- BE `tenant-notification-cc.ts` に `progressReportEnabled` patch semantics 拡張 (InMemory + Firestore 両 store + PUT validation + response 拡張)
+- FE `dispatch-settings/page.tsx` に「進捗レポート 定期配信」セクション追加 (既存 `ScheduleEditor` 流用、always-send-all 戦略)
+- FE `TenantCcEditor.tsx` にテナント opt-in トグル UI 追加 (always-send-all、dirty 判定拡張)
+- AC-PR-04 / 05 / 11 / 18 / 19 / 22 を満たす実装
+
+**Quality Gate 5 段階**:
+1. `/safe-refactor` → 問題なし
+2. `/code-review high` (7 angles × 1-vote verify) → 採用 fix 1 件 (Firestore payload spread 統一)
+3. Evaluator 分離 (5+ ファイル + 新機能、発動条件) → APPROVE
+4. Codex セカンドオピニオン → LOW 1 件反映 (true→false 明示 OFF テスト、truthy 退行防止)
+5. `/pr-review-toolkit:review-pr` (5 agents 並列) → Critical 3 + Important 2 件反映 (Phase 3 prefix 削除 + Codex 言及削除 + AC 番号修正 + 直交性テスト 2 件 + null 境界テスト追加)
+
+→ commit ce2184e (初版) + f46449d (review-pr 反映) → squash merged
+
+### 3. PR 3e 完成 + merged (#515、4 files、+1110/-21)
+
+**スコープ**: 進捗レポート定期自動配信の cutover 支援 infrastructure (impl-plan §PR 3e)
+- `scripts/progress-report-dry-run-cli.ts` (406 行): read-only dry-run CLI (Gmail/PDF/Firestore write なし、対象人数 + 規模試算 + scale trigger 検知)
+- `scripts/__tests__/progress-report-dry-run-cli.smoke.ts` (125 行): node:assert smoke (型 sanity + 内訳保証 invariant)
+- `.github/workflows/progress-report-dry-run.yml` (141 行): workflow_dispatch + WIF + artifact + step summary
+- `docs/runbook/dxcollege-progress-report-cutover.md` (438 行): Step 0-8 段階 cutover、完了通知 cutover mirror
+
+**Quality Gate 5 段階**:
+1. `/safe-refactor` → 問題なし
+2. `/code-review medium` → Important 1 + Suggestion 1 反映 (jq null fallback、skipReason 型コメント整合)
+3. Evaluator → 該当 (新機能ではない infra 中心)、本 PR ではスキップ
+4. Codex セカンドオピニオン → High 1 + Medium 2 + Low 1 すべて反映
+   - **High**: cron URI 修正 (`/internal/dispatch/progress-reports` → `/api/v2/internal/dispatch/run-progress-reports`、404 silent fail 回避)
+   - **Medium 1**: SA 名統一 (`dispatch-scheduler` → `dxcollege-scheduler@lms-279.iam.gserviceaccount.com`、完了通知レーン共用)
+   - **Medium 2**: candidateCount 集計位置 + invalidEmailCount 追加 (dry-run skip 規模取りこぼし防止)
+   - **Low**: scale trigger 楽観性緩和 (>300 名は原則 Step 6 保留 + 3 選択肢明文化)
+5. `/pr-review-toolkit:review-pr` (5 agents 並列) → Critical 5 + Important 1 件反映
+   - comment-analyzer Critical 3 (AI レビュワー言及削除 + impl-plan § anchor 削除 → ADR-039 統一)
+   - silent-failure-hunter Critical 2 (workflow exit 0 → exit 1 + tenant_doc_not_found stderr WARN)
+   - code-reviewer + silent-failure-hunter (重複) Important (runbook L207 旧 SA 名残置 → 置換)
+   - type-design-analyzer Important (`skipReason: string` → `DryRunSkipReason` union literal)
+
+→ commit 0d1f248 (初版) + 958d5ad (review-pr 反映) → squash merged
+
+### 4. CI / Deploy
+
+- 通常 CI 全 pass (Build / Lint / Test / Type Check / Playwright E2E)
+- `Deploy to Cloud Run` workflow が PR #515 merge 後 in_progress (handoff 時点 52s 経過、本セッション handoff 時点で未完了 — 開発者領分)
+
+---
+
+## Quality Gate 5 段階完全実施プロトコル (本セッションで確立)
+
+PR #514 / #515 両方で実施した順序を Phase 3 標準として記録:
+
+| 段階 | スキル / ツール | 目的 | 本セッション実績 |
+|---|---|---|---|
+| 1 | `/safe-refactor` | DRY / 未使用 / 複雑度 / 命名 / 型安全性 / エラー処理 簡易チェック | 両 PR とも問題なし |
+| 2 | `/code-review [effort]` | correctness bug 検出 (7 angles × 1-vote verify、high で再現性) | PR 3d high (採用 1)、PR 3e medium (採用 2) |
+| 3 | Evaluator 分離 (5+ ファイル + 新機能) | AC ベース PASS/FAIL/UNTESTABLE 判定 + 設計妥当性 + 見落としエッジケース | PR 3d 該当 → APPROVE、PR 3e 非該当 |
+| 4 | Codex セカンドオピニオン (3+ ファイル / 200+ 行) | 別 LLM の独立観点 | PR 3d LOW 1 件、PR 3e High 1 + Med 2 + Low 1 |
+| 5 | `/pr-review-toolkit:review-pr` (5 agents 並列) | code-reviewer / pr-test-analyzer / comment-analyzer / silent-failure-hunter / type-design-analyzer | PR 3d Critical 3 + Important 2、PR 3e Critical 5 + Important 1 |
+
+**確立した教訓**:
+- Quality Gate 4 段階だけでは comment-analyzer / silent-failure-hunter / type-design-analyzer の指摘 (PR 3d で Critical 3、PR 3e で Critical 5) を捕捉できない → **review-pr 5 agents を Phase 3 PR の標準として導入**
+- AI レビュワー言及 (`Codex MEDIUM 反映` 等) は CLAUDE.md 「現タスク参照禁止」違反として 2 PR 連続で同じ Critical を踏んだ → 次セッション以降コメント追記時に意識する
+
+---
+
+## Phase 4 OQ 累計 15 件 (次セッション以降の impl-plan 候補)
+
+前 Session 56 で #1-7 記録済、本セッションで #8-15 追加。すべて commit message + PR コメントに source 記載済。
+
+### Session 56 由来 (#1-7)
+詳細: `docs/handoff/archive/2026-06-03-session-56.md` §Phase 4 OQ
+
+### PR 3d 由来 (#8-9、Codex MEDIUM)
+- **#8**: tenant CC API の always-send-all 戦略は version 管理なしで lost update リスク (現状 `completionNotificationEnabled` も同じ既存設計問題)
+- **#9**: tenant-notification-cc PUT response が `existing` 由来で構築、並行更新時に stale 値返却
+
+### PR 3d review-pr 由来 (#10-12)
+- **#10** (silent-failure-hunter C-1): PUT handler try-catch 欠落 + global error handler shape 不一致 (silent fail 経路)
+- **#11** (silent-failure-hunter I-3): `progressReport.enabled=true` + `scheduleDaysOfWeek=[]` の矛盾状態が save 可能で inline warning なし
+- **#12** (type-design-analyzer Critical): 型設計の 3 役兼任 (`TenantNotificationCcConfig` が storage / wire response / wire request) + `progressReportEnabled?` の 2 義性 (省略=保持 / 明示=置換)
+
+### PR 3e 由来 + review-pr 由来 (#13-15)
+- **#13** (silent-failure-hunter I-2): Firestore TTL Policy `already exists` skip がフィールド名不一致を hide (`ttlExpireAt` 以外の名前で既存 TTL 登録 → 90 日保持 AC-PR-17 破綻リスク)
+- **#14** (silent-failure-hunter I-5): CLI tenant 走査の per-tenant error が全 tenant fail-stop + 失敗痕跡が tenantsSummary に残らないため debug 困難
+- **#15** (type-design-analyzer Important 集約): producer-side breakdown invariant assertion 不在 + `settingsLoaded` + `settingsSnapshot` redundant pair + `scaleTriggerExceeded` derived の同期問題 + PDF range ordering の型保証不在
+
+**OQ 整理の次セッション以降の進め方**:
+- 15 件を impl-plan の Phase 4 セクション (`docs/specs/2026-06-01-progress-report-dispatch-impl-plan.md` 既存 or 新規 `phase-4-*.md`) に転記
+- 優先度 (Critical / High / Medium / Low) を AI が試案 → 開発者が決裁
+- 1 OQ 1 PR の方針で順次着手 (Phase 3 PR のような 5 段階 Quality Gate を継続)
+
+---
+
+## Issue Net 変化
+
+- Close 数: 0 件
+- 起票数: 0 件
+- Net: 0 件
+
+**理由**: 本セッションは Phase 3 PR 3d/3e の実装 + merge + Quality Gate 5 段階完全実施が中心。triage 基準 (実害 / 再現バグ / CI 破壊 / rating ≥7 / ユーザー明示指示) を満たす個別タスク発生なし。review-pr 由来の指摘は本 PR 内で対応 (Critical) または Phase 4 OQ として commit message + PR コメントに記録 (Important / Suggestion) で、Issue 起票不要。Phase 4 OQ #8-15 は **次セッションで impl-plan として整理する設計**、現時点で Issue 化するのは時期尚早 (rating 5-6 の review agent 提案を機械的 Issue 化しない方針、`feedback_issue_triage.md` 基準準拠)。
+
+Net = 0 は本セッションの場合「実装 PR 2 件 merge + Phase 3 完結」を進捗として加味すべきで、`feedback_issue_triage.md` の「Net ≤ 0 は進捗ゼロ扱い」は **新規スコープ追加時の警告** であり、計画通りの実装完了 fase では適用外と判断。
+
+---
+
+## 残課題 (開発者領分、AI 着手不可)
+
+1. **業務スーパー管理者への返信送付** (Session 52 から継続中) — Phase 3 完結を共有し、cutover 開始の判断材料を提供
+2. **`Cleanup Orphan Auth Users` workflow_dispatch 手動実行** (孤児 Auth 3 件掃除、番号単位認可必要)
+3. **`Deploy to Cloud Run` 状況確認** (PR #515 merge 後 in_progress で離脱、本セッション handoff 時点未完了)
+4. **PR 3e cutover 開始判断** — `docs/runbook/dxcollege-progress-report-cutover.md` Step 0a/0b の Cloud Scheduler + TTL Policy 作成認可
+5. **Phase 4 OQ 15 件の impl-plan 反映可否判断** — `docs/specs/` 配下に Phase 4 spec 起票、優先度設定、着手順
+6. **AC-PR-20 Retry-After 対応方針** (本 PR 内 / Phase 4 / 仕様改訂、Session 56 から継続)
+
+---
+
+## 次のアクション
+
+1. 開発者の指示に応じて A (cutover 開始認可) / B (Phase 4 OQ 整理着手) / C (業務スーパー管理者連絡) / D (別タスク) のいずれか
+2. cutover 着手時は runbook §Step 0a → 番号単位明示認可 → gcloud コマンド実行
+3. Phase 4 OQ 着手時は #1-15 から優先度判定 → 1 OQ 1 PR の方針で順次
+4. postponed Issue 4 件 (#274 / #275 / #276 / #405) は明示指示なき限り着手不可
+
+Phase 3 (進捗レポート定期自動配信) は本セッションで実装計画通り完結。次セッションは Phase 4 着手判断 or cutover 支援 or 別フェーズ着手のいずれか。

--- a/docs/handoff/archive/2026-06-04-session-58.md
+++ b/docs/handoff/archive/2026-06-04-session-58.md
@@ -1,0 +1,197 @@
+# Session Handoff — 2026-06-04 (Session 58)
+
+## TL;DR
+
+Phase 4 α-7 (dry-run UI 両レーン化) **採用決定 + impl-plan 起票 + BE 実装完了**。同時に進捗レポート定期配信 cutover **Step 0a/0b/0c 完了** (Cloud Scheduler + Firestore TTL Policy + WIF 確認)。α-7-BE は 7 タスク全完了で 1 commit (`234c4e1`、16 files、+3,070/-472)。Quality Gate 5 段階は次セッションで実施 → PR 作成 → merge → α-7-FE 着手の流れ。
+
+| 主要成果 | 結果 |
+|---|---|
+| Cutover Step 0a (Cloud Scheduler `dxcollege-progress-reports`) | ✅ 作成、毎時 30 分起動、初回 JST 21:30 |
+| Cutover Step 0b (Firestore TTL Policy `progress_report_sends.ttlExpireAt`) | ✅ state=ACTIVE、90 日保持 |
+| Cutover Step 0c (WIF 確認、read-only) | ✅ `github-actions@` SA バインド済 |
+| Phase 4 OQ 整理 spec | ✅ `docs/specs/2026-06-03-phase-4-progress-report-followups.md` (15 + #16 = 16 件) |
+| OQ #16 採用決定 (dry-run UI 両レーン化) | ✅ HIGH 採用、Codex セカンドオピニオン経由 |
+| α-7-BE impl-plan 起票 | ✅ `docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md` (Codex 反映 + PR #490 撤廃理由解消) |
+| α-7-BE 実装完了 (7 タスク) | ✅ commit `234c4e1`、type-check + 1643 tests + 両 smoke PASS |
+| 業務スーパー管理者連絡文案 | ✅ 作成済、送信判断は開発者領分 |
+
+- **Issue Net**: 0 件 (Close 0 / 起票 0)
+- **マージ済 PR**: 0 件 (本セッションは α-7-BE 実装 commit のみ、PR 作成は次セッション)
+- **CI / Deploy**: ⏭️ α-7-BE commit は未 push、Quality Gate 完了後に PR 作成予定
+- **Open Issue**: active 0 / postponed 4 (#274 / #275 / #276 / #405、変化なし)
+- **残留プロセス**: ✅ なし
+- **未 push commit**: 1 件 (`234c4e1` on `feat/phase-4-pr-alpha-7-be-dry-run-ui`)
+
+---
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+# 1. 状況復元
+cat docs/handoff/LATEST.md
+
+# 2. main 最新と CI
+git fetch origin main && git log --oneline -5 origin/main
+gh run list --branch main --limit 5
+
+# 3. α-7-BE feature ブランチに切替 (本セッションで未 push の commit あり)
+git checkout feat/phase-4-pr-alpha-7-be-dry-run-ui
+git log --oneline -3
+
+# 4. cutover 状態確認
+gcloud scheduler jobs describe dxcollege-progress-reports --location=asia-northeast1 --project=lms-279 --format="value(state,schedule)"
+gcloud firestore fields ttls list --project=lms-279 --database='(default)' --filter="name~progress_report_sends" --format="value(name,ttlConfig.state)"
+
+# 5. OPEN Issue (4 件すべて postponed、明示指示なき限り着手不可)
+gh issue list --state open --limit 15
+
+# 6. 次の最有力候補 (開発者判断)
+#    A. α-7-BE の Quality Gate 5 段階 (/safe-refactor → /code-review high → Evaluator → Codex → review-pr 5 agents)
+#    B. 上記合格後 → α-7-BE PR 作成 → merge
+#    C. α-7-FE 着手 (FE viewer + 統合 + Playwright + runbook 更新)
+#    D. 業務スーパー管理者連絡文案の送付判断
+#    E. cutover Step 1-2 (テナント opt-in + 配信曜日/時刻初期化、業務スーパー管理者 UI 操作)
+#    F. 別タスク (開発者からの新規指示)
+```
+
+**次セッションの最初の一手**: Quality Gate 5 段階を fresh context で実施 (推奨)。これが完了するまで PR 作成は時期尚早。
+
+---
+
+## 重要な作業内容 (本セッション)
+
+### 1. Session 57 ハンドオフ受領 + 優先順着手
+
+Session 57 handoff の「次のアクション」(A/B/C/D) を優先順で受領し着手:
+1. ✅ A cutover Step 0a/0b 認可要請 → 開発者番号単位認可 → 実行 → Step 0c 確認
+2. ✅ B Phase 4 OQ 整理 spec 作成 → OQ #16 (dry-run UI) 採用決定
+3. ✅ C 業務スーパー管理者連絡文案 (3 回の改訂、専門用語削除 + 自律性反映 + 安全機能追加 cutover 遅延反映)
+4. ⏸️ D (別タスク) は未発生
+
+### 2. Cutover Step 0a/0b/0c (Cloud Scheduler + TTL + WIF)
+
+- **Step 0a**: `gcloud scheduler jobs create http dxcollege-progress-reports`
+  - schedule `30 * * * *` (JST、完了通知と 30 分ずらし)
+  - target `/api/v2/internal/dispatch/run-progress-reports`
+  - OIDC SA: `dxcollege-scheduler@lms-279.iam.gserviceaccount.com` (完了通知レーンと共用)
+  - `--max-retry-attempts=0` (AC-PR-06 occurrenceId 冪等化)
+- **Step 0b**: `gcloud firestore fields ttls update ttlExpireAt --collection-group=progress_report_sends --enable-ttl`
+  - state=ACTIVE、90 日保持 (AC-PR-17)
+  - Phase 4 OQ #13 注記クリア (フィールド名一致 `ttlExpireAt` 確認済)
+- **Step 0c**: WIF 確認 (read-only) — `github-actions@` SA に `roles/iam.workloadIdentityUser` 付与済
+
+### 3. Phase 4 OQ 整理 spec + OQ #16 採用決定
+
+- `docs/specs/2026-06-03-phase-4-progress-report-followups.md` 新規作成
+- 15 件 (Phase 3 PR 3c-3e 由来) + **#16 (本セッション開発者指摘由来、dry-run UI 両レーン化)** = 16 件
+- 優先度試案: HIGH 3 (#10, #13, **#16 採用決定**) / MEDIUM 10 / LOW 3
+- 着手戦略試案: 8 PR 集約 (α-1〜α-7、α-7 最優先 + cutover Step 6 前完了必須)
+- **OQ #16 採用理由**: 「安全性が重要、寄与できる内容なら積極的に導入」(2026-06-03 開発者決裁)
+  - スコープ B: 進捗 + 完了通知の両レーン同時 UI 化 (UX 統一性)
+  - cutover Step 4-5 を画面化、業務スーパー管理者の自律的運用を実現
+
+### 4. α-7 impl-plan 起票 + Codex セカンドオピニオン反映
+
+- `docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md` 新規作成
+- タスク分解: A1+A2+B+C1+C2+C3+A3 (BE) + D1+D2+D3+E1+E2 (FE) = 12 タスク (BE 7 / FE 5)
+- **Codex セカンドオピニオン (thread `019e8fc7-...`)** で High 3 / Medium 3 / Low 1 件指摘
+  - High: discriminated union 厳密化 / DoS 対策 (専用 limiter + single-flight) / 完了通知 regression (service-level test)
+  - Medium: 規模見積もり ~1,500-2,000 LOC / AC-α7-09-13 追加 (a11y / responsive / empty / request control / data freshness) / 性能 AC を flaky 化しない形に
+  - Low: 旧 router/page コメント更新
+- **PR #490 撤廃理由の解消セクション新設**: 過去 6 撤廃理由 × 解消方針を 1:1 マッピング、test-send 機能の永久撤廃方針を維持
+
+### 5. α-7-BE 実装完了 (7 タスク、commit 234c4e1)
+
+| # | タスク | 結果 |
+|---|---|---|
+| A1 | progress-report 共有 module 化 | service module + 17 unit tests PASS |
+| A2 | completion-notification 共有 module 化 | service module + 14 unit tests PASS (Codex 強化 5 パス) |
+| B | shared-types DTO discriminated union 追加 | `DispatchDryRunResult` + 9 関連型、shared-types build PASS |
+| C1 | BE endpoint + 専用 limiter + single-flight | 3 新規 file (route + middleware + service)、5 single-flight tests PASS |
+| C2 | dispatch-super-router.ts に dry-run router mount | DispatchSuperRouterDeps に loader 復活 (PR #490 削除分)、コメント更新 |
+| C3 | BE integration test + 完了通知 service-level regression | 15 tests PASS (200/500/limiter/独立 lane/完了通知 5 パス/PR #490 撤廃確認) |
+| A3 | CLI 2 本を薄 wrapper 化 + smoke 維持 | 出力 JSON 構造を `lane` field 除外で旧互換、両 smoke PASS |
+
+**最終検証**:
+- type-check 全 PASS
+- services/api 全 test **1643 PASS** (dry-run 関連 51 件追加、regression なし、flaky 1 件は外部要因)
+- progress-report-dry-run-cli + dispatch-dry-run-cli smoke 両方 PASS
+
+### 6. 業務スーパー管理者連絡文案 (3 回改訂)
+
+- 初版: 専門用語 (Phase 3 / Cloud Scheduler / TTL / kill switch 等) 多用 → 開発者指摘
+- 改訂 2: 専門用語削除、業務語に置換 → 「ご相談したい」項目は画面で完結すべきと開発者指摘
+- 改訂 3: 「すべて管理画面でご操作いただけます」を明示 + 安全機能追加開発中 (cutover 遅延) を反映
+- **送信判断・送信操作は decision-maker 領分** (執筆完了、送信は開発者承認待ち)
+
+---
+
+## Phase 4 OQ 累計 16 件 (本セッションで #16 採用決定)
+
+詳細: `docs/specs/2026-06-03-phase-4-progress-report-followups.md`
+
+| 優先度 | 件数 | 主な内容 |
+|---|---|---|
+| HIGH | 3 | #10 (PUT silent fail) / #13 (TTL silent fail) / **#16 (dry-run UI 両レーン化、採用決定済)** |
+| MEDIUM | 10 | DRY 集約 / 並行更新 / 型整合 / 仕様拡張 (Retry-After) / 業務自律性 |
+| LOW | 3 | 命名 / 集約 / データ品質 |
+
+**着手戦略試案 (8 PR 集約)**: α-1 (HIGH 集約) → **α-7 (dry-run UI、採用決定、最優先 + cutover Step 6 前完了必須)** → α-2 (設計品質集約) → α-3 (MIME 分離) → α-4 (AC 拡張) → α-5 (dispatch-settings 整合性) → α-6 (CLI 可観測性)
+
+---
+
+## α-7-BE 実装統計
+
+- production code: 約 +830 (削除分込み、CLI wrapper 化で実質減)
+  - service module: progress 271 + completion 196 = 467
+  - shared-types DTO: +133
+  - middleware (limiter): 38
+  - service (single-flight): 57
+  - route (dispatch-dry-run): 83
+  - super-router edit: +25
+  - index.ts: +1
+- test code: 約 1,312
+  - progress-report unit: 385
+  - completion-notification unit: 382
+  - single-flight unit: 95
+  - dispatch-dry-run integration: 450
+- 合計: ~2,142 LOC (impl-plan 見積もり ~1,500-2,000 と概ね合致、test 多め)
+- commit: 16 files changed, +3,070 / -472
+
+---
+
+## Issue Net 変化
+
+- **Close 数**: 0 件
+- **起票数**: 0 件
+- **Net**: 0 件
+
+**Net=0 の理由言語化** (`feedback_issue_triage.md` 準拠):
+
+本セッションは Phase 4 α-7-BE 実装 (commit 234c4e1) + cutover Step 0a/0b/0c 完了 + impl-plan / OQ spec 起票が中心。triage 基準 (実害 / 再現バグ / CI 破壊 / rating ≥ 7 / ユーザー明示指示) を満たす個別タスク発生なし。
+
+Codex セカンドオピニオン指摘 (High 3 / Medium 3 / Low 1) は本 PR 内で全反映、または impl-plan 内に明示記録のため Issue 化不要。Phase 4 OQ 16 件は spec ファイル (`docs/specs/2026-06-03-phase-4-progress-report-followups.md`) に集約管理しており、Issue 重複起票しない方針 (Session 56/57 と同パターン継続)。
+
+Net = 0 は本セッションの場合「α-7-BE 7 タスク完了 + cutover Step 0 完了 + 2 spec ファイル起票」を進捗として加味すべきで、`feedback_issue_triage.md` の「Net ≤ 0 は進捗ゼロ扱い」は新規スコープ追加時の警告であり、計画通りの実装完了フェーズでは適用外と判断。
+
+---
+
+## 残課題 (開発者領分、AI 着手不可)
+
+1. **業務スーパー管理者への返信送付** — Session 52 から継続。本セッションで Phase 3 完結 + 安全機能追加開発中 + cutover 遅延を反映した文案 (3 回改訂) を作成済、送信判断 + 内容承認を待つ
+2. **α-7-BE Quality Gate 5 段階** — 次セッションで実施 (/safe-refactor → /code-review high → Evaluator → Codex → review-pr 5 agents)
+3. **α-7-BE PR 作成 → merge** — Quality Gate 合格後
+4. **α-7-FE 着手** — α-7-BE merge 後 (cutover Step 6 前完了必須)
+5. **cutover Step 1-2** (業務スーパー管理者 UI 操作) — テナント opt-in + 配信曜日/時刻初期化、α-7-BE/FE と並行可
+6. **`Cleanup Orphan Auth Users` workflow_dispatch 手動実行** (孤児 Auth 3 件掃除、Session 57 から継続)
+
+---
+
+## 次のアクション
+
+1. 開発者の指示に応じて A (Quality Gate) / B (PR 作成 merge) / C (α-7-FE 着手) / D (業務スーパー管理者連絡送付) / E (cutover Step 1-2) / F (別タスク) のいずれか
+2. Quality Gate 着手時は fresh context で /safe-refactor から順次
+3. PR 作成時は本 handoff commit を含めた状態で `gh pr create`、Test plan に dry-run endpoint 動作確認を必須化
+4. postponed Issue 4 件 (#274 / #275 / #276 / #405) は明示指示なき限り着手不可
+
+Phase 4 α-7 は本セッションで BE 7 タスク完了 + impl-plan + Codex 反映 + PR #490 撤廃理由解消まで進めた。次セッションは Quality Gate → PR merge → FE 着手のフェーズに入る。

--- a/docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md
+++ b/docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md
@@ -1,0 +1,423 @@
+# Phase 4 PR α-7 実装計画: dry-run UI 両レーン化
+
+OQ #16 (採用決定 2026-06-03、`docs/specs/2026-06-03-phase-4-progress-report-followups.md`) の実装計画。
+
+## ⚠️ PR #490 撤廃理由の解消 (2026-06-03、必読)
+
+**PR #490 (2026-05-24、merged)** で同じ dry-run UI が同一開発者の判断で撤廃された経緯あり。本セッションで「前提変化として再導入」を決裁 (4 原則 §1 decision-maker 判断、2026-06-03)。
+
+### 前提変化
+
+| 観点 | 過去 (PR #490) | 今回 (α-7) |
+|---|---|---|
+| フェーズ | 完了通知レーン単独の cutover 検証段階 (テスト的) | 進捗レポートの本格 cutover + 業務スーパー管理者の自律運用 |
+| 運用主体 | AI 主導 (workflow_dispatch) で開発者が代行 | 業務スーパー管理者本人が自律判断 |
+| UI 必要性 | テスト段階のため UI 不要 | 本番運用の自律判断のため UI 必須 |
+
+### 過去撤廃理由とその解消方針 (impl-plan で必ず守る)
+
+| 過去撤廃理由 (PR #490) | 今回の解消方針 (本 impl-plan で必須) |
+|---|---|
+| 「test-send / dry-run は本番運用では常用不要」 | 本番運用段階で業務スーパー管理者の自律的事前確認が必要に (前提変化、開発者決裁済) |
+| 「むだな UI を増やさない」 | 「自律性のために必須な UI」として位置付け、過剰機能は禁止 |
+| **「UI に残すと誤操作リスク (誤って本番受講者へ test-send 等)」** | **test-send 機能は再導入しない (本 PR では絶対に追加しない)**。dry-run viewer のみ |
+| 「AI 代替経路 (workflow_dispatch) で十分」 | 業務スーパー管理者が AI 経由なしで自律判断する設計、workflow_dispatch は AI / 開発者用途で並存 |
+| 「`enabled=true` 切替を AI が誤って操作するリスク」 | 本機能は **read-only viewer のみ**、settings 更新 endpoint は触らない (既存 PUT は不変) |
+| 「dry-run と settings 編集 UI が混在する誤操作リスク」 | dry-run viewer は **タブ分離** で settings 編集と視覚的にも分離 (AC-α7-12 で必須化) |
+
+### 過去撤廃の影響を受けるファイル (再作成 or 流用判断)
+
+| ファイル | 過去 PR #490 での扱い | 今回 α-7 での扱い |
+|---|---|---|
+| `services/api/src/routes/super/dispatch-dry-run.ts` | 削除 | **新規作成** (read-only、両レーン対応、過去より厳格な single-flight + limiter) |
+| `services/api/src/routes/super/__tests__/dispatch-dry-run.test.ts` | 削除 | **新規作成** (両レーン + regression test 強化) |
+| `web/app/super/dispatch-settings/components/DryRunPanel.tsx` | 削除 | **新規作成** (`_components/DryRunPreview.tsx` として、過去と異なり両レーン discriminated 設計) |
+| `services/api/src/routes/super/dispatch-test-send.ts` | 削除 | **再導入しない** (本 PR スコープ外、永久撤廃方針) |
+| `web/app/super/dispatch-settings/components/TestSendButton.tsx` | 削除 | **再導入しない** (本 PR スコープ外、永久撤廃方針) |
+| `services/api/src/middleware/rate-limiter.ts` (`testSendLimiter`) | 削除 | **再導入しない**。代わりに **新規 `dispatchDryRunLimiter`** を作成 (testSendLimiter とは別名・別設計) |
+| `packages/shared-types` の `DryRunResponse` / `DryRunTarget` | 削除 | **新規追加** (`DispatchDryRunResult` discriminated union として、過去型より厳格) |
+
+> 過去撤廃された型を **そのままの名前で復活させない**。名前重複で git log 検索性が崩れるため、新規名前 (`DispatchDryRunResult` / `DryRunPreview` / `dispatchDryRunLimiter`) を採用。
+
+## Codex セカンドオピニオン反映 (2026-06-03)
+
+Codex (thread `019e8fc7-441b-7653-9983-f5f4b6c2f251`) の独立観点レビューを反映済。主要指摘:
+
+| 優先度 | 指摘 | 反映先 |
+|---|---|---|
+| **High** | `DryRunResult` は optional だらけの lane-neutral ではなく **discriminated union** で厳密化 | §3 タスク B + §5 AC + §推奨 DTO 例 |
+| **High** | dry-run endpoint 専用の **連打防止 / レート制限 / single-flight** を AC 化 | §3 タスク C + §5 AC-α7-12 |
+| **High** | 完了通知 regression は CLI smoke だけに依存せず **service/endpoint test** を追加 | §3 タスク C3 + §5 AC-α7-07 強化 |
+| **Medium** | 規模見積もりを **~1,500-2,000 LOC** に更新、BE PR が +600 LOC 超で 3 PR 分割条件追記 | §3 タスク詳細 + §3 PR 分割 |
+| **Medium** | AC に **a11y / responsive / empty state / data freshness** 追加 | §5 AC-α7-09 〜 13 |
+| **Medium** | 性能 AC「5 秒以内」を flaky な絶対条件ではなく **p95 / timeout / 表示方針込み** に修正 | §5 AC-α7-08 |
+| **Low** | 既存 router / page の旧コメント更新を E1 に含める | §3 タスク E1 |
+
+## 1. ゴール
+
+業務スーパー管理者が **「誰に / 何通 / どれくらいの規模で」配信されるかを画面で事前確認** し、開発者経由なしに本番有効化を判断できる状態を作る。両レーン (進捗レポート + 完了通知) で UX を統一する。
+
+成功定義:
+- super-admin 画面に「配信前プレビュー」タブが両レーンに存在
+- 業務スーパー管理者が画面操作のみで dry-run 結果 (対象者一覧 + 推定通数 + 規模試算 + skip 理由内訳 + scaleTrigger 警告) を取得できる
+- cutover runbook の Step 4-5 (dry-run 取得 + 対象一覧レビュー) を画面操作に置換できる
+
+## 2. スコープ
+
+### 含むもの
+- BE: 既存 CLI ロジックの共有 module 化 + super-admin HTTP endpoint 追加 (両レーン)
+- FE: super-admin 画面に共通 dry-run viewer コンポーネント追加 (両レーン)
+- shared-types: dry-run DTO の lane-neutral 化と export
+- cutover runbook の Step 4-5 を画面操作版に更新
+- 既存 CLI / workflow_dispatch の入出力互換維持 (regression 回避)
+
+### スコープ外 (Phase 4 別 OQ で扱う)
+- dry-run 結果の Firestore キャッシュ / 履歴保持 (毎回オンザフライ実行)
+- 完了通知レーンの既存挙動・既存 endpoint の変更 (read-only 追加のみ)
+- α-1 (#10 / #13 silent fail 強化)、α-2 (DRY 集約)、α-3〜α-6 の改善
+- 業務スーパー管理者向けのチュートリアル動画 / 文書 (別タスク)
+
+### 永久に再導入しない (PR #490 撤廃方針を維持)
+- **test-send 機能** (実際にメール送信する機能、PR #490 撤廃理由「誤って本番受講者へ送信リスク」)
+- `dispatch-test-send.ts` route / `TestSendButton.tsx` / `testSendLimiter` / `TestSendResponse` / `TEST_SEND_DAILY_LIMIT` 等の関連シンボル
+- 過去型 `DryRunResponse` / `DryRunTarget` の **同名復活** (新型 `DispatchDryRunResult` を採用)
+
+### 将来の拡張
+- dry-run 結果の CSV エクスポート
+- 「特定テナントのみ」絞り込みプレビュー
+- PDF サイズ実測 (現状は経験値レンジ)
+
+## 3. タスクグラフ
+
+### 依存関係図
+```
+A1: BE 共有 module 化 (progress)
+A2: BE 共有 module 化 (completion)
+B:  shared-types DTO 追加 (lane-neutral) ← A 完了後
+C1: BE endpoint 新規 (両レーン) ← A1, A2, B 完了後
+C2: BE router mount + auth 統合 ← C1 完了後
+C3: BE integration test ← C1, C2 完了後
+A3: CLI スクリプトを薄い wrapper に書き換え ← A1, A2 完了後
+D1: FE 共通コンポーネント DryRunPreview ← B 完了後
+D2: FE dispatch-settings 統合 ← D1 完了後
+D3: FE データ取得 hook + loading/error state ← D1 完了後
+E1: cutover runbook 更新 ← C, D 完了後
+E2: Quality Gate 5 段階 ← E1 完了後
+```
+
+### 実行順序
+1. **PR α-7-BE**: A1 + A2 + B + C1 + C2 + C3 + A3 (BE 完結、merge 可能、CLI 互換維持)
+2. **PR α-7-FE**: D1 + D2 + D3 + E1 + E2 (FE 統合 + runbook + Quality Gate)
+
+> 2 PR 分割の根拠: 単一 PR (~500-800 LOC) は review-pr 5 agents の負荷が高い。BE merge → FE merge で半分ずつにし、各 PR で Quality Gate 5 段階を独立実施。BE 単独 merge 時点では UI 未提供だが既存挙動は不変。
+
+### タスク詳細
+
+| タスク | 概要 | 影響ファイル | 推定規模 | 並列可否 |
+|---|---|---|---|---|
+| **A1** | progress-report-dry-run-cli.ts から純粋ロジック分離 | `services/api/src/services/dispatch/dry-run/progress-report-dry-run.ts` (新) | 中 (~200 LOC) | ○ (A2 と並列) |
+| **A2** | dispatch-dry-run-cli.ts から純粋ロジック分離 | `services/api/src/services/dispatch/dry-run/completion-notification-dry-run.ts` (新) | 中 (~180 LOC) | ○ (A1 と並列) |
+| **B** | shared-types に **discriminated union** `DispatchDryRunResult = ProgressDryRunResult \| CompletionDryRunResult` + 共通 base + DryRunTenantSummary + DryRunSkipReason 追加。lane 別フィールド (進捗: estimatedPdfSizeKbRange / scaleTriggerExceeded / 完了: wouldNotify / mimePreview) は厳密に分離 (optional 大量化禁止、§推奨 DTO 例参照) | `packages/shared-types/src/dispatch.ts` | 中 (~120 LOC) | × (A 後) |
+| **C1** | BE endpoint 新規: GET `/api/v2/super/dispatch/dry-run/progress` + `/completion` + **専用 limiter (10 req/min/superAdminEmail)** + **single-flight 制御** (同一 lane 実行中の重複リクエストは 429 or 進行中結果共有) | `services/api/src/routes/super/dispatch-dry-run.ts` (新)、`services/api/src/middleware/dispatch-dry-run-limiter.ts` (新) | 中 (~200 LOC) | × (A,B 後) |
+| **C2** | dispatch-super-router.ts に dispatch-dry-run router mount + super-admin auth 適用 + 専用 limiter wire | `services/api/src/routes/super/dispatch-super-router.ts` | 小 (~15 LOC) | × (C1 後) |
+| **C3** | BE integration test 強化: 両 endpoint × 200/403/429/500、InMemoryDataSource、ADR-028。**完了通知 regression を CLI smoke だけに依存せず service/endpoint level で確認** (既通知除外 / tenant disable / invalid email / no published courses / MIME preview の全パスを test 化) | `services/api/src/routes/super/__tests__/dispatch-dry-run.test.ts` (新)、`services/api/src/services/dispatch/dry-run/__tests__/*.test.ts` (新) | 大 (~400 LOC) | × (C1, C2 後) |
+| **A3** | CLI 2 本を共有 module を呼ぶ薄い wrapper に書き換え (入出力互換 + smoke 維持) | `scripts/progress-report-dry-run-cli.ts`, `scripts/dispatch-dry-run-cli.ts`, `scripts/__tests__/*` | 小 (~60 LOC) | × (A 後) |
+| **D1** | 共通 DryRunPreview コンポーネント (props: lane, result, isLoading, error) | `web/app/super/dispatch-settings/_components/DryRunPreview.tsx` (新) | 中 (~200 LOC) | × (B 後) |
+| **D2** | dispatch-settings/page.tsx の両レーンセクションにプレビュータブ統合 | `web/app/super/dispatch-settings/page.tsx`, `_components/TenantCcEditor.tsx` (既存) | 中 (~120 LOC) | × (D1 後) |
+| **D3** | データ取得 hook (`useDryRun(lane)`) + loading / error / retry UI + **自動連打防止 (初回表示で自動取得しない、明示再取得ボタンのみ、実行中は同 lane disabled)** | `web/app/super/dispatch-settings/_hooks/useDryRun.ts` (新) | 中 (~120 LOC) | × (D1 後) |
+| **E1** | cutover runbook Step 4-5 を画面操作版に置換 + **「α-7 FE merge 前後は同時に配信設定を編集しない」運用ロック注記** (α-5 未実施の lost update リスク回避) + 既存 router / page の旧コメント更新 | `docs/runbook/dxcollege-progress-report-cutover.md`, `docs/runbook/dxcollege-completion-notification-cutover.md`, `services/api/src/routes/super/dispatch-super-router.ts`, `web/app/super/dispatch-settings/page.tsx` (コメント更新のみ) | 小 (~80 LOC) | × (D 後) |
+| **E2** | Quality Gate 5 段階 × 2 PR | (全 PR) | - | - |
+
+**合計規模見積もり (Codex 反映後更新)**: **~1,500-2,000 LOC** + test。production ~850-1,100 LOC、test ~650-900 LOC。Codex 指摘:
+- A3 「薄 wrapper 60 LOC」は低すぎる可能性 → 100-150 LOC に上振れ想定
+- C3 「両 endpoint × 状態 × 両レーン差分」は 250 LOC では不足 → 400 LOC に拡大
+- FE は Playwright + component + hook test 込みで 300-500 LOC
+
+### PR 分割の発動条件 (Codex 反映)
+
+- 基本: **2 PR** (α-7-BE → α-7-FE)
+- **3 PR 化発動条件**: BE PR が **+600 LOC 超** または CLI 出力互換テストが大幅追加になった場合、`α-7-BE-foundation` (A1 + A2 + B + A3 + service-level test) + `α-7-BE-endpoint` (C1 + C2 + C3 endpoint test) + `α-7-FE` (D + E) の 3 PR 化を許容
+- 判断は α-7-BE 実装中に LOC 計測時点で決裁
+
+## 4. 統合影響分析 (Phase 2.5)
+
+### 4.1 関連既存機能
+
+#### 依存する既存機能
+- `FirestoreDispatchStorage` / `FirestoreTenantDataLoader`: dry-run ロジックの read 源
+- `super-admin auth middleware` (`services/api/src/middleware/super-admin.ts`): 新規 endpoint も適用
+- `progress-pdf` モジュール: PDF サイズ推定の経験値 (実 generation はしない)
+- `dispatch.ts` 既存型 (`DispatchSettings` / `DispatchLane`): lane-neutral 設計の前提
+- `ADR-028 InMemoryDataSource`: BE integration test の中心
+
+#### 依存される可能性がある機能
+- 既存 `progress-report-dry-run.yml` / `dispatch-dry-run.yml` workflow: CLI 入出力互換が保たれる限り影響なし (A3 で確認)
+- 既存 super-admin 画面の他セクション (dispatch-runs / audit-logs): 影響なし (別タブ・別 endpoint)
+- cutover runbook Step 4-5: 操作手順が画面化される (E1 で更新)
+
+#### 関連 ADR / 仕様書
+- ADR-028 (InMemoryDataSource 中心の統合テスト): ✅ 踏襲
+- ADR-039 (Phase 3 進捗レポート): ✅ 整合
+- `docs/specs/2026-06-01-progress-report-dispatch-design.md`: dry-run 仕様の根拠
+- `docs/specs/2026-05-20-completion-notification-design.md`: 完了通知 dry-run 仕様
+
+### 4.2 E2E フロー
+
+#### メインフロー (本機能で実現したいもの)
+1. 業務スーパー管理者が `/super/dispatch-settings` を開く
+2. 「進捗レポート 定期配信」セクションの「配信前プレビュー」タブをクリック
+3. → FE が `GET /api/v2/super/dispatch/dry-run/progress` を叩く
+4. → BE が tenants/* + super_dispatch_settings/global を read、dry-run 結果を返却 (write なし)
+5. FE が結果表示 (対象者一覧 / 推定通数 / 推定処理時間 / scaleTrigger 警告 / skip 理由内訳)
+6. 業務スーパー管理者が内容確認 → 問題なければメインスイッチを ON
+7. → 既存 PR 3d のスイッチ ON フロー (`progressReport.enabled=true`) → 次の cron で送信開始
+
+#### 完了通知レーン版フロー
+1-5 と同じ、対象 endpoint = `/api/v2/super/dispatch/dry-run/completion`
+
+### 4.3 検証計画
+
+| レベル | 対象 | 必須 |
+|---|---|---|
+| 単体 | dry-run service module (A1, A2)、DryRunPreview コンポーネント (D1) | ✅ |
+| 統合 | BE endpoint × 認証 × InMemoryDataSource (C3) | ✅ |
+| E2E (Playwright) | dispatch-settings 画面でプレビュータブ → 表示 → メインスイッチ ON | ✅ (関連機能 2+ で必須) |
+| Regression | CLI 入出力互換 (A3 smoke 維持)、既存 workflow_dispatch dry-run 動作 | ✅ |
+
+## 5. Acceptance Criteria (Phase 2.7)
+
+### AC-α7-01 (機能)
+- **Given**: 業務スーパー管理者が認証済 / 進捗レーンの settings が存在
+- **When**: `/super/dispatch-settings` 画面で「進捗レポート 定期配信」セクションの「配信前プレビュー」タブをクリック
+- **Then**: dry-run 結果が表示される (対象者一覧 / 推定通数 / 推定処理時間 / 全テナント totalWouldSendCount)
+- **検証**: Playwright
+
+### AC-α7-02 (機能、完了通知レーン)
+- **Given**: AC-α7-01 と同条件、完了通知レーン側
+- **When**: 「完了通知メール」セクションの「配信前プレビュー」タブをクリック
+- **Then**: 完了通知レーンの dry-run 結果が表示される (同じ UI コンポーネントが使われる)
+- **検証**: Playwright
+
+### AC-α7-03 (UI: scale warning)
+- **Given**: dry-run 結果に `scaleTriggerExceeded=true` (>300 名超)
+- **When**: プレビュータブを開く
+- **Then**: 警告バナーが表示される (色 / アイコン / 文言: "受講者数 N 名は規模が大きいため、段階的な配信をご検討ください")
+- **検証**: Playwright + unit test
+
+### AC-α7-04 (UI: skip 理由内訳)
+- **Given**: tenantsSummary の少なくとも 1 件で `skipped=true`
+- **When**: プレビュータブを開く
+- **Then**: skip 理由 (progress_report_disabled / no_published_courses / tenant_not_active / tenant_doc_not_found) が表示される (テナント別、内訳件数付き)
+- **検証**: Playwright + unit test
+
+### AC-α7-05 (API: 認証)
+- **Given**: super-admin 以外の認証ユーザー or 未認証
+- **When**: `GET /api/v2/super/dispatch/dry-run/{progress|completion}` を叩く
+- **Then**: 403 Forbidden (super-admin only)
+- **検証**: integration test
+
+### AC-α7-06 (API: read-only 保証、PR #490 撤廃理由解消)
+- **Given**: dry-run endpoint を任意のタイミングで叩く
+- **When**: BE 処理完了
+- **Then**:
+  - Firestore **write** / Gmail **send** / PDF **generation** はすべて発生しない (CLI と同じく read-only)
+  - **test-send 機能は含まない** (実際に受講者へメール送信する経路は本 endpoint に存在しない、PR #490 撤廃理由「誤って本番受講者へ送信リスク」の解消)
+  - dispatch-settings PUT 経路への影響なし (`progressReport.enabled` 等の書き換えは別 endpoint で既存運用維持)
+- **検証**:
+  - integration test (Firestore write 監視 + Gmail send mock fail-on-call + PDF generation mock fail-on-call)
+  - grep で `test-send` / `TestSend` / `testSendLimiter` の本 PR への混入を否定
+  - 実装レビュー (D1 / C1 で `enabled` 更新経路が存在しないことを確認)
+
+### AC-α7-07 (Regression: CLI 互換 + 完了通知 service-level、Codex 反映で強化)
+- **Given (CLI 互換)**: 既存 `progress-report-dry-run.yml` / `dispatch-dry-run.yml` workflow の入力
+- **When**: A3 で書き換えた CLI を実行
+- **Then**: 出力 JSON 構造 / 値 / artifact フォーマットが書き換え前と一致
+- **検証 (CLI 互換)**: smoke test (既存 `scripts/__tests__/progress-report-dry-run-cli.smoke.ts` の値域不変)
+- **Given (完了通知 service regression)**: 完了通知レーンの dry-run service module を直接呼ぶ
+- **When**: 以下の各パスを実行 — (a) 既通知ユーザー除外、(b) tenant disable、(c) invalid email reject、(d) no published courses skip、(e) MIME preview 生成
+- **Then**: いずれも書き換え前の挙動と一致 (output 値同値、副作用なし)
+- **検証 (完了通知)**: service-level test (`services/api/src/services/dispatch/dry-run/__tests__/completion-notification-dry-run.test.ts` 新規)
+
+### AC-α7-08 (Performance、Codex 反映で flaky 化回避)
+- **Given**: テナント数 10、各テナント 100 名想定の Firestore
+- **When**: dry-run endpoint を叩く
+- **Then**:
+  - p95 目標 **5 秒以内** (絶対条件ではない)
+  - **10 秒超** で UI に「集計に時間がかかっています」表示
+  - FE timeout **30 秒** (タイムアウト時は明示 error + retry ボタン)
+- **検証**: integration test (p95 ベンチマーク 50 回 sampling、failure threshold p95 > 8s) + Playwright (10s/30s 表示)
+
+### AC-α7-09 (Accessibility、Codex 反映で追加)
+- **Given**: dry-run プレビュータブ
+- **When**: keyboard 操作 (Tab / Shift+Tab / Enter / Space) のみで操作
+- **Then**:
+  - すべてのインタラクティブ要素 (タブ / 再取得ボタン / 警告バナーのリンク) に focus が当たる
+  - 各要素に `aria-label` または可視ラベル
+  - focus visible (outline) が CSS で表示される
+  - 警告バナーは `role="alert"` (or `role="status"`)
+- **検証**: Playwright (keyboard navigation テスト) + axe-core (a11y violations)
+
+### AC-α7-10 (Responsive、Codex 反映で追加)
+- **Given**: 画面幅 **375px** (iPhone SE 想定)
+- **When**: dry-run プレビュータブを開く
+- **Then**:
+  - 対象者一覧 / skip 内訳 / 警告バナーが横崩れしない
+  - 長い email / tenantId は折り返し or `text-overflow: ellipsis` で省略
+  - タブ切替が縦並びに崩れず操作可能
+- **検証**: Playwright (375px viewport、768px viewport)
+
+### AC-α7-11 (Empty / Disabled State、Codex 反映で追加)
+- **Given**: 以下の状態のいずれか
+  - (a) 対象者 0 件 (totalWouldSendCount=0)
+  - (b) settings 未保存 (settingsLoaded=false)
+  - (c) lane disabled (進捗: progressReportEnabled=false / 完了: completionNotificationEnabled=false)
+  - (d) scheduleDaysOfWeek=[] (進捗の空配列)
+- **When**: プレビュータブを開く
+- **Then**: 非エンジニア向け文言で各状態を説明
+  - (a) "配信対象の受講者がいません"
+  - (b) "配信設定がまだ保存されていません。曜日と時刻を設定してください。"
+  - (c) "このレーンは現在 OFF です"
+  - (d) "配信曜日が選択されていません"
+- **検証**: Playwright + component unit test
+
+### AC-α7-12 (Request Control、Codex 反映で追加)
+- **Given**: super-admin がプレビュータブを開く
+- **When**: タブを開く / 再取得を試行
+- **Then**:
+  - 初回表示で自動連打しない (明示「再取得」ボタンで取得開始)
+  - 取得実行中は同 lane の再取得ボタン disabled
+  - BE 専用 limiter (10 req/min/superAdminEmail) を super-admin 単位で適用
+  - 同一 lane の同時実行は single-flight (重複は進行中結果共有 or 429)
+- **検証**: Playwright (連打防止) + integration test (limiter / single-flight)
+
+### AC-α7-13 (Data Freshness、Codex 反映で追加)
+- **Given**: dry-run 結果取得後
+- **When**: プレビュータブを表示
+- **Then**:
+  - `evaluatedAt` (取得時刻、JST 表示) を画面表示
+  - 5 分以上経過した場合「結果が古い可能性があります」インフォメッセージ
+  - cutover runbook Step 5 認可時刻と紐付けるための時刻表記が明示
+- **検証**: Playwright + component unit test
+
+## 6. 実行戦略 (Phase 3)
+
+### 6.1 並列化判断
+
+- **A1 と A2**: 並列実装可 (異なるファイル、異なるレーン)
+- **D1 と D3**: D1 が型・骨格、D3 が hook 実装、D1 完了後に D3 を進める
+- **BE PR (A,B,C,A3) と FE PR (D,E)**: 順次 (BE merge 待ち)
+- **Quality Gate 5 段階**: 各 PR 内で逐次
+
+### 6.2 エージェント活用
+
+| 段階 | エージェント |
+|---|---|
+| 詳細仕様確認 (A1/A2 実装前) | Explore (CLI 既存ロジック調査) |
+| 実装 (A1, A2 並列) | general-purpose |
+| BE endpoint 実装 (C1, C2) | general-purpose |
+| Test 実装 (C3) | general-purpose |
+| FE 実装 (D1, D2, D3) | general-purpose |
+| Quality Gate Evaluator (5+ ファイル + 新機能発動条件 ✅) | evaluator |
+| Codex セカンドオピニオン (3+ ファイル / 200+ 行) | Codex |
+| review-pr (5 agents 並列) | pr-review-toolkit:review-pr |
+
+### 6.3 品質ゲート (大規模)
+
+- PR α-7-BE: Lint + Type Check + Test + Build + `/safe-refactor` + `/code-review high` + Evaluator + Codex + `/pr-review-toolkit:review-pr`
+- PR α-7-FE: 同上 + Playwright E2E
+- 各 PR で AC-α7-01〜08 のうち該当する基準を検証
+
+### 6.4 cutover との関係
+
+- **cutover Step 1, 2** (テナント opt-in + 配信曜日・時刻初期化、業務スーパー管理者作業) は **本 PR と並行可** (進捗レーンは `enabled=false` の間 no-op、完了通知レーンは既稼働)
+- **cutover Step 3** (cron no-op 確認、AI 主導) も並行可
+- **cutover Step 4, 5** (dry-run + 認可) は **PR α-7-FE merge 後に画面操作化**
+- **cutover Step 6** (本番有効化) は **PR α-7-FE merge 後**
+
+## 7. リスクと緩和 (Codex 反映で強化)
+
+| リスク | 緩和策 |
+|---|---|
+| 完了通知レーン側で regression | endpoint は新規追加のみ、既存 endpoint 変更なし、**CLI 互換 (A3 smoke) + service-level test (C3) の 2 層** で守る (CLI smoke だけに依存しない、Codex High 指摘) |
+| dry-run の Firestore read 量増加で課金影響 | **1 回 dry-run で複数 Firestore read** が発生 (settings 1 + tenant docs N + users / course / progress / notification reads)。専用 limiter (10 req/min/superAdmin) + FE 自動連打防止 (明示再取得 + 実行中 disabled) + single-flight。Codex 高優先指摘 |
+| dry-run endpoint への DoS / 誤操作 | super-admin 限定だが誤操作・ブラウザ再試行・複数タブで read 蓄積。**専用 limiter (10 req/min/superAdminEmail) + lane 単位 single-flight** を AC-α7-12 で必須化 |
+| 業務スーパー管理者が UI を見ても判断できない | scaleTrigger 警告 + skip 理由内訳 + テナント別件数を明示。**AC-α7-11 (empty/disabled state) を非エンジニア向け文言で必須**。文言調整は E1 で実機確認 |
+| BE PR と FE PR の merge 順序遵守失敗 | BE PR を merge → FE PR は BE PR の commit を含む状態で開く |
+| Phase 4 OQ α-2 (DRY 集約) との競合 | α-7 は新規ファイル中心。**過度な共通化を避け、α-2 に再集約余地を残す** (Codex 指摘)。α-7 の共有 module は「両 CLI を呼ぶ純粋ロジック分離」に留め、lane-common 統合は α-2 に委ねる |
+| Phase 4 OQ α-1 (#10 / #13 silent fail) の先送りリスク | α-7 実装中に dispatch-settings PUT (#10) や TTL setup (#13) を触るなら、**α-1 を先行 or 同時実装** (Codex 指摘)。α-7 が触らないなら α-7 → α-1 で OK |
+| 完了通知レーンの A3 CLI 抽出による既存 workflow 影響 | 本番稼働中のため、CLI extraction の regression テストを **CLI smoke + service-level test の 2 層** で厚く守る |
+| **α-5 未実施の lost update リスク (Codex 指摘)** | dispatch-settings PUT は always-send-all 戦略で version 管理なし。α-7 FE 開発 / 確認と業務スーパー管理者の Step 1, 2 操作が重なる時間帯は **「同時編集しない」運用ロックを runbook E1 で注記** |
+| 設計判断の落とし穴: optional 大量化 | shared-types DryRunResult は **discriminated union** で厳密化 (Codex High 指摘)。lane 別 detail は subcomponent で受ける (§推奨 DTO 例) |
+| **PR #490 撤廃 UI 再導入の整合性** (2026-05-24 同一開発者判断との一見の矛盾) | 「前提変化」を decision-maker が決裁済 (2026-06-03)。本 impl-plan §「PR #490 撤廃理由の解消」で過去理由 6 件 × 解消方針を 1:1 マッピング。前提変化の継続性は cutover 後 3 ヶ月で再評価 (運用実績との整合確認) |
+| **test-send 機能の誤復活リスク** (実装中に「ついでに」復活させない) | スコープ外明示 + AC-α7-06 で grep 検証 + PR review で「test-send / TestSend / testSendLimiter / TEST_SEND_DAILY_LIMIT の本 PR への混入を否定」を必須化 |
+| 過去シンボル復活で git log 検索性低下 | 過去型 `DryRunResponse` / `DryRunTarget` の同名復活禁止。新規シンボル `DispatchDryRunResult` / `DryRunPreview` / `dispatchDryRunLimiter` を採用 |
+
+## 8. 推奨 DTO 例 (Codex 提供、High 指摘の具体化)
+
+shared-types に追加する型は **discriminated union** で厳密化。optional 大量化を避け、UI 側で判断材料が薄まらないようにする。
+
+```ts
+// packages/shared-types/src/dispatch.ts (タスク B で追加)
+
+export type DispatchDryRunResult = ProgressDryRunResult | CompletionDryRunResult;
+
+export interface DryRunBase {
+  lane: DispatchLane; // 既存型を活用
+  evaluatedAt: string; // ISO8601、AC-α7-13 で UI 表示
+  settingsLoaded: boolean;
+  tenantsScanned: number;
+  tenantsSummary: DryRunTenantSummary[];
+}
+
+export interface ProgressDryRunResult extends DryRunBase {
+  lane: "progress";
+  totalWouldSendCount: number;
+  totalCcCount: number;
+  estimatedDurationMs: number;
+  estimatedPdfSizeKbRange: { min: number; typical: number; max: number };
+  scaleTriggerExceeded: boolean; // AC-α7-03 警告バナー条件
+}
+
+export interface CompletionDryRunResult extends DryRunBase {
+  lane: "completion";
+  wouldNotifyCount: number;
+  wouldNotify: CompletionDryRunTarget[]; // 既存 DryRunTargetCli を移管
+  mimePreview: DryRunMimePreview[]; // 既存型を移管
+}
+
+// 共通フィールドのみ持つ TenantSummary (lane に依らない)
+export interface DryRunTenantSummary {
+  tenantId: string;
+  skipped: boolean;
+  skipReason?: DryRunSkipReason;
+  usersScanned: number;
+  // 以下は lane で意味が異なる場合は lane 別型に移すべき
+  // 進捗: candidateCount / invalidEmailCount / completedCount / wouldSendCount / ccCount
+  // 完了: wouldNotifyCount のみ
+  // → さらに分離する場合は ProgressDryRunTenantSummary / CompletionDryRunTenantSummary に discriminated union 化
+}
+
+export type DryRunSkipReason =
+  | "tenant_doc_not_found"
+  | "tenant_not_active"
+  | "progress_report_disabled"     // progress lane 専用
+  | "completion_notification_disabled" // completion lane 専用
+  | "no_published_courses";
+```
+
+**FE コンポーネント設計**:
+- 共通 shell: `DryRunPreview` (tabs, retry button, evaluatedAt 表示, error / loading state, AC-α7-12 連打防止)
+- lane 別 detail: `ProgressDryRunDetail` (scaleTrigger 警告 + PDF 試算 + 推定時間) / `CompletionDryRunDetail` (MIME preview + wouldNotify table)
+- 過剰共通化は禁止 (Codex 指摘): 完全共通 table に寄せると、完了通知の MIME preview と進捗の PDF/scale 試算のどちらかが薄くなる
+
+## 9. 関連リソース
+
+- Phase 4 OQ spec: `docs/specs/2026-06-03-phase-4-progress-report-followups.md` (OQ #16)
+- Phase 3 設計仕様: `docs/specs/2026-06-01-progress-report-dispatch-design.md`
+- Phase 3 完了通知設計: `docs/specs/2026-05-20-completion-notification-design.md`
+- cutover runbook (進捗): `docs/runbook/dxcollege-progress-report-cutover.md`
+- cutover runbook (完了通知): `docs/runbook/dxcollege-completion-notification-cutover.md`
+- 既存 dry-run CLI: `scripts/progress-report-dry-run-cli.ts`, `scripts/dispatch-dry-run-cli.ts`
+- shared-types: `packages/shared-types/src/dispatch.ts`
+- 既存 super-admin route: `services/api/src/routes/super/dispatch-super-router.ts`
+- 既存 dispatch-settings 画面: `web/app/super/dispatch-settings/page.tsx`

--- a/docs/specs/2026-06-03-phase-4-progress-report-followups.md
+++ b/docs/specs/2026-06-03-phase-4-progress-report-followups.md
@@ -1,0 +1,116 @@
+# Phase 4 進捗レポート follow-up OQ 整理 (試案)
+
+Phase 3 全 5 PR (#506 / #509 / #511 / #512 / #514 / #515) の Quality Gate 5 段階で発見された改善候補 15 件を **impl-plan 反映前の試案** として整理。
+
+優先度 (HIGH / MEDIUM / LOW) は AI 試案。**最終的な優先度・着手順は開発者決裁** (4 原則 §1)。
+
+実装計画 (`docs/specs/2026-06-01-progress-report-dispatch-impl-plan.md`) §「Phase 4 OQ」への正式転記 / spec 新設は本ドキュメント決裁後に実施。
+
+## TL;DR
+
+- **16 件**: PR 3c 由来 7 件 (OQ-A〜OQ-G)、PR 3d 由来 5 件 (#8-12)、PR 3e 由来 3 件 (#13-15)、業務スーパー管理者連絡文案レビュー由来 1 件 (#16)
+- **HIGH 確定 3 件** (#10、#13、**#16 採用決定**): silent fail 経路 + 業務安全性
+- **MEDIUM 候補 10 件**: 設計品質 / DRY / 並行更新 / 型整合 / 仕様拡張
+- **LOW 候補 3 件** (OQ-C / OQ-D / OQ-G): 命名 / 集約 / データ品質
+- **着手戦略 (#16 採用後)**: **α-7 (dry-run UI 両レーン化) を最優先**、cutover Step 6 (本番有効化) 前に完了必須
+
+## 採用決定 (2026-06-03、開発者決裁)
+
+- **OQ #16 採用** = dry-run UI (両レーン化スコープ B)
+  - 理由: 「今回の機能は安全性が重要」、寄与できる内容は積極導入の方針
+  - スコープ: **進捗レーン + 完了通知レーンの両方を同時 UI 化** (UX 統一性 + 業務スーパー管理者の運用習熟負担最小化)
+  - 着手順: **最優先**、cutover Step 6 (進捗レーン本番有効化) 前完了必須
+  - 規模見積もり: ~500-800 LOC (FE viewer + BE endpoint × 2 レーン、共通コンポーネント化前提)
+  - 完了通知レーン側のリスク: 既本番稼働中のため、追加 UI のみで既存挙動・既存 endpoint は変更しない (read-only viewer 追加のみ)
+
+## OQ 一覧 (優先度試案付き)
+
+| # | source | 内容 | 影響 | 優先度試案 | 集約 PR 案 |
+|---|---|---|---|---|---|
+| OQ-A | PR 3c code-review / Codex | `run-progress-reports.ts` ⇄ `run-completion-notifications.ts` の DRY 重複 (`sha256` / `runWithConcurrency` / `getHttpStatus` / `classifyAndRecord`) を `dispatch-lane-common.ts` に集約 | 保守性 | MEDIUM | PR α-2 |
+| OQ-B | PR 3c code-review / Evaluator | AC-PR-13 `pdf_too_large` 専用 counter を `RunProgressReportsResponse.pdfTooLarge` フィールドとして shared-types に追加 | 観測性 | MEDIUM | PR α-4 |
+| OQ-C | PR 3c code-review | lane name (`"completion"` / `"progress"`) の string が route 層と service 層で独立定義 → `computeOccurrenceId(laneId, scheduleTime)` を lane-neutral helper として共有化 | 設計整合 | LOW | PR α-2 |
+| OQ-D | PR 3c code-review | `cc-email-validator.ts` の partial-invalid 反応を高位 helper (`validateCcAndAudit`) として両レーンから呼び出す形に統合 | DRY | LOW | PR α-2 |
+| OQ-E | PR 3c code-review / 既存 OQ-5 | `gmail-dwd-send.ts` の MIME 構築部 (`buildMessageMime`) を `mime-builder.ts` に分離 (transport ⇄ encoding 分離) | 設計分離 | MEDIUM | PR α-3 |
+| OQ-F | PR 3c Evaluator FAIL | AC-PR-20 「Retry-After 尊重」が `executeSendWithRetry` に未実装。500 名超で 429 多発時に不十分の可能性 | 本番安定性 (大規模) | MEDIUM (規模次第で HIGH) | PR α-4 |
+| OQ-G | PR 3c Codex MEDIUM | `durationMs` の実処理時間化 (clock provider inject)。現状 `now - new Date(runStartedAt)` で同一 timestamp により基本 0ms | データ品質 | LOW | PR α-6 |
+| #8 | PR 3d Codex MEDIUM | tenant CC API の always-send-all 戦略は version 管理なしで lost update リスク (現状 `completionNotificationEnabled` も同じ既存設計問題) | 並行更新 | MEDIUM | PR α-5 |
+| #9 | PR 3d Codex MEDIUM | tenant-notification-cc PUT response が `existing` 由来で構築、並行更新時に stale 値返却 | 並行更新 | MEDIUM | PR α-5 |
+| #10 | PR 3d silent-failure C-1 | PUT handler try-catch 欠落 + global error handler shape 不一致 (silent fail 経路) | **silent fail (本番)** | **HIGH** | PR α-1 |
+| #11 | PR 3d silent-failure I-3 | `progressReport.enabled=true` + `scheduleDaysOfWeek=[]` の矛盾状態が save 可能で inline warning なし | 設定ミス検知 | MEDIUM | PR α-5 |
+| #12 | PR 3d type-design Critical | 型の 3 役兼任 (`TenantNotificationCcConfig` が storage / wire response / wire request) + `progressReportEnabled?` の 2 義性 (省略=保持 / 明示=置換) | 設計品質 | MEDIUM | PR α-2 |
+| #13 | PR 3e silent-failure I-2 | Firestore TTL Policy `already exists` skip がフィールド名不一致を hide (`ttlExpireAt` 以外の名前で既存 TTL 登録 → 90 日保持 AC-PR-17 破綻リスク) | **silent fail (AC 破綻)** | **HIGH** | PR α-1 |
+| #14 | PR 3e silent-failure I-5 | CLI tenant 走査の per-tenant error が全 tenant fail-stop + 失敗痕跡が tenantsSummary に残らないため debug 困難 | 可観測性 | MEDIUM | PR α-6 |
+| #15 | PR 3e type-design Important 集約 | producer-side breakdown invariant assertion 不在 + `settingsLoaded` + `settingsSnapshot` redundant pair + `scaleTriggerExceeded` derived の同期問題 + PDF range ordering の型保証不在 | 型/不変条件 | MEDIUM | PR α-2 |
+| #16 | 業務スーパー管理者連絡文案レビュー (本セッション、開発者指摘) | 配信前 dry-run (対象者一覧 + 推定通数 + 規模試算) を管理画面に表示する UI 追加。**両レーン (進捗 + 完了通知) 同時 UI 化**。現状 GitHub Actions workflow_dispatch でしか取得できず、業務スーパー管理者が画面で事前確認できない (Phase 3 設計時の見落とし) | **安全性 + 業務自律性 (運用影響大)** | **HIGH (採用決定)** | PR α-7 |
+
+## 着手戦略試案 (8 PR 集約)
+
+| PR 案 | 含む OQ | スコープ | 規模見積 | 優先順 |
+|---|---|---|---|---|
+| **PR α-1** (HIGH 集約) | #10、#13 | PUT handler error path 強化 + TTL Policy フィールド名検証 | 中規模 (~150-200 LOC) | **最優先** |
+| **PR α-2** (設計品質集約) | OQ-A、OQ-C、OQ-D、#12、#15 | `dispatch-lane-common.ts` 新設 + lane-neutral helper + 型分解 | 大規模 (~400-600 LOC) | 2 番目 |
+| **PR α-3** (MIME 分離) | OQ-E | `mime-builder.ts` 分離 | 中規模 (~150 LOC) | 3 番目 |
+| **PR α-4** (AC 拡張) | OQ-B、OQ-F | `pdf_too_large` counter + Retry-After 尊重 (仕様改訂 + AC 追加検討) | 中-大規模 (~250-350 LOC + 仕様調整) | 4 番目 |
+| **PR α-5** (dispatch-settings 整合性) | #8、#9、#11 | version 管理 (or optimistic lock) + PUT response 整合 + 矛盾 save 阻止 inline warning | 中規模 (~200-300 LOC) | 5 番目 |
+| **PR α-6** (CLI 可観測性) | #14、OQ-G | per-tenant error 痕跡 + clock provider inject (durationMs 実処理時間化) | 中規模 (~150-200 LOC) | 6 番目 |
+| **PR α-7** (dry-run UI 両レーン化) | #16 | super-admin 画面「ディスパッチ設定」に dry-run 結果表示 UI 追加 (対象者一覧 + 推定通数 + 規模試算 + skip 理由内訳 + scaleTrigger 警告)。**進捗 + 完了通知の両レーン同時 UI 化** (共通 viewer コンポーネント)。BE は既存 `progress-report-dry-run-cli.ts` / `dispatch-dry-run-cli.ts` の共通ロジックを HTTP endpoint 化 (read-only、既存挙動を変更しない) | 大規模 (~500-800 LOC、FE viewer + BE endpoint × 2 レーン) | **採用決定、最優先、cutover Step 6 前完了必須** |
+
+> α-1 / α-2 は依存関係なし、α-2 → α-3 → α-4 → α-5 → α-6 は緩い順序 (α-2 で集約した lane-common module を α-3 以降で参照する形)。**α-7 は採用決定済、最優先着手**。他 PR と独立着手可、cutover Step 4 / Step 5 を画面化するため **本番有効化 (Step 6) 前完了必須** (= cutover 開始は α-7 マージ後)。
+
+## 各 OQ の根拠リンク
+
+### PR 3c 由来 (OQ-A 〜 OQ-G)
+- archive: `docs/handoff/archive/2026-06-03-session-56.md` §「Phase 4 OQ 7 件」
+- PR: #512 commit message + handoff
+
+### PR 3d 由来 (#8-12)
+- PR: #514 commit message (Codex MEDIUM 反映 + review-pr 反映)
+- 詳細:
+  - #8、#9: Codex セカンドオピニオン thread
+  - #10: silent-failure-hunter Critical-1
+  - #11: silent-failure-hunter Important-3
+  - #12: type-design-analyzer Critical
+
+### PR 3e 由来 (#13-15)
+- PR: #515 commit message (Codex 反映 + review-pr 反映)
+- 詳細:
+  - #13: silent-failure-hunter Important-2
+  - #14: silent-failure-hunter Important-5
+  - #15: type-design-analyzer Important 集約
+
+### 本セッション由来 (#16)
+- 起点: 業務スーパー管理者連絡文案の改訂レビュー (2026-06-03)
+- 開発者指摘: 「テナント opt-in / 配信曜日・時刻 / メインスイッチ ON はすべて画面で完結すべきで、開発者を経由する設計だと運用上不便」
+- 検証で発覚: 配信前の対象者一覧確認 (dry-run) **のみ** GitHub Actions workflow_dispatch でしか取得できず、業務スーパー管理者の自律的運用に開発者経由が必要になる構造
+- Phase 3 設計時 (`docs/specs/2026-06-01-progress-report-dispatch-design.md`) で UI 化スコープに含めなかった見落としを Phase 4 で補う形
+
+## 開発者決裁ポイント (本ドキュメント承認時)
+
+1. **優先度試案** (HIGH 2 件 / MEDIUM 10 件 / LOW 3 件) の妥当性
+2. **OQ-F 優先度**: 受講者規模次第で HIGH 昇格を検討
+   - 全テナント合計 < 300 名 → MEDIUM 維持で可
+   - dry-run で 300 名近接 → HIGH 昇格
+3. **PR 集約方針** (α-1 〜 α-6) の妥当性
+   - 集約しすぎ ⇄ 細切れすぎのバランス
+   - α-2 の規模 (~400-600 LOC) は review-pr 5 agents 対応上限近接
+4. **着手順** (α-1 → α-2 → ... の順序)
+   - 並行可: α-1 と α-2 は独立着手可
+5. **impl-plan への反映タイミング**
+   - 即時: `2026-06-01-progress-report-dispatch-impl-plan.md` §「Phase 4 OQ」を本表で置換
+   - 別 spec: `docs/specs/2026-06-XX-phase-4-impl-plan.md` を新規作成 (impl-plan skill で正式化)
+6. **cutover との関係**
+   - α-1 (HIGH) は cutover 開始前に着手すべきか、cutover 後でも可か
+   - #13 (TTL Policy フィールド名検証) は Step 0b 実施前に対応する方が安全
+   - **α-7 (#16 dry-run UI)** は cutover Step 6 (本番有効化) 前に完了するのが望ましい (業務スーパー管理者の事前確認ステップを画面化、開発者経由を削減)
+7. **OQ #16 (dry-run UI) のスコープ — 採用決定済**
+   - 表示項目: 対象者一覧 / 推定通数 / 規模試算 / skip 理由内訳 / `scaleTriggerExceeded` 警告
+   - データ取得経路: 既存 `progress-report-dry-run-cli.ts` + `dispatch-dry-run-cli.ts` を共有 module 化 + HTTP endpoint で UI に提供
+   - 表示位置: super-admin「ディスパッチ設定」画面の各レーンセクション直下に "配信前プレビュー" タブ追加
+   - 両レーン UI 化: 進捗 + 完了通知の両方を同時 UI 化、共通 `DryRunPreview` コンポーネントで UX 統一
+   - 完了通知レーン側の保護: 既本番稼働中のため、追加 UI のみで既存 endpoint・既存挙動は変更しない (read-only viewer 追加のみ)
+   - 課金影響: dry-run 自体は Gmail / Firestore write を伴わないため軽量だが、PDF 試算ロジックの read 量を確認
+
+## Phase 4 OQ と postponed Issue の関係
+
+postponed Issue 4 件 (#274 / #275 / #276 / #405) はすべて allowed_emails / Gmail draft 系で **本 Phase 4 OQ と独立**。本 spec の集約 PR に含めない。

--- a/packages/shared-types/src/dispatch.ts
+++ b/packages/shared-types/src/dispatch.ts
@@ -493,6 +493,139 @@ export type ProgressReportClaimOutcome =
     };
 
 // ============================================================
+// Dry-Run DTO (Phase 4 α-7、PR #490 撤廃済型を別名で再導入)
+// ============================================================
+//
+// 進捗レポート + 完了通知の両レーンを **discriminated union** で厳密化。
+// PR #490 (2026-05-24) で撤廃された旧 `DryRunResponse` / `DryRunTarget` は
+// 同名復活させず、`DispatchDryRunResult` / `CompletionDryRunTarget` 等の
+// 別名で再導入する (git log 検索性 + 過去 PR との差別化)。
+//
+// 関連: docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md §「PR #490 撤廃理由の解消」
+// 関連: docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md §8 推奨 DTO 例
+
+/**
+ * 進捗レポート dry-run の skip 理由 (`skipped === true` のときのみ意味を持つ)。
+ *
+ * `tenant_doc_not_found` は listAllTenantIds() が tenantId を返したが tenants/{tid}
+ * doc が存在しない異常状態。logger 経由で運用者の注意を喚起する。
+ */
+export type ProgressDryRunSkipReason =
+  | "tenant_doc_not_found"
+  | "tenant_not_active"
+  | "progress_report_disabled"
+  | "no_published_courses";
+
+export interface ProgressDryRunTenantSummary {
+  tenantId: string;
+  skipped: boolean;
+  /** `skipped === true` のときのみ設定される */
+  skipReason?: ProgressDryRunSkipReason;
+  usersScanned: number;
+  /** listProgressReportTargetUsers の戻り値そのまま (進捗 1% 以上 + 期限内 + student) */
+  candidateCount: number;
+  /** email が cc-email-validator で reject された user 数 (送信不能) */
+  invalidEmailCount: number;
+  /** 100% 完了者 (進捗レーンは skip 対象、AC-PR-02。完了通知レーンがカバー済) */
+  completedCount: number;
+  /** 実送信対象数 = candidateCount - invalidEmailCount - completedCount */
+  wouldSendCount: number;
+  /** dedup 後の CC 件数 (ownerEmail + notificationCcEmails) */
+  ccCount: number;
+}
+
+/** 進捗レポート dry-run の戻り値。`lane: "progress"` で discriminated union のタグ化。 */
+export interface ProgressDryRunResult {
+  lane: "progress";
+  evaluatedAt: string;
+  settingsLoaded: boolean;
+  settingsSnapshot: {
+    progressReportEnabled: boolean;
+    scheduleDaysOfWeek: number[];
+    scheduleHourJst: number;
+    signatureName: string;
+  } | null;
+  tenantsScanned: number;
+  tenantsSummary: ProgressDryRunTenantSummary[];
+  /** 全テナント合算の実送信対象数 */
+  totalWouldSendCount: number;
+  /** 全テナント合算の CC 件数 (To 1 件あたり付与される CC の延べ数) */
+  totalCcCount: number;
+  /** 推定処理時間 (ミリ秒)、user 並列度 + PDF 生成経験値で算出 */
+  estimatedDurationMs: number;
+  /** 推定 PDF サイズ範囲 (KB)、PR 3a 以前の draft 経験値 */
+  estimatedPdfSizeKbRange: { min: number; typical: number; max: number };
+  /** scale trigger: 全テナント合計 300 名超で Cloud Tasks 移行検討 */
+  scaleTriggerExceeded: boolean;
+}
+
+/**
+ * 完了通知 dry-run の skip 理由。
+ *
+ * 注意: 進捗レポートと異なり `tenant_not_active` / `tenant_doc_not_found` は判定対象外
+ * (既存 CLI 挙動と整合、CC config の `completionNotificationEnabled` に統一)。
+ */
+export type CompletionDryRunSkipReason =
+  | "tenant_completion_notification_disabled"
+  | "no_published_courses";
+
+/** MIME プレビュー (CC dedup 後の最終形、completion lane のみで生成)。 */
+export interface DryRunMimePreview {
+  from: string;
+  to: string;
+  cc: string[];
+  subject: string;
+  body: string;
+}
+
+export interface CompletionDryRunTarget {
+  tenantId: string;
+  userId: string;
+  userEmail: string;
+  userName: string;
+  courseIdsSnapshot: string[];
+  mimePreview: DryRunMimePreview;
+}
+
+export interface CompletionDryRunTenantSummary {
+  tenantId: string;
+  skipped: boolean;
+  /** `skipped === true` のときのみ設定される */
+  skipReason?: CompletionDryRunSkipReason;
+  usersScanned: number;
+  eligibleCount: number;
+}
+
+/** 完了通知 dry-run の戻り値。`lane: "completion"` で discriminated union のタグ化。 */
+export interface CompletionDryRunResult {
+  lane: "completion";
+  evaluatedAt: string;
+  settingsLoaded: boolean;
+  settingsSnapshot: {
+    enabled: boolean;
+    scheduleDaysOfWeek: number[];
+    scheduleHourJst: number;
+    signatureName: string;
+    completionMessageBodyLength: number;
+  } | null;
+  tenantsScanned: number;
+  tenantsSummary: CompletionDryRunTenantSummary[];
+  wouldNotifyCount: number;
+  wouldNotify: CompletionDryRunTarget[];
+}
+
+/**
+ * 両レーン共通の戻り値型 (discriminated union)。
+ *
+ * FE 側で `result.lane === "progress"` の type narrowing により
+ * `result.totalWouldSendCount` 等の lane 固有 field に安全アクセスできる。
+ * `lane` field を必ず先頭で switch することで optional 大量化を避ける。
+ */
+export type DispatchDryRunResult =
+  | ProgressDryRunResult
+  | CompletionDryRunResult;
+
+// ============================================================
 // 制約値 (export して FE/BE で共有)
 // ============================================================
 

--- a/packages/shared-types/src/dispatch.ts
+++ b/packages/shared-types/src/dispatch.ts
@@ -528,7 +528,14 @@ export interface ProgressDryRunTenantSummary {
   invalidEmailCount: number;
   /** 100% 完了者 (進捗レーンは skip 対象、AC-PR-02。完了通知レーンがカバー済) */
   completedCount: number;
-  /** 実送信対象数 = candidateCount - invalidEmailCount - completedCount */
+  /**
+   * eligibility が `not_completed` 以外の `false` 状態 (missing_progress /
+   * malformed_progress / malformed_course / lesson_count_mismatch /
+   * no_published_courses) で本番 processProgressUser が skip + audit する不適格者数。
+   * Phase 4 α-7 code-review F1 反映: 本番との挙動一致のため dry-run でも分離計上。
+   */
+  ineligibleCount: number;
+  /** 実送信対象数 = candidateCount - invalidEmailCount - completedCount - ineligibleCount */
   wouldSendCount: number;
   /** dedup 後の CC 件数 (ownerEmail + notificationCcEmails) */
   ccCount: number;
@@ -594,6 +601,13 @@ export interface CompletionDryRunTenantSummary {
   skipReason?: CompletionDryRunSkipReason;
   usersScanned: number;
   eligibleCount: number;
+  /**
+   * email が cc-email-validator で reject された user 数 (送信不能)。
+   * Phase 4 α-7 code-review F8 反映: ProgressDryRunTenantSummary との対称性を回復し、
+   * cutover 認可で「想定 N 名のうち M 名が malformed email で silent skip される」事象を
+   * preview 段階で可視化する。
+   */
+  invalidEmailCount: number;
 }
 
 /** 完了通知 dry-run の戻り値。`lane: "completion"` で discriminated union のタグ化。 */
@@ -606,7 +620,12 @@ export interface CompletionDryRunResult {
     scheduleDaysOfWeek: number[];
     scheduleHourJst: number;
     signatureName: string;
-    completionMessageBodyLength: number;
+    /**
+     * Phase 4 α-7 code-review F3 反映: PutDispatchSettingsRequest の Partial 化
+     * (patch semantics) で completionMessageBody が undefined 状態でも 500 を起こさない
+     * よう null 許容に拡張。`null` は「doc は存在するが本文未設定」を表す。
+     */
+    completionMessageBodyLength: number | null;
   } | null;
   tenantsScanned: number;
   tenantsSummary: CompletionDryRunTenantSummary[];

--- a/scripts/__tests__/dispatch-dry-run-cli.smoke.ts
+++ b/scripts/__tests__/dispatch-dry-run-cli.smoke.ts
@@ -55,6 +55,9 @@ import {
     skipped: false,
     usersScanned: 10,
     eligibleCount: 1,
+    // Phase 4 α-7 Codex review (2026-06-04): F8 で進捗レーンと対称化された
+    // invalidEmailCount を smoke fixture に追加し、DTO 拡張時の回帰検知を機能させる。
+    invalidEmailCount: 0,
   };
   const result: DryRunResultCli = {
     evaluatedAt: "2026-05-23T12:00:00.000Z",
@@ -75,6 +78,13 @@ import {
   // 構造 invariants
   assert.equal(result.wouldNotifyCount, result.wouldNotify.length);
   assert.ok(result.tenantsSummary.every((s) => s.eligibleCount >= 0));
+  // F8 反映: invalidEmailCount は非負整数 (cc-email-validator で reject された送信不能数)
+  assert.ok(
+    result.tenantsSummary.every(
+      (s) => Number.isInteger(s.invalidEmailCount) && s.invalidEmailCount >= 0,
+    ),
+    "invalidEmailCount must be a non-negative integer",
+  );
   assert.match(target.mimePreview.from, /<.*@.*>$/, "from header MUST contain angle-bracketed email");
 }
 
@@ -86,6 +96,7 @@ import {
     skipReason: "tenant_completion_notification_disabled",
     usersScanned: 0,
     eligibleCount: 0,
+    invalidEmailCount: 0,
   };
   assert.equal(skipped.usersScanned, 0, "skipped tenant has 0 users scanned");
   assert.equal(skipped.eligibleCount, 0, "skipped tenant has 0 eligible");

--- a/scripts/__tests__/progress-report-dry-run-cli.smoke.ts
+++ b/scripts/__tests__/progress-report-dry-run-cli.smoke.ts
@@ -45,6 +45,9 @@ import {
     candidateCount: 10,
     invalidEmailCount: 2,
     completedCount: 1,
+    // Phase 4 α-7 Codex review (2026-06-04): F1 で追加された ineligibleCount を
+    // smoke fixture / invariant に追随させ、DTO 拡張時の回帰検知を機能させる。
+    ineligibleCount: 0,
     wouldSendCount: 7,
     ccCount: 2,
   };
@@ -75,10 +78,13 @@ import {
   assert.ok(
     result.tenantsSummary.every(
       (s) =>
-        s.wouldSendCount + s.completedCount + s.invalidEmailCount ===
+        s.wouldSendCount +
+          s.completedCount +
+          s.invalidEmailCount +
+          s.ineligibleCount ===
         s.candidateCount,
     ),
-    "candidateCount == wouldSendCount + completedCount + invalidEmailCount (内訳保証)",
+    "candidateCount == wouldSendCount + completedCount + invalidEmailCount + ineligibleCount (内訳保証、F1 反映)",
   );
   assert.ok(
     result.estimatedPdfSizeKbRange.min <= result.estimatedPdfSizeKbRange.typical &&
@@ -97,6 +103,7 @@ import {
     candidateCount: 0,
     invalidEmailCount: 0,
     completedCount: 0,
+    ineligibleCount: 0,
     wouldSendCount: 0,
     ccCount: 0,
   };

--- a/scripts/dispatch-dry-run-cli.ts
+++ b/scripts/dispatch-dry-run-cli.ts
@@ -33,16 +33,9 @@
  */
 
 import { pathToFileURL } from "node:url";
-import { readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { writeFileSync } from "node:fs";
 
-import {
-  applicationDefault,
-  cert,
-  initializeApp,
-  type ServiceAccount,
-} from "firebase-admin/app";
-import { getFirestore, type Firestore } from "firebase-admin/firestore";
+import type { Firestore } from "firebase-admin/firestore";
 
 import { FirestoreDispatchStorage } from "../services/api/src/services/dispatch/firestore-dispatch-storage.js";
 import { FirestoreTenantDataLoader } from "../services/api/src/services/dispatch/firestore-tenant-data-loader.js";
@@ -54,6 +47,11 @@ import type {
   CompletionDryRunTenantSummary,
   DryRunMimePreview as SharedDryRunMimePreview,
 } from "@lms-279/shared-types";
+import {
+  GCP_PROJECT_ID,
+  SENDER_EMAIL,
+  initFirestoreForCli,
+} from "./lib/init-firebase-admin.js";
 
 // ============================================================
 // 旧 CLI 公開型 (A3 wrapper 化、smoke test との 1:1 互換維持)
@@ -69,40 +67,9 @@ export type DryRunTenantSummary = CompletionDryRunTenantSummary;
  */
 export type DryRunResultCli = Omit<CompletionDryRunResult, "lane">;
 
-// ============================================================
-// 環境変数
-// ============================================================
-
-const GCP_PROJECT_ID =
-  process.env.GOOGLE_CLOUD_PROJECT ?? process.env.FIREBASE_PROJECT_ID ?? "lms-279";
-const SENDER_EMAIL = process.env.DXCOLLEGE_SENDER_EMAIL ?? "dxcollege@279279.net";
-
-// ============================================================
-// Firebase Admin SDK 初期化 (progress-report-dry-run-cli と同パターン)
-// ============================================================
-
-function initFirestore(): Firestore {
-  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-  if (credPath) {
-    const jsonPath = resolve(process.cwd(), credPath);
-    const credJson = JSON.parse(readFileSync(jsonPath, "utf-8")) as {
-      type?: string;
-    };
-    if (credJson.type === "service_account") {
-      initializeApp({ credential: cert(credJson as ServiceAccount) });
-      console.error(`[init] 認証: サービスアカウント JSON (${jsonPath})`);
-    } else {
-      initializeApp({ credential: applicationDefault() });
-      console.error(
-        `[init] 認証: ADC (cred file type=${credJson.type ?? "unknown"}, WIF 想定)`,
-      );
-    }
-  } else {
-    initializeApp({ credential: applicationDefault() });
-    console.error("[init] 認証: Application Default Credentials");
-  }
-  return getFirestore();
-}
+// 環境変数 (GCP_PROJECT_ID / SENDER_EMAIL) と Firebase Admin SDK 初期化は
+// scripts/lib/init-firebase-admin.ts に集約 (safe-refactor M1)。
+// 旧 `initFirestore()` ローカル定義は撤去。
 
 // ============================================================
 // CLI wrapper エントリ (service module 呼出 + lane field 除外で旧互換維持)
@@ -132,7 +99,7 @@ async function main(): Promise<void> {
   console.error(`  sender:  ${SENDER_EMAIL}`);
   console.error("");
 
-  const db = initFirestore();
+  const db = initFirestoreForCli();
   const result = await runDryRunCli(db);
 
   // stdout に JSON 出力 (workflow log でも見える)

--- a/scripts/dispatch-dry-run-cli.ts
+++ b/scripts/dispatch-dry-run-cli.ts
@@ -1,26 +1,21 @@
 #!/usr/bin/env npx tsx
 /**
- * DXcollege 自動完了通知 dry-run admin SDK CLI (Phase 8 Step 5 代替)。
+ * DXcollege 自動完了通知 dry-run admin SDK CLI (Phase 4 α-7 A3 で薄 wrapper 化)。
  *
- * 目的:
- *   `/super/dispatch-settings` UI の「ドライラン」ボタン (`/api/v2/super/dispatch/dry-run`)
- *   を経由せず、Firestore admin SDK で直接対象一覧 + MIME プレビューを取得する。
- *   既存 UI / API endpoint は撤廃予定 (PR-B) のため、本 CLI が cutover 検証手段。
+ * 純粋ロジックは `services/api/src/services/dispatch/dry-run/completion-notification-dry-run.ts`
+ * に移管済 (HTTP endpoint と共有)。本 CLI は以下の責務に絞った薄 wrapper:
+ *   - Firebase Admin SDK の初期化 (CLI 環境固有: GOOGLE_APPLICATION_CREDENTIALS / ADC)
+ *   - service module の呼び出し
+ *   - 出力 JSON 書き出し (stdout + artifact file)
+ *   - workflow log 向けの summary stderr
  *
- *   完全 read-only:
- *     - Gmail 送信なし
- *     - Firestore write なし (settings / dispatch_runs / completion_notifications いずれも write しない)
- *     - 既存 `services/api/src/services/dispatch/{firestore-tenant-data-loader,firestore-dispatch-storage}`
- *       を直接利用するため本番ロジックと query 構造が完全一致 (重複再実装によるドリフトを回避)。
+ * 出力 JSON 構造は α-7 以前 (本 wrapper 化前) と **1:1 互換** を維持:
+ *   - 旧 `DryRunResultCli` 型 = shared-types `CompletionDryRunResult` から `lane` field を除外
+ *   - 既存 `dispatch-dry-run-result-*.json` artifact の構造を変えない
  *
- * 動作:
- *   1. super_dispatch_settings/global 読み取り (default にフォールバック)
- *   2. tenants 一覧取得 → 各 tenant について completionNotificationEnabled チェック
- *   3. published courses + users を走査
- *   4. evaluateCompletionEligibility で 100% 完了判定
- *   5. completion_notifications/{userId} 存在チェック (既送信は除外)
- *   6. 各 user 向け MIME プレビュー (件名/本文/署名/CC) を組み立て
- *   7. 結果を JSON で stdout + `dispatch-dry-run-result-<ts>.json` に出力
+ * 完全 read-only:
+ *   - Gmail 送信なし
+ *   - Firestore write なし
  *
  * 使用方法:
  *   # ローカル (ADC 経由)
@@ -32,9 +27,9 @@
  *   GitHub Actions UI > Dispatch Dry Run > Run workflow
  *
  * 関連:
- *   - 設計仕様書 §8 (Phase 8 cutover) / AC-8 (dry-run は read-only)
+ *   - impl-plan: docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md §3 タスク A3
+ *   - service module: services/api/src/services/dispatch/dry-run/completion-notification-dry-run.ts
  *   - playbook: docs/runbook/dxcollege-completion-notification-cutover.md Step 5
- *   - 既存 API endpoint (撤廃予定): services/api/src/routes/super/dispatch-dry-run.ts
  */
 
 import { pathToFileURL } from "node:url";
@@ -51,83 +46,42 @@ import { getFirestore, type Firestore } from "firebase-admin/firestore";
 
 import { FirestoreDispatchStorage } from "../services/api/src/services/dispatch/firestore-dispatch-storage.js";
 import { FirestoreTenantDataLoader } from "../services/api/src/services/dispatch/firestore-tenant-data-loader.js";
-import { evaluateCompletionEligibility } from "../services/api/src/services/dispatch/completion-eligibility.js";
-import {
-  validateAndDedupeCcEmails,
-  validateSingleEmail,
-} from "../services/api/src/services/dispatch/cc-email-validator.js";
-import { buildCompletionMail } from "../services/api/src/services/dispatch/completion-notification-mail.js";
 import { sanitizeErrorForAudit } from "../services/api/src/services/dispatch/dispatch-error-sanitizer.js";
-import type { DispatchSettings } from "@lms-279/shared-types";
+import { runCompletionNotificationDryRun } from "../services/api/src/services/dispatch/dry-run/completion-notification-dry-run.js";
+import type {
+  CompletionDryRunResult,
+  CompletionDryRunTarget,
+  CompletionDryRunTenantSummary,
+  DryRunMimePreview as SharedDryRunMimePreview,
+} from "@lms-279/shared-types";
 
 // ============================================================
-// 型定義 (CLI 出力 JSON shape)
+// 旧 CLI 公開型 (A3 wrapper 化、smoke test との 1:1 互換維持)
 // ============================================================
+// service module / shared-types に移管済の型を旧 CLI 名で re-export。
 
-export interface DryRunMimePreview {
-  from: string;
-  to: string;
-  cc: string[];
-  subject: string;
-  body: string;
-}
-
-export interface DryRunTargetCli {
-  tenantId: string;
-  userId: string;
-  userEmail: string;
-  userName: string;
-  courseIdsSnapshot: string[];
-  mimePreview: DryRunMimePreview;
-}
-
-export interface DryRunTenantSummary {
-  tenantId: string;
-  skipped: boolean;
-  skipReason?: string;
-  usersScanned: number;
-  eligibleCount: number;
-}
-
-export interface DryRunResultCli {
-  evaluatedAt: string;
-  settingsLoaded: boolean;
-  settingsSnapshot: {
-    enabled: boolean;
-    scheduleDaysOfWeek: number[];
-    scheduleHourJst: number;
-    signatureName: string;
-    completionMessageBodyLength: number;
-  } | null;
-  tenantsScanned: number;
-  tenantsSummary: DryRunTenantSummary[];
-  wouldNotifyCount: number;
-  wouldNotify: DryRunTargetCli[];
-}
+export type DryRunMimePreview = SharedDryRunMimePreview;
+export type DryRunTargetCli = CompletionDryRunTarget;
+export type DryRunTenantSummary = CompletionDryRunTenantSummary;
+/**
+ * 旧 CLI 戻り値型 (Phase 4 α-7 wrapper 化前と完全互換)。
+ * service module の `CompletionDryRunResult` から `lane: "completion"` discriminator を除外。
+ */
+export type DryRunResultCli = Omit<CompletionDryRunResult, "lane">;
 
 // ============================================================
-// 環境変数 / 定数
+// 環境変数
 // ============================================================
 
 const GCP_PROJECT_ID =
   process.env.GOOGLE_CLOUD_PROJECT ?? process.env.FIREBASE_PROJECT_ID ?? "lms-279";
 const SENDER_EMAIL = process.env.DXCOLLEGE_SENDER_EMAIL ?? "dxcollege@279279.net";
 
-// settings 未保存テナント / フォールバック時の default 値 (本番では doc 必須だが、初期化前
-// の cutover リハーサルでも対象一覧プレビューを返せるようにする)。
-const DEFAULT_SIGNATURE = "DXcollege運営スタッフ";
-const DEFAULT_BODY = "(本文未設定 — super_dispatch_settings/global.completionMessageBody を保存してください)";
-
 // ============================================================
-// Firebase Admin SDK 初期化
+// Firebase Admin SDK 初期化 (progress-report-dry-run-cli と同パターン)
 // ============================================================
 
 function initFirestore(): Firestore {
-  // 認証経路の分岐 (cleanup-orphan-auth-users.ts と同じパターン):
-  //   1. type=service_account の JSON (ローカル SA key) → cert() で初期化
-  //   2. type=external_account の JSON (GitHub Actions WIF 経由) → applicationDefault() で ADC 委譲
-  //   3. GOOGLE_APPLICATION_CREDENTIALS 未設定 → applicationDefault() (Cloud Run ADC 等)
-  // type を読まずに cert() を使うと WIF JSON で project_id property 不在エラーになる。
   const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
   if (credPath) {
     const jsonPath = resolve(process.cwd(), credPath);
@@ -151,136 +105,25 @@ function initFirestore(): Firestore {
 }
 
 // ============================================================
-// メイン dry-run ロジック
+// CLI wrapper エントリ (service module 呼出 + lane field 除外で旧互換維持)
 // ============================================================
 
 export async function runDryRunCli(db: Firestore): Promise<DryRunResultCli> {
   const storage = new FirestoreDispatchStorage(db);
   const loader = new FirestoreTenantDataLoader(db);
-
-  // ① settings 読み取り
-  // doc missing (storage.getDispatchSettings が null 返却) は許容: 初期化前の cutover
-  // リハーサル想定で default 文言を埋めて preview を返す。
-  // read/parse error (throw) は cutover 判断材料の整合性に直結するため致命扱いし、
-  // workflow を失敗させる (codex review 2026-05-24 PR #488 Low-1 反映)。
-  const settings: DispatchSettings | null = await storage.getDispatchSettings();
-
-  const signature = settings?.signatureName ?? DEFAULT_SIGNATURE;
-  const messageBody = settings?.completionMessageBody ?? DEFAULT_BODY;
-
-  // ② tenants 走査
-  const tenantIds = await loader.listAllTenantIds();
-  const tenantsSummary: DryRunTenantSummary[] = [];
-  const wouldNotify: DryRunTargetCli[] = [];
-
-  for (const tenantId of tenantIds) {
-    const ccConfig = await loader.getTenantCcConfig(tenantId);
-
-    // テナント単位 disable は対象外 (本番 dispatch-dry-run.ts の logic と整合)
-    if (!ccConfig?.completionNotificationEnabled) {
-      tenantsSummary.push({
-        tenantId,
-        skipped: true,
-        skipReason: "tenant_completion_notification_disabled",
-        usersScanned: 0,
-        eligibleCount: 0,
-      });
-      continue;
-    }
-
-    const dataView = loader.getTenantDataView(tenantId);
-    const publishedCourses = await dataView.listPublishedCourses();
-    if (publishedCourses.length === 0) {
-      tenantsSummary.push({
-        tenantId,
-        skipped: true,
-        skipReason: "no_published_courses",
-        usersScanned: 0,
-        eligibleCount: 0,
-      });
-      continue;
-    }
-
-    const users = await dataView.listNotificationTargetUsers();
-    let eligibleCount = 0;
-
-    for (const user of users) {
-      // email 無効はどのみち送信されない (AC-19)
-      const emailV = validateSingleEmail(user.email);
-      if (!emailV.ok) continue;
-
-      const progresses = await dataView.listCourseProgressForUser(user.id);
-      const eligibility = evaluateCompletionEligibility(publishedCourses, progresses);
-      if (!eligibility.eligible) continue;
-
-      // 既存 notification (sent/reserved/failed/manual) は再送されない
-      const existing = await storage.getCompletionNotification(tenantId, user.id);
-      if (existing) continue;
-
-      // MIME プレビュー組立
-      const built = buildCompletionMail({
-        userName: user.name,
-        completionMessageBody: messageBody,
-        signatureName: signature,
-      });
-
-      // CC 組立は本番送信側 (run-completion-notifications.ts) と完全同期させるため、
-      // validateAndDedupeCcEmails を使う (trim / 形式検証 / CRLF・カンマ排除 /
-      // case-insensitive dedupe を実施)。codex review (2026-05-24 PR #488 Medium-1) で
-      // 本番ロジック (gmail-dwd-send.ts) との preview ドリフトを指摘されたため反映。
-      const ccResult = validateAndDedupeCcEmails(
-        ccConfig.notificationCcEmails ?? [],
-        ccConfig.ownerEmail,
-      );
-      const ccList = ccResult.validCcEmails;
-
-      wouldNotify.push({
-        tenantId,
-        userId: user.id,
-        userEmail: emailV.value,
-        userName: user.name ?? "",
-        courseIdsSnapshot: eligibility.courseIdsSnapshot,
-        mimePreview: {
-          from: `${signature} <${SENDER_EMAIL}>`,
-          to: emailV.value,
-          cc: ccList,
-          subject: built.subject,
-          body: built.body,
-        },
-      });
-      eligibleCount++;
-    }
-
-    tenantsSummary.push({
-      tenantId,
-      skipped: false,
-      usersScanned: users.length,
-      eligibleCount,
-    });
-  }
-
-  const result: DryRunResultCli = {
-    evaluatedAt: new Date().toISOString(),
-    settingsLoaded: settings !== null,
-    settingsSnapshot: settings
-      ? {
-          enabled: settings.enabled,
-          scheduleDaysOfWeek: settings.scheduleDaysOfWeek,
-          scheduleHourJst: settings.scheduleHourJst,
-          signatureName: settings.signatureName,
-          completionMessageBodyLength: settings.completionMessageBody.length,
-        }
-      : null,
-    tenantsScanned: tenantIds.length,
-    tenantsSummary,
-    wouldNotifyCount: wouldNotify.length,
-    wouldNotify,
-  };
-  return result;
+  const result = await runCompletionNotificationDryRun({
+    storage,
+    loader,
+    senderEmail: SENDER_EMAIL,
+    now: new Date(),
+  });
+  // 旧 CLI 出力構造との互換維持: lane field を除外 (smoke test + artifact 構造保持)
+  const { lane: _lane, ...legacyShape } = result;
+  return legacyShape;
 }
 
 // ============================================================
-// CLI エントリポイント
+// CLI エントリポイント (旧 main と同等の挙動)
 // ============================================================
 
 async function main(): Promise<void> {

--- a/scripts/lib/init-firebase-admin.ts
+++ b/scripts/lib/init-firebase-admin.ts
@@ -1,0 +1,67 @@
+/**
+ * dispatch dry-run CLI 用の Firebase Admin SDK 初期化 helper (Phase 4 α-7、safe-refactor M1)。
+ *
+ * scripts/dispatch-dry-run-cli.ts と scripts/progress-report-dry-run-cli.ts で
+ * 完全重複していた `initFirestore()` 関数と env 読み取り定数を抽出。
+ *
+ * - GOOGLE_APPLICATION_CREDENTIALS が指す JSON の type field を見て
+ *   service_account / WIF (ADC) を切り分け
+ * - 認証経路を `console.error` で出力 (workflow log で診断容易)
+ *
+ * 関連:
+ *   - 設計仕様書 / 旧 CLI コメント: 「ローカル ADC 経由」「workflow_dispatch WIF 認証」両対応
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  applicationDefault,
+  cert,
+  initializeApp,
+  type ServiceAccount,
+} from "firebase-admin/app";
+import { getFirestore, type Firestore } from "firebase-admin/firestore";
+
+/** GCP プロジェクト ID (env 優先、未設定時 default `lms-279`) */
+export const GCP_PROJECT_ID =
+  process.env.GOOGLE_CLOUD_PROJECT ??
+  process.env.FIREBASE_PROJECT_ID ??
+  "lms-279";
+
+/** dispatch 送信元 email (env 優先、未設定時 default `dxcollege@279279.net`) */
+export const SENDER_EMAIL =
+  process.env.DXCOLLEGE_SENDER_EMAIL ?? "dxcollege@279279.net";
+
+/**
+ * Firebase Admin SDK を初期化し Firestore client を返す。
+ *
+ * 認証経路の優先順位:
+ *   1. `GOOGLE_APPLICATION_CREDENTIALS` 指定 + JSON の `type === "service_account"`
+ *      → service account JSON 経由 (ローカル開発で多用)
+ *   2. `GOOGLE_APPLICATION_CREDENTIALS` 指定 + その他 type
+ *      → ADC 経由 (WIF 想定、cred file は WIF 設定ファイル)
+ *   3. 未指定 → ADC 経由 (gcloud / metadata server 等)
+ */
+export function initFirestoreForCli(): Firestore {
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (credPath) {
+    const jsonPath = resolve(process.cwd(), credPath);
+    const credJson = JSON.parse(readFileSync(jsonPath, "utf-8")) as {
+      type?: string;
+    };
+    if (credJson.type === "service_account") {
+      initializeApp({ credential: cert(credJson as ServiceAccount) });
+      console.error(`[init] 認証: サービスアカウント JSON (${jsonPath})`);
+    } else {
+      initializeApp({ credential: applicationDefault() });
+      console.error(
+        `[init] 認証: ADC (cred file type=${credJson.type ?? "unknown"}, WIF 想定)`,
+      );
+    }
+  } else {
+    initializeApp({ credential: applicationDefault() });
+    console.error("[init] 認証: Application Default Credentials");
+  }
+  return getFirestore();
+}

--- a/scripts/progress-report-dry-run-cli.ts
+++ b/scripts/progress-report-dry-run-cli.ts
@@ -1,31 +1,22 @@
 #!/usr/bin/env npx tsx
 /**
- * 進捗レポート定期自動配信 dry-run admin SDK CLI (ADR-039)。
+ * 進捗レポート定期自動配信 dry-run admin SDK CLI (Phase 4 α-7 A3 で薄 wrapper 化)。
  *
- * 目的:
- *   cutover 前に「次の cron 実行で何件送られるか」「テナント別の対象人数 / CC 数」
- *   「推定処理時間 / 推定 PDF サイズ範囲」を read-only で確認する。
+ * 純粋ロジックは `services/api/src/services/dispatch/dry-run/progress-report-dry-run.ts`
+ * に移管済 (HTTP endpoint と共有)。本 CLI は以下の責務に絞った薄 wrapper:
+ *   - Firebase Admin SDK の初期化 (CLI 環境固有: GOOGLE_APPLICATION_CREDENTIALS / ADC)
+ *   - service module の呼び出し
+ *   - 出力 JSON 書き出し (stdout + artifact file)
+ *   - workflow log 向けの summary stderr
  *
- *   完全 read-only:
- *     - Gmail 送信なし
- *     - PDF 実生成なし (cutover smoke `progress-report-smoke.yml` で計測)
- *     - Firestore write なし (settings / dispatch_runs / progress_report_sends いずれも write しない)
- *     - 既存 `services/api/src/services/dispatch/{firestore-tenant-data-loader,firestore-dispatch-storage}`
- *       を直接利用するため本番ロジックと query 構造が完全一致 (重複再実装によるドリフトを回避)。
+ * 出力 JSON 構造は α-7 以前 (本 wrapper 化前) と **1:1 互換** を維持:
+ *   - 旧 `DryRunResultCli` 型 = shared-types `ProgressDryRunResult` から `lane` field を除外
+ *   - 既存 `progress-report-dry-run-result-*.json` artifact の構造を変えない
  *
- * 動作:
- *   1. super_dispatch_settings/global 読み取り (default にフォールバック)
- *   2. tenants 一覧取得 → 各 tenant について active + progressReportEnabled チェック
- *   3. listProgressReportTargetUsers (Plan A: student + 期限内 + 進捗 1% 以上)
- *   4. email validation + CC dedup (本番 run-progress-reports.ts と同じロジック)
- *   5. 100% 完了者は記録上「除外候補」として別カウンタへ (実送信時は完了通知レーンが
- *      カバー済、AC-PR-02)
- *   6. 集計を JSON で stdout + `progress-report-dry-run-result-<ts>.json` に出力
- *
- * 出力に含まれないもの (cutover smoke で別途確認):
- *   - 実 PDF サイズ (テナント / 受講者ごとに変動、5MB 超 skip は本番ロジックでカバー)
- *   - 実 MIME バイトサイズ (PDF 添付込み)
- *   - 実 Gmail rate limit 影響 (per-second sliding window)
+ * 完全 read-only:
+ *   - Gmail 送信なし
+ *   - PDF 実生成なし (cutover smoke `progress-report-smoke.yml` で計測)
+ *   - Firestore write なし
  *
  * 使用方法:
  *   # ローカル (ADC 経由)
@@ -37,9 +28,10 @@
  *   GitHub Actions UI > Progress Report Dry Run > Run workflow
  *
  * 関連:
- *   - impl-plan: docs/specs/2026-06-01-progress-report-dispatch-impl-plan.md §PR 3e
+ *   - impl-plan: docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md §3 タスク A3
+ *   - service module: services/api/src/services/dispatch/dry-run/progress-report-dry-run.ts
  *   - runbook: docs/runbook/dxcollege-progress-report-cutover.md
- *   - 既存 mirror: scripts/dispatch-dry-run-cli.ts (完了通知レーン dry-run)
+ *   - 完了通知レーン mirror: scripts/dispatch-dry-run-cli.ts
  */
 
 import { pathToFileURL } from "node:url";
@@ -56,94 +48,39 @@ import { getFirestore, type Firestore } from "firebase-admin/firestore";
 
 import { FirestoreDispatchStorage } from "../services/api/src/services/dispatch/firestore-dispatch-storage.js";
 import { FirestoreTenantDataLoader } from "../services/api/src/services/dispatch/firestore-tenant-data-loader.js";
-import { evaluateCompletionEligibility } from "../services/api/src/services/dispatch/completion-eligibility.js";
-import {
-  validateAndDedupeCcEmails,
-  validateSingleEmail,
-} from "../services/api/src/services/dispatch/cc-email-validator.js";
 import { sanitizeErrorForAudit } from "../services/api/src/services/dispatch/dispatch-error-sanitizer.js";
-import type { DispatchSettings } from "@lms-279/shared-types";
+import {
+  runProgressReportDryRun,
+  CONSOLE_PROGRESS_DRY_RUN_LOGGER,
+  SCALE_TRIGGER_THRESHOLD,
+} from "../services/api/src/services/dispatch/dry-run/progress-report-dry-run.js";
+import type {
+  ProgressDryRunResult,
+  ProgressDryRunSkipReason,
+  ProgressDryRunTenantSummary,
+} from "@lms-279/shared-types";
 
 // ============================================================
-// 型定義 (CLI 出力 JSON shape)
+// 旧 CLI 公開型 (A3 wrapper 化、smoke test との 1:1 互換維持)
 // ============================================================
+// service module / shared-types に移管済の型を旧 CLI 名で re-export。
+// `DryRunResultCli` は旧 CLI 戻り値構造 (lane field なし) を保つため Omit で表現。
 
+export type DryRunSkipReason = ProgressDryRunSkipReason;
+export type DryRunTenantSummary = ProgressDryRunTenantSummary;
 /**
- * tenant 単位で skip された場合の理由。`skipped === true` のときのみ意味を持つ。
- *
- * `tenant_doc_not_found` は listAllTenantIds() が tenantId を返したが tenants/{tid}
- * doc が存在しない異常状態 (subcollection 孤児等)。stderr に WARN を出して運用者の
- * 注意を喚起する。他の skip 理由は通常運用範囲内。
+ * 旧 CLI 戻り値型 (Phase 4 α-7 wrapper 化前と完全互換)。
+ * service module の `ProgressDryRunResult` から `lane: "progress"` discriminator を除外したもの。
  */
-export type DryRunSkipReason =
-  | "tenant_doc_not_found"
-  | "tenant_not_active"
-  | "progress_report_disabled"
-  | "no_published_courses";
-
-export interface DryRunTenantSummary {
-  tenantId: string;
-  skipped: boolean;
-  /** `skipped === true` のときのみ設定される */
-  skipReason?: DryRunSkipReason;
-  usersScanned: number;
-  /** listProgressReportTargetUsers の戻り値そのまま (進捗 1% 以上 + 期限内 + student) */
-  candidateCount: number;
-  /** email が cc-email-validator で reject された user 数 (送信不能) */
-  invalidEmailCount: number;
-  /** 100% 完了者 (進捗レーンは skip 対象、AC-PR-02。完了通知レーンがカバー済) */
-  completedCount: number;
-  /** 実送信対象数 = candidateCount - invalidEmailCount - completedCount */
-  wouldSendCount: number;
-  /** dedup 後の CC 件数 (ownerEmail + notificationCcEmails) */
-  ccCount: number;
-}
-
-export interface DryRunResultCli {
-  evaluatedAt: string;
-  settingsLoaded: boolean;
-  settingsSnapshot: {
-    progressReportEnabled: boolean;
-    scheduleDaysOfWeek: number[];
-    scheduleHourJst: number;
-    signatureName: string;
-  } | null;
-  tenantsScanned: number;
-  tenantsSummary: DryRunTenantSummary[];
-  /** 全テナント合算の実送信対象数 */
-  totalWouldSendCount: number;
-  /** 全テナント合算の CC 件数 (To 1 件あたり付与される CC の延べ数) */
-  totalCcCount: number;
-  /**
-   * 推定処理時間 (ミリ秒)。user 並列度 8 + PDF 生成 / Gmail 送信あたり ~2 秒の経験値で
-   * 雑算した参考値。実測は cutover smoke で確認すること。
-   */
-  estimatedDurationMs: number;
-  /**
-   * 推定 PDF サイズ範囲 (KB)。過去の手動レポート (PR 3a 以前の progress-pdf-draft) の
-   * 経験値レンジ。実測は cutover smoke で確認すること。
-   */
-  estimatedPdfSizeKbRange: { min: number; typical: number; max: number };
-  /** scale trigger: 全テナント合計 300 名超は Cloud Tasks 移行検討 */
-  scaleTriggerExceeded: boolean;
-}
+export type DryRunResultCli = Omit<ProgressDryRunResult, "lane">;
 
 // ============================================================
-// 環境変数 / 定数
+// 環境変数
 // ============================================================
 
 const GCP_PROJECT_ID =
   process.env.GOOGLE_CLOUD_PROJECT ?? process.env.FIREBASE_PROJECT_ID ?? "lms-279";
 const SENDER_EMAIL = process.env.DXCOLLEGE_SENDER_EMAIL ?? "dxcollege@279279.net";
-
-/** 1 通あたりの平均処理時間目安 (PDF 生成 1.5s + Gmail send 0.3s + Firestore write 0.2s) */
-const AVG_PER_USER_MS = 2000;
-/** user 並列度 (run-progress-reports DEFAULT_USER_CONCURRENCY と一致) */
-const USER_CONCURRENCY = 8;
-/** scale trigger threshold */
-const SCALE_TRIGGER_THRESHOLD = 300;
-/** 推定 PDF サイズ範囲 (KB)。実測は cutover smoke で確認 */
-const PDF_SIZE_KB_RANGE = { min: 150, typical: 350, max: 1200 };
 
 // ============================================================
 // Firebase Admin SDK 初期化 (dispatch-dry-run-cli と同パターン)
@@ -173,7 +110,7 @@ function initFirestore(): Firestore {
 }
 
 // ============================================================
-// メイン dry-run ロジック
+// CLI wrapper エントリ (service module 呼出 + lane field 除外で旧互換維持)
 // ============================================================
 
 export async function runProgressReportDryRunCli(
@@ -182,172 +119,19 @@ export async function runProgressReportDryRunCli(
 ): Promise<DryRunResultCli> {
   const storage = new FirestoreDispatchStorage(db);
   const loader = new FirestoreTenantDataLoader(db);
-
-  // ① settings 読み取り
-  // doc missing 許容: 初期化前 cutover リハーサル想定で「対象規模見積もり」だけは返す。
-  // read/parse error は致命扱いし fail-fast にする (silent fallback は cutover 判断材料の
-  // 整合性を壊すため、dispatch-dry-run-cli と同パターン)。
-  const settings: DispatchSettings | null = await storage.getDispatchSettings();
-
-  // ② tenants 走査
-  const tenantIds = await loader.listAllTenantIds();
-  const tenantsSummary: DryRunTenantSummary[] = [];
-  let totalWouldSendCount = 0;
-  let totalCcCount = 0;
-
-  for (const tenantId of tenantIds) {
-    // ③ active + progressReportEnabled チェック (AC-PR-04)
-    const tenantInfo = await loader.getTenantInfo(tenantId);
-    if (!tenantInfo) {
-      // listAllTenantIds() は tenantId を返したが tenants/{tid} doc が不在。
-      // subcollection 孤児やテナント cascade delete 未完了の可能性があり、
-      // 後で同一 tenantId が再利用されたら誤配信に直結するため stderr で alert。
-      console.error(
-        `[WARN] tenant_doc_not_found: tenants/${tenantId} doc が存在しません。subcollection 孤児の可能性があるため運用者の確認推奨。`,
-      );
-      tenantsSummary.push({
-        tenantId,
-        skipped: true,
-        skipReason: "tenant_doc_not_found",
-        usersScanned: 0,
-        candidateCount: 0,
-        invalidEmailCount: 0,
-        completedCount: 0,
-        wouldSendCount: 0,
-        ccCount: 0,
-      });
-      continue;
-    }
-    if (!tenantInfo.active) {
-      tenantsSummary.push({
-        tenantId,
-        skipped: true,
-        skipReason: "tenant_not_active",
-        usersScanned: 0,
-        candidateCount: 0,
-        invalidEmailCount: 0,
-        completedCount: 0,
-        wouldSendCount: 0,
-        ccCount: 0,
-      });
-      continue;
-    }
-    if (!tenantInfo.progressReportEnabled) {
-      tenantsSummary.push({
-        tenantId,
-        skipped: true,
-        skipReason: "progress_report_disabled",
-        usersScanned: 0,
-        candidateCount: 0,
-        invalidEmailCount: 0,
-        completedCount: 0,
-        wouldSendCount: 0,
-        ccCount: 0,
-      });
-      continue;
-    }
-
-    // ④ CC config 取得 (進捗レーンは CC null でも To 単独で送信、AC-PR-11 設定独立性)
-    const ccConfig = await loader.getTenantCcConfig(tenantId);
-    const ccDedup = validateAndDedupeCcEmails(
-      ccConfig?.notificationCcEmails ?? [],
-      ccConfig?.ownerEmail ?? null,
-    );
-    const ccCount = ccDedup.validCcEmails.length;
-
-    // ⑤ 対象 user 列挙 (Plan A: student + 期限内 + 進捗 1% 以上、ADR-039 D-5)
-    const dataView = loader.getTenantDataView(tenantId);
-    const publishedCourses = await dataView.listPublishedCourses();
-    if (publishedCourses.length === 0) {
-      tenantsSummary.push({
-        tenantId,
-        skipped: true,
-        skipReason: "no_published_courses",
-        usersScanned: 0,
-        candidateCount: 0,
-        invalidEmailCount: 0,
-        completedCount: 0,
-        wouldSendCount: 0,
-        ccCount,
-      });
-      continue;
-    }
-
-    const users = await dataView.listProgressReportTargetUsers(now);
-    // candidateCount は listProgressReportTargetUsers 戻り値全体を表す。
-    // 送信不能要因 (invalid email / 100% 完了) は内訳カウンタで切り分け、運用者が
-    // 「dry-run で見えない skip 規模」を取りこぼさないようにする。
-    const candidateCount = users.length;
-    let invalidEmailCount = 0;
-    let completedCount = 0;
-    let wouldSendCount = 0;
-
-    for (const user of users) {
-      // email validation (進捗レーンも完了通知レーンと同様、無効 email は送信不能)
-      const emailV = validateSingleEmail(user.email);
-      if (!emailV.ok) {
-        invalidEmailCount += 1;
-        continue;
-      }
-
-      // 100% 完了者は進捗レーン skip (AC-PR-02、完了通知レーンがカバー済)
-      const progresses = await dataView.listCourseProgressForUser(user.id);
-      const eligibility = evaluateCompletionEligibility(
-        publishedCourses,
-        progresses,
-      );
-      if (eligibility.eligible) {
-        completedCount += 1;
-        continue;
-      }
-
-      wouldSendCount += 1;
-    }
-
-    tenantsSummary.push({
-      tenantId,
-      skipped: false,
-      usersScanned: users.length,
-      candidateCount,
-      invalidEmailCount,
-      completedCount,
-      wouldSendCount,
-      ccCount,
-    });
-
-    totalWouldSendCount += wouldSendCount;
-    totalCcCount += wouldSendCount * ccCount;
-  }
-
-  // ⑥ 推定処理時間 = (totalWouldSendCount / userConcurrency) * AVG_PER_USER_MS
-  // 並列度 8 を超える user 数では Cloud Run timeout (280s) を意識した値になる
-  const estimatedDurationMs =
-    Math.ceil(totalWouldSendCount / USER_CONCURRENCY) * AVG_PER_USER_MS;
-
-  const result: DryRunResultCli = {
-    evaluatedAt: now.toISOString(),
-    settingsLoaded: settings !== null,
-    settingsSnapshot: settings
-      ? {
-          progressReportEnabled: settings.progressReport?.enabled ?? false,
-          scheduleDaysOfWeek: settings.progressReport?.scheduleDaysOfWeek ?? [],
-          scheduleHourJst: settings.progressReport?.scheduleHourJst ?? 0,
-          signatureName: settings.signatureName,
-        }
-      : null,
-    tenantsScanned: tenantIds.length,
-    tenantsSummary,
-    totalWouldSendCount,
-    totalCcCount,
-    estimatedDurationMs,
-    estimatedPdfSizeKbRange: PDF_SIZE_KB_RANGE,
-    scaleTriggerExceeded: totalWouldSendCount > SCALE_TRIGGER_THRESHOLD,
-  };
-  return result;
+  const result = await runProgressReportDryRun({
+    storage,
+    loader,
+    now,
+    logger: CONSOLE_PROGRESS_DRY_RUN_LOGGER,
+  });
+  // 旧 CLI 出力構造との互換維持: lane field を除外 (smoke test + artifact 構造保持)
+  const { lane: _lane, ...legacyShape } = result;
+  return legacyShape;
 }
 
 // ============================================================
-// CLI エントリポイント
+// CLI エントリポイント (旧 main と同等の挙動)
 // ============================================================
 
 async function main(): Promise<void> {

--- a/scripts/progress-report-dry-run-cli.ts
+++ b/scripts/progress-report-dry-run-cli.ts
@@ -35,16 +35,9 @@
  */
 
 import { pathToFileURL } from "node:url";
-import { readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { writeFileSync } from "node:fs";
 
-import {
-  applicationDefault,
-  cert,
-  initializeApp,
-  type ServiceAccount,
-} from "firebase-admin/app";
-import { getFirestore, type Firestore } from "firebase-admin/firestore";
+import type { Firestore } from "firebase-admin/firestore";
 
 import { FirestoreDispatchStorage } from "../services/api/src/services/dispatch/firestore-dispatch-storage.js";
 import { FirestoreTenantDataLoader } from "../services/api/src/services/dispatch/firestore-tenant-data-loader.js";
@@ -59,6 +52,11 @@ import type {
   ProgressDryRunSkipReason,
   ProgressDryRunTenantSummary,
 } from "@lms-279/shared-types";
+import {
+  GCP_PROJECT_ID,
+  SENDER_EMAIL,
+  initFirestoreForCli,
+} from "./lib/init-firebase-admin.js";
 
 // ============================================================
 // 旧 CLI 公開型 (A3 wrapper 化、smoke test との 1:1 互換維持)
@@ -74,40 +72,9 @@ export type DryRunTenantSummary = ProgressDryRunTenantSummary;
  */
 export type DryRunResultCli = Omit<ProgressDryRunResult, "lane">;
 
-// ============================================================
-// 環境変数
-// ============================================================
-
-const GCP_PROJECT_ID =
-  process.env.GOOGLE_CLOUD_PROJECT ?? process.env.FIREBASE_PROJECT_ID ?? "lms-279";
-const SENDER_EMAIL = process.env.DXCOLLEGE_SENDER_EMAIL ?? "dxcollege@279279.net";
-
-// ============================================================
-// Firebase Admin SDK 初期化 (dispatch-dry-run-cli と同パターン)
-// ============================================================
-
-function initFirestore(): Firestore {
-  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-  if (credPath) {
-    const jsonPath = resolve(process.cwd(), credPath);
-    const credJson = JSON.parse(readFileSync(jsonPath, "utf-8")) as {
-      type?: string;
-    };
-    if (credJson.type === "service_account") {
-      initializeApp({ credential: cert(credJson as ServiceAccount) });
-      console.error(`[init] 認証: サービスアカウント JSON (${jsonPath})`);
-    } else {
-      initializeApp({ credential: applicationDefault() });
-      console.error(
-        `[init] 認証: ADC (cred file type=${credJson.type ?? "unknown"}, WIF 想定)`,
-      );
-    }
-  } else {
-    initializeApp({ credential: applicationDefault() });
-    console.error("[init] 認証: Application Default Credentials");
-  }
-  return getFirestore();
-}
+// 環境変数 (GCP_PROJECT_ID / SENDER_EMAIL) と Firebase Admin SDK 初期化は
+// scripts/lib/init-firebase-admin.ts に集約 (safe-refactor M1)。
+// 旧 `initFirestore()` ローカル定義は撤去。
 
 // ============================================================
 // CLI wrapper エントリ (service module 呼出 + lane field 除外で旧互換維持)
@@ -140,7 +107,7 @@ async function main(): Promise<void> {
   console.error(`  sender:  ${SENDER_EMAIL}`);
   console.error("");
 
-  const db = initFirestore();
+  const db = initFirestoreForCli();
   const result = await runProgressReportDryRunCli(db);
 
   // stdout に JSON 出力 (workflow log でも見える)

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -242,6 +242,7 @@ if (dispatchFactory) {
     superAdminAuthMiddleware,
     createDispatchSuperRouter({
       storage: dispatchFactory.storage,
+      loader: dispatchFactory.loader,
       env: dispatchFactory.env,
       ccStore: inMemoryCcStore,
     }),

--- a/services/api/src/middleware/dispatch-dry-run-limiter.ts
+++ b/services/api/src/middleware/dispatch-dry-run-limiter.ts
@@ -1,0 +1,50 @@
+/**
+ * dispatch-dry-run endpoint 専用レート制限ミドルウェア (Phase 4 α-7、AC-α7-12)。
+ *
+ * 目的:
+ *   - super-admin 限定 endpoint だが、誤操作・複数タブ・ブラウザ再試行で
+ *     Firestore read 量が増える懸念 (Codex High 指摘)
+ *   - IP ベース (globalLimiter) ではなく **super-admin email ベース** で抑制
+ *
+ * 設計:
+ *   - 10 req/min/superAdminEmail
+ *   - keyGenerator で req.user.email を取得 (super-admin auth middleware で
+ *     セット済前提)。fallback は IP → "anonymous"
+ *   - testSendLimiter (PR #490 で撤廃) とは別名・別設計 (過去シンボル復活回避)
+ *
+ * 関連:
+ *   - impl-plan: docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md §3 タスク C1
+ *   - AC-α7-12: dry-run endpoint への DoS / 連打防止
+ */
+
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
+import type { Request } from "express";
+
+/**
+ * dispatch-dry-run 専用 limiter。
+ * `Router.get(path, dispatchDryRunLimiter, handler)` の形で wire する。
+ *
+ * `req.user` は親 super-admin auth middleware で set される (型は middleware 側で
+ * Express namespace 拡張)。本 limiter はその拡張に依存せず、email field を最小限
+ * 取り出す duck typing で keyGenerator を実装。
+ */
+export const dispatchDryRunLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 10,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  keyGenerator: (req: Request) => {
+    const user = (req as unknown as { user?: { email?: string | null } }).user;
+    const email = user?.email;
+    if (email) return `email:${email.toLowerCase()}`;
+    // super-admin auth 失敗時の fallback (本来は middleware が先に 403 で弾く想定)。
+    // ipKeyGenerator(ip, subnet?) helper で IPv6 prefix を考慮 (ERR_ERL_KEY_GEN_IPV6 回避)
+    return `ip:${ipKeyGenerator(req.ip ?? "")}`;
+  },
+  message: {
+    error: {
+      code: "RATE_LIMIT_EXCEEDED",
+      message: "Too many dry-run requests. Please wait a minute and retry.",
+    },
+  },
+});

--- a/services/api/src/middleware/dispatch-dry-run-limiter.ts
+++ b/services/api/src/middleware/dispatch-dry-run-limiter.ts
@@ -8,7 +8,7 @@
  *
  * 設計:
  *   - 10 req/min/superAdminEmail
- *   - keyGenerator で req.user.email を取得 (super-admin auth middleware で
+ *   - keyGenerator で req.superAdmin.email を取得 (super-admin auth middleware で
  *     セット済前提)。fallback は IP → "anonymous"
  *   - testSendLimiter (PR #490 で撤廃) とは別名・別設計 (過去シンボル復活回避)
  *
@@ -24,9 +24,11 @@ import type { Request } from "express";
  * dispatch-dry-run 専用 limiter。
  * `Router.get(path, dispatchDryRunLimiter, handler)` の形で wire する。
  *
- * `req.user` は親 super-admin auth middleware で set される (型は middleware 側で
- * Express namespace 拡張)。本 limiter はその拡張に依存せず、email field を最小限
- * 取り出す duck typing で keyGenerator を実装。
+ * `req.superAdmin` は親 `superAdminAuthMiddleware` で `{ email, firebaseUid? }`
+ * として set される (services/api/src/middleware/super-admin.ts:376 / :485)。
+ * 本 limiter はその拡張に依存せず、email field を最小限取り出す duck typing で
+ * keyGenerator を実装。Codex review (2026-06-04) で `req.user` 読みは middleware
+ * と shape 不一致のため IP fallback に collapse する誤りが指摘され修正済。
  */
 export const dispatchDryRunLimiter = rateLimit({
   windowMs: 60 * 1000,
@@ -34,8 +36,10 @@ export const dispatchDryRunLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false,
   keyGenerator: (req: Request) => {
-    const user = (req as unknown as { user?: { email?: string | null } }).user;
-    const email = user?.email;
+    const superAdmin = (
+      req as unknown as { superAdmin?: { email?: string | null } }
+    ).superAdmin;
+    const email = superAdmin?.email;
     if (email) return `email:${email.toLowerCase()}`;
     // super-admin auth 失敗時の fallback (本来は middleware が先に 403 で弾く想定)。
     // Phase 4 α-7 code-review F6 反映: `req.ip ?? ""` を `ipKeyGenerator` に渡すと

--- a/services/api/src/middleware/dispatch-dry-run-limiter.ts
+++ b/services/api/src/middleware/dispatch-dry-run-limiter.ts
@@ -38,8 +38,12 @@ export const dispatchDryRunLimiter = rateLimit({
     const email = user?.email;
     if (email) return `email:${email.toLowerCase()}`;
     // super-admin auth 失敗時の fallback (本来は middleware が先に 403 で弾く想定)。
-    // ipKeyGenerator(ip, subnet?) helper で IPv6 prefix を考慮 (ERR_ERL_KEY_GEN_IPV6 回避)
-    return `ip:${ipKeyGenerator(req.ip ?? "")}`;
+    // Phase 4 α-7 code-review F6 反映: `req.ip ?? ""` を `ipKeyGenerator` に渡すと
+    // 空文字解釈で全 anonymous request が固定 key に collapse し self-DoS の温床に
+    // なる。fallback を fixed sentinel に切り替え、本来到達しないコード経路で
+    // 偶発的 collapse が起きないようにする。
+    const ip = req.ip;
+    return ip ? `ip:${ipKeyGenerator(ip)}` : "ip:anonymous-no-ip";
   },
   message: {
     error: {

--- a/services/api/src/routes/super/__tests__/dispatch-dry-run.test.ts
+++ b/services/api/src/routes/super/__tests__/dispatch-dry-run.test.ts
@@ -54,9 +54,12 @@ function makeApp(
   app.use(express.json());
   // fake super-admin auth (親 router で適用される設計)
   app.use((req, _res, next) => {
-    // limiter の keyGenerator が duck typing で email field のみ読む。
-    // 強い型 assertion で AuthUser (id / role 必須) との不一致を回避。
-    (req as unknown as { user: { email: string } }).user = {
+    // 本番 superAdminAuthMiddleware (services/api/src/middleware/super-admin.ts:376 /
+    // :485) は `req.superAdmin = { email, firebaseUid? }` を set する。Codex review
+    // (2026-06-04) で test が `req.user` を入れていたため、limiter の
+    // keyGenerator が本番と test で異なる field を読む偽陽性が発生していた問題を
+    // 解消するため、本 test も `req.superAdmin` に揃える。
+    (req as unknown as { superAdmin: { email: string } }).superAdmin = {
       email: ADMIN_EMAIL,
     };
     next();

--- a/services/api/src/routes/super/__tests__/dispatch-dry-run.test.ts
+++ b/services/api/src/routes/super/__tests__/dispatch-dry-run.test.ts
@@ -18,28 +18,36 @@ import request from "supertest";
 import rateLimit from "express-rate-limit";
 import type {
   CompletionDryRunResult,
-  DispatchSettings,
   ProgressDryRunResult,
 } from "@lms-279/shared-types";
 
 import { InMemoryDispatchStorage } from "../../../services/dispatch/in-memory-dispatch-storage.js";
 import {
   InMemoryTenantDataLoader,
-  type InMemoryTenantFixture,
+  type TenantDataLoader,
+  type DispatchTenantDataView,
 } from "../../../services/dispatch/tenant-data-loader.js";
 import { createDispatchDryRunSingleFlightForTest } from "../../../services/dispatch/dry-run/single-flight.js";
+import type { ProgressDryRunLogger } from "../../../services/dispatch/dry-run/progress-report-dry-run.js";
 import { createDispatchDryRunRouter } from "../dispatch-dry-run.js";
+import {
+  FIXTURE_SENDER_EMAIL as SENDER,
+  makeSettings,
+  makeFixture,
+  partialProgress,
+  completedProgress,
+} from "../../../services/dispatch/dry-run/__tests__/dry-run-fixtures.js";
 
 const ADMIN_EMAIL = "admin@example.com";
-const SENDER = "dxcollege@279279.net";
 
 function makeApp(
   storage: InMemoryDispatchStorage,
-  loader: InMemoryTenantDataLoader,
+  loader: InMemoryTenantDataLoader | TenantDataLoader,
   opts: {
     enableLimiter?: boolean;
     limiterLimit?: number;
     singleFlight?: ReturnType<typeof createDispatchDryRunSingleFlightForTest>;
+    progressDryRunLogger?: ProgressDryRunLogger;
   } = {},
 ): express.Express {
   const app = express();
@@ -71,6 +79,10 @@ function makeApp(
       })
     : noopLimiter;
 
+  // Default test logger は noop で標準出力汚染を避ける。F4 regression test では
+  // 明示的に spy logger を渡して呼び出しを assert する。
+  const noopLogger: ProgressDryRunLogger = { warnTenantDocNotFound: () => {} };
+
   app.use(
     "/api/v2/super",
     createDispatchDryRunRouter({
@@ -80,56 +92,14 @@ function makeApp(
       limiter: testLimiter,
       singleFlight:
         opts.singleFlight ?? createDispatchDryRunSingleFlightForTest(),
+      progressDryRunLogger: opts.progressDryRunLogger ?? noopLogger,
     }),
   );
   return app;
 }
 
-function makeFixture(
-  partial: Partial<InMemoryTenantFixture> = {},
-): InMemoryTenantFixture {
-  return {
-    publishedCourses: [{ id: "c1", lessonOrder: ["l1", "l2", "l3"] }],
-    users: [],
-    courseProgresses: new Map(),
-    ccConfig: {
-      completionNotificationEnabled: true,
-      ownerEmail: null,
-      notificationCcEmails: [],
-    },
-    info: { active: true, progressReportEnabled: true },
-    ...partial,
-  };
-}
-
-function makeSettings(
-  partial: Partial<DispatchSettings> = {},
-): DispatchSettings {
-  return {
-    enabled: true,
-    scheduleDaysOfWeek: [1, 4],
-    scheduleHourJst: 9,
-    signatureName: "DXcollege運営スタッフ",
-    completionMessageBody: "受講お疲れ様でした。",
-    senderEmail: SENDER,
-    updatedAt: "2026-05-20T00:00:00.000Z",
-    updatedBy: "admin@279279.net",
-    version: 1,
-    ...partial,
-  };
-}
-
-function partialProgress(courseId = "c1") {
-  return [
-    { courseId, isCompleted: false, totalLessons: 3, completedLessons: 1 },
-  ];
-}
-
-function completedProgress(courseId = "c1") {
-  return [
-    { courseId, isCompleted: true, totalLessons: 3, completedLessons: 3 },
-  ];
-}
+// makeFixture / makeSettings / partialProgress / completedProgress は
+// services/api/src/services/dispatch/dry-run/__tests__/dry-run-fixtures.ts に集約 (safe-refactor M2)。
 
 // ============================================================
 // GET /super/dispatch/dry-run/progress
@@ -307,6 +277,47 @@ describe("single-flight integration", () => {
 });
 
 // ============================================================
+// logger injection (F4 silent-fail-paired-signal regression)
+// ============================================================
+
+describe("progressDryRunLogger integration (F4)", () => {
+  it("should invoke injected logger.warnTenantDocNotFound when tenant doc is missing", async () => {
+    // Phase 4 α-7 code-review F4: HTTP route が tenant_doc_not_found 警告を silent
+    // drop しないことを担保。CLI 経由は CONSOLE_PROGRESS_DRY_RUN_LOGGER で stderr に
+    // 出ていたが、HTTP route は NOOP に fallback していたため Cloud Logging に痕跡が
+    // 残らず CLAUDE.md silent-fail-paired-signal ルールに抵触していた。
+    const storage = new InMemoryDispatchStorage();
+    const ghostLoader: TenantDataLoader = {
+      async listAllTenantIds() {
+        return ["ghost"];
+      },
+      async getTenantInfo() {
+        return null;
+      },
+      async getTenantCcConfig() {
+        return null;
+      },
+      getTenantDataView(): DispatchTenantDataView {
+        throw new Error("not reachable: tenant_doc_not_found path should skip");
+      },
+    };
+    const warnSpy = vi.fn();
+    const app = makeApp(storage, ghostLoader, {
+      progressDryRunLogger: { warnTenantDocNotFound: warnSpy },
+    });
+
+    const res = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/progress",
+    );
+
+    expect(res.status).toBe(200);
+    const body = res.body as ProgressDryRunResult;
+    expect(body.tenantsSummary[0]?.skipReason).toBe("tenant_doc_not_found");
+    expect(warnSpy).toHaveBeenCalledExactlyOnceWith("ghost");
+  });
+});
+
+// ============================================================
 // limiter integration (429)
 // ============================================================
 
@@ -328,6 +339,75 @@ describe("limiter integration (429)", () => {
     expect(r2.status).toBe(200);
     expect(r3.status).toBe(429);
     expect(r3.body.error?.code).toBe("RATE_LIMIT_EXCEEDED");
+  });
+
+  it("should share limiter budget across progress and completion lanes (F5 documented behavior)", async () => {
+    // Phase 4 α-7 code-review F5 / Evaluator エッジ-1 反映:
+    // 単一 dispatchDryRunLimiter instance を両 handler に貼っているため、10 req/min は
+    // **両 lane 合算** の budget となる仕様。本 test で lane 横断バジェット共有を
+    // pin し、将来 per-lane 化への refactor が入ったときに気付けるようにする。
+    const storage = new InMemoryDispatchStorage();
+    const loader = new InMemoryTenantDataLoader();
+    const app = makeApp(storage, loader, {
+      enableLimiter: true,
+      limiterLimit: 2,
+    });
+
+    const r1 = await request(app).get("/api/v2/super/dispatch/dry-run/progress");
+    const r2 = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/completion",
+    );
+    const r3 = await request(app).get("/api/v2/super/dispatch/dry-run/progress");
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r3.status).toBe(429);
+    expect(r3.body.error?.code).toBe("RATE_LIMIT_EXCEEDED");
+  });
+});
+
+// ============================================================
+// AC-α7-05: super-admin auth 拒否時 403 (Evaluator 反映)
+// ============================================================
+
+describe("AC-α7-05 super-admin auth rejection", () => {
+  it("should return 403 when parent auth middleware rejects (no super-admin)", async () => {
+    // 親 router (本番 index.ts では `/api/v2/super` に superAdminAuthMiddleware を
+    // mount) が 403 を返す状況を模擬。createDispatchDryRunRouter は auth を内包
+    // しない設計なので、本テストは「auth middleware 不在なら handler に到達しない」
+    // 責務分離を pin する。AC-α7-05 の BE 側保証。
+    const storage = new InMemoryDispatchStorage();
+    const loader = new InMemoryTenantDataLoader();
+    const app = express();
+    app.use(express.json());
+    // 親で 403 を返す fake auth (super-admin 以外を一律拒否する形を模擬)
+    app.use("/api/v2/super", (_req, res) => {
+      res.status(403).json({
+        error: { code: "FORBIDDEN", message: "super-admin only" },
+      });
+    });
+    // 上の middleware で response が返るため、下の router には到達しない
+    app.use(
+      "/api/v2/super",
+      createDispatchDryRunRouter({
+        storage,
+        loader,
+        senderEmail: SENDER,
+        singleFlight: createDispatchDryRunSingleFlightForTest(),
+        progressDryRunLogger: { warnTenantDocNotFound: () => {} },
+      }),
+    );
+
+    const progressRes = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/progress",
+    );
+    const completionRes = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/completion",
+    );
+
+    expect(progressRes.status).toBe(403);
+    expect(completionRes.status).toBe(403);
+    expect(progressRes.body.error?.code).toBe("FORBIDDEN");
   });
 });
 

--- a/services/api/src/routes/super/__tests__/dispatch-dry-run.test.ts
+++ b/services/api/src/routes/super/__tests__/dispatch-dry-run.test.ts
@@ -1,0 +1,522 @@
+/**
+ * createDispatchDryRunRouter (Phase 4 α-7 GET /super/dispatch/dry-run/{progress|completion}) の integration test。
+ *
+ * 観点:
+ *   - 200 OK + discriminated union output (lane field の正確性)
+ *   - 500 (storage / loader が throw)
+ *   - 429 (専用 limiter、10 req/min/superAdminEmail、AC-α7-12)
+ *   - single-flight 統合 (同 lane 並行 → fn 1 回呼び出し、Codex High Firestore read 抑制)
+ *   - read-only 保証 (Firestore write API を route が呼ばない、AC-α7-06)
+ *   - PR #490 撤廃方針の維持: test-send 経路ゼロ
+ *   - 完了通知 service-level regression (Codex AC-α7-07 強化、5 パス: tenant disable / no courses / invalid email / 既通知 / MIME preview)
+ *
+ * 認可は親で適用される前提のため、テストでは fake superAdmin middleware を挟む。
+ */
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import rateLimit from "express-rate-limit";
+import type {
+  CompletionDryRunResult,
+  DispatchSettings,
+  ProgressDryRunResult,
+} from "@lms-279/shared-types";
+
+import { InMemoryDispatchStorage } from "../../../services/dispatch/in-memory-dispatch-storage.js";
+import {
+  InMemoryTenantDataLoader,
+  type InMemoryTenantFixture,
+} from "../../../services/dispatch/tenant-data-loader.js";
+import { createDispatchDryRunSingleFlightForTest } from "../../../services/dispatch/dry-run/single-flight.js";
+import { createDispatchDryRunRouter } from "../dispatch-dry-run.js";
+
+const ADMIN_EMAIL = "admin@example.com";
+const SENDER = "dxcollege@279279.net";
+
+function makeApp(
+  storage: InMemoryDispatchStorage,
+  loader: InMemoryTenantDataLoader,
+  opts: {
+    enableLimiter?: boolean;
+    limiterLimit?: number;
+    singleFlight?: ReturnType<typeof createDispatchDryRunSingleFlightForTest>;
+  } = {},
+): express.Express {
+  const app = express();
+  app.use(express.json());
+  // fake super-admin auth (親 router で適用される設計)
+  app.use((req, _res, next) => {
+    // limiter の keyGenerator が duck typing で email field のみ読む。
+    // 強い型 assertion で AuthUser (id / role 必須) との不一致を回避。
+    (req as unknown as { user: { email: string } }).user = {
+      email: ADMIN_EMAIL,
+    };
+    next();
+  });
+  // test 用 limiter: default 無効 (noop)、必要時のみ enable
+  const noopLimiter: express.RequestHandler = (_req, _res, next) => next();
+  const testLimiter = opts.enableLimiter
+    ? rateLimit({
+        windowMs: 60 * 1000,
+        limit: opts.limiterLimit ?? 10,
+        standardHeaders: "draft-7",
+        legacyHeaders: false,
+        keyGenerator: () => "test-key", // 全リクエスト同一 key で test 簡素化
+        message: {
+          error: {
+            code: "RATE_LIMIT_EXCEEDED",
+            message: "Too many dry-run requests.",
+          },
+        },
+      })
+    : noopLimiter;
+
+  app.use(
+    "/api/v2/super",
+    createDispatchDryRunRouter({
+      storage,
+      loader,
+      senderEmail: SENDER,
+      limiter: testLimiter,
+      singleFlight:
+        opts.singleFlight ?? createDispatchDryRunSingleFlightForTest(),
+    }),
+  );
+  return app;
+}
+
+function makeFixture(
+  partial: Partial<InMemoryTenantFixture> = {},
+): InMemoryTenantFixture {
+  return {
+    publishedCourses: [{ id: "c1", lessonOrder: ["l1", "l2", "l3"] }],
+    users: [],
+    courseProgresses: new Map(),
+    ccConfig: {
+      completionNotificationEnabled: true,
+      ownerEmail: null,
+      notificationCcEmails: [],
+    },
+    info: { active: true, progressReportEnabled: true },
+    ...partial,
+  };
+}
+
+function makeSettings(
+  partial: Partial<DispatchSettings> = {},
+): DispatchSettings {
+  return {
+    enabled: true,
+    scheduleDaysOfWeek: [1, 4],
+    scheduleHourJst: 9,
+    signatureName: "DXcollege運営スタッフ",
+    completionMessageBody: "受講お疲れ様でした。",
+    senderEmail: SENDER,
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    updatedBy: "admin@279279.net",
+    version: 1,
+    ...partial,
+  };
+}
+
+function partialProgress(courseId = "c1") {
+  return [
+    { courseId, isCompleted: false, totalLessons: 3, completedLessons: 1 },
+  ];
+}
+
+function completedProgress(courseId = "c1") {
+  return [
+    { courseId, isCompleted: true, totalLessons: 3, completedLessons: 3 },
+  ];
+}
+
+// ============================================================
+// GET /super/dispatch/dry-run/progress
+// ============================================================
+
+describe("GET /super/dispatch/dry-run/progress", () => {
+  it("should return 200 with empty result when no tenants", async () => {
+    const storage = new InMemoryDispatchStorage();
+    const loader = new InMemoryTenantDataLoader();
+    const app = makeApp(storage, loader);
+
+    const res = await request(app).get("/api/v2/super/dispatch/dry-run/progress");
+
+    expect(res.status).toBe(200);
+    const body = res.body as ProgressDryRunResult;
+    expect(body.lane).toBe("progress");
+    expect(body.tenantsScanned).toBe(0);
+    expect(body.tenantsSummary).toEqual([]);
+    expect(body.totalWouldSendCount).toBe(0);
+    expect(body.scaleTriggerExceeded).toBe(false);
+  });
+
+  it("should return 200 with progress-specific fields (totalWouldSendCount / estimatedDurationMs / scaleTriggerExceeded)", async () => {
+    const storage = new InMemoryDispatchStorage();
+    const loader = new InMemoryTenantDataLoader();
+    const courseProgresses = new Map<string, ReturnType<typeof partialProgress>>();
+    courseProgresses.set("u1", partialProgress());
+    loader.setTenant(
+      "t1",
+      makeFixture({
+        users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+        courseProgresses,
+      }),
+    );
+    const app = makeApp(storage, loader);
+
+    const res = await request(app).get("/api/v2/super/dispatch/dry-run/progress");
+
+    expect(res.status).toBe(200);
+    const body = res.body as ProgressDryRunResult;
+    expect(body.lane).toBe("progress");
+    expect(body.totalWouldSendCount).toBe(1);
+    expect(body.estimatedDurationMs).toBeGreaterThan(0);
+    expect(body.estimatedPdfSizeKbRange).toMatchObject({
+      min: expect.any(Number),
+      typical: expect.any(Number),
+      max: expect.any(Number),
+    });
+  });
+
+  it("should propagate 500 when loader throws", async () => {
+    const storage = new InMemoryDispatchStorage();
+    const loader = new InMemoryTenantDataLoader();
+    // listAllTenantIds を override して throw させる
+    loader.listAllTenantIds = vi.fn(async () => {
+      throw new Error("simulated firestore failure");
+    });
+
+    const app = makeApp(storage, loader);
+    // Express default error handler が 500 を返すことを確認
+    // ただし vitest デフォルト挙動では console.error が出るため、抑制
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const res = await request(app).get("/api/v2/super/dispatch/dry-run/progress");
+
+    expect(res.status).toBe(500);
+    consoleSpy.mockRestore();
+  });
+});
+
+// ============================================================
+// GET /super/dispatch/dry-run/completion
+// ============================================================
+
+describe("GET /super/dispatch/dry-run/completion", () => {
+  it("should return 200 with empty result when no tenants", async () => {
+    const storage = new InMemoryDispatchStorage();
+    const loader = new InMemoryTenantDataLoader();
+    const app = makeApp(storage, loader);
+
+    const res = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/completion",
+    );
+
+    expect(res.status).toBe(200);
+    const body = res.body as CompletionDryRunResult;
+    expect(body.lane).toBe("completion");
+    expect(body.tenantsScanned).toBe(0);
+    expect(body.wouldNotifyCount).toBe(0);
+    expect(body.wouldNotify).toEqual([]);
+  });
+
+  it("should return 200 with completion-specific fields (wouldNotify[] + MIME preview)", async () => {
+    const storage = new InMemoryDispatchStorage();
+    storage.__setSettingsForTest(makeSettings());
+    const loader = new InMemoryTenantDataLoader();
+    const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
+    courseProgresses.set("u1", completedProgress());
+    loader.setTenant(
+      "t1",
+      makeFixture({
+        users: [{ id: "u1", email: "u1@example.com", name: "ユーザー一郎" }],
+        courseProgresses,
+      }),
+    );
+    const app = makeApp(storage, loader);
+
+    const res = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/completion",
+    );
+
+    expect(res.status).toBe(200);
+    const body = res.body as CompletionDryRunResult;
+    expect(body.lane).toBe("completion");
+    expect(body.wouldNotifyCount).toBe(1);
+    expect(body.wouldNotify[0]).toMatchObject({
+      tenantId: "t1",
+      userId: "u1",
+      userEmail: "u1@example.com",
+    });
+    // MIME preview: subject / body / from
+    expect(body.wouldNotify[0]?.mimePreview.from).toContain(SENDER);
+    expect(body.wouldNotify[0]?.mimePreview.subject).toBeTruthy();
+    expect(body.wouldNotify[0]?.mimePreview.body).toBeTruthy();
+  });
+
+  it("should propagate 500 when storage throws", async () => {
+    const storage = new InMemoryDispatchStorage();
+    storage.getDispatchSettings = vi.fn(async () => {
+      throw new Error("simulated firestore failure");
+    });
+    const loader = new InMemoryTenantDataLoader();
+    const app = makeApp(storage, loader);
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const res = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/completion",
+    );
+
+    expect(res.status).toBe(500);
+    consoleSpy.mockRestore();
+  });
+});
+
+// ============================================================
+// single-flight integration (Codex High: Firestore read 抑制)
+// ============================================================
+
+describe("single-flight integration", () => {
+  // 注: 「same-lane 並行リクエストで fn 1 回」の単体担保は
+  // single-flight.test.ts (DI 直接 test、5 cases) で完了済。
+  // supertest の HTTP 並行モデルでは process-tick タイミングで
+  // 1 リクエスト目が sf.run() の Map.set 完了前に 2 リクエスト目が到達することがあり
+  // flaky になりやすいため、route integration では「異なる lane の独立実行」のみ確認する。
+
+  it("should execute independently for different lanes", async () => {
+    const storage = new InMemoryDispatchStorage();
+    const loader = new InMemoryTenantDataLoader();
+    const app = makeApp(storage, loader);
+
+    const [progressRes, completionRes] = await Promise.all([
+      request(app).get("/api/v2/super/dispatch/dry-run/progress"),
+      request(app).get("/api/v2/super/dispatch/dry-run/completion"),
+    ]);
+
+    expect(progressRes.status).toBe(200);
+    expect((progressRes.body as ProgressDryRunResult).lane).toBe("progress");
+    expect(completionRes.status).toBe(200);
+    expect((completionRes.body as CompletionDryRunResult).lane).toBe("completion");
+  });
+});
+
+// ============================================================
+// limiter integration (429)
+// ============================================================
+
+describe("limiter integration (429)", () => {
+  it("should return 429 after exceeding limit per superAdmin email", async () => {
+    const storage = new InMemoryDispatchStorage();
+    const loader = new InMemoryTenantDataLoader();
+    // limit 2 で test を加速
+    const app = makeApp(storage, loader, {
+      enableLimiter: true,
+      limiterLimit: 2,
+    });
+
+    const r1 = await request(app).get("/api/v2/super/dispatch/dry-run/progress");
+    const r2 = await request(app).get("/api/v2/super/dispatch/dry-run/progress");
+    const r3 = await request(app).get("/api/v2/super/dispatch/dry-run/progress");
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r3.status).toBe(429);
+    expect(r3.body.error?.code).toBe("RATE_LIMIT_EXCEEDED");
+  });
+});
+
+// ============================================================
+// 完了通知 service-level regression (Codex High: AC-α7-07 強化、5 パス)
+// ============================================================
+
+describe("完了通知 service-level regression (5 paths)", () => {
+  it("should skip tenant with completionNotificationEnabled=false (path 1: tenant disable)", async () => {
+    const storage = new InMemoryDispatchStorage();
+    storage.__setSettingsForTest(makeSettings());
+    const loader = new InMemoryTenantDataLoader();
+    loader.setTenant(
+      "t1",
+      makeFixture({
+        ccConfig: {
+          completionNotificationEnabled: false,
+          ownerEmail: null,
+          notificationCcEmails: [],
+        },
+      }),
+    );
+    const app = makeApp(storage, loader);
+
+    const res = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/completion",
+    );
+
+    const body = res.body as CompletionDryRunResult;
+    expect(body.tenantsSummary[0]?.skipReason).toBe(
+      "tenant_completion_notification_disabled",
+    );
+    expect(body.wouldNotifyCount).toBe(0);
+  });
+
+  it("should skip tenant with empty publishedCourses (path 2: no courses)", async () => {
+    const storage = new InMemoryDispatchStorage();
+    storage.__setSettingsForTest(makeSettings());
+    const loader = new InMemoryTenantDataLoader();
+    loader.setTenant("t1", makeFixture({ publishedCourses: [] }));
+    const app = makeApp(storage, loader);
+
+    const res = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/completion",
+    );
+
+    const body = res.body as CompletionDryRunResult;
+    expect(body.tenantsSummary[0]?.skipReason).toBe("no_published_courses");
+    expect(body.wouldNotifyCount).toBe(0);
+  });
+
+  it("should reject invalid email (path 3: invalid email)", async () => {
+    const storage = new InMemoryDispatchStorage();
+    storage.__setSettingsForTest(makeSettings());
+    const loader = new InMemoryTenantDataLoader();
+    const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
+    courseProgresses.set("u-invalid", completedProgress());
+    loader.setTenant(
+      "t1",
+      makeFixture({
+        users: [
+          { id: "u-invalid", email: "not-an-email", name: "U-Invalid" },
+        ],
+        courseProgresses,
+      }),
+    );
+    const app = makeApp(storage, loader);
+
+    const res = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/completion",
+    );
+
+    const body = res.body as CompletionDryRunResult;
+    expect(body.wouldNotifyCount).toBe(0);
+    expect(body.tenantsSummary[0]?.eligibleCount).toBe(0);
+  });
+
+  it("should skip user whose notification already exists (path 4: already notified)", async () => {
+    const storage = new InMemoryDispatchStorage();
+    storage.__setSettingsForTest(makeSettings());
+    // 既通知 user を inject (storage 内部 state)
+    storage.getCompletionNotification = vi.fn(async (_tid, uid) =>
+      uid === "u1"
+        ? ({
+            userId: "u1",
+            status: "sent",
+            runId: "run-1",
+            reservedAt: "2026-05-01T00:00:00.000Z",
+            leaseExpiresAt: "2026-05-01T00:30:00.000Z",
+            notifiedAt: "2026-05-01T00:01:00.000Z",
+            messageId: "msg",
+            errorCode: null,
+            errorMessage: null,
+            failedAt: null,
+            progressSnapshot: {
+              completedLessons: 3,
+              totalLessons: 3,
+              coursesCompleted: 1,
+              coursesTotal: 1,
+            },
+            courseIdsSnapshot: ["c1"],
+            publishedCourseCount: 1,
+            recipientToHash: "h",
+            recipientCcHashes: [],
+            pdfSizeBytes: null,
+          } as Awaited<ReturnType<typeof storage.getCompletionNotification>>)
+        : null,
+    );
+    const loader = new InMemoryTenantDataLoader();
+    const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
+    courseProgresses.set("u1", completedProgress());
+    loader.setTenant(
+      "t1",
+      makeFixture({
+        users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+        courseProgresses,
+      }),
+    );
+    const app = makeApp(storage, loader);
+
+    const res = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/completion",
+    );
+
+    const body = res.body as CompletionDryRunResult;
+    expect(body.wouldNotifyCount).toBe(0);
+  });
+
+  it("should generate MIME preview for eligible new user (path 5: MIME preview)", async () => {
+    const storage = new InMemoryDispatchStorage();
+    storage.__setSettingsForTest(makeSettings());
+    const loader = new InMemoryTenantDataLoader();
+    const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
+    courseProgresses.set("u1", completedProgress());
+    loader.setTenant(
+      "t1",
+      makeFixture({
+        users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+        courseProgresses,
+        ccConfig: {
+          completionNotificationEnabled: true,
+          ownerEmail: "owner@example.com",
+          notificationCcEmails: ["cc@example.com"],
+        },
+      }),
+    );
+    const app = makeApp(storage, loader);
+
+    const res = await request(app).get(
+      "/api/v2/super/dispatch/dry-run/completion",
+    );
+
+    const body = res.body as CompletionDryRunResult;
+    expect(body.wouldNotifyCount).toBe(1);
+    expect(body.wouldNotify[0]?.mimePreview.to).toBe("u1@example.com");
+    expect(body.wouldNotify[0]?.mimePreview.cc).toEqual(
+      expect.arrayContaining(["owner@example.com", "cc@example.com"]),
+    );
+    expect(body.wouldNotify[0]?.mimePreview.subject).toBeTruthy();
+    expect(body.wouldNotify[0]?.mimePreview.body).toBeTruthy();
+  });
+});
+
+// ============================================================
+// PR #490 撤廃方針の維持: test-send 経路ゼロ
+// ============================================================
+
+describe("PR #490 撤廃方針の維持", () => {
+  it("should NOT expose POST /dispatch/test-send (404 or method not allowed)", async () => {
+    const storage = new InMemoryDispatchStorage();
+    const loader = new InMemoryTenantDataLoader();
+    const app = makeApp(storage, loader);
+
+    const res = await request(app)
+      .post("/api/v2/super/dispatch/test-send")
+      .send({ to: "victim@example.com" });
+
+    // 404 (router 未登録) を想定。test-send 経路は本 PR で復活させない。
+    expect(res.status).toBe(404);
+  });
+
+  it("should NOT expose POST /dispatch/dry-run (404, GET only)", async () => {
+    const storage = new InMemoryDispatchStorage();
+    const loader = new InMemoryTenantDataLoader();
+    const app = makeApp(storage, loader);
+
+    // 旧 PR #490 撤廃前は POST /dispatch/dry-run。α-7 では GET /dispatch/dry-run/{lane} のみ。
+    const res = await request(app).post("/api/v2/super/dispatch/dry-run").send({});
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/services/api/src/routes/super/dispatch-dry-run.ts
+++ b/services/api/src/routes/super/dispatch-dry-run.ts
@@ -1,0 +1,96 @@
+/**
+ * スーパー管理者向け dispatch dry-run 取得ルート (Phase 4 α-7 C1)。
+ *
+ * GET /api/v2/super/dispatch/dry-run/progress
+ *   200: ProgressDryRunResult (DispatchDryRunResult discriminated union の "progress" variant)
+ * GET /api/v2/super/dispatch/dry-run/completion
+ *   200: CompletionDryRunResult (DispatchDryRunResult discriminated union の "completion" variant)
+ *
+ * いずれも:
+ *   - 認可: 親 router で superAdminAuthMiddleware 適用 (AC-α7-05)
+ *   - レート制限: dispatchDryRunLimiter (10 req/min/superAdminEmail、AC-α7-12)
+ *   - 重複制御: lane 単位 single-flight (進行中は結果共有で Firestore read 抑制)
+ *   - read-only: Firestore write / Gmail send / PDF 実生成なし (AC-α7-06)
+ *   - test-send 経路を含まない (PR #490 撤廃方針維持)
+ *
+ * Phase 4 α-7 C2 で dispatch-super-router.ts から mount される。
+ *
+ * 関連:
+ *   - impl-plan: docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md §3 タスク C1
+ *   - PR #490 撤廃理由の解消: 同 impl-plan §「PR #490 撤廃理由の解消」
+ *   - 過去の同名 route (PR #490 で削除): services/api/src/routes/super/dispatch-dry-run.ts
+ *     (本ファイルは別設計 (両レーン対応 / discriminated union / 専用 limiter / single-flight) で再導入)
+ */
+
+import { Router, type Request, type RequestHandler, type Response } from "express";
+import type { DispatchDryRunResult } from "@lms-279/shared-types";
+
+import { dispatchDryRunLimiter } from "../../middleware/dispatch-dry-run-limiter.js";
+import { runProgressReportDryRun } from "../../services/dispatch/dry-run/progress-report-dry-run.js";
+import { runCompletionNotificationDryRun } from "../../services/dispatch/dry-run/completion-notification-dry-run.js";
+import {
+  sharedDispatchDryRunSingleFlight,
+  type DispatchDryRunSingleFlight,
+} from "../../services/dispatch/dry-run/single-flight.js";
+import type { DispatchStorage } from "../../services/dispatch/dispatch-storage.js";
+import type { TenantDataLoader } from "../../services/dispatch/tenant-data-loader.js";
+
+export interface DispatchDryRunRouteDeps {
+  storage: DispatchStorage;
+  loader: TenantDataLoader;
+  /** 完了通知 dry-run の MIME From アドレス (環境変数から index.ts で読み取り inject) */
+  senderEmail: string;
+  /**
+   * test では独立 single-flight instance を inject 可能。
+   * production / 通常は省略して module スコープ singleton を使用。
+   */
+  singleFlight?: DispatchDryRunSingleFlight;
+  /**
+   * test では noop or 独立 limiter instance を inject 可能 (module スコープ
+   * `dispatchDryRunLimiter` は process スコープ state を持ち test 間で残るため)。
+   * production / 通常は省略して default `dispatchDryRunLimiter` を使用。
+   */
+  limiter?: RequestHandler;
+}
+
+export function createDispatchDryRunRouter(
+  deps: DispatchDryRunRouteDeps,
+): Router {
+  const router = Router();
+  const sf = deps.singleFlight ?? sharedDispatchDryRunSingleFlight;
+  const limiter = deps.limiter ?? dispatchDryRunLimiter;
+
+  router.get(
+    "/dispatch/dry-run/progress",
+    limiter,
+    async (_req: Request, res: Response): Promise<void> => {
+      const result: DispatchDryRunResult = await sf.run("progress", () =>
+        runProgressReportDryRun({
+          storage: deps.storage,
+          loader: deps.loader,
+          now: new Date(),
+          // logger は省略 (default NOOP)、Phase 4 後続で構造化 logger 注入を検討
+        }),
+      );
+      res.json(result);
+    },
+  );
+
+  router.get(
+    "/dispatch/dry-run/completion",
+    limiter,
+    async (_req: Request, res: Response): Promise<void> => {
+      const result: DispatchDryRunResult = await sf.run("completion", () =>
+        runCompletionNotificationDryRun({
+          storage: deps.storage,
+          loader: deps.loader,
+          senderEmail: deps.senderEmail,
+          now: new Date(),
+        }),
+      );
+      res.json(result);
+    },
+  );
+
+  return router;
+}

--- a/services/api/src/routes/super/dispatch-dry-run.ts
+++ b/services/api/src/routes/super/dispatch-dry-run.ts
@@ -26,7 +26,11 @@ import { Router, type Request, type RequestHandler, type Response } from "expres
 import type { DispatchDryRunResult } from "@lms-279/shared-types";
 
 import { dispatchDryRunLimiter } from "../../middleware/dispatch-dry-run-limiter.js";
-import { runProgressReportDryRun } from "../../services/dispatch/dry-run/progress-report-dry-run.js";
+import {
+  runProgressReportDryRun,
+  createStructuredProgressDryRunLogger,
+  type ProgressDryRunLogger,
+} from "../../services/dispatch/dry-run/progress-report-dry-run.js";
 import { runCompletionNotificationDryRun } from "../../services/dispatch/dry-run/completion-notification-dry-run.js";
 import {
   sharedDispatchDryRunSingleFlight,
@@ -34,23 +38,55 @@ import {
 } from "../../services/dispatch/dry-run/single-flight.js";
 import type { DispatchStorage } from "../../services/dispatch/dispatch-storage.js";
 import type { TenantDataLoader } from "../../services/dispatch/tenant-data-loader.js";
+import { logger as defaultLogger } from "../../utils/logger.js";
+
+/**
+ * Phase 4 α-7 code-review F9 反映: `storage` を read-only API のみに narrow し、
+ * 将来 route 層で writer メソッドが直接呼ばれる事故を型レベルで防ぐ。
+ * service 側 (`Pick<DispatchStorage, "getDispatchSettings">` 等) と整合し、
+ * AC-α7-06 (read-only 保証の型レベル担保) を route 層まで貫徹する。
+ */
+export type DispatchDryRunStorage = Pick<
+  DispatchStorage,
+  "getDispatchSettings" | "getCompletionNotification"
+>;
 
 export interface DispatchDryRunRouteDeps {
-  storage: DispatchStorage;
+  storage: DispatchDryRunStorage;
   loader: TenantDataLoader;
   /** 完了通知 dry-run の MIME From アドレス (環境変数から index.ts で読み取り inject) */
   senderEmail: string;
   /**
    * test では独立 single-flight instance を inject 可能。
    * production / 通常は省略して module スコープ singleton を使用。
+   *
+   * Phase 4 α-7 code-review F7 (documented behavior): single-flight は同 lane の
+   * concurrent waiter に同一 Promise を共有させる。先発 caller の transient error
+   * (例: Firestore DEADLINE_EXCEEDED) は後発 caller にもそのまま伝播し、
+   * `evaluatedAt` も先発時刻に固定される。これは Firestore read 重複を抑制する
+   * 設計上の fail-fast 挙動であり、cross-caller 識別が必要なケースでは limiter
+   * (email 単位) の方が先に弾く前提。
    */
   singleFlight?: DispatchDryRunSingleFlight;
   /**
    * test では noop or 独立 limiter instance を inject 可能 (module スコープ
    * `dispatchDryRunLimiter` は process スコープ state を持ち test 間で残るため)。
    * production / 通常は省略して default `dispatchDryRunLimiter` を使用。
+   *
+   * Phase 4 α-7 code-review F5 (documented behavior): default `dispatchDryRunLimiter`
+   * は単一 instance を progress / completion 両 handler に貼っているため、
+   * 10 req/min/superAdminEmail は **両 lane 合算** の budget となる
+   * (impl-plan §3 C1 文言通り、per-lane granularity は採用しない)。
+   * 将来 per-lane に切り替える場合は `limiter` を lane 別に inject する形へ拡張。
    */
   limiter?: RequestHandler;
+  /**
+   * Phase 4 α-7 code-review F4 反映: tenant_doc_not_found を含む WARN を Cloud Logging
+   * に出力させるための構造化 logger 注入点。default は `utils/logger.ts` の構造化
+   * logger を adapter 経由で使用 (silent-fail-paired-signal 違反を回避)。
+   * test では noop 注入で標準出力汚染を避ける。
+   */
+  progressDryRunLogger?: ProgressDryRunLogger;
 }
 
 export function createDispatchDryRunRouter(
@@ -59,6 +95,8 @@ export function createDispatchDryRunRouter(
   const router = Router();
   const sf = deps.singleFlight ?? sharedDispatchDryRunSingleFlight;
   const limiter = deps.limiter ?? dispatchDryRunLimiter;
+  const progressLogger =
+    deps.progressDryRunLogger ?? createStructuredProgressDryRunLogger(defaultLogger);
 
   router.get(
     "/dispatch/dry-run/progress",
@@ -69,7 +107,7 @@ export function createDispatchDryRunRouter(
           storage: deps.storage,
           loader: deps.loader,
           now: new Date(),
-          // logger は省略 (default NOOP)、Phase 4 後続で構造化 logger 注入を検討
+          logger: progressLogger,
         }),
       );
       res.json(result);

--- a/services/api/src/routes/super/dispatch-super-router.ts
+++ b/services/api/src/routes/super/dispatch-super-router.ts
@@ -1,17 +1,28 @@
 /**
- * DXcollege 自動完了通知 スーパー管理者 API の集約ルータ (Phase 5)。
+ * DXcollege 配信 スーパー管理者 API の集約ルータ (Phase 5、Phase 4 α-7 で dry-run 再導入)。
  *
- * 4 endpoint を 1 ルータに束ね、index.ts で superAdminAuthMiddleware 配下に mount する。
+ * 6 endpoint を 1 ルータに束ね、index.ts で superAdminAuthMiddleware 配下に mount する。
  *   GET/PUT /dispatch/settings
  *   GET/PUT /tenants/:tenantId/notification-cc-emails
  *   GET     /dispatch/audit-logs
  *   GET     /dispatch/runs
+ *   GET     /dispatch/dry-run/progress      (Phase 4 α-7 で追加)
+ *   GET     /dispatch/dry-run/completion    (Phase 4 α-7 で追加)
  *
- * 旧 POST /dispatch/dry-run / /dispatch/test-send は 2026-05-24 PR-B で撤廃済み:
- *   - dry-run の代替は `.github/workflows/dispatch-dry-run.yml` + `scripts/dispatch-dry-run-cli.ts`
- *     (admin SDK workflow_dispatch、UI ボタン撤廃方針)
- *   - test-send は SendAs send smoke (`smoke-dwd-gmail-send.yml`) と本機能本体の
- *     monitoring で代替 (固定 dummy 送信は cutover 時の検証で完了済)
+ * dry-run UI 再導入の経緯 (2026-06-03 開発者決裁):
+ *   2026-05-24 PR #490 で dry-run UI / API は「UI に残すと誤操作リスク」「AI 代替経路で十分」
+ *   との判断で撤廃。Phase 3 進捗レポート機能の本格 cutover + 業務スーパー管理者の自律的
+ *   運用フェーズへの移行に伴い「画面で事前確認できないと運用リスク」が顕在化したため、
+ *   下記の前提変化を満たす範囲で再導入:
+ *     - read-only viewer 限定 (test-send 機能は再導入しない)
+ *     - 専用 limiter (10 req/min/superAdminEmail) + lane 単位 single-flight で抑制
+ *     - 両レーン同時 UI 化 (UX 統一)
+ *   詳細: docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md §「PR #490 撤廃理由の解消」
+ *
+ * 旧 POST /dispatch/test-send は引き続き撤廃 (再導入しない、PR #490 撤廃方針を維持)。
+ * 旧 dry-run の代替 workflow は引き続き運用継続 (AI / 開発者向け):
+ *   - `.github/workflows/dispatch-dry-run.yml`
+ *   - `.github/workflows/progress-report-dry-run.yml`
  *
  * production wiring は dispatch factory (storage/loader/env) を inject。
  * tenant CC store は default 実体を使うが、テストでは差し替え可能。
@@ -19,6 +30,7 @@
 
 import { Router } from "express";
 import type { DispatchStorage } from "../../services/dispatch/dispatch-storage.js";
+import type { TenantDataLoader } from "../../services/dispatch/tenant-data-loader.js";
 import type { DispatchEnv } from "../../services/dispatch/run-completion-notifications.js";
 import { createDispatchSettingsRouter } from "./dispatch-settings.js";
 import {
@@ -28,9 +40,12 @@ import {
 } from "./tenant-notification-cc.js";
 import { createDispatchAuditLogsRouter } from "./dispatch-audit-logs.js";
 import { createDispatchRunsRouter } from "./dispatch-runs.js";
+import { createDispatchDryRunRouter } from "./dispatch-dry-run.js";
 
 export interface DispatchSuperRouterDeps {
   storage: DispatchStorage;
+  /** Phase 4 α-7 で dry-run UI 再導入に伴い deps に復活 (PR #490 撤廃時に削除されていた) */
+  loader: TenantDataLoader;
   env: DispatchEnv;
   /** tenant CC I/O (default: Firestore) */
   ccStore?: TenantCcConfigStore;
@@ -54,6 +69,13 @@ export function createDispatchSuperRouter(
   );
   router.use(createDispatchAuditLogsRouter({ storage: deps.storage }));
   router.use(createDispatchRunsRouter({ storage: deps.storage }));
+  router.use(
+    createDispatchDryRunRouter({
+      storage: deps.storage,
+      loader: deps.loader,
+      senderEmail: deps.env.fromEmail,
+    }),
+  );
 
   return router;
 }

--- a/services/api/src/services/dispatch/dry-run/__tests__/completion-notification-dry-run.test.ts
+++ b/services/api/src/services/dispatch/dry-run/__tests__/completion-notification-dry-run.test.ts
@@ -15,71 +15,21 @@
 import { describe, it, expect } from "vitest";
 import type { DispatchSettings, CompletionNotification } from "@lms-279/shared-types";
 
-import { InMemoryDispatchStorage } from "../../in-memory-dispatch-storage.js";
-import {
-  InMemoryTenantDataLoader,
-  type InMemoryTenantFixture,
-} from "../../tenant-data-loader.js";
-import type { DispatchStorage } from "../../dispatch-storage.js";
+import { InMemoryTenantDataLoader } from "../../tenant-data-loader.js";
 import {
   runCompletionNotificationDryRun,
   DEFAULT_SIGNATURE,
   DEFAULT_BODY,
   type RunCompletionNotificationDryRunInput,
 } from "../completion-notification-dry-run.js";
-
-// ============================================================
-// fixture / helper
-// ============================================================
-
-const NOW = new Date("2026-06-03T00:00:00.000Z");
-const SENDER_EMAIL = "dxcollege@279279.net";
-
-function makeSettings(partial: Partial<DispatchSettings> = {}): DispatchSettings {
-  return {
-    enabled: true,
-    scheduleDaysOfWeek: [1, 4],
-    scheduleHourJst: 9,
-    signatureName: "DXcollege運営スタッフ",
-    completionMessageBody: "受講お疲れ様でした。",
-    senderEmail: SENDER_EMAIL,
-    updatedAt: "2026-05-20T00:00:00.000Z",
-    updatedBy: "admin@279279.net",
-    version: 1,
-    ...partial,
-  };
-}
-
-function makeFixture(
-  partial: Partial<InMemoryTenantFixture> = {},
-): InMemoryTenantFixture {
-  return {
-    publishedCourses: [{ id: "c1", lessonOrder: ["l1", "l2", "l3"] }],
-    users: [],
-    courseProgresses: new Map(),
-    ccConfig: {
-      completionNotificationEnabled: true,
-      ownerEmail: null,
-      notificationCcEmails: [],
-    },
-    info: { active: true, progressReportEnabled: false },
-    ...partial,
-  };
-}
-
-/** progressRatio = 3/3 = 100% の進捗 (eligibility true、対象) */
-function completedProgress(courseId = "c1") {
-  return [
-    { courseId, isCompleted: true, totalLessons: 3, completedLessons: 3 },
-  ];
-}
-
-/** progressRatio = 1/3 ≈ 33% の進捗 (eligibility false、skip 対象) */
-function partialProgress(courseId = "c1") {
-  return [
-    { courseId, isCompleted: false, totalLessons: 3, completedLessons: 1 },
-  ];
-}
+import {
+  FIXTURE_NOW as NOW,
+  FIXTURE_SENDER_EMAIL as SENDER_EMAIL,
+  makeSettings,
+  makeFixture,
+  partialProgress,
+  completedProgress,
+} from "./dry-run-fixtures.js";
 
 /**
  * test 用 storage stub。`getCompletionNotification` を inject 可能にし、
@@ -170,6 +120,25 @@ describe("runCompletionNotificationDryRun", () => {
         completionMessageBodyLength: "テスト本文 12 文字".length,
       });
     });
+
+    it("should return completionMessageBodyLength=null when settings.completionMessageBody is undefined (F3 regression)", async () => {
+      // Phase 4 α-7 code-review F3: PutDispatchSettingsRequest が patch semantics で
+      // 全 field optional になり、Firestore に partial doc が残ると storage 経由で
+      // `completionMessageBody: undefined` が返る。旧実装は `.length` で TypeError を
+      // throw して 500 → cutover preview が UI で死ぬ。null 許容で graceful fallback。
+      const settings = makeSettings();
+      // 型をすり抜けて undefined を強制 (storage roundtrip 経由のパーシャル状態を模倣)
+      delete (settings as { completionMessageBody?: string }).completionMessageBody;
+
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ storage: new TestDryRunStorage(settings) }),
+      );
+
+      expect(result.settingsLoaded).toBe(true);
+      expect(result.settingsSnapshot?.completionMessageBodyLength).toBeNull();
+      // signatureName 等の他フィールドは引き続き取れる (no throw)
+      expect(result.settingsSnapshot?.signatureName).toBe("DXcollege運営スタッフ");
+    });
   });
 
   describe("skip reasons (Codex AC-α7-07: 5 パス regression 強化)", () => {
@@ -227,7 +196,10 @@ describe("runCompletionNotificationDryRun", () => {
       });
     });
 
-    it("should reject invalid email and exclude from wouldNotify (not counted in eligibleCount)", async () => {
+    it("should reject invalid email and expose invalidEmailCount=1 (F8 regression)", async () => {
+      // Phase 4 α-7 code-review F8: 進捗レーンとの対称性回復のため、完了通知レーンでも
+      // invalidEmailCount を tenantsSummary で公開する。malformed email user は
+      // eligibleCount に含めず invalidEmailCount に独立計上する。
       const loader = new InMemoryTenantDataLoader();
       const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
       courseProgresses.set("u-invalid", completedProgress());
@@ -247,6 +219,7 @@ describe("runCompletionNotificationDryRun", () => {
         skipped: false,
         usersScanned: 1,
         eligibleCount: 0,
+        invalidEmailCount: 1,
       });
       expect(result.wouldNotifyCount).toBe(0);
     });

--- a/services/api/src/services/dispatch/dry-run/__tests__/completion-notification-dry-run.test.ts
+++ b/services/api/src/services/dispatch/dry-run/__tests__/completion-notification-dry-run.test.ts
@@ -1,0 +1,455 @@
+/**
+ * completion-notification-dry-run service module の unit test (Phase 4 α-7 A2)。
+ *
+ * Codex 高優先指摘 (impl-plan AC-α7-07 強化) 反映:
+ *   - 既通知ユーザー除外
+ *   - tenant disable
+ *   - invalid email reject
+ *   - no published courses
+ *   - MIME preview 生成 (subject / body / from / cc)
+ *
+ * 既存 CLI (scripts/dispatch-dry-run-cli.ts) の振る舞いを 1:1 維持する
+ * regression test の役割も兼ねる。
+ */
+
+import { describe, it, expect } from "vitest";
+import type { DispatchSettings, CompletionNotification } from "@lms-279/shared-types";
+
+import { InMemoryDispatchStorage } from "../../in-memory-dispatch-storage.js";
+import {
+  InMemoryTenantDataLoader,
+  type InMemoryTenantFixture,
+} from "../../tenant-data-loader.js";
+import type { DispatchStorage } from "../../dispatch-storage.js";
+import {
+  runCompletionNotificationDryRun,
+  DEFAULT_SIGNATURE,
+  DEFAULT_BODY,
+  type RunCompletionNotificationDryRunInput,
+} from "../completion-notification-dry-run.js";
+
+// ============================================================
+// fixture / helper
+// ============================================================
+
+const NOW = new Date("2026-06-03T00:00:00.000Z");
+const SENDER_EMAIL = "dxcollege@279279.net";
+
+function makeSettings(partial: Partial<DispatchSettings> = {}): DispatchSettings {
+  return {
+    enabled: true,
+    scheduleDaysOfWeek: [1, 4],
+    scheduleHourJst: 9,
+    signatureName: "DXcollege運営スタッフ",
+    completionMessageBody: "受講お疲れ様でした。",
+    senderEmail: SENDER_EMAIL,
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    updatedBy: "admin@279279.net",
+    version: 1,
+    ...partial,
+  };
+}
+
+function makeFixture(
+  partial: Partial<InMemoryTenantFixture> = {},
+): InMemoryTenantFixture {
+  return {
+    publishedCourses: [{ id: "c1", lessonOrder: ["l1", "l2", "l3"] }],
+    users: [],
+    courseProgresses: new Map(),
+    ccConfig: {
+      completionNotificationEnabled: true,
+      ownerEmail: null,
+      notificationCcEmails: [],
+    },
+    info: { active: true, progressReportEnabled: false },
+    ...partial,
+  };
+}
+
+/** progressRatio = 3/3 = 100% の進捗 (eligibility true、対象) */
+function completedProgress(courseId = "c1") {
+  return [
+    { courseId, isCompleted: true, totalLessons: 3, completedLessons: 3 },
+  ];
+}
+
+/** progressRatio = 1/3 ≈ 33% の進捗 (eligibility false、skip 対象) */
+function partialProgress(courseId = "c1") {
+  return [
+    { courseId, isCompleted: false, totalLessons: 3, completedLessons: 1 },
+  ];
+}
+
+/**
+ * test 用 storage stub。`getCompletionNotification` を inject 可能にし、
+ * 既通知ユーザーの skip 経路を test しやすくする。
+ *
+ * `Pick<DispatchStorage, "getDispatchSettings" | "getCompletionNotification">` の
+ * 最小 API のみ実装 (read-only 担保)。
+ */
+class TestDryRunStorage {
+  constructor(
+    private readonly settings: DispatchSettings | null,
+    private readonly existingNotifications = new Map<string, CompletionNotification>(),
+  ) {}
+
+  async getDispatchSettings(): Promise<DispatchSettings | null> {
+    return this.settings;
+  }
+
+  async getCompletionNotification(
+    tenantId: string,
+    userId: string,
+  ): Promise<CompletionNotification | null> {
+    return this.existingNotifications.get(`${tenantId}::${userId}`) ?? null;
+  }
+}
+
+function makeStorageWithExisting(
+  settings: DispatchSettings | null,
+  existing: Array<{ tenantId: string; userId: string; notification: CompletionNotification }>,
+) {
+  const map = new Map<string, CompletionNotification>();
+  for (const e of existing) {
+    map.set(`${e.tenantId}::${e.userId}`, e.notification);
+  }
+  return new TestDryRunStorage(settings, map);
+}
+
+function defaultInput(
+  overrides: Partial<RunCompletionNotificationDryRunInput> = {},
+): RunCompletionNotificationDryRunInput {
+  return {
+    storage: new TestDryRunStorage(null),
+    loader: new InMemoryTenantDataLoader(),
+    senderEmail: SENDER_EMAIL,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+// ============================================================
+// tests
+// ============================================================
+
+describe("runCompletionNotificationDryRun", () => {
+  describe("no tenants", () => {
+    it("should return empty tenantsSummary and wouldNotifyCount=0", async () => {
+      const result = await runCompletionNotificationDryRun(defaultInput());
+
+      expect(result.tenantsScanned).toBe(0);
+      expect(result.tenantsSummary).toEqual([]);
+      expect(result.wouldNotifyCount).toBe(0);
+      expect(result.wouldNotify).toEqual([]);
+    });
+  });
+
+  describe("settings snapshot", () => {
+    it("should return settingsLoaded=false and snapshot=null when settings missing", async () => {
+      const result = await runCompletionNotificationDryRun(defaultInput());
+
+      expect(result.settingsLoaded).toBe(false);
+      expect(result.settingsSnapshot).toBeNull();
+    });
+
+    it("should populate snapshot from settings (including completionMessageBodyLength)", async () => {
+      const settings = makeSettings({
+        completionMessageBody: "テスト本文 12 文字",
+      });
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ storage: new TestDryRunStorage(settings) }),
+      );
+
+      expect(result.settingsLoaded).toBe(true);
+      expect(result.settingsSnapshot).toMatchObject({
+        enabled: true,
+        scheduleDaysOfWeek: [1, 4],
+        scheduleHourJst: 9,
+        signatureName: "DXcollege運営スタッフ",
+        completionMessageBodyLength: "テスト本文 12 文字".length,
+      });
+    });
+  });
+
+  describe("skip reasons (Codex AC-α7-07: 5 パス regression 強化)", () => {
+    it("should skip with reason=tenant_completion_notification_disabled when ccConfig.completionNotificationEnabled=false", async () => {
+      const loader = new InMemoryTenantDataLoader();
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          ccConfig: {
+            completionNotificationEnabled: false,
+            ownerEmail: null,
+            notificationCcEmails: [],
+          },
+        }),
+      );
+
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ loader }),
+      );
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        tenantId: "t1",
+        skipped: true,
+        skipReason: "tenant_completion_notification_disabled",
+        eligibleCount: 0,
+      });
+      expect(result.wouldNotifyCount).toBe(0);
+    });
+
+    it("should skip with reason=tenant_completion_notification_disabled when ccConfig is null", async () => {
+      const loader = new InMemoryTenantDataLoader();
+      loader.setTenant("t1", makeFixture({ ccConfig: null }));
+
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ loader }),
+      );
+
+      expect(result.tenantsSummary[0]?.skipReason).toBe(
+        "tenant_completion_notification_disabled",
+      );
+    });
+
+    it("should skip with reason=no_published_courses", async () => {
+      const loader = new InMemoryTenantDataLoader();
+      loader.setTenant("t1", makeFixture({ publishedCourses: [] }));
+
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ loader }),
+      );
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        tenantId: "t1",
+        skipped: true,
+        skipReason: "no_published_courses",
+      });
+    });
+
+    it("should reject invalid email and exclude from wouldNotify (not counted in eligibleCount)", async () => {
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
+      courseProgresses.set("u-invalid", completedProgress());
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u-invalid", email: "not-an-email", name: "U-Invalid" }],
+          courseProgresses,
+        }),
+      );
+
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ loader }),
+      );
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        skipped: false,
+        usersScanned: 1,
+        eligibleCount: 0,
+      });
+      expect(result.wouldNotifyCount).toBe(0);
+    });
+
+    it("should skip when CompletionNotification already exists (any status)", async () => {
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
+      courseProgresses.set("u1", completedProgress());
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+          courseProgresses,
+        }),
+      );
+
+      const sentNotification: CompletionNotification = {
+        userId: "u1",
+        status: "sent",
+        runId: "run-1",
+        reservedAt: "2026-05-01T00:00:00.000Z",
+        leaseExpiresAt: "2026-05-01T00:30:00.000Z",
+        notifiedAt: "2026-05-01T00:01:00.000Z",
+        messageId: "msg-1",
+        errorCode: null,
+        errorMessage: null,
+        failedAt: null,
+        progressSnapshot: {
+          completedLessons: 3,
+          totalLessons: 3,
+          coursesCompleted: 1,
+          coursesTotal: 1,
+        },
+        courseIdsSnapshot: ["c1"],
+        publishedCourseCount: 1,
+        recipientToHash: "sha256-abc",
+        recipientCcHashes: [],
+        pdfSizeBytes: null,
+      };
+      const storage = makeStorageWithExisting(null, [
+        { tenantId: "t1", userId: "u1", notification: sentNotification },
+      ]);
+
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ loader, storage }),
+      );
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        skipped: false,
+        usersScanned: 1,
+        eligibleCount: 0, // 既送信は eligibleCount に含めない
+      });
+      expect(result.wouldNotifyCount).toBe(0);
+    });
+  });
+
+  describe("eligible target generation + MIME preview", () => {
+    it("should include 100% completed user in wouldNotify with valid MIME preview", async () => {
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
+      courseProgresses.set("u1", completedProgress());
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u1", email: "u1@example.com", name: "ユーザー一郎" }],
+          courseProgresses,
+          ccConfig: {
+            completionNotificationEnabled: true,
+            ownerEmail: "owner@example.com",
+            notificationCcEmails: ["cc1@example.com"],
+          },
+        }),
+      );
+      const settings = makeSettings();
+      const storage = new TestDryRunStorage(settings);
+
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ loader, storage }),
+      );
+
+      expect(result.wouldNotifyCount).toBe(1);
+      const target = result.wouldNotify[0];
+      expect(target).toMatchObject({
+        tenantId: "t1",
+        userId: "u1",
+        userEmail: "u1@example.com",
+        userName: "ユーザー一郎",
+        courseIdsSnapshot: ["c1"],
+      });
+      expect(target?.mimePreview.from).toBe(
+        `DXcollege運営スタッフ <${SENDER_EMAIL}>`,
+      );
+      expect(target?.mimePreview.to).toBe("u1@example.com");
+      expect(target?.mimePreview.cc).toEqual(
+        expect.arrayContaining(["owner@example.com", "cc1@example.com"]),
+      );
+      expect(typeof target?.mimePreview.subject).toBe("string");
+      expect(target?.mimePreview.subject.length).toBeGreaterThan(0);
+      expect(typeof target?.mimePreview.body).toBe("string");
+      expect(target?.mimePreview.body.length).toBeGreaterThan(0);
+    });
+
+    it("should NOT include partial-progress (< 100%) user in wouldNotify", async () => {
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof partialProgress>>();
+      courseProgresses.set("u1", partialProgress());
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+          courseProgresses,
+        }),
+      );
+
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ loader }),
+      );
+
+      expect(result.wouldNotifyCount).toBe(0);
+      expect(result.tenantsSummary[0]?.eligibleCount).toBe(0);
+    });
+
+    it("should use DEFAULT_SIGNATURE and DEFAULT_BODY in MIME when settings is null", async () => {
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
+      courseProgresses.set("u1", completedProgress());
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+          courseProgresses,
+        }),
+      );
+
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ loader }),
+      );
+
+      expect(result.wouldNotifyCount).toBe(1);
+      const target = result.wouldNotify[0];
+      expect(target?.mimePreview.from).toBe(
+        `${DEFAULT_SIGNATURE} <${SENDER_EMAIL}>`,
+      );
+      // DEFAULT_BODY が MIME body のどこかに含まれることを期待
+      expect(target?.mimePreview.body.includes(DEFAULT_BODY)).toBe(true);
+    });
+  });
+
+  describe("CC dedup", () => {
+    it("should dedupe ownerEmail and notificationCcEmails (case-insensitive)", async () => {
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
+      courseProgresses.set("u1", completedProgress());
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+          courseProgresses,
+          ccConfig: {
+            completionNotificationEnabled: true,
+            ownerEmail: "Owner@example.com",
+            notificationCcEmails: ["owner@example.com", "cc@example.com"],
+          },
+        }),
+      );
+
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ loader }),
+      );
+
+      const cc = result.wouldNotify[0]?.mimePreview.cc ?? [];
+      // case-insensitive dedup: Owner@example.com と owner@example.com は 1 件にまとまる
+      expect(cc).toHaveLength(2);
+    });
+  });
+
+  describe("sender email injection", () => {
+    it("should use injected senderEmail in MIME preview from field", async () => {
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
+      courseProgresses.set("u1", completedProgress());
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+          courseProgresses,
+        }),
+      );
+
+      const customSender = "custom-sender@example.org";
+      const result = await runCompletionNotificationDryRun(
+        defaultInput({ loader, senderEmail: customSender }),
+      );
+
+      expect(result.wouldNotify[0]?.mimePreview.from).toContain(customSender);
+    });
+  });
+
+  describe("output invariants", () => {
+    it("should serialize evaluatedAt as ISO string from injected now", async () => {
+      const result = await runCompletionNotificationDryRun(defaultInput());
+
+      expect(result.evaluatedAt).toBe(NOW.toISOString());
+    });
+  });
+});

--- a/services/api/src/services/dispatch/dry-run/__tests__/dry-run-fixtures.ts
+++ b/services/api/src/services/dispatch/dry-run/__tests__/dry-run-fixtures.ts
@@ -1,0 +1,104 @@
+/**
+ * dispatch dry-run 関連 test 共通 fixture (Phase 4 α-7、safe-refactor M2)。
+ *
+ * 以下 3 つの test ファイルで個別重複していた `makeSettings` / `makeFixture` /
+ * `partialProgress` / `completedProgress` を抽出。
+ *   - services/api/src/services/dispatch/dry-run/__tests__/progress-report-dry-run.test.ts
+ *   - services/api/src/services/dispatch/dry-run/__tests__/completion-notification-dry-run.test.ts
+ *   - services/api/src/routes/super/__tests__/dispatch-dry-run.test.ts
+ *
+ * default 値は両レーン test で「skip されない正常パス」を表現:
+ *   - publishedCourses: 1 件 (no_published_courses 回避)
+ *   - ccConfig.completionNotificationEnabled: true (completion レーンの skip 回避)
+ *   - info.active: true, info.progressReportEnabled: true (progress レーンの skip 回避)
+ *
+ * skip 系 test では呼び出し側で `partial` 引数を渡して上書きする。
+ */
+
+import type {
+  DispatchSettings,
+} from "@lms-279/shared-types";
+import type { InMemoryTenantFixture } from "../../tenant-data-loader.js";
+
+/** dispatch dry-run test 共通の固定 now (Phase 4 採用時刻) */
+export const FIXTURE_NOW = new Date("2026-06-03T00:00:00.000Z");
+
+/** dispatch dry-run test 共通の sender email */
+export const FIXTURE_SENDER_EMAIL = "dxcollege@279279.net";
+
+/**
+ * dispatch dry-run test 共通の DispatchSettings fixture。
+ *
+ * `progressReport` は default に含めない (旧 completion テストの未指定形と一致)。
+ * progress テストでは `makeSettings({ progressReport: { ... } })` で明示注入する。
+ */
+export function makeSettings(
+  partial: Partial<DispatchSettings> = {},
+): DispatchSettings {
+  return {
+    enabled: true,
+    scheduleDaysOfWeek: [1, 4],
+    scheduleHourJst: 9,
+    signatureName: "DXcollege運営スタッフ",
+    completionMessageBody: "受講お疲れ様でした。",
+    senderEmail: FIXTURE_SENDER_EMAIL,
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    updatedBy: "admin@279279.net",
+    version: 1,
+    ...partial,
+  };
+}
+
+/**
+ * dispatch dry-run test 共通の InMemoryTenantFixture base。
+ *
+ * default は両レーン test で「skip されない正常パス」を表現する形:
+ *   - publishedCourses: 1 件 (no_published_courses 回避)
+ *   - ccConfig: completion 有効、CC 0 件
+ *   - info: active + progressReportEnabled: true (旧 progress テスト相当)
+ *
+ * 旧 completion テストの default `progressReportEnabled: false` は completion lane
+ * のロジックで参照されないため、true 統一しても動作差分なし。
+ */
+export function makeFixture(
+  partial: Partial<InMemoryTenantFixture> = {},
+): InMemoryTenantFixture {
+  return {
+    publishedCourses: [{ id: "c1", lessonOrder: ["l1", "l2", "l3"] }],
+    users: [],
+    courseProgresses: new Map(),
+    ccConfig: {
+      completionNotificationEnabled: true,
+      ownerEmail: null,
+      notificationCcEmails: [],
+    },
+    info: { active: true, progressReportEnabled: true },
+    ...partial,
+  };
+}
+
+/**
+ * progressRatio = 1/3 ≈ 33% の進捗。
+ * `evaluateCompletionEligibility` で eligibility false。
+ *
+ * 進捗レーン: `wouldSendCount` に算入される対象。
+ * 完了通知レーン: skip 対象 (100% 未満)。
+ */
+export function partialProgress(courseId = "c1") {
+  return [
+    { courseId, isCompleted: false, totalLessons: 3, completedLessons: 1 },
+  ];
+}
+
+/**
+ * progressRatio = 3/3 = 100% の進捗。
+ * `evaluateCompletionEligibility` で eligibility true。
+ *
+ * 進捗レーン: skip 対象 (`completedCount` に算入、完了通知レーンがカバー済)。
+ * 完了通知レーン: `wouldNotify` に算入される対象。
+ */
+export function completedProgress(courseId = "c1") {
+  return [
+    { courseId, isCompleted: true, totalLessons: 3, completedLessons: 3 },
+  ];
+}

--- a/services/api/src/services/dispatch/dry-run/__tests__/progress-report-dry-run.test.ts
+++ b/services/api/src/services/dispatch/dry-run/__tests__/progress-report-dry-run.test.ts
@@ -1,0 +1,509 @@
+/**
+ * progress-report-dry-run service module の unit test (Phase 4 α-7 A1)。
+ *
+ * 観点:
+ *   - skip 理由ごとの動作 (tenant_not_active / progress_report_disabled /
+ *     no_published_courses / tenant_doc_not_found)
+ *   - 内訳カウンタ (candidateCount / invalidEmailCount / completedCount / wouldSendCount)
+ *   - 集計 (totalWouldSendCount / totalCcCount / estimatedDurationMs / scaleTriggerExceeded)
+ *   - settings snapshot 反映
+ *   - logger DI (default noop / 注入時 call)
+ *
+ * 既存 CLI (scripts/progress-report-dry-run-cli.ts) の振る舞いを 1:1 維持する
+ * regression test の役割も兼ねる。
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { DispatchSettings } from "@lms-279/shared-types";
+
+import { InMemoryDispatchStorage } from "../../in-memory-dispatch-storage.js";
+import {
+  InMemoryTenantDataLoader,
+  type InMemoryTenantFixture,
+  type TenantDataLoader,
+  type DispatchTenantDataView,
+} from "../../tenant-data-loader.js";
+import {
+  runProgressReportDryRun,
+  type ProgressDryRunLogger,
+  AVG_PER_USER_MS,
+  USER_CONCURRENCY,
+  SCALE_TRIGGER_THRESHOLD,
+  PDF_SIZE_KB_RANGE,
+} from "../progress-report-dry-run.js";
+
+// ============================================================
+// fixture / helper
+// ============================================================
+
+const NOW = new Date("2026-06-03T00:00:00.000Z");
+
+function makeSettings(partial: Partial<DispatchSettings> = {}): DispatchSettings {
+  return {
+    enabled: true,
+    scheduleDaysOfWeek: [1, 4],
+    scheduleHourJst: 9,
+    signatureName: "DXcollege運営スタッフ",
+    completionMessageBody: "受講お疲れ様でした。",
+    senderEmail: "dxcollege@279279.net",
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    updatedBy: "admin@279279.net",
+    version: 1,
+    progressReport: {
+      enabled: false,
+      scheduleDaysOfWeek: [1],
+      scheduleHourJst: 10,
+    },
+    ...partial,
+  };
+}
+
+function makeFixture(
+  partial: Partial<InMemoryTenantFixture> = {},
+): InMemoryTenantFixture {
+  return {
+    publishedCourses: [{ id: "c1", lessonOrder: ["l1", "l2", "l3"] }],
+    users: [],
+    courseProgresses: new Map(),
+    ccConfig: null,
+    info: { active: true, progressReportEnabled: true },
+    ...partial,
+  };
+}
+
+/** progressRatio = 1/3 ≈ 33% の進捗 (eligibility false、対象) */
+function partialProgress(courseId = "c1") {
+  return [
+    { courseId, isCompleted: false, totalLessons: 3, completedLessons: 1 },
+  ];
+}
+
+/** progressRatio = 3/3 = 100% の進捗 (eligibility true、skip 対象) */
+function completedProgress(courseId = "c1") {
+  return [
+    { courseId, isCompleted: true, totalLessons: 3, completedLessons: 3 },
+  ];
+}
+
+// ============================================================
+// tests
+// ============================================================
+
+describe("runProgressReportDryRun", () => {
+  describe("no tenants", () => {
+    it("should return empty summary with totalWouldSendCount=0", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.tenantsScanned).toBe(0);
+      expect(result.tenantsSummary).toEqual([]);
+      expect(result.totalWouldSendCount).toBe(0);
+      expect(result.totalCcCount).toBe(0);
+    });
+  });
+
+  describe("settings snapshot", () => {
+    it("should return settingsLoaded=false and snapshot=null when settings missing", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      // 明示的に null に設定 (default は null だが、テストの意図を明示)
+      storage.__setSettingsForTest(null);
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.settingsLoaded).toBe(false);
+      expect(result.settingsSnapshot).toBeNull();
+    });
+
+    it("should populate settingsSnapshot from progressReport sub-config when settings present", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      storage.__setSettingsForTest(
+        makeSettings({
+          progressReport: {
+            enabled: true,
+            scheduleDaysOfWeek: [2, 5],
+            scheduleHourJst: 14,
+          },
+        }),
+      );
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.settingsLoaded).toBe(true);
+      expect(result.settingsSnapshot).toEqual({
+        progressReportEnabled: true,
+        scheduleDaysOfWeek: [2, 5],
+        scheduleHourJst: 14,
+        signatureName: "DXcollege運営スタッフ",
+      });
+    });
+  });
+
+  describe("skip reasons", () => {
+    it("should skip with reason=tenant_not_active", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      loader.setTenant(
+        "t1",
+        makeFixture({ info: { active: false, progressReportEnabled: true } }),
+      );
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.tenantsSummary).toHaveLength(1);
+      expect(result.tenantsSummary[0]).toMatchObject({
+        tenantId: "t1",
+        skipped: true,
+        skipReason: "tenant_not_active",
+        wouldSendCount: 0,
+      });
+    });
+
+    it("should skip with reason=progress_report_disabled", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      loader.setTenant(
+        "t1",
+        makeFixture({ info: { active: true, progressReportEnabled: false } }),
+      );
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        tenantId: "t1",
+        skipped: true,
+        skipReason: "progress_report_disabled",
+      });
+    });
+
+    it("should skip with reason=no_published_courses", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      loader.setTenant("t1", makeFixture({ publishedCourses: [] }));
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        tenantId: "t1",
+        skipped: true,
+        skipReason: "no_published_courses",
+      });
+    });
+
+    it("should skip with reason=tenant_doc_not_found and call logger when getTenantInfo returns null", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const warnSpy = vi.fn();
+      const logger: ProgressDryRunLogger = {
+        warnTenantDocNotFound: warnSpy,
+      };
+      // 専用 mock: listAllTenantIds で出るが getTenantInfo は null
+      const ghostLoader: TenantDataLoader = {
+        async listAllTenantIds() {
+          return ["ghost"];
+        },
+        async getTenantInfo() {
+          return null;
+        },
+        async getTenantCcConfig() {
+          return null;
+        },
+        getTenantDataView(): DispatchTenantDataView {
+          throw new Error("not reachable: tenant_doc_not_found path should skip before dataView");
+        },
+      };
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader: ghostLoader,
+        now: NOW,
+        logger,
+      });
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        tenantId: "ghost",
+        skipped: true,
+        skipReason: "tenant_doc_not_found",
+      });
+      expect(warnSpy).toHaveBeenCalledExactlyOnceWith("ghost");
+    });
+  });
+
+  describe("count breakdown (candidate / invalid / completed / would-send)", () => {
+    it("should count valid + partial-progress user as wouldSendCount=1", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<
+        string,
+        ReturnType<typeof partialProgress>
+      >();
+      courseProgresses.set("u1", partialProgress());
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+          courseProgresses,
+        }),
+      );
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        tenantId: "t1",
+        skipped: false,
+        candidateCount: 1,
+        invalidEmailCount: 0,
+        completedCount: 0,
+        wouldSendCount: 1,
+      });
+      expect(result.totalWouldSendCount).toBe(1);
+    });
+
+    it("should count invalid email as invalidEmailCount=1 (not wouldSendCount)", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof partialProgress>>();
+      courseProgresses.set("u1", partialProgress());
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u1", email: "not-an-email", name: "U1" }],
+          courseProgresses,
+        }),
+      );
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        candidateCount: 1,
+        invalidEmailCount: 1,
+        completedCount: 0,
+        wouldSendCount: 0,
+      });
+    });
+
+    it("should count 100% completed user as completedCount=1 (not wouldSendCount)", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof completedProgress>>();
+      courseProgresses.set("u1", completedProgress());
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+          courseProgresses,
+        }),
+      );
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        candidateCount: 1,
+        invalidEmailCount: 0,
+        completedCount: 1,
+        wouldSendCount: 0,
+      });
+    });
+  });
+
+  describe("CC config + totalCcCount", () => {
+    it("should populate ccCount from validated + deduped notificationCcEmails", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof partialProgress>>();
+      courseProgresses.set("u1", partialProgress());
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+          courseProgresses,
+          ccConfig: {
+            completionNotificationEnabled: true,
+            ownerEmail: "owner@example.com",
+            notificationCcEmails: ["cc1@example.com", "cc2@example.com"],
+          },
+        }),
+      );
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      // owner + 2 cc = 3 valid (dedup 後)
+      expect(result.tenantsSummary[0]?.ccCount).toBe(3);
+      // wouldSendCount=1 * ccCount=3 = 3
+      expect(result.totalCcCount).toBe(3);
+    });
+  });
+
+  describe("scale trigger + estimated duration", () => {
+    it("should set scaleTriggerExceeded=false when totalWouldSendCount <= threshold", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof partialProgress>>();
+      const users: { id: string; email: string; name: string }[] = [];
+      for (let i = 0; i < SCALE_TRIGGER_THRESHOLD; i++) {
+        const uid = `u${i}`;
+        users.push({ id: uid, email: `${uid}@example.com`, name: uid });
+        courseProgresses.set(uid, partialProgress());
+      }
+      loader.setTenant("t1", makeFixture({ users, courseProgresses }));
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.totalWouldSendCount).toBe(SCALE_TRIGGER_THRESHOLD);
+      expect(result.scaleTriggerExceeded).toBe(false);
+    });
+
+    it("should set scaleTriggerExceeded=true when totalWouldSendCount > threshold", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof partialProgress>>();
+      const users: { id: string; email: string; name: string }[] = [];
+      const targetCount = SCALE_TRIGGER_THRESHOLD + 1;
+      for (let i = 0; i < targetCount; i++) {
+        const uid = `u${i}`;
+        users.push({ id: uid, email: `${uid}@example.com`, name: uid });
+        courseProgresses.set(uid, partialProgress());
+      }
+      loader.setTenant("t1", makeFixture({ users, courseProgresses }));
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.totalWouldSendCount).toBe(targetCount);
+      expect(result.scaleTriggerExceeded).toBe(true);
+    });
+
+    it("should calculate estimatedDurationMs = ceil(N / concurrency) * AVG", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<string, ReturnType<typeof partialProgress>>();
+      const users: { id: string; email: string; name: string }[] = [];
+      // 8 users → ceil(8/8) = 1 batch → 2000ms
+      for (let i = 0; i < USER_CONCURRENCY; i++) {
+        const uid = `u${i}`;
+        users.push({ id: uid, email: `${uid}@example.com`, name: uid });
+        courseProgresses.set(uid, partialProgress());
+      }
+      loader.setTenant("t1", makeFixture({ users, courseProgresses }));
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.totalWouldSendCount).toBe(USER_CONCURRENCY);
+      expect(result.estimatedDurationMs).toBe(AVG_PER_USER_MS);
+    });
+  });
+
+  describe("output invariants", () => {
+    it("should always include PDF_SIZE_KB_RANGE constant", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.estimatedPdfSizeKbRange).toEqual(PDF_SIZE_KB_RANGE);
+    });
+
+    it("should serialize evaluatedAt as ISO string from injected now", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.evaluatedAt).toBe(NOW.toISOString());
+    });
+  });
+
+  describe("logger DI", () => {
+    it("should default to noop logger when none injected (no console call for tenant_doc_not_found)", async () => {
+      const storage = new InMemoryDispatchStorage();
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      const ghostLoader: TenantDataLoader = {
+        async listAllTenantIds() {
+          return ["ghost"];
+        },
+        async getTenantInfo() {
+          return null;
+        },
+        async getTenantCcConfig() {
+          return null;
+        },
+        getTenantDataView(): DispatchTenantDataView {
+          throw new Error("not reachable");
+        },
+      };
+
+      await runProgressReportDryRun({
+        storage,
+        loader: ghostLoader,
+        now: NOW,
+        // logger 未指定 → NOOP_LOGGER
+      });
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/services/api/src/services/dispatch/dry-run/__tests__/progress-report-dry-run.test.ts
+++ b/services/api/src/services/dispatch/dry-run/__tests__/progress-report-dry-run.test.ts
@@ -14,12 +14,10 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import type { DispatchSettings } from "@lms-279/shared-types";
 
 import { InMemoryDispatchStorage } from "../../in-memory-dispatch-storage.js";
 import {
   InMemoryTenantDataLoader,
-  type InMemoryTenantFixture,
   type TenantDataLoader,
   type DispatchTenantDataView,
 } from "../../tenant-data-loader.js";
@@ -31,59 +29,13 @@ import {
   SCALE_TRIGGER_THRESHOLD,
   PDF_SIZE_KB_RANGE,
 } from "../progress-report-dry-run.js";
-
-// ============================================================
-// fixture / helper
-// ============================================================
-
-const NOW = new Date("2026-06-03T00:00:00.000Z");
-
-function makeSettings(partial: Partial<DispatchSettings> = {}): DispatchSettings {
-  return {
-    enabled: true,
-    scheduleDaysOfWeek: [1, 4],
-    scheduleHourJst: 9,
-    signatureName: "DXcollege運営スタッフ",
-    completionMessageBody: "受講お疲れ様でした。",
-    senderEmail: "dxcollege@279279.net",
-    updatedAt: "2026-05-20T00:00:00.000Z",
-    updatedBy: "admin@279279.net",
-    version: 1,
-    progressReport: {
-      enabled: false,
-      scheduleDaysOfWeek: [1],
-      scheduleHourJst: 10,
-    },
-    ...partial,
-  };
-}
-
-function makeFixture(
-  partial: Partial<InMemoryTenantFixture> = {},
-): InMemoryTenantFixture {
-  return {
-    publishedCourses: [{ id: "c1", lessonOrder: ["l1", "l2", "l3"] }],
-    users: [],
-    courseProgresses: new Map(),
-    ccConfig: null,
-    info: { active: true, progressReportEnabled: true },
-    ...partial,
-  };
-}
-
-/** progressRatio = 1/3 ≈ 33% の進捗 (eligibility false、対象) */
-function partialProgress(courseId = "c1") {
-  return [
-    { courseId, isCompleted: false, totalLessons: 3, completedLessons: 1 },
-  ];
-}
-
-/** progressRatio = 3/3 = 100% の進捗 (eligibility true、skip 対象) */
-function completedProgress(courseId = "c1") {
-  return [
-    { courseId, isCompleted: true, totalLessons: 3, completedLessons: 3 },
-  ];
-}
+import {
+  FIXTURE_NOW as NOW,
+  makeSettings,
+  makeFixture,
+  partialProgress,
+  completedProgress,
+} from "./dry-run-fixtures.js";
 
 // ============================================================
 // tests
@@ -339,6 +291,88 @@ describe("runProgressReportDryRun", () => {
         candidateCount: 1,
         invalidEmailCount: 0,
         completedCount: 1,
+        ineligibleCount: 0,
+        wouldSendCount: 0,
+      });
+    });
+
+    it("should count user with missing courseProgress as ineligibleCount=1 (not wouldSendCount, F1 regression)", async () => {
+      // 進捗 user 既出 + 一部 course の courseProgress doc 不在 →
+      // evaluateCompletionEligibility は {eligible: false, reason: "missing_progress"}
+      // を返す。本番 processProgressUser は reason !== "not_completed" を skip するため、
+      // dry-run も ineligibleCount に計上して wouldSendCount overestimate を防ぐ
+      // (Phase 4 α-7 code-review F1)。
+      // ※ リアルシナリオ: ユーザーが c1 を完了した後に管理者が c2 を新規 publish
+      //    したケース。listProgressReportTargetUsers は ratio>=1% で候補化、
+      //    evaluateCompletionEligibility は publishedCourses 順走査で c1 (完了) →
+      //    c2 (progress doc 不在) で `missing_progress` reason を返す。
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<
+        string,
+        { courseId: string; isCompleted: boolean; totalLessons: number; completedLessons: number }[]
+      >();
+      courseProgresses.set("u1", [
+        { courseId: "c1", isCompleted: true, totalLessons: 3, completedLessons: 3 },
+      ]);
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          publishedCourses: [
+            { id: "c1", lessonOrder: ["l1", "l2", "l3"] },
+            { id: "c2", lessonOrder: ["l1", "l2", "l3"] },
+          ],
+          users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+          courseProgresses,
+        }),
+      );
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        candidateCount: 1,
+        invalidEmailCount: 0,
+        completedCount: 0,
+        ineligibleCount: 1,
+        wouldSendCount: 0,
+      });
+      expect(result.totalWouldSendCount).toBe(0);
+    });
+
+    it("should count user with lesson_count_mismatch as ineligibleCount=1 (not wouldSendCount, F1 regression)", async () => {
+      // isCompleted:true だが totalLessons (2) !== course.lessonOrder.length (3)
+      // → eligibility = {eligible: false, reason: "lesson_count_mismatch"}
+      // 本番 processProgressUser は skip 扱い、dry-run も ineligibleCount に算入する。
+      const storage = new InMemoryDispatchStorage();
+      const loader = new InMemoryTenantDataLoader();
+      const courseProgresses = new Map<
+        string,
+        { courseId: string; isCompleted: boolean; totalLessons: number; completedLessons: number }[]
+      >();
+      courseProgresses.set("u1", [
+        { courseId: "c1", isCompleted: true, totalLessons: 2, completedLessons: 2 },
+      ]);
+      loader.setTenant(
+        "t1",
+        makeFixture({
+          users: [{ id: "u1", email: "u1@example.com", name: "U1" }],
+          courseProgresses,
+        }),
+      );
+
+      const result = await runProgressReportDryRun({
+        storage,
+        loader,
+        now: NOW,
+      });
+
+      expect(result.tenantsSummary[0]).toMatchObject({
+        candidateCount: 1,
+        ineligibleCount: 1,
         wouldSendCount: 0,
       });
     });

--- a/services/api/src/services/dispatch/dry-run/__tests__/single-flight.test.ts
+++ b/services/api/src/services/dispatch/dry-run/__tests__/single-flight.test.ts
@@ -1,0 +1,108 @@
+/**
+ * dispatch-dry-run single-flight 制御の unit test (Phase 4 α-7 C1)。
+ *
+ * 観点:
+ *   - 同一 lane の重複リクエストで結果共有 (fn 呼び出しは 1 回のみ)
+ *   - lane が異なれば独立実行
+ *   - 完了後は Map から削除され、次回リクエストは新規実行
+ *   - reject も結果共有 (fail-fast)
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import { createDispatchDryRunSingleFlightForTest } from "../single-flight.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("DispatchDryRunSingleFlight", () => {
+  it("should execute fn only once for concurrent same-lane requests and share result", async () => {
+    const sf = createDispatchDryRunSingleFlightForTest();
+    const d = deferred<string>();
+    const fn = vi.fn(() => d.promise);
+
+    // 同 lane に 3 リクエスト並行で投入
+    const p1 = sf.run("progress", fn);
+    const p2 = sf.run("progress", fn);
+    const p3 = sf.run("progress", fn);
+
+    d.resolve("result-A");
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(r1).toBe("result-A");
+    expect(r2).toBe("result-A");
+    expect(r3).toBe("result-A");
+  });
+
+  it("should execute independently for different lanes", async () => {
+    const sf = createDispatchDryRunSingleFlightForTest();
+    const progressFn = vi.fn(async () => "progress-result");
+    const completionFn = vi.fn(async () => "completion-result");
+
+    const [pr, cr] = await Promise.all([
+      sf.run("progress", progressFn),
+      sf.run("completion", completionFn),
+    ]);
+
+    expect(progressFn).toHaveBeenCalledTimes(1);
+    expect(completionFn).toHaveBeenCalledTimes(1);
+    expect(pr).toBe("progress-result");
+    expect(cr).toBe("completion-result");
+  });
+
+  it("should clear inflight slot after completion (next call re-executes fn)", async () => {
+    const sf = createDispatchDryRunSingleFlightForTest();
+    let counter = 0;
+    const fn = vi.fn(async () => {
+      counter += 1;
+      return `call-${counter}`;
+    });
+
+    const first = await sf.run("progress", fn);
+    const second = await sf.run("progress", fn);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(first).toBe("call-1");
+    expect(second).toBe("call-2");
+  });
+
+  it("should share rejected error to concurrent waiters", async () => {
+    const sf = createDispatchDryRunSingleFlightForTest();
+    const d = deferred<string>();
+    const fn = vi.fn(() => d.promise);
+
+    const p1 = sf.run("progress", fn);
+    const p2 = sf.run("progress", fn);
+
+    const err = new Error("dry-run failed");
+    d.reject(err);
+
+    await expect(p1).rejects.toThrow("dry-run failed");
+    await expect(p2).rejects.toThrow("dry-run failed");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should re-execute fn on next call after a rejection", async () => {
+    const sf = createDispatchDryRunSingleFlightForTest();
+    let counter = 0;
+    const fn = vi.fn(async () => {
+      counter += 1;
+      if (counter === 1) throw new Error("first call fails");
+      return `call-${counter}`;
+    });
+
+    await expect(sf.run("progress", fn)).rejects.toThrow("first call fails");
+    const second = await sf.run("progress", fn);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(second).toBe("call-2");
+  });
+});

--- a/services/api/src/services/dispatch/dry-run/completion-notification-dry-run.ts
+++ b/services/api/src/services/dispatch/dry-run/completion-notification-dry-run.ts
@@ -108,6 +108,7 @@ export async function runCompletionNotificationDryRun(
         skipReason: "tenant_completion_notification_disabled",
         usersScanned: 0,
         eligibleCount: 0,
+        invalidEmailCount: 0,
       });
       continue;
     }
@@ -121,17 +122,24 @@ export async function runCompletionNotificationDryRun(
         skipReason: "no_published_courses",
         usersScanned: 0,
         eligibleCount: 0,
+        invalidEmailCount: 0,
       });
       continue;
     }
 
     const users = await dataView.listNotificationTargetUsers();
     let eligibleCount = 0;
+    let invalidEmailCount = 0;
 
     for (const user of users) {
       // email 無効はどのみち送信されない (AC-19)
+      // Phase 4 α-7 code-review F8 反映: invalidEmailCount を独立計上し、
+      // 進捗レーンの ProgressDryRunTenantSummary.invalidEmailCount と対称化。
       const emailV = validateSingleEmail(user.email);
-      if (!emailV.ok) continue;
+      if (!emailV.ok) {
+        invalidEmailCount += 1;
+        continue;
+      }
 
       const progresses = await dataView.listCourseProgressForUser(user.id);
       const eligibility = evaluateCompletionEligibility(
@@ -182,6 +190,7 @@ export async function runCompletionNotificationDryRun(
       skipped: false,
       usersScanned: users.length,
       eligibleCount,
+      invalidEmailCount,
     });
   }
 
@@ -195,7 +204,14 @@ export async function runCompletionNotificationDryRun(
           scheduleDaysOfWeek: settings.scheduleDaysOfWeek,
           scheduleHourJst: settings.scheduleHourJst,
           signatureName: settings.signatureName,
-          completionMessageBodyLength: settings.completionMessageBody.length,
+          // Phase 4 α-7 code-review F3 反映: PutDispatchSettingsRequest が patch
+          // semantics (Partial) で completionMessageBody optional 化後、storage 経由で
+          // undefined が来た場合に `undefined.length` で TypeError を起こすのを防ぐ。
+          // `null` は「doc 存在 + 本文未設定」を表す。
+          completionMessageBodyLength:
+            typeof settings.completionMessageBody === "string"
+              ? settings.completionMessageBody.length
+              : null,
         }
       : null,
     tenantsScanned: tenantIds.length,

--- a/services/api/src/services/dispatch/dry-run/completion-notification-dry-run.ts
+++ b/services/api/src/services/dispatch/dry-run/completion-notification-dry-run.ts
@@ -1,0 +1,206 @@
+/**
+ * 完了通知 dry-run service module (Phase 4 α-7 A2)。
+ *
+ * 目的:
+ *   - 既存 `scripts/dispatch-dry-run-cli.ts` の純粋ロジックを抽出
+ *   - HTTP endpoint (Phase 4 α-7 C1) と CLI wrapper (Phase 4 α-7 A3) の両方から
+ *     共通利用するための DI 化された service
+ *
+ * 完全 read-only:
+ *   - Firestore write なし (storage は getDispatchSettings + getCompletionNotification のみ)
+ *   - Gmail send なし
+ *   - test-send 経路は本 module に **存在しない** (PR #490 撤廃方針維持)
+ *
+ * 関連:
+ *   - impl-plan: docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md §3 タスク A2
+ *   - PR #490 撤廃理由の解消: 同 impl-plan §「PR #490 撤廃理由の解消」
+ *   - 旧 CLI: scripts/dispatch-dry-run-cli.ts (A3 で薄 wrapper 化)
+ */
+
+import type {
+  DispatchSettings,
+  CompletionDryRunResult,
+  CompletionDryRunTarget,
+  CompletionDryRunTenantSummary,
+} from "@lms-279/shared-types";
+
+import { validateAndDedupeCcEmails, validateSingleEmail } from "../cc-email-validator.js";
+import { evaluateCompletionEligibility } from "../completion-eligibility.js";
+import { buildCompletionMail } from "../completion-notification-mail.js";
+import type { DispatchStorage } from "../dispatch-storage.js";
+import type { TenantDataLoader } from "../tenant-data-loader.js";
+
+// 型定義は `@lms-279/shared-types` に集約 (B タスクで移管完了)。
+// CompletionDryRunResult / CompletionDryRunTarget / CompletionDryRunTenantSummary /
+// CompletionDryRunSkipReason / DryRunMimePreview は FE / BE / CLI 全部 shared-types から import。
+
+// ============================================================
+// 定数 (CLI と同じ、変更時は両方を同期)
+// ============================================================
+
+/** settings 未保存テナント / フォールバック時の default 値 */
+export const DEFAULT_SIGNATURE = "DXcollege運営スタッフ";
+/** settings 未保存時の default 本文 (本番では doc 必須だが、cutover リハーサルでも preview を返せるように) */
+export const DEFAULT_BODY =
+  "(本文未設定 — super_dispatch_settings/global.completionMessageBody を保存してください)";
+
+// ============================================================
+// 依存性注入 interface
+// ============================================================
+
+/**
+ * `runCompletionNotificationDryRun` の入力。
+ *
+ * `storage` は `Pick<DispatchStorage, ...>` で **明示的に read-only API のみ** に絞る
+ * (Phase 4 α-7 AC-α7-06: read-only 保証の型レベル担保)。
+ */
+export interface RunCompletionNotificationDryRunInput {
+  storage: Pick<
+    DispatchStorage,
+    "getDispatchSettings" | "getCompletionNotification"
+  >;
+  loader: TenantDataLoader;
+  /**
+   * From アドレス (CLI/endpoint で指定、env からは取得しない)。
+   * 旧 CLI では `process.env.DXCOLLEGE_SENDER_EMAIL` (default `dxcollege@279279.net`)
+   * を参照していたが、service module では引数化して副作用を排除。
+   */
+  senderEmail: string;
+  /** test では fixed Date を inject、CLI / endpoint では `new Date()` */
+  now?: Date;
+}
+
+// ============================================================
+// メイン dry-run ロジック
+// ============================================================
+
+/**
+ * 完了通知の dry-run を実行し、対象一覧 + MIME プレビューを返す。
+ *
+ * 旧 CLI の `runDryRunCli` を DI 化した実装。CLI 互換は A3 の薄 wrapper で維持する。
+ */
+export async function runCompletionNotificationDryRun(
+  input: RunCompletionNotificationDryRunInput,
+): Promise<CompletionDryRunResult> {
+  const { storage, loader, senderEmail, now = new Date() } = input;
+
+  // ① settings 読み取り
+  // doc missing 許容: 初期化前 cutover リハーサル想定で default 文言で preview を返す。
+  // read/parse error (throw) は cutover 判断材料の整合性に直結するため致命扱い。
+  const settings: DispatchSettings | null = await storage.getDispatchSettings();
+
+  const signature = settings?.signatureName ?? DEFAULT_SIGNATURE;
+  const messageBody = settings?.completionMessageBody ?? DEFAULT_BODY;
+
+  // ② tenants 走査
+  const tenantIds = await loader.listAllTenantIds();
+  const tenantsSummary: CompletionDryRunTenantSummary[] = [];
+  const wouldNotify: CompletionDryRunTarget[] = [];
+
+  for (const tenantId of tenantIds) {
+    const ccConfig = await loader.getTenantCcConfig(tenantId);
+
+    // テナント単位 disable は対象外 (本番 run-completion-notifications.ts の logic と整合)
+    if (!ccConfig?.completionNotificationEnabled) {
+      tenantsSummary.push({
+        tenantId,
+        skipped: true,
+        skipReason: "tenant_completion_notification_disabled",
+        usersScanned: 0,
+        eligibleCount: 0,
+      });
+      continue;
+    }
+
+    const dataView = loader.getTenantDataView(tenantId);
+    const publishedCourses = await dataView.listPublishedCourses();
+    if (publishedCourses.length === 0) {
+      tenantsSummary.push({
+        tenantId,
+        skipped: true,
+        skipReason: "no_published_courses",
+        usersScanned: 0,
+        eligibleCount: 0,
+      });
+      continue;
+    }
+
+    const users = await dataView.listNotificationTargetUsers();
+    let eligibleCount = 0;
+
+    for (const user of users) {
+      // email 無効はどのみち送信されない (AC-19)
+      const emailV = validateSingleEmail(user.email);
+      if (!emailV.ok) continue;
+
+      const progresses = await dataView.listCourseProgressForUser(user.id);
+      const eligibility = evaluateCompletionEligibility(
+        publishedCourses,
+        progresses,
+      );
+      if (!eligibility.eligible) continue;
+
+      // 既存 notification (sent/reserved/failed/manual) は再送されない
+      const existing = await storage.getCompletionNotification(tenantId, user.id);
+      if (existing) continue;
+
+      // MIME プレビュー組立
+      const built = buildCompletionMail({
+        userName: user.name,
+        completionMessageBody: messageBody,
+        signatureName: signature,
+      });
+
+      // CC 組立は本番送信側 (run-completion-notifications.ts) と完全同期させるため、
+      // validateAndDedupeCcEmails を使う (trim / 形式検証 / CRLF・カンマ排除 /
+      // case-insensitive dedupe を実施)。
+      const ccResult = validateAndDedupeCcEmails(
+        ccConfig.notificationCcEmails ?? [],
+        ccConfig.ownerEmail,
+      );
+      const ccList = ccResult.validCcEmails;
+
+      wouldNotify.push({
+        tenantId,
+        userId: user.id,
+        userEmail: emailV.value,
+        userName: user.name ?? "",
+        courseIdsSnapshot: eligibility.courseIdsSnapshot,
+        mimePreview: {
+          from: `${signature} <${senderEmail}>`,
+          to: emailV.value,
+          cc: ccList,
+          subject: built.subject,
+          body: built.body,
+        },
+      });
+      eligibleCount++;
+    }
+
+    tenantsSummary.push({
+      tenantId,
+      skipped: false,
+      usersScanned: users.length,
+      eligibleCount,
+    });
+  }
+
+  return {
+    lane: "completion",
+    evaluatedAt: now.toISOString(),
+    settingsLoaded: settings !== null,
+    settingsSnapshot: settings
+      ? {
+          enabled: settings.enabled,
+          scheduleDaysOfWeek: settings.scheduleDaysOfWeek,
+          scheduleHourJst: settings.scheduleHourJst,
+          signatureName: settings.signatureName,
+          completionMessageBodyLength: settings.completionMessageBody.length,
+        }
+      : null,
+    tenantsScanned: tenantIds.length,
+    tenantsSummary,
+    wouldNotifyCount: wouldNotify.length,
+    wouldNotify,
+  };
+}

--- a/services/api/src/services/dispatch/dry-run/progress-report-dry-run.ts
+++ b/services/api/src/services/dispatch/dry-run/progress-report-dry-run.ts
@@ -1,0 +1,268 @@
+/**
+ * 進捗レポート定期自動配信 dry-run service module (Phase 4 α-7 A1)。
+ *
+ * 目的:
+ *   - 既存 `scripts/progress-report-dry-run-cli.ts` の純粋ロジックを抽出
+ *   - HTTP endpoint (Phase 4 α-7 C1) と CLI wrapper (Phase 4 α-7 A3) の両方から
+ *     共通利用するための DI 化された service
+ *
+ * 完全 read-only:
+ *   - Firestore write なし (storage は getDispatchSettings のみ参照)
+ *   - Gmail send / PDF 実生成なし
+ *   - test-send 経路は本 module に **存在しない** (PR #490 撤廃方針維持)
+ *
+ * 関連:
+ *   - impl-plan: docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md §3 タスク A1
+ *   - PR #490 撤廃理由の解消: 同 impl-plan §「PR #490 撤廃理由の解消」
+ *   - 旧 CLI: scripts/progress-report-dry-run-cli.ts (A3 で薄 wrapper 化)
+ */
+
+import type {
+  DispatchSettings,
+  ProgressDryRunResult,
+  ProgressDryRunTenantSummary,
+} from "@lms-279/shared-types";
+
+import {
+  validateAndDedupeCcEmails,
+  validateSingleEmail,
+} from "../cc-email-validator.js";
+import { evaluateCompletionEligibility } from "../completion-eligibility.js";
+import type { DispatchStorage } from "../dispatch-storage.js";
+import type { TenantDataLoader } from "../tenant-data-loader.js";
+
+// 型定義は `@lms-279/shared-types` に集約 (B タスクで移管完了)。
+// ProgressDryRunResult / ProgressDryRunTenantSummary / ProgressDryRunSkipReason は
+// FE / BE / CLI すべてが shared-types から import する。
+
+// ============================================================
+// 定数 (CLI と同じ、変更時は両方を同期)
+// ============================================================
+
+/** 1 通あたりの平均処理時間目安 (PDF 生成 1.5s + Gmail send 0.3s + Firestore write 0.2s) */
+export const AVG_PER_USER_MS = 2000;
+/** user 並列度 (run-progress-reports DEFAULT_USER_CONCURRENCY と一致) */
+export const USER_CONCURRENCY = 8;
+/** scale trigger threshold */
+export const SCALE_TRIGGER_THRESHOLD = 300;
+/** 推定 PDF サイズ範囲 (KB)。実測は cutover smoke で確認 */
+export const PDF_SIZE_KB_RANGE = { min: 150, typical: 350, max: 1200 };
+
+// ============================================================
+// 依存性注入 interface
+// ============================================================
+
+/**
+ * 警告 logger inject。CLI 経由では console.error、HTTP endpoint 経由では
+ * 構造化ログ、test では noop を渡せる。
+ */
+export interface ProgressDryRunLogger {
+  warnTenantDocNotFound(tenantId: string): void;
+}
+
+const NOOP_LOGGER: ProgressDryRunLogger = {
+  warnTenantDocNotFound: () => {},
+};
+
+/**
+ * console.error 出力する logger 実装 (CLI 経由デフォルト)。
+ * メッセージ書式は旧 CLI と同一。
+ */
+export const CONSOLE_PROGRESS_DRY_RUN_LOGGER: ProgressDryRunLogger = {
+  warnTenantDocNotFound: (tenantId) => {
+    console.error(
+      `[WARN] tenant_doc_not_found: tenants/${tenantId} doc が存在しません。subcollection 孤児の可能性があるため運用者の確認推奨。`,
+    );
+  },
+};
+
+/**
+ * `runProgressReportDryRun` の入力。
+ *
+ * `storage` は `Pick<DispatchStorage, "getDispatchSettings">` で **明示的に
+ * read-only API のみ** に絞る (Phase 4 α-7 AC-α7-06: read-only 保証の型レベル担保)。
+ */
+export interface RunProgressReportDryRunInput {
+  storage: Pick<DispatchStorage, "getDispatchSettings">;
+  loader: TenantDataLoader;
+  /** test では fixed Date を inject、CLI / endpoint では `new Date()` */
+  now?: Date;
+  /** test / endpoint では noop or 構造化、CLI では `CONSOLE_PROGRESS_DRY_RUN_LOGGER` */
+  logger?: ProgressDryRunLogger;
+}
+
+// ============================================================
+// メイン dry-run ロジック
+// ============================================================
+
+/**
+ * 進捗レポート定期配信の dry-run を実行し、対象人数 / 規模試算を返す。
+ *
+ * 旧 CLI の `runProgressReportDryRunCli` を DI 化した実装。
+ * CLI 互換は A3 の薄 wrapper で維持する。
+ */
+export async function runProgressReportDryRun(
+  input: RunProgressReportDryRunInput,
+): Promise<ProgressDryRunResult> {
+  const { storage, loader, now = new Date(), logger = NOOP_LOGGER } = input;
+
+  // ① settings 読み取り
+  // doc missing 許容: 初期化前 cutover リハーサル想定で「対象規模見積もり」だけは返す。
+  // read/parse error は致命扱いし fail-fast にする (silent fallback は cutover 判断材料の
+  // 整合性を壊すため、completion-notification-dry-run と同パターン)。
+  const settings: DispatchSettings | null = await storage.getDispatchSettings();
+
+  // ② tenants 走査
+  const tenantIds = await loader.listAllTenantIds();
+  const tenantsSummary: ProgressDryRunTenantSummary[] = [];
+  let totalWouldSendCount = 0;
+  let totalCcCount = 0;
+
+  for (const tenantId of tenantIds) {
+    // ③ active + progressReportEnabled チェック (AC-PR-04)
+    const tenantInfo = await loader.getTenantInfo(tenantId);
+    if (!tenantInfo) {
+      // listAllTenantIds() は tenantId を返したが tenants/{tid} doc が不在。
+      // subcollection 孤児やテナント cascade delete 未完了の可能性があり、
+      // 後で同一 tenantId が再利用されたら誤配信に直結するため logger 経由で alert。
+      logger.warnTenantDocNotFound(tenantId);
+      tenantsSummary.push({
+        tenantId,
+        skipped: true,
+        skipReason: "tenant_doc_not_found",
+        usersScanned: 0,
+        candidateCount: 0,
+        invalidEmailCount: 0,
+        completedCount: 0,
+        wouldSendCount: 0,
+        ccCount: 0,
+      });
+      continue;
+    }
+    if (!tenantInfo.active) {
+      tenantsSummary.push({
+        tenantId,
+        skipped: true,
+        skipReason: "tenant_not_active",
+        usersScanned: 0,
+        candidateCount: 0,
+        invalidEmailCount: 0,
+        completedCount: 0,
+        wouldSendCount: 0,
+        ccCount: 0,
+      });
+      continue;
+    }
+    if (!tenantInfo.progressReportEnabled) {
+      tenantsSummary.push({
+        tenantId,
+        skipped: true,
+        skipReason: "progress_report_disabled",
+        usersScanned: 0,
+        candidateCount: 0,
+        invalidEmailCount: 0,
+        completedCount: 0,
+        wouldSendCount: 0,
+        ccCount: 0,
+      });
+      continue;
+    }
+
+    // ④ CC config 取得 (進捗レーンは CC null でも To 単独で送信、AC-PR-11 設定独立性)
+    const ccConfig = await loader.getTenantCcConfig(tenantId);
+    const ccDedup = validateAndDedupeCcEmails(
+      ccConfig?.notificationCcEmails ?? [],
+      ccConfig?.ownerEmail ?? null,
+    );
+    const ccCount = ccDedup.validCcEmails.length;
+
+    // ⑤ 対象 user 列挙 (Plan A: student + 期限内 + 進捗 1% 以上、ADR-039 D-5)
+    const dataView = loader.getTenantDataView(tenantId);
+    const publishedCourses = await dataView.listPublishedCourses();
+    if (publishedCourses.length === 0) {
+      tenantsSummary.push({
+        tenantId,
+        skipped: true,
+        skipReason: "no_published_courses",
+        usersScanned: 0,
+        candidateCount: 0,
+        invalidEmailCount: 0,
+        completedCount: 0,
+        wouldSendCount: 0,
+        ccCount,
+      });
+      continue;
+    }
+
+    const users = await dataView.listProgressReportTargetUsers(now);
+    // candidateCount は listProgressReportTargetUsers 戻り値全体を表す。
+    // 送信不能要因 (invalid email / 100% 完了) は内訳カウンタで切り分け、運用者が
+    // 「dry-run で見えない skip 規模」を取りこぼさないようにする。
+    const candidateCount = users.length;
+    let invalidEmailCount = 0;
+    let completedCount = 0;
+    let wouldSendCount = 0;
+
+    for (const user of users) {
+      // email validation (進捗レーンも完了通知レーンと同様、無効 email は送信不能)
+      const emailV = validateSingleEmail(user.email);
+      if (!emailV.ok) {
+        invalidEmailCount += 1;
+        continue;
+      }
+
+      // 100% 完了者は進捗レーン skip (AC-PR-02、完了通知レーンがカバー済)
+      const progresses = await dataView.listCourseProgressForUser(user.id);
+      const eligibility = evaluateCompletionEligibility(
+        publishedCourses,
+        progresses,
+      );
+      if (eligibility.eligible) {
+        completedCount += 1;
+        continue;
+      }
+
+      wouldSendCount += 1;
+    }
+
+    tenantsSummary.push({
+      tenantId,
+      skipped: false,
+      usersScanned: users.length,
+      candidateCount,
+      invalidEmailCount,
+      completedCount,
+      wouldSendCount,
+      ccCount,
+    });
+
+    totalWouldSendCount += wouldSendCount;
+    totalCcCount += wouldSendCount * ccCount;
+  }
+
+  // ⑥ 推定処理時間 = (totalWouldSendCount / userConcurrency) * AVG_PER_USER_MS
+  // 並列度 8 を超える user 数では Cloud Run timeout (280s) を意識した値になる
+  const estimatedDurationMs =
+    Math.ceil(totalWouldSendCount / USER_CONCURRENCY) * AVG_PER_USER_MS;
+
+  return {
+    lane: "progress",
+    evaluatedAt: now.toISOString(),
+    settingsLoaded: settings !== null,
+    settingsSnapshot: settings
+      ? {
+          progressReportEnabled: settings.progressReport?.enabled ?? false,
+          scheduleDaysOfWeek: settings.progressReport?.scheduleDaysOfWeek ?? [],
+          scheduleHourJst: settings.progressReport?.scheduleHourJst ?? 0,
+          signatureName: settings.signatureName,
+        }
+      : null,
+    tenantsScanned: tenantIds.length,
+    tenantsSummary,
+    totalWouldSendCount,
+    totalCcCount,
+    estimatedDurationMs,
+    estimatedPdfSizeKbRange: PDF_SIZE_KB_RANGE,
+    scaleTriggerExceeded: totalWouldSendCount > SCALE_TRIGGER_THRESHOLD,
+  };
+}

--- a/services/api/src/services/dispatch/dry-run/progress-report-dry-run.ts
+++ b/services/api/src/services/dispatch/dry-run/progress-report-dry-run.ts
@@ -54,7 +54,11 @@ export const PDF_SIZE_KB_RANGE = { min: 150, typical: 350, max: 1200 };
 
 /**
  * 警告 logger inject。CLI 経由では console.error、HTTP endpoint 経由では
- * 構造化ログ、test では noop を渡せる。
+ * 構造化ログ (`utils/logger.ts`)、test では noop を渡せる。
+ *
+ * Phase 4 α-7 code-review F4 反映: HTTP endpoint 経由でも tenant_doc_not_found
+ * WARN が Cloud Logging に出るよう、route 層で構造化 logger を inject する。
+ * NOOP fallback は test 専用とし、production 経路では必ず logger を渡す。
  */
 export interface ProgressDryRunLogger {
   warnTenantDocNotFound(tenantId: string): void;
@@ -75,6 +79,23 @@ export const CONSOLE_PROGRESS_DRY_RUN_LOGGER: ProgressDryRunLogger = {
     );
   },
 };
+
+/**
+ * 構造化 logger (`utils/logger.ts`) を adapter として包む実装 (HTTP endpoint default)。
+ * Cloud Logging に WARNING severity + tenantId メタデータ付きで出力される。
+ */
+export function createStructuredProgressDryRunLogger(structured: {
+  warn(message: string, metadata?: Record<string, unknown>): void;
+}): ProgressDryRunLogger {
+  return {
+    warnTenantDocNotFound: (tenantId) => {
+      structured.warn(
+        "dispatch.dry_run.tenant_doc_not_found: tenants/{tenantId} doc 不在、subcollection 孤児疑い",
+        { tenantId, lane: "progress" },
+      );
+    },
+  };
+}
 
 /**
  * `runProgressReportDryRun` の入力。
@@ -134,6 +155,7 @@ export async function runProgressReportDryRun(
         candidateCount: 0,
         invalidEmailCount: 0,
         completedCount: 0,
+        ineligibleCount: 0,
         wouldSendCount: 0,
         ccCount: 0,
       });
@@ -148,6 +170,7 @@ export async function runProgressReportDryRun(
         candidateCount: 0,
         invalidEmailCount: 0,
         completedCount: 0,
+        ineligibleCount: 0,
         wouldSendCount: 0,
         ccCount: 0,
       });
@@ -162,6 +185,7 @@ export async function runProgressReportDryRun(
         candidateCount: 0,
         invalidEmailCount: 0,
         completedCount: 0,
+        ineligibleCount: 0,
         wouldSendCount: 0,
         ccCount: 0,
       });
@@ -188,6 +212,7 @@ export async function runProgressReportDryRun(
         candidateCount: 0,
         invalidEmailCount: 0,
         completedCount: 0,
+        ineligibleCount: 0,
         wouldSendCount: 0,
         ccCount,
       });
@@ -196,11 +221,12 @@ export async function runProgressReportDryRun(
 
     const users = await dataView.listProgressReportTargetUsers(now);
     // candidateCount は listProgressReportTargetUsers 戻り値全体を表す。
-    // 送信不能要因 (invalid email / 100% 完了) は内訳カウンタで切り分け、運用者が
-    // 「dry-run で見えない skip 規模」を取りこぼさないようにする。
+    // 送信不能要因 (invalid email / 100% 完了 / 不適格データ状態) は内訳カウンタで
+    // 切り分け、運用者が「dry-run で見えない skip 規模」を取りこぼさないようにする。
     const candidateCount = users.length;
     let invalidEmailCount = 0;
     let completedCount = 0;
+    let ineligibleCount = 0;
     let wouldSendCount = 0;
 
     for (const user of users) {
@@ -211,7 +237,12 @@ export async function runProgressReportDryRun(
         continue;
       }
 
-      // 100% 完了者は進捗レーン skip (AC-PR-02、完了通知レーンがカバー済)
+      // eligibility 判定 (本番 processProgressUser:439-468 と同分岐)
+      //  - eligible === true     → 100% 完了 = 完了通知レーンがカバー、当レーンは skip
+      //  - reason !== "not_completed" → 不適格データ (missing_progress 等)、本番も skip
+      //  - reason === "not_completed" のみ → 進捗レポート送信対象
+      // Phase 4 α-7 code-review F1 反映: 旧実装は eligible:false を全部 wouldSendCount
+      // に算入していたため preview が overestimate していた。本番との整合性を回復する。
       const progresses = await dataView.listCourseProgressForUser(user.id);
       const eligibility = evaluateCompletionEligibility(
         publishedCourses,
@@ -219,6 +250,10 @@ export async function runProgressReportDryRun(
       );
       if (eligibility.eligible) {
         completedCount += 1;
+        continue;
+      }
+      if (eligibility.reason !== "not_completed") {
+        ineligibleCount += 1;
         continue;
       }
 
@@ -232,6 +267,7 @@ export async function runProgressReportDryRun(
       candidateCount,
       invalidEmailCount,
       completedCount,
+      ineligibleCount,
       wouldSendCount,
       ccCount,
     });

--- a/services/api/src/services/dispatch/dry-run/single-flight.ts
+++ b/services/api/src/services/dispatch/dry-run/single-flight.ts
@@ -1,0 +1,62 @@
+/**
+ * dispatch-dry-run の lane 単位 single-flight 制御 (Phase 4 α-7、AC-α7-12)。
+ *
+ * 目的:
+ *   - 同じ lane (progress / completion) への dry-run リクエストが進行中の場合、
+ *     新規 Firestore read を発生させず、進行中の Promise を共有して同じ結果を返す
+ *   - super-admin 連打・複数タブ・ブラウザ再試行のとき、Firestore read 量を
+ *     1 リクエスト分に抑える (Codex High 指摘の Firestore read 課金抑制)
+ *
+ * 設計:
+ *   - lane 単位の `Map<lane, Promise<unknown>>` で in-flight Promise を保持
+ *   - 完了 (fulfilled or rejected) で Map から自動削除
+ *   - module スコープで singleton (process 内で 1 つ、Cloud Run instance scope)
+ *
+ * 注意:
+ *   - Cloud Run の instance scope のため、複数 instance では single-flight が
+ *     instance ごとに独立 (許容、limiter で全体は抑制済)
+ *   - error 時も結果共有: 進行中 Promise が reject されると、共有していたリクエストも
+ *     同じ error を受ける (fail-fast、retry は呼び出し側)
+ */
+
+export type DispatchLaneKey = "progress" | "completion";
+
+export interface DispatchDryRunSingleFlight {
+  run<T>(lane: DispatchLaneKey, fn: () => Promise<T>): Promise<T>;
+}
+
+class DispatchDryRunSingleFlightImpl implements DispatchDryRunSingleFlight {
+  private inflight = new Map<DispatchLaneKey, Promise<unknown>>();
+
+  async run<T>(lane: DispatchLaneKey, fn: () => Promise<T>): Promise<T> {
+    const existing = this.inflight.get(lane);
+    if (existing) {
+      // 進行中 → 結果共有 (fulfilled / rejected の両方を await で透過)
+      return existing as Promise<T>;
+    }
+    const p = fn().finally(() => {
+      // 完了 (resolve / reject 共通) で Map から削除
+      // 同じ lane の次回リクエストは新規実行になる
+      if (this.inflight.get(lane) === p) {
+        this.inflight.delete(lane);
+      }
+    });
+    this.inflight.set(lane, p);
+    return p;
+  }
+}
+
+/**
+ * dispatch-dry-run のグローバル singleton single-flight 制御。
+ * 各 Cloud Run instance 内で 1 つ。
+ */
+export const sharedDispatchDryRunSingleFlight: DispatchDryRunSingleFlight =
+  new DispatchDryRunSingleFlightImpl();
+
+/**
+ * test 用 factory。test ごとに独立 state を持たせるために new instance を返す。
+ * production code から呼ばないこと。
+ */
+export function createDispatchDryRunSingleFlightForTest(): DispatchDryRunSingleFlight {
+  return new DispatchDryRunSingleFlightImpl();
+}


### PR DESCRIPTION
## Summary

Phase 4 α-7-BE: 配信 dispatch dry-run の **進捗レポート lane + 完了通知 lane の両 lane 化 BE 実装**。
Quality Gate 段階 1-4 (`/safe-refactor` + `/code-review high` + Evaluator + `/codex review`) を完走、指摘 13 件 (F1〜F9 + C1/C3) を本 PR 内で消化。残 1 件 (Codex C2 = user 単位 read failure divergence) は **Phase 4 OQ #17 候補** として follow-up に明示。

- 6 commits、23 files、+4001 / -674 (うち refactor で -205 行重複削減)
- 1649 tests PASS (Session 58 baseline 1643 から +6 regression test)、type-check / lint 全 PASS
- shared-types DTO 3 件拡張 (`ineligibleCount` / `invalidEmailCount` / `completionMessageBodyLength: number | null`)

## 主要変更

| commit | 内容 |
|---|---|
| `234c4e1` feat | dry-run UI 両 lane 化 BE 実装 (Session 58) |
| `fe9b429` refactor | `/safe-refactor` M1 (CLI init helper 抽出) + M2 (test fixture 共通化) |
| `260790d` feat | `/code-review high` F1-F9 反映 + Evaluator フォロー 2 件 (AC-α7-05 403 / 限ter 両 lane 合算 budget) |
| `6a1060a` docs | Session 59 ハンドオフ |
| `e2aace5` fix | `/codex review` C1 (limiter key) + C3 (CLI smoke DTO 追随) 反映 |

## Quality Gate 段階別サマリー

### 段階 1 `/safe-refactor`
- M1: scripts/dispatch-dry-run-cli.ts / scripts/progress-report-dry-run-cli.ts の Firebase Admin SDK 初期化重複 (約 22 行 × 2) を `scripts/lib/init-firebase-admin.ts` に集約
- M2: 3 つの dry-run test fixture (各 40-50 行) を `services/api/src/services/dispatch/dry-run/__tests__/dry-run-fixtures.ts` に集約
- 純減 -35 行 (重複削減 -205 行 + helper 170 行)

### 段階 2 `/code-review high` (7 angle × 約 42 候補 → 10 findings)

| F# | severity | 内容 | 対応 |
|---|---|---|---|
| F1 | HIGH | progress dry-run eligibility 分岐不在 (overestimate) | fix 済 (`ineligibleCount` 新カウンタ追加) |
| F3 | HIGH | completionMessageBodyLength undefined throw | fix 済 (`number \| null` 拡張) |
| F4 | HIGH | HTTP route logger NOOP silent fail | fix 済 (logger injection) |
| F6 | MEDIUM | limiter IP fallback collapse self-DoS | fix 済 (sentinel `ip:anonymous-no-ip`) |
| F8 | MEDIUM | completion lane `invalidEmailCount` 欠落 | fix 済 (DTO 対称化) |
| F9 | LOW-MEDIUM | storage 型 read-only 担保 | fix 済 (`Pick` narrow) |
| F5 | MEDIUM | 両 lane 共有 limiter | documented (route deps コメント) |
| F7 | MEDIUM | single-flight cross-caller fail-fast | documented |
| F2 | MEDIUM | shouldRunProgressReportNow check 欠落 | OQ #17 候補 |
| F10 | MEDIUM | completion expired reserved promote 欠落 | OQ #17 候補 |

### 段階 3 Evaluator (別コンテキスト、`rules/quality-gate.md` 発動条件該当)

5 BE-scope AC 評価 → **READY-WITH-NOTES**:
- AC-α7-05 (super-admin 403): **PARTIAL** → 本 PR 内で 403 直接 assert 追加 fix
- AC-α7-06 (read-only / test-send 不在): **PASS**
- AC-α7-07 (CLI 互換 + 完了通知 5 パス regression): **PASS**
- AC-α7-08 (Performance p95 5 秒以内): **UNTESTABLE** (BE benchmark integration なし、InMemory で μs オーダー)
- AC-α7-12 (limiter + single-flight): **PASS**

### 段階 4 `/codex review` (MCP、セカンドオピニオン、CLAUDE.md 大規模 PR MUST)

| C# | severity | confidence | 内容 | 対応 |
|---|---|---|---|---|
| C1 | MEDIUM | 96% | limiter `req.user.email` → `req.superAdmin.email` shape 不一致 | **本 PR で fix** |
| C3 | LOW | 95% | CLI smoke fixture が新 DTO 未追随で回帰検知できない | **本 PR で fix** |
| C2 | MEDIUM | 88% | user 単位 read failure で dry-run vs 本番 divergence | **OQ #17 候補** |

Codex 総合判定: **GO-WITH-FOLLOWUP** (C1 が merge 前修正推奨 → 完了)

## shared-types DTO 拡張

```ts
// F1 反映 (本番 processProgressUser:439-468 と一致)
ProgressDryRunTenantSummary.ineligibleCount: number

// F3 反映 (PutDispatchSettingsRequest Partial 化対応)
CompletionDryRunResult.settingsSnapshot.completionMessageBodyLength: number | null

// F8 反映 (進捗レーンと対称化)
CompletionDryRunTenantSummary.invalidEmailCount: number
```

**α-7-FE 着手前に `/impact-analysis` 実施推奨**: FE viewer 連動 (AC-α7-04 skip 内訳表示) で `ineligibleCount` / `invalidEmailCount` の UI 表現を要設計。

## Acceptance Criteria 担保

| AC | 担保箇所 |
|---|---|
| AC-α7-05 (super-admin 403) | route test 403 直接 assert (`dispatch-dry-run.test.ts`) + middleware 認可 fix (限ter key shape も整合) |
| AC-α7-06 (read-only / test-send 不在) | `Pick<DispatchStorage, "getDispatchSettings" \| "getCompletionNotification">` で型レベル read-only 担保 |
| AC-α7-07 (CLI 互換 + 完了通知 5 パス regression) | CLI smoke 2 件 + service test 5 パス (tenant disable / no courses / invalid email / 既通知 / MIME preview) |
| AC-α7-08 (Performance p95 5 秒以内) | UNTESTABLE (InMemory + 本番 benchmark integration なし) |
| AC-α7-12 (limiter + single-flight) | limiter 429 + single-flight 5 unit test + 両 lane 合算 budget test + route 429 確認 |

## Test plan

- [x] `npm run test -w @lms-279/api` — 1649 PASS (Session 58: 1643 → +6 regression test)
- [x] `npm run type-check` — 全ワークスペース PASS
- [x] `npm run lint` — 0 errors (既存 warning 1 件は本 PR 無関係)
- [x] `npx tsx scripts/__tests__/progress-report-dry-run-cli.smoke.ts` — PASS
- [x] `npx tsx scripts/__tests__/dispatch-dry-run-cli.smoke.ts` — PASS
- [ ] CI: GitHub Actions (push 後自動実行) — 確認待ち
- [ ] PR review: `/review-pr` 6 エージェント並列 — 本 PR 上で実施

## Follow-up (Phase 4 OQ #17 候補、decision-maker 判断)

1. **F2** (shouldRunProgressReportNow check 欠落) — dry-run を「今走るか」判定に使う UI なら誤判断につながる。ただし現 DTO は settings snapshot を返すため「対象規模 preview」と割り切る仕様なら follow-up で十分
2. **F10** (completion expired reserved promote 欠落) — wouldNotify 数の誤増加ではなく stuck reservation の可視化不足。DTO 拡張込み
3. **C2** (user 単位 read failure の本番 vs dry-run divergence) — 修正には `readErrorCount` 追加 or `ineligibleCount` への集約方針判断が必要

3 件まとめて OQ #17 で扱う方針 (起票は開発者明示指示後)。

## 関連

- impl-plan: `docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md`
- Phase 4 OQ #16 採用決定 (Session 58、`docs/handoff/archive/`)
- ADR-039 (scale trigger 300 名超 Cloud Tasks 移行検討)

🤖 Generated with [Claude Code](https://claude.com/claude-code)