### PR TITLE
fix(super-attendance): 退室理由フィルタに「未退出」選択肢を追加 (#532)

### DIFF
--- a/web/app/super/attendance/__tests__/exit-reason-filter.test.ts
+++ b/web/app/super/attendance/__tests__/exit-reason-filter.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  EXIT_REASON_NONE_VALUE,
+  matchesExitReasonFilter,
+} from "../_helpers/exit-reason-filter";
+
+describe("matchesExitReasonFilter", () => {
+  describe("退室理由が確定しているレコード", () => {
+    it("選択された退室理由にマッチする", () => {
+      const selected = new Set(["quiz_submitted", "time_limit"]);
+      expect(matchesExitReasonFilter("quiz_submitted", selected)).toBe(true);
+      expect(matchesExitReasonFilter("time_limit", selected)).toBe(true);
+    });
+
+    it("選択されていない退室理由はマッチしない", () => {
+      const selected = new Set(["quiz_submitted"]);
+      expect(matchesExitReasonFilter("time_limit", selected)).toBe(false);
+      expect(matchesExitReasonFilter("pause_timeout", selected)).toBe(false);
+    });
+
+    it("null sentinel しか選択されていない場合、確定済み退室理由はマッチしない", () => {
+      const selected = new Set([EXIT_REASON_NONE_VALUE]);
+      expect(matchesExitReasonFilter("quiz_submitted", selected)).toBe(false);
+      expect(matchesExitReasonFilter("time_limit", selected)).toBe(false);
+    });
+  });
+
+  describe("exitReason が null (在室中 / 未確定)", () => {
+    it("EXIT_REASON_NONE_VALUE が選択されていればマッチする (#532 fix)", () => {
+      const selected = new Set([EXIT_REASON_NONE_VALUE]);
+      expect(matchesExitReasonFilter(null, selected)).toBe(true);
+    });
+
+    it("EXIT_REASON_NONE_VALUE が未選択ならマッチしない (旧挙動と互換)", () => {
+      const selected = new Set(["quiz_submitted", "time_limit", "pause_timeout"]);
+      expect(matchesExitReasonFilter(null, selected)).toBe(false);
+    });
+
+    it("空セットの場合はマッチしない (呼び出し側で size > 0 ガード前提)", () => {
+      const selected = new Set<string>();
+      expect(matchesExitReasonFilter(null, selected)).toBe(false);
+    });
+
+    it("確定済みと null sentinel の両方が選択されていれば null もマッチする", () => {
+      const selected = new Set(["quiz_submitted", EXIT_REASON_NONE_VALUE]);
+      expect(matchesExitReasonFilter(null, selected)).toBe(true);
+      expect(matchesExitReasonFilter("quiz_submitted", selected)).toBe(true);
+      expect(matchesExitReasonFilter("time_limit", selected)).toBe(false);
+    });
+  });
+});

--- a/web/app/super/attendance/__tests__/exit-reason-filter.test.ts
+++ b/web/app/super/attendance/__tests__/exit-reason-filter.test.ts
@@ -4,6 +4,28 @@ import {
   matchesExitReasonFilter,
 } from "../_helpers/exit-reason-filter";
 
+// ADR-027 で定義された退室理由 enum 値。本 sentinel が将来追加される値と衝突しないことを保証する。
+// page.tsx 内 EXIT_REASON_LABELS と同期して保守する。
+const SERVER_EXIT_REASON_KEYS = [
+  "quiz_submitted",
+  "pause_timeout",
+  "time_limit",
+  "browser_close",
+  "max_attempts_failed",
+] as const;
+
+describe("EXIT_REASON_NONE_VALUE sentinel", () => {
+  it("既存の退室理由 enum 値と衝突しない (silent failure regression guard)", () => {
+    // 将来 ADR-027 に新しい退室理由値が追加された際、sentinel と同名にしないこと。
+    // 衝突すると null セッションと「その新理由」が誤マッチする silent failure になる。
+    expect(SERVER_EXIT_REASON_KEYS as readonly string[]).not.toContain(EXIT_REASON_NONE_VALUE);
+  });
+
+  it("__ プレフィックスで明確に内部 sentinel と識別できる", () => {
+    expect(EXIT_REASON_NONE_VALUE.startsWith("__")).toBe(true);
+  });
+});
+
 describe("matchesExitReasonFilter", () => {
   describe("退室理由が確定しているレコード", () => {
     it("選択された退室理由にマッチする", () => {

--- a/web/app/super/attendance/_helpers/exit-reason-filter.ts
+++ b/web/app/super/attendance/_helpers/exit-reason-filter.ts
@@ -1,0 +1,23 @@
+/**
+ * 退室理由フィルタ用 sentinel と判定関数。
+ *
+ * SuperAttendanceRecord.exitReason は string | null だが、FilterOption.value は string のみ。
+ * exitReason=null (在室中/異常終了で退室理由未確定) のセッションを表すために sentinel "__none__" を使う。
+ */
+
+export const EXIT_REASON_NONE_VALUE = "__none__";
+export const EXIT_REASON_NONE_LABEL = "未退出";
+
+/**
+ * フィルタ選択状態 (Set<string>) に対し、レコードの exitReason がマッチするか判定。
+ * null の場合は EXIT_REASON_NONE_VALUE が選択されていればマッチ。
+ */
+export function matchesExitReasonFilter(
+  recordExitReason: string | null,
+  selectedReasons: Set<string>,
+): boolean {
+  if (recordExitReason === null) {
+    return selectedReasons.has(EXIT_REASON_NONE_VALUE);
+  }
+  return selectedReasons.has(recordExitReason);
+}

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -34,6 +34,11 @@ import type {
   SuperAttendanceRecord,
   SuperAttendanceResponse,
 } from "@lms-279/shared-types";
+import {
+  EXIT_REASON_NONE_LABEL,
+  EXIT_REASON_NONE_VALUE,
+  matchesExitReasonFilter,
+} from "./_helpers/exit-reason-filter";
 
 type Tenant = { id: string; name: string };
 
@@ -231,7 +236,10 @@ export default function AttendanceReportPage() {
     return Array.from(map, ([value, label]) => ({ value, label })).sort((a, b) => a.label.localeCompare(b.label, "ja"));
   }, [report]);
 
-  const exitReasonOptions: FilterOption[] = Object.entries(EXIT_REASON_LABELS).map(([value, label]) => ({ value, label }));
+  const exitReasonOptions: FilterOption[] = [
+    ...Object.entries(EXIT_REASON_LABELS).map(([value, label]) => ({ value, label })),
+    { value: EXIT_REASON_NONE_VALUE, label: EXIT_REASON_NONE_LABEL },
+  ];
   const quizPassedOptions: FilterOption[] = [
     { value: "passed", label: "合格" },
     { value: "failed", label: "不合格" },
@@ -254,7 +262,7 @@ export default function AttendanceReportPage() {
       records = records.filter((r) => filterLessons.has(r.lessonId));
     }
     if (filterExitReasons.size > 0) {
-      records = records.filter((r) => r.exitReason !== null && filterExitReasons.has(r.exitReason));
+      records = records.filter((r) => matchesExitReasonFilter(r.exitReason, filterExitReasons));
     }
     if (filterQuizPassed.size > 0) {
       records = records.filter((r) => {


### PR DESCRIPTION
## Summary

- 退室理由フィルタに「未退出」選択肢を追加 (sentinel `__none__`)
- フィルタ判定を `matchesExitReasonFilter` helper に抽出して pure function 化、7 件の単体テストで境界値カバー
- 進捗ページ ↔ 出席レポートの「データは整合しているのに画面で食い違って見える」問題の半分を解消

Closes #532

## 背景

長遊園様テナント (`8vexhzpc`) で進捗 vs 出席の不一致報告を調査したところ、UI フィルタ仕様で `exitReason=null` (在室中 / 異常終了で退室理由未確定) のセッションが画面に出ない事象を確認:

- 進捗側: `latestSessionId=7gmfYRHmvcs5KbCpUelo` (entry 2026/6/1 8:15:21, exit null) を表示
- 出席 API: 同 session ID を**正しく返している**
- 出席 UI: 全 5 種類フィルタ選択でも該当行が出ない

`web/app/super/attendance/page.tsx:257` の `r.exitReason !== null` 無条件除外が原因。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `web/app/super/attendance/page.tsx` | filter logic を helper に置換、import 追加 |
| `web/app/super/attendance/_helpers/exit-reason-filter.ts` | 新規: sentinel 定数 + pure filter 関数 |
| `web/app/super/attendance/__tests__/exit-reason-filter.test.ts` | 新規: 7 ケース単体テスト |

## Test plan

- [x] `npm run type-check` PASS
- [x] `npm run test` 全 267 件 PASS (+7 新規テスト含む)
- [x] `npm run lint` 0 errors
- [x] `npm run build -w @lms-279/web` PASS (静的生成 OK)
- [ ] 本番デプロイ後、長遊園様で「未退出」選択肢が出る/動くことを開発者確認
- [ ] 退室理由全選択時 (6 種類) で API が返す全レコードが画面に出ることを確認

## 関連

- 別 Issue として残存: #533 (lesson_sessions に痕跡が残らない真の不整合 4 件、コード修正 + backfill 要)
- 同期 Issue: #531 (滞在時間カラム追加)