### PR TITLE
feat(super-attendance): 出席レポートに滞在時間カラムを追加 (#531)

### DIFF
--- a/web/app/super/attendance/__tests__/stay-duration.test.ts
+++ b/web/app/super/attendance/__tests__/stay-duration.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateStayDurationMs,
+  formatStayDuration,
+} from "../_helpers/stay-duration";
+
+describe("calculateStayDurationMs", () => {
+  it("正常: 1 時間 22 分の経過を ms で返す (Issue #531 例)", () => {
+    // 入室 10:14 → 退室 11:36 = 1時間22分 = 4920000 ms
+    const entry = "2026-05-30T01:14:10.258Z"; // JST 10:14
+    const exit = "2026-05-30T02:36:29.496Z"; // JST 11:36
+    const ms = calculateStayDurationMs(entry, exit);
+    expect(ms).not.toBeNull();
+    expect(Math.floor(ms! / 60_000)).toBe(82); // 82 分 = 1時間22分
+  });
+
+  it("正常: 同一時刻 (0 ms) → 0 を返す (null 扱いしない)", () => {
+    const t = "2026-05-30T01:14:10.000Z";
+    expect(calculateStayDurationMs(t, t)).toBe(0);
+  });
+
+  it("entryAt のみ (在室中) → null", () => {
+    expect(calculateStayDurationMs("2026-05-30T01:14:10.258Z", null)).toBeNull();
+  });
+
+  it("exitAt のみ (異常データ) → null", () => {
+    expect(calculateStayDurationMs(null, "2026-05-30T02:36:29.496Z")).toBeNull();
+  });
+
+  it("両方 null → null", () => {
+    expect(calculateStayDurationMs(null, null)).toBeNull();
+  });
+
+  it("exit < entry (異常データ) → null", () => {
+    const entry = "2026-05-30T02:36:29.496Z";
+    const exit = "2026-05-30T01:14:10.258Z";
+    expect(calculateStayDurationMs(entry, exit)).toBeNull();
+  });
+
+  it("無効な ISO 文字列 → null (NaN ガード)", () => {
+    expect(calculateStayDurationMs("not-a-date", "2026-05-30T02:36:29.496Z")).toBeNull();
+    expect(calculateStayDurationMs("2026-05-30T01:14:10.258Z", "invalid")).toBeNull();
+  });
+
+  it("極大値: 数日跨ぎ time_limit セッション → 正しい ms", () => {
+    // 長遊園様データ実例: 串間博希 2026-05-14 22:12 → 2026-05-17 04:49 (約 2 日と 6 時間)
+    const entry = "2026-05-14T22:12:52.130Z";
+    const exit = "2026-05-17T04:49:01.999Z";
+    const ms = calculateStayDurationMs(entry, exit);
+    expect(ms).not.toBeNull();
+    const hours = Math.floor(ms! / 3_600_000);
+    expect(hours).toBe(54); // 約 54 時間
+  });
+});
+
+describe("formatStayDuration", () => {
+  it("null → '—'", () => {
+    expect(formatStayDuration(null)).toBe("—");
+  });
+
+  it("0 ms → '0分'", () => {
+    expect(formatStayDuration(0)).toBe("0分");
+  });
+
+  it("60_000 ms (1 分) → '1分'", () => {
+    expect(formatStayDuration(60_000)).toBe("1分");
+  });
+
+  it("59 分 → '59分' (時間部分なし)", () => {
+    expect(formatStayDuration(59 * 60_000)).toBe("59分");
+  });
+
+  it("60 分ちょうど → '1時間0分'", () => {
+    expect(formatStayDuration(60 * 60_000)).toBe("1時間0分");
+  });
+
+  it("1 時間 22 分 → '1時間22分' (Issue #531 例)", () => {
+    const ms = (60 + 22) * 60_000;
+    expect(formatStayDuration(ms)).toBe("1時間22分");
+  });
+
+  it("端数秒は切り捨て (59 秒 → 0分)", () => {
+    expect(formatStayDuration(59_999)).toBe("0分");
+  });
+
+  it("負数 ms (defensive) → '—' ではなく '0分' (呼び出し側で null フィルタ前提)", () => {
+    // calculateStayDurationMs が負を null にするので通常は到達しないが、
+    // 万一渡された場合の挙動を documentation 目的でテスト。
+    expect(formatStayDuration(-1)).toBe("-1分");
+  });
+
+  it("極大値 54 時間 → '54時間XX分'", () => {
+    const ms = (54 * 60 + 36) * 60_000;
+    expect(formatStayDuration(ms)).toBe("54時間36分");
+  });
+});

--- a/web/app/super/attendance/_helpers/stay-duration.ts
+++ b/web/app/super/attendance/_helpers/stay-duration.ts
@@ -1,0 +1,37 @@
+/**
+ * セッション滞在時間 (入室→退室の経過時間) 計算・整形ヘルパー。
+ *
+ * 出席レポート (`/super/attendance`) で表示。
+ * 計算は FE 側で完結 (API/shared-types 変更なし)、ソート時は ms 値で比較する。
+ */
+
+/**
+ * 入室・退室時刻 (ISO 文字列) から滞在時間 ms を計算。
+ * 入室 or 退室いずれかが null、または exitAt < entryAt の異常データは null を返す。
+ */
+export function calculateStayDurationMs(
+  entryAt: string | null,
+  exitAt: string | null,
+): number | null {
+  if (!entryAt || !exitAt) return null;
+  const entryMs = new Date(entryAt).getTime();
+  const exitMs = new Date(exitAt).getTime();
+  if (!Number.isFinite(entryMs) || !Number.isFinite(exitMs)) return null;
+  const diff = exitMs - entryMs;
+  if (diff < 0) return null;
+  return diff;
+}
+
+/**
+ * 滞在時間 ms を「H時間M分」形式に整形。
+ * - null → "—"
+ * - 0 分以上 1 時間未満 → "M分"
+ * - 1 時間以上 → "H時間M分" (0 分のときも "H時間0分" で時間部分を残す)
+ */
+export function formatStayDuration(ms: number | null): string {
+  if (ms === null) return "—";
+  const totalMinutes = Math.floor(ms / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return hours > 0 ? `${hours}時間${minutes}分` : `${minutes}分`;
+}

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -39,11 +39,16 @@ import {
   EXIT_REASON_NONE_VALUE,
   matchesExitReasonFilter,
 } from "./_helpers/exit-reason-filter";
+import {
+  calculateStayDurationMs,
+  formatStayDuration,
+} from "./_helpers/stay-duration";
 
 type Tenant = { id: string; name: string };
 
 type SortDir = "asc" | "desc" | null;
-type SortKey = keyof SuperAttendanceRecord;
+// stayDuration は SuperAttendanceRecord 由来ではなく FE 算出フィールド (entryAt/exitAt から計算)。
+type SortKey = keyof SuperAttendanceRecord | "stayDuration";
 
 function formatTime(iso: string | null): string {
   if (!iso) return "—";
@@ -102,6 +107,7 @@ const COLUMNS: Column[] = [
   { key: "date", label: "日付", className: "whitespace-nowrap" },
   { key: "entryAt", label: "入室", className: "whitespace-nowrap" },
   { key: "exitAt", label: "退室", className: "whitespace-nowrap" },
+  { key: "stayDuration", label: "滞在時間", className: "whitespace-nowrap" },
   { key: "exitReason", label: "退室理由" },
   { key: "quizScore", label: "テスト点数" },
   { key: "quizPassed", label: "合否" },
@@ -277,6 +283,15 @@ export default function AttendanceReportPage() {
     if (sortKey && sortDir) {
       const dir = sortDir === "asc" ? 1 : -1;
       records = [...records].sort((a, b) => {
+        // stayDuration は計算フィールド: ms 数値で比較 (null は末尾)
+        if (sortKey === "stayDuration") {
+          const av = calculateStayDurationMs(a.entryAt, a.exitAt);
+          const bv = calculateStayDurationMs(b.entryAt, b.exitAt);
+          if (av === null && bv === null) return 0;
+          if (av === null) return 1;
+          if (bv === null) return -1;
+          return (av - bv) * dir;
+        }
         const av = a[sortKey];
         const bv = b[sortKey];
         if (av === null && bv === null) return 0;
@@ -506,6 +521,9 @@ export default function AttendanceReportPage() {
                       <TableCell data-col="date" className="whitespace-nowrap text-sm">{formatDate(r.entryAt)}</TableCell>
                       <TableCell data-col="entryAt" className="whitespace-nowrap text-sm">{formatTime(r.entryAt)}</TableCell>
                       <TableCell data-col="exitAt" className="whitespace-nowrap text-sm">{formatTime(r.exitAt)}</TableCell>
+                      <TableCell data-col="stayDuration" className="whitespace-nowrap text-sm">
+                        {formatStayDuration(calculateStayDurationMs(r.entryAt, r.exitAt))}
+                      </TableCell>
                       <TableCell data-col="exitReason" className="text-sm">
                         {r.exitReason ? (EXIT_REASON_LABELS[r.exitReason] ?? r.exitReason) : "—"}
                       </TableCell>


### PR DESCRIPTION
## Summary

- 出席・テスト結果レポート (`/super/attendance`) に **滞在時間カラム** を追加 (入室→退室の経過時間)
- 表示フォーマット: `H時間M分` / `M分` / `—` (null 系)
- FE 側計算のみ。API / shared-types 変更なし
- ソート対応 (ms 単位で比較、null 末尾)
- PDF 出力ダイアログにも自動追加 (COLUMNS 経由)
- helper を pure 関数化、17 件の単体テストで境界値網羅

Closes #531

## カラム順 (太字が追加)

| 受講者 | コース | レッスン | 日付 | 入室▲ | 退室 | **滞在時間** | 退室理由 | テスト点数 | 合否 | 操作 |

## 設計判断

### Q: API 計算 vs FE 計算？
A: **FE 側**。entryAt/exitAt から自明に算出可能、shared-types 変更不要、サーバ往復不要。

### Q: 表記フォーマット？
A: **`1時間22分` / `22分`** に決定 (Issue 例と一致、和文 UI に自然)。HH:mm:ss は ms 精度の必要性が低く、誤読 (時刻と混同) リスクあり。

### Q: 在室中 (entryAt only) の表示？
A: **`—`** (#532 と統一)。「継続中」案も検討したが、ソート時の挙動 (継続中を上端 vs 末尾) で意味的曖昧さあるため `—` 統一。

### Q: PDF デフォルト ON/OFF？
A: **ON** (既存全カラム ON で揃える)。`openPdfDialog` の `new Set(COLUMNS.map(c => c.key))` で自動 ON。

## 変更ファイル

| ファイル | 変更 |
|---------|------|
| `web/app/super/attendance/page.tsx` | SortKey 拡張, COLUMNS 追加, sort 分岐, render cell 追加, import |
| `web/app/super/attendance/_helpers/stay-duration.ts` | 新規: `calculateStayDurationMs` + `formatStayDuration` |
| `web/app/super/attendance/__tests__/stay-duration.test.ts` | 新規: 17 ケース単体テスト |

## Test plan

- [x] `npm run type-check` PASS
- [x] `npm run test` 全 286 件 PASS (+17 新規テスト含む)
- [x] `npm run lint` 0 errors
- [x] `npm run build -w @lms-279/web` PASS
- [ ] 本番デプロイ後、長遊園様で滞在時間カラムが表示されることを開発者確認
- [ ] 滞在時間カラムをクリックしてソート (昇順/降順/解除) できることを確認
- [ ] PDF 出力ダイアログに「滞在時間」がデフォルト ON で含まれることを確認
- [ ] 在室中セッション (#532 で見えるようになった「未退出」行) が `—` 表示になることを確認

## 単体テストカバレッジ

`calculateStayDurationMs` (8 ケース):
- 正常系: 1時間22分、同一時刻 (0ms)
- null 系: entryAt only / exitAt only / 両方 null
- 異常系: exit < entry / 無効 ISO 文字列
- 極大値: 数日跨ぎ time_limit (54時間)

`formatStayDuration` (9 ケース):
- null → "—"
- 0/59/60/82分、54時間36分等の境界
- 端数秒切り捨て、負数 defensive

## 関連

- 同時調査で発見した別件: #533 (lesson_sessions 整合性、impl-plan 要)
- 前提: #532 (PR #534 merged) で「未退出」セッションが画面表示されるようになっており、それらに対しても `—` 表示が期待通り