### PR TITLE
feat(dispatch-settings): OQ #17 #11+#12 Playwright E2E ハイブリッド実装 + AC-α7-11/13 拡張

### DIFF
--- a/e2e/tests/dispatch-dry-run-api.spec.ts
+++ b/e2e/tests/dispatch-dry-run-api.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * dispatch dry-run API E2E (Phase 4 α-7、OQ #17 #12)。
+ *
+ * 検証対象: AC-α7-05 (super-admin authentication boundary)
+ *   - GET /api/v2/super/dispatch/dry-run/{progress,completion}
+ *   - X-User-Email 未指定 → 401
+ *   - 非 super email → 403
+ *
+ * 共有 fixture: e2e/playwright.config.ts の webServer env (DISPATCH_USE_IN_MEMORY=true /
+ * SUPER_ADMIN_EMAILS=admin@example.com / DISPATCH_IN_MEMORY_SEED_TENANTS=demo) を活用。
+ *
+ * 関連:
+ *   - 設計仕様書: docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md §5 AC-α7-05
+ *   - route 実装: services/api/src/routes/super/dispatch-dry-run.ts
+ *   - 集約 Issue: #521 (OQ #17 #12)
+ *   - 戦略 B (ハイブリッド) 採用根拠: rules/testing.md (E2E 致命的導線のみ) +
+ *     既存 e2e/dispatch-settings-api.spec.ts の制約 (AUTH_MODE=dev で super UI 遷移不可)、
+ *     Session 64 で開発者承認
+ *
+ * 補足:
+ *   - AC-α7-05 の 200 OK 正常応答 (super-admin 認証通過後) は本 spec に含めない:
+ *     - dispatch-dry-run route 経路で in-memory wiring 下でも Firestore Query を発火する
+ *       依存があり、E2E webServer (in-memory mode) で 500 PERMISSION_DENIED が出る
+ *     - 200 OK + body shape は既存 BE integration test
+ *       (services/api/src/routes/super/__tests__/dispatch-dry-run.test.ts) で
+ *       direct app mount + InMemoryTenantDataLoader seed 経路で網羅済
+ *     - E2E 200 化は OQ #17 follow-up (in-memory wiring 調査) として記録
+ *   - AC-α7-12 BE 側 (limiter 429 / single-flight) は既存 BE integration test
+ *     (dispatch-dry-run.test.ts L349) でカバー済のため E2E 重複なし
+ *   - AC-α7-06 read-only 保証は service-level test
+ *     (services/api/src/services/dispatch/dry-run/__tests__/) でカバー
+ */
+
+import { expect, test } from "@playwright/test";
+
+const API = "http://localhost:8080";
+const NON_SUPER_HEADERS = { "X-User-Email": "user@example.com" };
+
+test.describe("dispatch dry-run API 認可境界 (AC-α7-05)", () => {
+  for (const lane of ["progress", "completion"] as const) {
+    test.describe(`${lane} lane`, () => {
+      const path = `/api/v2/super/dispatch/dry-run/${lane}`;
+
+      test(`X-User-Email 未指定で ${path} は 401`, async ({ request }) => {
+        const res = await request.get(`${API}${path}`);
+        expect(res.status()).toBe(401);
+      });
+
+      test(`非 super email で ${path} は 403`, async ({ request }) => {
+        const res = await request.get(`${API}${path}`, {
+          headers: NON_SUPER_HEADERS,
+        });
+        expect(res.status()).toBe(403);
+      });
+    });
+  }
+});

--- a/web/app/super/dispatch-settings/components/DryRunPreview.tsx
+++ b/web/app/super/dispatch-settings/components/DryRunPreview.tsx
@@ -135,7 +135,7 @@ export function DryRunPreview(props: DryRunPreviewProps) {
 
       {result && !error && (
         <div className="space-y-3">
-          <PreviewHeader result={result} />
+          <PreviewHeader result={result} lastFetchedAt={lastFetchedAt} />
           {result.lane === "progress" ? (
             <ProgressPreview result={result} />
           ) : (
@@ -153,11 +153,46 @@ export function DryRunPreview(props: DryRunPreviewProps) {
   );
 }
 
+const FRESHNESS_THRESHOLD_MS = 5 * 60 * 1000;
+
+function isLaneDisabled(
+  result: ProgressDryRunResult | CompletionDryRunResult,
+): boolean {
+  if (!result.settingsSnapshot) return false;
+  if (result.lane === "progress") {
+    return result.settingsSnapshot.progressReportEnabled === false;
+  }
+  return result.settingsSnapshot.enabled === false;
+}
+
+function hasEmptySchedule(
+  result: ProgressDryRunResult | CompletionDryRunResult,
+): boolean {
+  if (!result.settingsSnapshot) return false;
+  return (result.settingsSnapshot.scheduleDaysOfWeek ?? []).length === 0;
+}
+
+function isStale(lastFetchedAt: string | null): boolean {
+  if (!lastFetchedAt) return false;
+  const fetched = new Date(lastFetchedAt).getTime();
+  if (Number.isNaN(fetched)) return false;
+  return Date.now() - fetched > FRESHNESS_THRESHOLD_MS;
+}
+
 function PreviewHeader({
   result,
+  lastFetchedAt,
 }: {
   result: ProgressDryRunResult | CompletionDryRunResult;
+  lastFetchedAt: string | null;
 }) {
+  // AC-α7-11 (c): lane disabled (progressReportEnabled=false / enabled=false)
+  const laneDisabled = isLaneDisabled(result);
+  // AC-α7-11 (d): scheduleDaysOfWeek=[]
+  const emptySchedule = hasEmptySchedule(result);
+  // AC-α7-13: 5 分超で古いプレビュー警告
+  const stale = isStale(lastFetchedAt);
+
   return (
     <div className="space-y-1 text-xs text-muted-foreground">
       <p>評価時刻: {formatJst(result.evaluatedAt)} (JST)</p>
@@ -167,6 +202,21 @@ function PreviewHeader({
       {!result.settingsLoaded && (
         <p className="text-amber-700 dark:text-amber-400" role="status">
           ⚠️ 配信設定が未保存です。プレビューは default 値で計算されています。
+        </p>
+      )}
+      {laneDisabled && (
+        <p className="text-amber-700 dark:text-amber-400" role="status">
+          ⚠️ このレーンは現在 OFF です。マスタートグルを ON にしてから配信が始まります。
+        </p>
+      )}
+      {emptySchedule && (
+        <p className="text-amber-700 dark:text-amber-400" role="status">
+          ⚠️ 配信曜日が選択されていません。「曜日と時刻」セクションで曜日を 1 つ以上選んでください。
+        </p>
+      )}
+      {stale && (
+        <p className="text-amber-700 dark:text-amber-400" role="status">
+          ⚠️ 結果が古い可能性があります (5 分以上経過)。最新の状態で確認するには「プレビューを取得」を再実行してください。
         </p>
       )}
     </div>

--- a/web/app/super/dispatch-settings/components/__tests__/DryRunPreview.test.tsx
+++ b/web/app/super/dispatch-settings/components/__tests__/DryRunPreview.test.tsx
@@ -8,7 +8,7 @@
  *   - empty state / disabled state (AC-α7-11)
  *   - loading 中の aria-busy / button disable (AC-α7-12)
  */
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type {
   CompletionDryRunResult,
@@ -285,6 +285,350 @@ describe("DryRunPreview (completion)", () => {
       />,
     );
     expect(screen.getByText(/送信内容プレビュー \(1 件\)/)).toBeInTheDocument();
+  });
+});
+
+describe("DryRunPreview (AC-α7-04 全 skipReason 網羅)", () => {
+  // progress lane の 4 skipReason すべて表示確認
+  it.each([
+    ["tenant_doc_not_found", "テナントドキュメント未検出"],
+    ["tenant_not_active", "テナント無効"],
+    ["progress_report_disabled", "進捗レポート OFF"],
+    ["no_published_courses", "公開講座なし"],
+  ] as const)(
+    "progress lane skipReason=%s で日本語ラベル『%s』が表示される",
+    (reason, label) => {
+      render(
+        <DryRunPreview
+          lane="progress"
+          result={makeProgressResult({
+            tenantsSummary: [
+              {
+                tenantId: `tenant-${reason}`,
+                skipped: true,
+                skipReason: reason,
+                usersScanned: 0,
+                candidateCount: 0,
+                invalidEmailCount: 0,
+                completedCount: 0,
+                ineligibleCount: 0,
+                wouldSendCount: 0,
+                ccCount: 0,
+              },
+            ],
+          })}
+          isLoading={false}
+          error={null}
+          lastFetchedAt={NOW}
+          onRefresh={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(label)).toBeInTheDocument();
+    },
+  );
+
+  // completion lane の 2 skipReason すべて表示確認
+  it.each([
+    ["tenant_completion_notification_disabled", "完了通知 OFF"],
+    ["no_published_courses", "公開講座なし"],
+  ] as const)(
+    "completion lane skipReason=%s で日本語ラベル『%s』が表示される",
+    (reason, label) => {
+      render(
+        <DryRunPreview
+          lane="completion"
+          result={makeCompletionResult({
+            tenantsSummary: [
+              {
+                tenantId: `tenant-${reason}`,
+                skipped: true,
+                skipReason: reason,
+                usersScanned: 0,
+                eligibleCount: 0,
+                invalidEmailCount: 0,
+              },
+            ],
+          })}
+          isLoading={false}
+          error={null}
+          lastFetchedAt={NOW}
+          onRefresh={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(label)).toBeInTheDocument();
+    },
+  );
+});
+
+describe("DryRunPreview (AC-α7-09 a11y semantic)", () => {
+  it("再取得 button は明示的 aria-label を持つ (lane 別)", () => {
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={null}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={null}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "進捗レポート 配信プレビューを再取得" }),
+    ).toBeInTheDocument();
+  });
+
+  it("error 表示時に role='alert' が配置される (critical)", () => {
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={null}
+        isLoading={false}
+        error={new ApiError(500, "internal_error", "boom")}
+        lastFetchedAt={null}
+        onRefresh={vi.fn()}
+      />,
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("プレビュー取得に失敗しました");
+  });
+
+  it("scaleTriggerExceeded の警告は role='alert' (緊急性高)", () => {
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={makeProgressResult({ scaleTriggerExceeded: true })}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={NOW}
+        onRefresh={vi.fn()}
+      />,
+    );
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts.some((el) => /scale trigger 超過/.test(el.textContent ?? ""))).toBe(
+      true,
+    );
+  });
+
+  it("settingsLoaded=false の警告は role='status' (info)", () => {
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={makeProgressResult({
+          settingsLoaded: false,
+          settingsSnapshot: null,
+        })}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={NOW}
+        onRefresh={vi.fn()}
+      />,
+    );
+    const statuses = screen.getAllByRole("status");
+    expect(statuses.some((el) => /配信設定が未保存/.test(el.textContent ?? ""))).toBe(
+      true,
+    );
+  });
+
+  it("再取得 button は focusable (tabIndex で keyboard navigation 可能)", () => {
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={null}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={null}
+        onRefresh={vi.fn()}
+      />,
+    );
+    const button = screen.getByRole("button", {
+      name: /進捗レポート 配信プレビューを再取得/,
+    });
+    // button 要素は default で focusable (tabIndex 0)、disabled=true で除外される
+    expect(button).not.toBeDisabled();
+    button.focus();
+    expect(button).toHaveFocus();
+  });
+
+  it("table の <th> 全てに scope='col' 属性が付く", () => {
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={makeProgressResult()}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={NOW}
+        onRefresh={vi.fn()}
+      />,
+    );
+    const ths = screen.getAllByRole("columnheader");
+    ths.forEach((th) => {
+      expect(th).toHaveAttribute("scope", "col");
+    });
+  });
+
+  it("table caption は sr-only で読み上げ対応 (lane 別)", () => {
+    render(
+      <DryRunPreview
+        lane="completion"
+        result={makeCompletionResult()}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={NOW}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("完了通知 配信予定 テナント別内訳")).toBeInTheDocument();
+  });
+});
+
+describe("DryRunPreview (AC-α7-11 empty/disabled state)", () => {
+  it("(c) progress lane disabled (progressReportEnabled=false) で OFF 警告表示", () => {
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={makeProgressResult({
+          settingsSnapshot: {
+            progressReportEnabled: false,
+            scheduleDaysOfWeek: [1],
+            scheduleHourJst: 9,
+            signatureName: "DXcollege運営スタッフ",
+          },
+        })}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={NOW}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/このレーンは現在 OFF です/)).toBeInTheDocument();
+  });
+
+  it("(c) completion lane disabled (enabled=false) で OFF 警告表示", () => {
+    render(
+      <DryRunPreview
+        lane="completion"
+        result={makeCompletionResult({
+          settingsSnapshot: {
+            enabled: false,
+            scheduleDaysOfWeek: [1],
+            scheduleHourJst: 9,
+            signatureName: "DXcollege運営スタッフ",
+            completionMessageBodyLength: 49,
+          },
+        })}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={NOW}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/このレーンは現在 OFF です/)).toBeInTheDocument();
+  });
+
+  it("(d) scheduleDaysOfWeek=[] で曜日未選択警告表示", () => {
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={makeProgressResult({
+          settingsSnapshot: {
+            progressReportEnabled: true,
+            scheduleDaysOfWeek: [],
+            scheduleHourJst: 9,
+            signatureName: "DXcollege運営スタッフ",
+          },
+        })}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={NOW}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/配信曜日が選択されていません/),
+    ).toBeInTheDocument();
+  });
+
+  it("(a) completion wouldNotify=[] で「送信予定の受講者はいません」明示", () => {
+    render(
+      <DryRunPreview
+        lane="completion"
+        result={makeCompletionResult({ wouldNotifyCount: 0, wouldNotify: [] })}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={NOW}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("送信予定の受講者はいません。")).toBeInTheDocument();
+  });
+});
+
+describe("DryRunPreview (AC-α7-13 data freshness)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("evaluatedAt は JST format で表示される (Asia/Tokyo)", () => {
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={makeProgressResult({ evaluatedAt: "2026-06-04T10:00:00.000Z" })}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={NOW}
+        onRefresh={vi.fn()}
+      />,
+    );
+    // UTC 10:00 → JST 19:00
+    expect(screen.getByText(/評価時刻:.*19:00:00.*\(JST\)/)).toBeInTheDocument();
+  });
+
+  it("lastFetchedAt 6 分前で stale 警告表示 (5 分閾値超え)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-04T20:00:00.000Z"));
+    const sixMinAgo = new Date("2026-06-04T19:54:00.000Z").toISOString();
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={makeProgressResult()}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={sixMinAgo}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/結果が古い可能性があります/)).toBeInTheDocument();
+  });
+
+  it("lastFetchedAt 4 分前は stale 警告なし (5 分閾値以内、境界値)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-04T20:00:00.000Z"));
+    const fourMinAgo = new Date("2026-06-04T19:56:00.000Z").toISOString();
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={makeProgressResult()}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={fourMinAgo}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/結果が古い可能性があります/)).not.toBeInTheDocument();
+  });
+
+  it("lastFetchedAt=null は stale 警告なし (まだ未取得)", () => {
+    render(
+      <DryRunPreview
+        lane="progress"
+        result={makeProgressResult()}
+        isLoading={false}
+        error={null}
+        lastFetchedAt={null}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/結果が古い可能性があります/)).not.toBeInTheDocument();
   });
 });
 

--- a/web/app/super/dispatch-settings/hooks/__tests__/useDryRun.test.tsx
+++ b/web/app/super/dispatch-settings/hooks/__tests__/useDryRun.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * useDryRun hook 単独 test (Phase 4 α-7-FE、OQ #17 #11 + AC-α7-12 UI 部分)。
+ *
+ * テスト対象 (impl-plan: /Users/yyyhhh/.claude/plans/silly-puzzling-moore.md T1):
+ *   - T1-1: 初回マウント時に自動 fetch しない (AC-α7-12 連打防止の起点)
+ *   - T1-2: refresh() 呼出で fetch 開始、成功時 state 更新 + lastFetchedAt set
+ *   - T1-3: in-flight 中 unmount で AbortController.abort 発火、unhandled rejection なし
+ *   - T1-4: AbortError (DOMException) は error=null で silently swallow (CRIT-1 反映)
+ *   - 追加: in-flight 中の 2nd refresh() は dedupe (console.debug + no-op、CRIT-2 反映)
+ *   - 追加: reset() で進行中 abort + state 初期化
+ *   - 追加: ApiError 以外の通信エラーは ApiError(0, "network_error") に wrap + console.error
+ *
+ * 関連:
+ *   - hook: ../useDryRun.ts
+ *   - 設計仕様書: docs/specs/2026-06-03-phase-4-pr-alpha-7-dry-run-ui-impl-plan.md §5 AC-α7-12
+ *   - 集約 Issue: #521 (OQ #17)
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProgressDryRunResult } from "@lms-279/shared-types";
+import { ApiError } from "@/lib/api";
+import { useDryRun } from "../useDryRun";
+
+const superFetchMock = vi.fn();
+vi.mock("@/lib/super-api", () => ({
+  useSuperAdminFetch: () => ({ superFetch: superFetchMock }),
+}));
+
+const consoleDebugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+beforeEach(() => {
+  superFetchMock.mockReset();
+  consoleDebugSpy.mockClear();
+  consoleErrorSpy.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function progressResult(
+  overrides: Partial<ProgressDryRunResult> = {},
+): ProgressDryRunResult {
+  return {
+    lane: "progress",
+    evaluatedAt: "2026-06-04T15:00:00.000Z",
+    settingsLoaded: true,
+    settingsSnapshot: {
+      progressReportEnabled: true,
+      scheduleDaysOfWeek: [1],
+      scheduleHourJst: 9,
+      signatureName: "Test",
+    },
+    tenantsScanned: 1,
+    tenantsSummary: [],
+    totalWouldSendCount: 0,
+    totalCcCount: 0,
+    estimatedDurationMs: 0,
+    estimatedPdfSizeKbRange: { min: 150, typical: 350, max: 1200 },
+    scaleTriggerExceeded: false,
+    ...overrides,
+  };
+}
+
+describe("useDryRun (Phase 4 α-7 OQ #17 #11 + AC-α7-12)", () => {
+  it("T1-1: 初回マウント時に自動 fetch しない (AC-α7-12 連打防止の起点)", () => {
+    const { result } = renderHook(() => useDryRun("progress"));
+
+    expect(superFetchMock).not.toHaveBeenCalled();
+    expect(result.current.result).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastFetchedAt).toBeNull();
+  });
+
+  it("T1-2: refresh() で fetch 開始、成功時に state 更新 + lastFetchedAt set", async () => {
+    const fetched = progressResult({ totalWouldSendCount: 3 });
+    superFetchMock.mockResolvedValueOnce(fetched);
+
+    const { result } = renderHook(() => useDryRun("progress"));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(superFetchMock).toHaveBeenCalledTimes(1);
+    expect(superFetchMock).toHaveBeenCalledWith(
+      "/api/v2/super/dispatch/dry-run/progress",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result.current.result).toEqual(fetched);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastFetchedAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    );
+  });
+
+  it("T1-3: in-flight 中 unmount で AbortController.abort 発火、unhandled rejection なし", async () => {
+    // refresh() の Promise を解決しないまま unmount するため、abort signal が
+    // fetch 側に届くまで pending な Promise を返す。
+    let abortSignal: AbortSignal | undefined;
+    superFetchMock.mockImplementationOnce(
+      (_path: string, init: { signal: AbortSignal }) => {
+        abortSignal = init.signal;
+        return new Promise(() => {
+          /* never resolves; abort で cleanup される */
+        });
+      },
+    );
+
+    const { result, unmount } = renderHook(() => useDryRun("progress"));
+
+    act(() => {
+      void result.current.refresh();
+    });
+
+    // unmount cleanup で abortRef.current?.abort() が走る
+    unmount();
+
+    expect(abortSignal?.aborted).toBe(true);
+  });
+
+  it("T1-4: AbortError (DOMException) は error=null で silently swallow (CRIT-1)", async () => {
+    superFetchMock.mockRejectedValueOnce(
+      new DOMException("aborted", "AbortError"),
+    );
+
+    const { result } = renderHook(() => useDryRun("progress"));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    // signal.aborted=false でも DOMException AbortError は早期 return で
+    // state を変更しない (CRIT-1: network_error と混同しない)
+    expect(result.current.error).toBeNull();
+    expect(result.current.result).toBeNull();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("in-flight 中の 2nd refresh() は dedupe (console.debug + no-op、CRIT-2)", async () => {
+    let resolveFirst: ((value: ProgressDryRunResult) => void) | undefined;
+    superFetchMock.mockImplementationOnce(
+      () =>
+        new Promise<ProgressDryRunResult>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useDryRun("progress"));
+
+    // 1st refresh() は in-flight 状態のまま放置
+    act(() => {
+      void result.current.refresh();
+    });
+
+    // 2nd refresh() は dedupe される (superFetch 呼出回数増えない)
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(superFetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleDebugSpy).toHaveBeenCalledWith(
+      "[useDryRun] refresh skipped, in-flight",
+      { lane: "progress" },
+    );
+
+    // cleanup: 1st refresh() を完了させて in-flight 解除
+    await act(async () => {
+      resolveFirst?.(progressResult());
+      await Promise.resolve();
+    });
+  });
+
+  it("reset() で in-flight abort + state 初期化", async () => {
+    // 完了した refresh() で state を埋めてから reset を確認
+    const fetched = progressResult({ totalWouldSendCount: 7 });
+    superFetchMock.mockResolvedValueOnce(fetched);
+
+    const { result } = renderHook(() => useDryRun("progress"));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.result).not.toBeNull();
+    expect(result.current.lastFetchedAt).not.toBeNull();
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.result).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastFetchedAt).toBeNull();
+  });
+
+  it("ApiError 以外の通信エラーは ApiError(0, network_error) に wrap + console.error", async () => {
+    const unknownError = new TypeError("Failed to fetch");
+    superFetchMock.mockRejectedValueOnce(unknownError);
+
+    const { result } = renderHook(() => useDryRun("progress"));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+    expect(result.current.error).toBeInstanceOf(ApiError);
+    expect(result.current.error?.status).toBe(0);
+    expect(result.current.error?.code).toBe("network_error");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[useDryRun] unexpected error",
+      expect.objectContaining({ lane: "progress", err: unknownError }),
+    );
+  });
+
+  it("ApiError は wrap せずそのまま state.error に格納", async () => {
+    const apiError = new ApiError(429, "rate_limited", "Too many requests");
+    superFetchMock.mockRejectedValueOnce(apiError);
+
+    const { result } = renderHook(() => useDryRun("progress"));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(apiError);
+    });
+    // ApiError は console.error で wrap log されない (元情報が既に明示的)
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("completion lane 指定時に completion endpoint を叩く", async () => {
+    superFetchMock.mockResolvedValueOnce({
+      lane: "completion",
+      evaluatedAt: "2026-06-04T15:00:00.000Z",
+      settingsLoaded: true,
+      settingsSnapshot: {
+        enabled: false,
+        scheduleDaysOfWeek: [1],
+        scheduleHourJst: 9,
+        signatureName: "Test",
+        completionMessageBodyLength: 49,
+      },
+      tenantsScanned: 0,
+      tenantsSummary: [],
+      wouldNotifyCount: 0,
+      wouldNotify: [],
+    });
+
+    const { result } = renderHook(() => useDryRun("completion"));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(superFetchMock).toHaveBeenCalledWith(
+      "/api/v2/super/dispatch/dry-run/completion",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

OQ #17 (Issue #521) 配下 **#11 (useDryRun hook 単独 test、rating 7) + #12 (Playwright E2E AC-α7-04/05/09/10/11/12/13)** を戦略 B (ハイブリッド) で実装。**cutover Step 6 (本番マスタートグル ON) 前完了必須項目**。

### 戦略 B 採用根拠 (Session 64 で開発者承認)

- `rules/testing.md`: E2E は致命的ビジネス導線のみ、UI ロジック網羅は component test で担保
- 既存 `e2e/dispatch-settings-api.spec.ts`: AUTH_MODE=dev で super UI 遷移不可、UI 検証は component test 側で実施と明記
- 設計仕様書 §5「Playwright + component test」両者要求のうち、Playwright 側は API スコープに絞る

### 実装内訳

| Layer | ファイル | 規模 | カバレッジ |
|-------|---------|------|----------|
| Production | `DryRunPreview.tsx` | +52 行 | AC-α7-11 (c)(d) + AC-α7-13 警告追加 |
| Hook test | `useDryRun.test.tsx` (新規) | 269 行 | #11 + AC-α7-12 UI 連打抑止 (T1-1〜T1-4 + 追加 4) |
| Component test | `DryRunPreview.test.tsx` | +346 行 | AC-α7-04 全 6 skip + AC-α7-09 a11y + AC-α7-11 4 状態 + AC-α7-13 freshness |
| API E2E | `dispatch-dry-run-api.spec.ts` (新規) | 57 行 | AC-α7-05 認証 401/403 両 lane |

### Scope に含まない (cutover 後 follow-up)

- AC-α7-10 完全 visual responsive (要 super UI auth 機構拡張)
- AC-α7-12 BE limiter 429 E2E 重複 (BE integration test 済)
- axe-core 依存追加 (cost > benefit)
- E2E 200 系 (in-memory wiring 調査要、500 PERMISSION_DENIED) ← BE integration test で網羅済

### Quality Gate

| 項目 | 結果 |
|------|------|
| `npm run lint` | ✅ PASS (warning 1 件は既存、本 PR 関係なし) |
| `npm run type-check` | ✅ PASS 全 workspace |
| `npm test -w @lms-279/web` | ✅ 260 件 PASS / 22 ファイル (前回 245 → +15) |
| `npx playwright test dispatch-dry-run-api.spec.ts` | ✅ 4 件 PASS (4.1s) |
| `/safe-refactor` | ✅ 修正不要 (LOW 2 件は overengineering 回避でスキップ推奨) |
| `/code-review medium` | ✅ correctness bug 検出 0 件 (REFUTED 4 / PLAUSIBLE LOW 2) |

### Issue #521 (OQ #17) 進捗

- ✅ **#11** useDryRun hook 単独 test 完遂 (rating 7、AC-α7-12 UI 連打抑止含む)
- ✅ **#12** Playwright E2E 戦略 B (ハイブリッド) で完遂
- 🟡 **#13** a11y 補強 部分消化 (role / aria-label semantic は完了、axe-core は cost > benefit で見送り)
- ⏸️ 残 12 件 (#1-#10 + #14 + #15) は cutover 後 / 個別 PR

## Test plan

- [x] `npm run lint` PASS
- [x] `npm run type-check` PASS
- [x] `npm test -w @lms-279/web` 260 件 PASS
- [x] `npx playwright test dispatch-dry-run-api.spec.ts` 4 件 PASS
- [ ] CI 全 checks GREEN (Build / Lint / Test / Type Check / Playwright E2E / Cloud Run deploy)
- [ ] merge 後の Cloud Run deploy GREEN
- [ ] Issue #521 に進捗 comment 追加 (T6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)