### PR TITLE
feat(backfill): 過去の合成 session 欠落 (#533 Phase 2) を遡及作成する admin workflow

### DIFF
--- a/.github/workflows/backfill-synthetic-sessions.yml
+++ b/.github/workflows/backfill-synthetic-sessions.yml
@@ -1,0 +1,126 @@
+name: Backfill Synthetic Lesson Sessions
+
+# Issue #533 Phase 2: 過去の合格 quiz_attempt のうち lesson_sessions に痕跡が残っていないもの
+# (activeSession=null での提出) について、Phase 1 createSyntheticCompletedSession 相当の
+# synthetic_{attemptId} doc を遡及作成する admin workflow。
+#
+# Phase 1 (PR #537) で新規発生は予防済み。本 workflow は過去発生分の整合性回復用。
+#
+# 実行方法:
+#   GitHub Actions UI > Backfill Synthetic Lesson Sessions > Run workflow
+#   インプット未指定で dry-run (全テナント横断、件数 + サンプル表示のみ)
+#   execute=true で実際に書き込み (環境 protection 必須)
+#
+# 安全機構:
+#   - dry-run 既定
+#   - main ブランチでのみ実行可
+#   - execute=true は environment: production で approval 必須
+#   - expected_count 完全一致ガード (本番 apply で必須運用)
+#   - 件数アサーション (max_targets)
+#   - スコープ絞り込み (tenant_id / user_email / user_id)
+#   - 更新前バックアップ artifact (commit SHA / run id / actor / 関連 session snapshot)
+#   - tx.create で race-safe + 冪等
+#   - 書き込み後の読み戻し検証
+#
+# セキュリティ: workflow_dispatch 入力はすべて env 経由で受け、run: 内で直接補間しない
+# (https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/)
+
+on:
+  workflow_dispatch:
+    inputs:
+      execute:
+        description: '実書き込みモード (false=dry-run / true=apply)。true 時は environment approval 必須'
+        type: boolean
+        default: false
+      tenant_id:
+        description: 'テナント ID で絞り込み (空 = 全テナント横断)'
+        required: false
+        type: string
+      user_email:
+        description: 'ユーザー email で絞り込み (user_id と排他)'
+        required: false
+        type: string
+      user_id:
+        description: 'ユーザー ID で絞り込み (user_email と排他)'
+        required: false
+        type: string
+      max_targets:
+        description: 'backfill 対象の上限件数 (既定 100、超えると中断)'
+        required: false
+        default: '100'
+        type: string
+      expected_count:
+        description: '対象件数の完全一致ガード (本番 apply で必須運用、不一致時 fail)'
+        required: false
+        type: string
+
+jobs:
+  backfill:
+    name: Backfill
+    # main branch でのみ実行可 (Codex M3 反映)
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    # execute=true 時のみ environment approval を要求 (Codex M3 反映)
+    environment: ${{ inputs.execute && 'production' || 'dev' }}
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      FIREBASE_PROJECT_ID: lms-279
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/1034821634012/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-actions@lms-279.iam.gserviceaccount.com
+
+      - name: Run backfill script
+        env:
+          GOOGLE_CLOUD_PROJECT: lms-279
+          EXECUTE: ${{ inputs.execute }}
+          TENANT_ID: ${{ inputs.tenant_id }}
+          USER_EMAIL: ${{ inputs.user_email }}
+          USER_ID: ${{ inputs.user_id }}
+          MAX_TARGETS: ${{ inputs.max_targets }}
+          EXPECTED_COUNT: ${{ inputs.expected_count }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          # execute=true には expected_count 必須 (件数ガード強制、Codex M2 反映)。
+          # 空のまま apply されると validateExpectedCount がスキップされ防護が外れる。
+          if [ "$EXECUTE" = "true" ] && [ -z "$EXPECTED_COUNT" ]; then
+            echo "[FATAL] execute=true には expected_count 入力必須 (件数完全一致ガード)" >&2
+            exit 1
+          fi
+          FLAGS=()
+          if [ "$EXECUTE" = "true" ]; then FLAGS+=("--execute"); fi
+          if [ -n "$TENANT_ID" ]; then FLAGS+=("--tenant-id=$TENANT_ID"); fi
+          if [ -n "$USER_EMAIL" ]; then FLAGS+=("--user-email=$USER_EMAIL"); fi
+          if [ -n "$USER_ID" ]; then FLAGS+=("--user-id=$USER_ID"); fi
+          if [ -n "$MAX_TARGETS" ]; then FLAGS+=("--max-targets=$MAX_TARGETS"); fi
+          if [ -n "$EXPECTED_COUNT" ]; then FLAGS+=("--expected-count=$EXPECTED_COUNT"); fi
+          echo "Running with flags: ${FLAGS[*]:-(none)}"
+          npx tsx scripts/backfill-synthetic-sessions.ts "${FLAGS[@]}"
+
+      - name: Upload backup artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backfill-synthetic-backup-${{ github.run_id }}
+          path: backfill-synthetic-backup-*.json
+          if-no-files-found: ignore
+          retention-days: 30

--- a/scripts/__tests__/backfill-synthetic-sessions.test.ts
+++ b/scripts/__tests__/backfill-synthetic-sessions.test.ts
@@ -8,7 +8,7 @@
  *     Firestore fake で検証。AC2.1〜AC2.11 を網羅。
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   type AttemptInfo,
   type BackfillTarget,
@@ -21,6 +21,7 @@ import {
   findBackfillTargets,
   parseArgs,
   resolveSessionDurationMs,
+  runMain,
   sanitizeForWrite,
   validateExpectedCount,
   validateReadback,
@@ -691,6 +692,7 @@ describe("findBackfillTargets [integration]", () => {
       status: string;
     }>;
     lessonExists?: boolean;
+    videoExists?: boolean;
     videoId?: string;
   }) {
     const lessonId = "lesson-1";
@@ -729,9 +731,14 @@ describe("findBackfillTargets [integration]", () => {
       [`tenants/${opts.tenantId}/quizzes`]: {
         [quizId]: { lessonId, courseId },
       },
+      // lesson 存在確認用 (videoId field は読まない、canonical は videos.lessonId)
       [`tenants/${opts.tenantId}/lessons`]: opts.lessonExists === false
         ? {}
-        : { [lessonId]: { videoId } },
+        : { [lessonId]: { title: "test lesson" } },
+      // videoId 解決用 (Phase 1 helper と同じ videos.lessonId where 検索)
+      [`tenants/${opts.tenantId}/videos`]: opts.videoExists === false
+        ? {}
+        : { [videoId]: { lessonId, title: "test video" } },
       [`tenants/${opts.tenantId}/lesson_sessions`]: sessions,
     };
 
@@ -811,6 +818,19 @@ describe("findBackfillTargets [integration]", () => {
       attemptStatus: "submitted",
       isPassed: true,
       lessonExists: false,
+    });
+    const { targets, auditOnly } = await findBackfillTargets(db, ["t1"]);
+    expect(targets.length).toBe(0);
+    expect(auditOnly.length).toBe(0);
+  });
+
+  it("video 未紐付け (videos に lessonId 該当なし) → skip + warn (review-pr C1 反映)", async () => {
+    const db = setupTenantWithAttempt({
+      tenantId: "t1",
+      attemptId: "a1",
+      attemptStatus: "submitted",
+      isPassed: true,
+      videoExists: false,
     });
     const { targets, auditOnly } = await findBackfillTargets(db, ["t1"]);
     expect(targets.length).toBe(0);
@@ -926,6 +946,227 @@ describe("applyBackfill [integration]", () => {
 });
 
 // ============================================================
+// ALREADY_EXISTS race condition (review-pr C2 反映)
+// ============================================================
+
+describe("applyBackfill: ALREADY_EXISTS race [integration]", () => {
+  /**
+   * tx.get で exists=false の後、tx.create で race により ALREADY_EXISTS が throw された
+   * ケースを模擬する。実 Firestore admin SDK では並行 process 間で発生する。
+   * runTransaction は ABORTED を retry するが、permanent error の場合は catch に到達する。
+   */
+  function createFakeWithRaceError(
+    errorCode: number | string
+  ): Firestore {
+    const fakeRef = { _path: "tenants/t1/lesson_sessions", id: "synthetic_a1" };
+    return {
+      collection: (_path: string) => ({
+        doc: (_id: string) => fakeRef,
+      }),
+      runTransaction: async <T>(
+        fn: (tx: {
+          get: (ref: typeof fakeRef) => Promise<{ exists: boolean; data: () => undefined }>;
+          create: (ref: typeof fakeRef, data: unknown) => void;
+        }) => Promise<T>
+      ): Promise<T> => {
+        return await fn({
+          get: async () => ({ exists: false, data: () => undefined }),
+          create: () => {
+            const e = new Error("simulated race ALREADY_EXISTS") as Error & {
+              code: number | string;
+            };
+            e.code = errorCode;
+            throw e;
+          },
+        });
+      },
+    } as unknown as Firestore;
+  }
+
+  function makeTarget(attemptId: string): BackfillTarget {
+    return {
+      tenantId: "t1",
+      attempt: {
+        id: attemptId,
+        status: "submitted",
+        isPassed: true,
+        startedAt: "2026-01-09T10:00:00.000Z",
+        submittedAt: "2026-01-09T10:30:00.000Z",
+        quizId: "quiz-1",
+        userId: "user-1",
+        attemptNumber: 1,
+        score: 80,
+      },
+      lessonId: "lesson-1",
+      courseId: "course-1",
+      videoId: "video-1",
+      relatedSessions: [],
+    };
+  }
+
+  it("gRPC code=6 → skipped 扱い", async () => {
+    const db = createFakeWithRaceError(6);
+    const result = await applyBackfill(db, [makeTarget("a1")]);
+    expect(result.skipped).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.created).toBe(0);
+  });
+
+  it("admin SDK 文字列 'ALREADY_EXISTS' → skipped 扱い", async () => {
+    const db = createFakeWithRaceError("ALREADY_EXISTS");
+    const result = await applyBackfill(db, [makeTarget("a1")]);
+    expect(result.skipped).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  it("Web SDK 文字列 'already-exists' (lower-case) → skipped 扱い (review-pr 反映)", async () => {
+    const db = createFakeWithRaceError("already-exists");
+    const result = await applyBackfill(db, [makeTarget("a1")]);
+    expect(result.skipped).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  it("ALREADY_EXISTS 以外の error code → failed 扱い", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const db = createFakeWithRaceError(13); // gRPC INTERNAL
+    const result = await applyBackfill(db, [makeTarget("a1")]);
+    expect(result.failed).toBe(1);
+    expect(result.skipped).toBe(0);
+    errorSpy.mockRestore();
+  });
+});
+
+// ============================================================
+// runMain integration (review-pr C3 / I5 反映)
+// ============================================================
+
+describe("runMain [integration]", () => {
+  function withProcessExitMock(): {
+    exitSpy: ReturnType<typeof vi.spyOn>;
+    errorSpy: ReturnType<typeof vi.spyOn>;
+    logSpy: ReturnType<typeof vi.spyOn>;
+    restore: () => void;
+  } {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((code?: string | number | null | undefined) => {
+        throw new Error(`exit:${code ?? 0}`);
+      });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    return {
+      exitSpy,
+      errorSpy,
+      logSpy,
+      restore: () => {
+        exitSpy.mockRestore();
+        errorSpy.mockRestore();
+        logSpy.mockRestore();
+      },
+    };
+  }
+
+  function setupDbWithTargets(count: number): Firestore {
+    const attempts: Record<string, Record<string, unknown>> = {};
+    for (let i = 0; i < count; i++) {
+      attempts[`a${i}`] = {
+        quizId: "quiz-1",
+        userId: "user-1",
+        attemptNumber: 1,
+        status: "submitted",
+        isPassed: true,
+        score: 80,
+        startedAt: "2026-01-09T10:00:00.000Z",
+        submittedAt: "2026-01-09T10:30:00.000Z",
+      };
+    }
+    return createFakeFirestore({
+      tenants: ["t1"],
+      data: {
+        "tenants/t1/quiz_attempts": attempts,
+        "tenants/t1/quizzes": {
+          "quiz-1": { lessonId: "lesson-1", courseId: "course-1" },
+        },
+        "tenants/t1/lessons": { "lesson-1": { title: "lesson" } },
+        "tenants/t1/videos": {
+          "video-1": { lessonId: "lesson-1", title: "video" },
+        },
+      },
+    });
+  }
+
+  it("--execute && --no-backup → exit(1) (review-pr C3 反映、destructive guard)", async () => {
+    const { restore, errorSpy } = withProcessExitMock();
+    const db = setupDbWithTargets(1);
+
+    await expect(
+      runMain(db, {
+        execute: true,
+        noBackup: true,
+        maxTargets: 100,
+      })
+    ).rejects.toThrow("exit:1");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("--execute と --no-backup")
+    );
+    restore();
+  });
+
+  it("targets.length > max_targets → exit(1) (review-pr I5 反映)", async () => {
+    const { restore, errorSpy } = withProcessExitMock();
+    const db = setupDbWithTargets(5);
+
+    await expect(
+      runMain(db, {
+        execute: false,
+        noBackup: true,
+        maxTargets: 3,
+      })
+    ).rejects.toThrow("exit:1");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("backfill 対象が 3 件を超えています (5 件)")
+    );
+    restore();
+  });
+
+  it("expected_count 不一致 → exit(1)", async () => {
+    const { restore, errorSpy } = withProcessExitMock();
+    const db = setupDbWithTargets(2);
+
+    await expect(
+      runMain(db, {
+        execute: false,
+        noBackup: true,
+        maxTargets: 100,
+        expectedCount: 3,
+      })
+    ).rejects.toThrow("exit:1");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("expected_count=3")
+    );
+    restore();
+  });
+
+  it("targets ゼロ件 + expected_count=0 → 正常終了 (空振り検証)", async () => {
+    const { restore } = withProcessExitMock();
+    const db = setupDbWithTargets(0);
+
+    await expect(
+      runMain(db, {
+        execute: false,
+        noBackup: true,
+        maxTargets: 100,
+        expectedCount: 0,
+      })
+    ).resolves.toBeUndefined();
+    restore();
+  });
+});
+
+// ============================================================
 // End-to-end (audit → dry-run → apply → idempotency)
 // ============================================================
 
@@ -950,7 +1191,10 @@ describe("E2E [audit → dry-run → apply → idempotency]", () => {
           "quiz-1": { lessonId: "lesson-1", courseId: "course-1" },
         },
         "tenants/t-nagaono/lessons": {
-          "lesson-1": { videoId: "video-1" },
+          "lesson-1": { title: "lesson" },
+        },
+        "tenants/t-nagaono/videos": {
+          "video-1": { lessonId: "lesson-1", title: "video" },
         },
       },
     });

--- a/scripts/__tests__/backfill-synthetic-sessions.test.ts
+++ b/scripts/__tests__/backfill-synthetic-sessions.test.ts
@@ -1,0 +1,973 @@
+/**
+ * #533 Phase 2: backfill-synthetic-sessions のテスト
+ *
+ * 構成:
+ *   - 純粋関数の単体テスト (categorizeAttempt / buildSyntheticSessionData /
+ *     validateExpectedCount / validateReadback / parseArgs / sanitizeForWrite)
+ *   - integration テスト (findBackfillTargets / applyBackfill) を in-memory
+ *     Firestore fake で検証。AC2.1〜AC2.11 を網羅。
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type AttemptInfo,
+  type BackfillTarget,
+  type SessionInfo,
+  type SyntheticSessionData,
+  applyBackfill,
+  buildSyntheticSessionData,
+  buildWritePayload,
+  categorizeAttempt,
+  findBackfillTargets,
+  parseArgs,
+  resolveSessionDurationMs,
+  sanitizeForWrite,
+  validateExpectedCount,
+  validateReadback,
+} from "../backfill-synthetic-sessions.js";
+import type { Firestore } from "firebase-admin/firestore";
+
+// ============================================================
+// テスト用ヘルパー
+// ============================================================
+
+function makeAttempt(overrides: Partial<AttemptInfo> = {}): AttemptInfo {
+  return {
+    id: "attempt-1",
+    status: "submitted",
+    isPassed: true,
+    startedAt: "2026-01-09T10:00:00.000Z",
+    submittedAt: "2026-01-09T10:30:00.000Z",
+    quizId: "quiz-1",
+    userId: "user-1",
+    attemptNumber: 1,
+    score: 80,
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: "session-1",
+    userId: "user-1",
+    lessonId: "lesson-1",
+    courseId: "course-1",
+    videoId: "video-1",
+    status: "completed",
+    entryAt: "2026-01-09T09:00:00.000Z",
+    exitAt: "2026-01-09T10:30:00.000Z",
+    exitReason: "quiz_submitted",
+    quizAttemptId: null,
+    ...overrides,
+  };
+}
+
+// ============================================================
+// categorizeAttempt
+// ============================================================
+
+describe("categorizeAttempt", () => {
+  it("status=submitted + isPassed=true + 関連 session なし → backfill_target", () => {
+    const attempt = makeAttempt();
+    expect(categorizeAttempt(attempt, [])).toBe("backfill_target");
+  });
+
+  it("status=submitted + isPassed=true + 関連 session あるが quizAttemptId 一致なし → backfill_target", () => {
+    const attempt = makeAttempt({ id: "attempt-A" });
+    const session = makeSession({ quizAttemptId: "attempt-OTHER" });
+    expect(categorizeAttempt(attempt, [session])).toBe("backfill_target");
+  });
+
+  it("status=submitted + isPassed=true + quizAttemptId 一致 session あり → audit_only", () => {
+    const attempt = makeAttempt({ id: "attempt-A" });
+    const session = makeSession({ quizAttemptId: "attempt-A" });
+    expect(categorizeAttempt(attempt, [session])).toBe("audit_only");
+  });
+
+  it("status=submitted + isPassed=true + abandoned session に quizAttemptId 一致 → audit_only (apply 対象外)", () => {
+    const attempt = makeAttempt({ id: "attempt-A" });
+    const session = makeSession({
+      quizAttemptId: "attempt-A",
+      status: "abandoned",
+    });
+    expect(categorizeAttempt(attempt, [session])).toBe("audit_only");
+  });
+
+  it("status=in_progress → null", () => {
+    const attempt = makeAttempt({ status: "in_progress" });
+    expect(categorizeAttempt(attempt, [])).toBeNull();
+  });
+
+  it("status=timed_out → null (Codex 指摘: 'passed' でなく 'submitted' のみ)", () => {
+    const attempt = makeAttempt({ status: "timed_out" });
+    expect(categorizeAttempt(attempt, [])).toBeNull();
+  });
+
+  it("status='passed' (旧仕様、型に存在しないが念のため) → null", () => {
+    const attempt = makeAttempt({ status: "passed" });
+    expect(categorizeAttempt(attempt, [])).toBeNull();
+  });
+
+  it("status=submitted + isPassed=false → null", () => {
+    const attempt = makeAttempt({ isPassed: false });
+    expect(categorizeAttempt(attempt, [])).toBeNull();
+  });
+
+  it("status=submitted + isPassed=null → null", () => {
+    const attempt = makeAttempt({ isPassed: null });
+    expect(categorizeAttempt(attempt, [])).toBeNull();
+  });
+
+  it("startedAt 欠落 → null", () => {
+    const attempt = makeAttempt({ startedAt: null });
+    expect(categorizeAttempt(attempt, [])).toBeNull();
+  });
+
+  it("submittedAt 欠落 → null", () => {
+    const attempt = makeAttempt({ submittedAt: null });
+    expect(categorizeAttempt(attempt, [])).toBeNull();
+  });
+
+  it("複数 session のうち 1 件のみ quizAttemptId 一致 → audit_only", () => {
+    const attempt = makeAttempt({ id: "attempt-A" });
+    const sessions = [
+      makeSession({ id: "s1", quizAttemptId: null }),
+      makeSession({ id: "s2", quizAttemptId: "attempt-A", status: "completed" }),
+      makeSession({ id: "s3", quizAttemptId: "attempt-OTHER" }),
+    ];
+    expect(categorizeAttempt(attempt, sessions)).toBe("audit_only");
+  });
+});
+
+// ============================================================
+// buildSyntheticSessionData
+// ============================================================
+
+describe("buildSyntheticSessionData", () => {
+  it("Phase 1 createSyntheticCompletedSession と同じフィールドを生成", () => {
+    const attempt = makeAttempt();
+    const data = buildSyntheticSessionData(
+      attempt,
+      "lesson-1",
+      "course-1",
+      "video-1"
+    );
+    expect(data.userId).toBe("user-1");
+    expect(data.lessonId).toBe("lesson-1");
+    expect(data.courseId).toBe("course-1");
+    expect(data.videoId).toBe("video-1");
+    expect(data.sessionToken).toBe("synthetic-attempt-1");
+    expect(data.status).toBe("completed");
+    expect(data.entryAt).toBe("2026-01-09T10:00:00.000Z");
+    expect(data.exitAt).toBe("2026-01-09T10:30:00.000Z");
+    expect(data.exitReason).toBe("quiz_submitted");
+    expect(data.pauseStartedAt).toBeNull();
+    expect(data.longestPauseSec).toBe(0);
+    expect(data.sessionVideoCompleted).toBe(true);
+    expect(data.quizAttemptId).toBe("attempt-1");
+    expect(data.isSynthetic).toBe(true);
+  });
+
+  it("deadlineAt = entryAt + SESSION_DURATION_MS (default 2 時間)", () => {
+    const attempt = makeAttempt({
+      startedAt: "2026-01-09T10:00:00.000Z",
+    });
+    const data = buildSyntheticSessionData(
+      attempt,
+      "lesson-1",
+      "course-1",
+      "video-1"
+    );
+    expect(data.deadlineAt).toBe("2026-01-09T12:00:00.000Z");
+  });
+
+  it("カスタム sessionDurationMs を指定可能", () => {
+    const attempt = makeAttempt({
+      startedAt: "2026-01-09T10:00:00.000Z",
+    });
+    const data = buildSyntheticSessionData(
+      attempt,
+      "lesson-1",
+      "course-1",
+      "video-1",
+      3_600_000 // 1 時間
+    );
+    expect(data.deadlineAt).toBe("2026-01-09T11:00:00.000Z");
+  });
+
+  it("startedAt 欠落で例外", () => {
+    const attempt = makeAttempt({ startedAt: null });
+    expect(() =>
+      buildSyntheticSessionData(attempt, "lesson-1", "course-1", "video-1")
+    ).toThrow(/startedAt\/submittedAt が欠落/);
+  });
+
+  it("submittedAt 欠落で例外", () => {
+    const attempt = makeAttempt({ submittedAt: null });
+    expect(() =>
+      buildSyntheticSessionData(attempt, "lesson-1", "course-1", "video-1")
+    ).toThrow(/startedAt\/submittedAt が欠落/);
+  });
+});
+
+// ============================================================
+// validateExpectedCount
+// ============================================================
+
+describe("validateExpectedCount", () => {
+  it("expected 未指定 → ok=true (audit 用)", () => {
+    expect(validateExpectedCount(4, undefined)).toEqual({ ok: true });
+    expect(validateExpectedCount(0, undefined)).toEqual({ ok: true });
+  });
+
+  it("一致 → ok=true", () => {
+    expect(validateExpectedCount(4, 4)).toEqual({ ok: true });
+    expect(validateExpectedCount(0, 0)).toEqual({ ok: true });
+  });
+
+  it("不一致 (実際の方が多い) → ok=false", () => {
+    const result = validateExpectedCount(5, 4);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("expected_count=4");
+    expect(result.reason).toContain("実際の対象件数は 5 件");
+  });
+
+  it("不一致 (実際の方が少ない) → ok=false (空振り検知)", () => {
+    const result = validateExpectedCount(0, 4);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("実際の対象件数は 0 件");
+  });
+});
+
+// ============================================================
+// validateReadback
+// ============================================================
+
+describe("validateReadback", () => {
+  function makeExpected(): SyntheticSessionData {
+    return {
+      userId: "user-1",
+      lessonId: "lesson-1",
+      courseId: "course-1",
+      videoId: "video-1",
+      sessionToken: "synthetic-attempt-1",
+      status: "completed",
+      entryAt: "2026-01-09T10:00:00.000Z",
+      exitAt: "2026-01-09T10:30:00.000Z",
+      exitReason: "quiz_submitted",
+      deadlineAt: "2026-01-09T12:00:00.000Z",
+      pauseStartedAt: null,
+      longestPauseSec: 0,
+      sessionVideoCompleted: true,
+      quizAttemptId: "attempt-1",
+      isSynthetic: true,
+    };
+  }
+
+  it("全フィールド一致 → ok=true", () => {
+    const expected = makeExpected();
+    const actual = {
+      id: "synthetic_attempt-1",
+      ...expected,
+    } as unknown as SessionInfo & {
+      sessionVideoCompleted?: boolean;
+      longestPauseSec?: number;
+    };
+    const result = validateReadback(expected, actual);
+    expect(result.ok).toBe(true);
+    expect(result.mismatches).toEqual([]);
+  });
+
+  it("isSynthetic が false → mismatch", () => {
+    const expected = makeExpected();
+    const actual = {
+      id: "synthetic_attempt-1",
+      ...expected,
+      isSynthetic: false,
+    } as unknown as SessionInfo & {
+      sessionVideoCompleted?: boolean;
+      longestPauseSec?: number;
+    };
+    const result = validateReadback(expected, actual);
+    expect(result.ok).toBe(false);
+    expect(result.mismatches.some((m) => m.startsWith("isSynthetic:"))).toBe(true);
+  });
+
+  it("entryAt が異なる → mismatch", () => {
+    const expected = makeExpected();
+    const actual = {
+      id: "synthetic_attempt-1",
+      ...expected,
+      entryAt: "2026-01-09T11:00:00.000Z",
+    } as unknown as SessionInfo & {
+      sessionVideoCompleted?: boolean;
+      longestPauseSec?: number;
+    };
+    const result = validateReadback(expected, actual);
+    expect(result.ok).toBe(false);
+    expect(result.mismatches.some((m) => m.startsWith("entryAt:"))).toBe(true);
+  });
+
+  it("複数フィールド差分を全て報告", () => {
+    const expected = makeExpected();
+    const actual = {
+      id: "synthetic_attempt-1",
+      ...expected,
+      status: "active",
+      isSynthetic: undefined,
+    } as unknown as SessionInfo & {
+      sessionVideoCompleted?: boolean;
+      longestPauseSec?: number;
+    };
+    const result = validateReadback(expected, actual);
+    expect(result.ok).toBe(false);
+    expect(result.mismatches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("pauseStartedAt が undefined → mismatch (Codex 反映: fieldsToCheck に追加)", () => {
+    const expected = makeExpected();
+    const actual = {
+      id: "synthetic_attempt-1",
+      ...expected,
+      pauseStartedAt: undefined,
+    } as unknown as SessionInfo & {
+      sessionVideoCompleted?: boolean;
+      longestPauseSec?: number;
+      pauseStartedAt?: string | null;
+    };
+    const result = validateReadback(expected, actual);
+    expect(result.ok).toBe(false);
+    expect(result.mismatches.some((m) => m.startsWith("pauseStartedAt:"))).toBe(true);
+  });
+});
+
+// ============================================================
+// resolveSessionDurationMs (Codex C1 反映: env 読み出し)
+// ============================================================
+
+describe("resolveSessionDurationMs", () => {
+  it("env 未指定 → 2 時間 (7,200,000 ms)", () => {
+    expect(resolveSessionDurationMs(undefined)).toBe(7_200_000);
+  });
+
+  it("env=10800000 (本番 3 時間) → 10,800,000 ms", () => {
+    expect(resolveSessionDurationMs("10800000")).toBe(10_800_000);
+  });
+
+  it("env=abc (NaN) → fallback", () => {
+    expect(resolveSessionDurationMs("abc")).toBe(7_200_000);
+  });
+
+  it("env=0 → fallback (1 以上必須)", () => {
+    expect(resolveSessionDurationMs("0")).toBe(7_200_000);
+  });
+
+  it("env=-100 → fallback", () => {
+    expect(resolveSessionDurationMs("-100")).toBe(7_200_000);
+  });
+
+  it("env=3600.5 (非整数) → fallback", () => {
+    expect(resolveSessionDurationMs("3600.5")).toBe(7_200_000);
+  });
+
+  it("env=空文字 → fallback", () => {
+    expect(resolveSessionDurationMs("")).toBe(7_200_000);
+  });
+
+  it("env=86400000 (上限 24h ちょうど) → 86,400,000 ms", () => {
+    expect(resolveSessionDurationMs("86400000")).toBe(86_400_000);
+  });
+
+  it("env=86400001 (上限 24h 超え) → fallback (Codex M2: Date 範囲外を防ぐ)", () => {
+    expect(resolveSessionDurationMs("86400001")).toBe(7_200_000);
+  });
+
+  it("env=1e20 (極大値) → fallback", () => {
+    expect(resolveSessionDurationMs("1e20")).toBe(7_200_000);
+  });
+});
+
+// ============================================================
+// buildWritePayload (Codex C5 反映: createdAt/updatedAt を Date オブジェクトで型保証)
+// ============================================================
+
+describe("buildWritePayload", () => {
+  function makePlanned(): SyntheticSessionData {
+    return buildSyntheticSessionData(
+      {
+        id: "attempt-1",
+        status: "submitted",
+        isPassed: true,
+        startedAt: "2026-01-09T10:00:00.000Z",
+        submittedAt: "2026-01-09T10:30:00.000Z",
+        quizId: "quiz-1",
+        userId: "user-1",
+        attemptNumber: 1,
+        score: 80,
+      },
+      "lesson-1",
+      "course-1",
+      "video-1"
+    );
+  }
+
+  it("planned 全フィールド + createdAt/updatedAt が Date オブジェクトとして付与", () => {
+    const planned = makePlanned();
+    const now = new Date("2026-06-09T10:00:00.000Z");
+    const payload = buildWritePayload(planned, now);
+    // planned のフィールドが保持される
+    expect(payload.userId).toBe("user-1");
+    expect(payload.sessionToken).toBe("synthetic-attempt-1");
+    expect(payload.isSynthetic).toBe(true);
+    // Phase 1 createLessonSessionWithId と一致する Date オブジェクト型 (Firestore Timestamp 型保存)
+    expect(payload.createdAt).toBeInstanceOf(Date);
+    expect(payload.updatedAt).toBeInstanceOf(Date);
+    expect(payload.createdAt.toISOString()).toBe("2026-06-09T10:00:00.000Z");
+    expect(payload.updatedAt.toISOString()).toBe("2026-06-09T10:00:00.000Z");
+  });
+
+  it("createdAt と updatedAt は同じ Date インスタンスを参照 (一括書き込み)", () => {
+    const planned = makePlanned();
+    const now = new Date();
+    const payload = buildWritePayload(planned, now);
+    expect(payload.createdAt).toBe(payload.updatedAt);
+  });
+});
+
+// ============================================================
+// parseArgs
+// ============================================================
+
+describe("parseArgs", () => {
+  it("引数なし → デフォルト値", () => {
+    const result = parseArgs([]);
+    expect(result.execute).toBe(false);
+    expect(result.tenantId).toBeUndefined();
+    expect(result.userId).toBeUndefined();
+    expect(result.userEmail).toBeUndefined();
+    expect(result.maxTargets).toBe(100);
+    expect(result.expectedCount).toBeUndefined();
+    expect(result.noBackup).toBe(false);
+  });
+
+  it("--execute フラグ", () => {
+    expect(parseArgs(["--execute"]).execute).toBe(true);
+  });
+
+  it("--tenant-id=xxx", () => {
+    expect(parseArgs(["--tenant-id=t1"]).tenantId).toBe("t1");
+  });
+
+  it("--user-email は lowercase + trim", () => {
+    const result = parseArgs(["--user-email= Foo@Bar.Com "]);
+    expect(result.userEmail).toBe("foo@bar.com");
+  });
+
+  it("--max-targets=50", () => {
+    expect(parseArgs(["--max-targets=50"]).maxTargets).toBe(50);
+  });
+
+  it("--expected-count=4", () => {
+    expect(parseArgs(["--expected-count=4"]).expectedCount).toBe(4);
+  });
+
+  it("--expected-count=0 は許可 (空振り検知用)", () => {
+    expect(parseArgs(["--expected-count=0"]).expectedCount).toBe(0);
+  });
+
+  it("--user-id と --user-email 両指定で例外", () => {
+    expect(() =>
+      parseArgs(["--user-id=u1", "--user-email=foo@bar.com"])
+    ).toThrow(/同時指定できません/);
+  });
+
+  it("--max-targets=0 で例外 (1 以上必須)", () => {
+    expect(() => parseArgs(["--max-targets=0"])).toThrow(/1 以上の数値/);
+  });
+
+  it("--max-targets=-1 で例外", () => {
+    expect(() => parseArgs(["--max-targets=-1"])).toThrow(/1 以上の数値/);
+  });
+
+  it("--max-targets=abc (NaN) で例外", () => {
+    expect(() => parseArgs(["--max-targets=abc"])).toThrow(/1 以上の数値/);
+  });
+
+  it("--expected-count=-1 で例外", () => {
+    expect(() => parseArgs(["--expected-count=-1"])).toThrow(/0 以上の整数/);
+  });
+
+  it("--expected-count=0.5 (非整数) で例外 (Codex M1 反映)", () => {
+    expect(() => parseArgs(["--expected-count=0.5"])).toThrow(/0 以上の整数/);
+  });
+
+  it("--expected-count=2.7 (非整数) で例外", () => {
+    expect(() => parseArgs(["--expected-count=2.7"])).toThrow(/0 以上の整数/);
+  });
+
+  it("未知のフラグで例外", () => {
+    expect(() => parseArgs(["--unknown"])).toThrow(/未知のフラグ/);
+  });
+
+  it("--no-backup フラグ", () => {
+    expect(parseArgs(["--no-backup"]).noBackup).toBe(true);
+  });
+});
+
+// ============================================================
+// sanitizeForWrite
+// ============================================================
+
+describe("sanitizeForWrite", () => {
+  it("undefined フィールドを除去", () => {
+    const result = sanitizeForWrite({
+      a: 1,
+      b: undefined,
+      c: "x",
+      d: null,
+      e: false,
+      f: 0,
+    });
+    expect(result).toEqual({ a: 1, c: "x", d: null, e: false, f: 0 });
+    expect("b" in result).toBe(false);
+  });
+
+  it("null は保持 (Firestore で有効な値、undefined のみ除去)", () => {
+    const result = sanitizeForWrite({ a: null });
+    expect(result).toEqual({ a: null });
+  });
+
+  it("空オブジェクト → 空オブジェクト", () => {
+    expect(sanitizeForWrite({})).toEqual({});
+  });
+});
+
+// ============================================================
+// In-memory Firestore fake (integration test 用)
+// ============================================================
+
+/**
+ * admin SDK の最小サブセット (collection / doc / get / where / runTransaction) を満たす fake。
+ * findBackfillTargets / applyBackfill が必要とする API のみ実装。
+ */
+function createFakeFirestore(initial: {
+  tenants: string[];
+  data: Record<string, Record<string, Record<string, unknown>>>; // path → docId → data
+}): Firestore {
+  const store: Record<string, Map<string, Record<string, unknown>>> = {};
+  for (const [path, docs] of Object.entries(initial.data)) {
+    store[path] = new Map(Object.entries(docs));
+  }
+  for (const tid of initial.tenants) {
+    store["tenants"] ??= new Map();
+    store["tenants"].set(tid, { id: tid });
+  }
+
+  function makeDocRef(path: string, id: string) {
+    return {
+      id,
+      _path: path,
+      async get() {
+        const doc = store[path]?.get(id);
+        return {
+          exists: doc !== undefined,
+          id,
+          data: () => doc,
+        };
+      },
+    };
+  }
+
+  function makeQuery(path: string, filters: Array<[string, string, unknown]>) {
+    return {
+      where(field: string, op: string, value: unknown) {
+        return makeQuery(path, [...filters, [field, op, value]]);
+      },
+      limit(_n: number) {
+        return this;
+      },
+      async get() {
+        const docs = Array.from(store[path]?.entries() ?? []).filter(([_id, d]) =>
+          filters.every(([f, op, v]) => {
+            if (op !== "==") throw new Error(`fake: only == supported`);
+            return d[f] === v;
+          })
+        );
+        return {
+          empty: docs.length === 0,
+          docs: docs.map(([id, d]) => ({
+            id,
+            data: () => d,
+            ref: { id },
+          })),
+        };
+      },
+    };
+  }
+
+  function makeCollection(path: string) {
+    return {
+      doc(id: string) {
+        return makeDocRef(path, id);
+      },
+      where(field: string, op: string, value: unknown) {
+        return makeQuery(path, [[field, op, value]]);
+      },
+      async get() {
+        return makeQuery(path, []).get();
+      },
+    };
+  }
+
+  const fake = {
+    collection: (path: string) => makeCollection(path),
+    async runTransaction<T>(
+      fn: (tx: {
+        get: (ref: { _path: string; id: string }) => Promise<{
+          exists: boolean;
+          data: () => Record<string, unknown> | undefined;
+        }>;
+        create: (
+          ref: { _path: string; id: string },
+          data: Record<string, unknown>
+        ) => void;
+        update: (
+          ref: { _path: string; id: string },
+          data: Record<string, unknown>
+        ) => void;
+      }) => Promise<T>
+    ): Promise<T> {
+      const writes: Array<
+        | { type: "create"; path: string; id: string; data: Record<string, unknown> }
+        | { type: "update"; path: string; id: string; data: Record<string, unknown> }
+      > = [];
+      const tx = {
+        async get(ref: { _path: string; id: string }) {
+          const doc = store[ref._path]?.get(ref.id);
+          return {
+            exists: doc !== undefined,
+            data: () => doc,
+          };
+        },
+        create(ref: { _path: string; id: string }, data: Record<string, unknown>) {
+          if (store[ref._path]?.get(ref.id) !== undefined) {
+            throw new Error(`fake: ALREADY_EXISTS at ${ref._path}/${ref.id}`);
+          }
+          writes.push({ type: "create", path: ref._path, id: ref.id, data });
+        },
+        update(ref: { _path: string; id: string }, data: Record<string, unknown>) {
+          writes.push({ type: "update", path: ref._path, id: ref.id, data });
+        },
+      };
+      const result = await fn(tx);
+      for (const w of writes) {
+        store[w.path] ??= new Map();
+        if (w.type === "create") store[w.path].set(w.id, w.data);
+        else
+          store[w.path].set(w.id, {
+            ...(store[w.path].get(w.id) ?? {}),
+            ...w.data,
+          });
+      }
+      return result;
+    },
+  };
+  return fake as unknown as Firestore;
+}
+
+// ============================================================
+// findBackfillTargets (integration)
+// ============================================================
+
+describe("findBackfillTargets [integration]", () => {
+  function setupTenantWithAttempt(opts: {
+    tenantId: string;
+    attemptId: string;
+    attemptStatus: string;
+    isPassed: boolean | null;
+    relatedSessions?: Array<{
+      id: string;
+      quizAttemptId: string | null;
+      status: string;
+    }>;
+    lessonExists?: boolean;
+    videoId?: string;
+  }) {
+    const lessonId = "lesson-1";
+    const courseId = "course-1";
+    const videoId = opts.videoId ?? "video-1";
+    const quizId = "quiz-1";
+
+    const sessions: Record<string, Record<string, unknown>> = {};
+    for (const s of opts.relatedSessions ?? []) {
+      sessions[s.id] = {
+        userId: "user-1",
+        lessonId,
+        courseId,
+        videoId,
+        status: s.status,
+        entryAt: "2026-01-09T09:00:00.000Z",
+        exitAt: "2026-01-09T10:00:00.000Z",
+        exitReason: s.status === "completed" ? "quiz_submitted" : null,
+        quizAttemptId: s.quizAttemptId,
+      };
+    }
+
+    const data: Record<string, Record<string, Record<string, unknown>>> = {
+      [`tenants/${opts.tenantId}/quiz_attempts`]: {
+        [opts.attemptId]: {
+          quizId,
+          userId: "user-1",
+          attemptNumber: 1,
+          status: opts.attemptStatus,
+          isPassed: opts.isPassed,
+          score: 80,
+          startedAt: "2026-01-09T10:00:00.000Z",
+          submittedAt: "2026-01-09T10:30:00.000Z",
+        },
+      },
+      [`tenants/${opts.tenantId}/quizzes`]: {
+        [quizId]: { lessonId, courseId },
+      },
+      [`tenants/${opts.tenantId}/lessons`]: opts.lessonExists === false
+        ? {}
+        : { [lessonId]: { videoId } },
+      [`tenants/${opts.tenantId}/lesson_sessions`]: sessions,
+    };
+
+    return createFakeFirestore({
+      tenants: [opts.tenantId],
+      data,
+    });
+  }
+
+  it("AC2.1: status=submitted + isPassed=true + 関連 session 0 件 → backfill_target", async () => {
+    const db = setupTenantWithAttempt({
+      tenantId: "t1",
+      attemptId: "a1",
+      attemptStatus: "submitted",
+      isPassed: true,
+    });
+    const { targets, auditOnly } = await findBackfillTargets(db, ["t1"]);
+    expect(targets.length).toBe(1);
+    expect(auditOnly.length).toBe(0);
+    expect(targets[0].attempt.id).toBe("a1");
+    expect(targets[0].lessonId).toBe("lesson-1");
+    expect(targets[0].courseId).toBe("course-1");
+    expect(targets[0].videoId).toBe("video-1");
+  });
+
+  it("Codex 反映: status=submitted のみ拾い、'passed'/'in_progress'/'timed_out' は対象外", async () => {
+    const dbInProgress = setupTenantWithAttempt({
+      tenantId: "t1",
+      attemptId: "a1",
+      attemptStatus: "in_progress",
+      isPassed: true,
+    });
+    const { targets: t1 } = await findBackfillTargets(dbInProgress, ["t1"]);
+    expect(t1.length).toBe(0);
+
+    const dbTimedOut = setupTenantWithAttempt({
+      tenantId: "t1",
+      attemptId: "a1",
+      attemptStatus: "timed_out",
+      isPassed: true,
+    });
+    const { targets: t2 } = await findBackfillTargets(dbTimedOut, ["t1"]);
+    expect(t2.length).toBe(0);
+  });
+
+  it("isPassed=false は対象外", async () => {
+    const db = setupTenantWithAttempt({
+      tenantId: "t1",
+      attemptId: "a1",
+      attemptStatus: "submitted",
+      isPassed: false,
+    });
+    const { targets } = await findBackfillTargets(db, ["t1"]);
+    expect(targets.length).toBe(0);
+  });
+
+  it("quizAttemptId 一致 session あり → audit_only (apply 対象外)", async () => {
+    const db = setupTenantWithAttempt({
+      tenantId: "t1",
+      attemptId: "a1",
+      attemptStatus: "submitted",
+      isPassed: true,
+      relatedSessions: [
+        { id: "s-existing", quizAttemptId: "a1", status: "abandoned" },
+      ],
+    });
+    const { targets, auditOnly } = await findBackfillTargets(db, ["t1"]);
+    expect(targets.length).toBe(0);
+    expect(auditOnly.length).toBe(1);
+    expect(auditOnly[0].reason).toContain("quizAttemptId 一致 session が 1 件");
+  });
+
+  it("lesson 削除済み → skip + warn (apply 対象外)", async () => {
+    const db = setupTenantWithAttempt({
+      tenantId: "t1",
+      attemptId: "a1",
+      attemptStatus: "submitted",
+      isPassed: true,
+      lessonExists: false,
+    });
+    const { targets, auditOnly } = await findBackfillTargets(db, ["t1"]);
+    expect(targets.length).toBe(0);
+    expect(auditOnly.length).toBe(0);
+  });
+});
+
+// ============================================================
+// applyBackfill (integration)
+// ============================================================
+
+describe("applyBackfill [integration]", () => {
+  function makeTarget(attemptId: string, tenantId = "t1"): BackfillTarget {
+    return {
+      tenantId,
+      attempt: {
+        id: attemptId,
+        status: "submitted",
+        isPassed: true,
+        startedAt: "2026-01-09T10:00:00.000Z",
+        submittedAt: "2026-01-09T10:30:00.000Z",
+        quizId: "quiz-1",
+        userId: "user-1",
+        attemptNumber: 1,
+        score: 80,
+      },
+      lessonId: "lesson-1",
+      courseId: "course-1",
+      videoId: "video-1",
+      relatedSessions: [],
+    };
+  }
+
+  it("AC2.3: tx.create で synthetic_{attemptId} doc が作成され、6 フィールド値が正しい", async () => {
+    const db = createFakeFirestore({ tenants: ["t1"], data: {} });
+    const targets = [makeTarget("a1")];
+    const result = await applyBackfill(db, targets);
+    expect(result.created).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.readbackVerified).toBe(1);
+    expect(result.readbackFailed).toBe(0);
+
+    // 直接 store を read して値検証
+    const doc = await db
+      .collection("tenants/t1/lesson_sessions")
+      .doc("synthetic_a1")
+      .get();
+    expect(doc.exists).toBe(true);
+    const data = doc.data()!;
+    expect(data.isSynthetic).toBe(true);
+    expect(data.entryAt).toBe("2026-01-09T10:00:00.000Z");
+    expect(data.exitAt).toBe("2026-01-09T10:30:00.000Z");
+    expect(data.status).toBe("completed");
+    expect(data.exitReason).toBe("quiz_submitted");
+    expect(data.sessionVideoCompleted).toBe(true);
+    expect(data.sessionToken).toBe("synthetic-a1");
+    expect(data.quizAttemptId).toBe("a1");
+    expect(data.createdAt).toBeTruthy();
+    expect(data.updatedAt).toBeTruthy();
+  });
+
+  it("AC2.4: 同 target を 2 回 apply しても重複作成しない (idempotency)", async () => {
+    const db = createFakeFirestore({ tenants: ["t1"], data: {} });
+    const targets = [makeTarget("a1")];
+    const r1 = await applyBackfill(db, targets);
+    expect(r1.created).toBe(1);
+
+    const r2 = await applyBackfill(db, targets);
+    expect(r2.created).toBe(0);
+    expect(r2.skipped).toBe(1);
+    expect(r2.failed).toBe(0);
+  });
+
+  it("AC2.8: 1 件失敗で全体停止しない (per-attempt try/catch)", async () => {
+    // a1 は正常、a2 は ALREADY_EXISTS をシミュレート (apply の tx.get で exists=true 扱い)
+    const db = createFakeFirestore({
+      tenants: ["t1"],
+      data: {
+        "tenants/t1/lesson_sessions": {
+          synthetic_a2: { isSynthetic: true, userId: "pre-existing" },
+        },
+      },
+    });
+    const targets = [makeTarget("a1"), makeTarget("a2")];
+    const result = await applyBackfill(db, targets);
+    expect(result.created).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  it("複数テナント混在 + 複数 target を順次処理", async () => {
+    const db = createFakeFirestore({
+      tenants: ["t1", "t2"],
+      data: {},
+    });
+    const targets = [
+      makeTarget("a1", "t1"),
+      makeTarget("a2", "t1"),
+      makeTarget("a3", "t2"),
+    ];
+    const result = await applyBackfill(db, targets);
+    expect(result.created).toBe(3);
+    expect(result.skipped).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.readbackVerified).toBe(3);
+
+    const t1docs = await db.collection("tenants/t1/lesson_sessions").get();
+    const t2docs = await db.collection("tenants/t2/lesson_sessions").get();
+    expect(t1docs.docs.length).toBe(2);
+    expect(t2docs.docs.length).toBe(1);
+  });
+});
+
+// ============================================================
+// End-to-end (audit → dry-run → apply → idempotency)
+// ============================================================
+
+describe("E2E [audit → dry-run → apply → idempotency]", () => {
+  it("検出 → apply → 再検出で 0 件 (Phase 2 のフルフロー)", async () => {
+    const db = createFakeFirestore({
+      tenants: ["t-nagaono"],
+      data: {
+        "tenants/t-nagaono/quiz_attempts": {
+          a1: {
+            quizId: "quiz-1",
+            userId: "user-1",
+            attemptNumber: 1,
+            status: "submitted",
+            isPassed: true,
+            score: 100,
+            startedAt: "2026-01-09T10:00:00.000Z",
+            submittedAt: "2026-01-09T10:30:00.000Z",
+          },
+        },
+        "tenants/t-nagaono/quizzes": {
+          "quiz-1": { lessonId: "lesson-1", courseId: "course-1" },
+        },
+        "tenants/t-nagaono/lessons": {
+          "lesson-1": { videoId: "video-1" },
+        },
+      },
+    });
+
+    // Phase 1: audit (検出)
+    const before = await findBackfillTargets(db, ["t-nagaono"]);
+    expect(before.targets.length).toBe(1);
+
+    // Phase 2: apply
+    const applyResult = await applyBackfill(db, before.targets);
+    expect(applyResult.created).toBe(1);
+    expect(applyResult.readbackVerified).toBe(1);
+
+    // Phase 3: re-audit → 0 件 (idempotency)
+    const after = await findBackfillTargets(db, ["t-nagaono"]);
+    expect(after.targets.length).toBe(0);
+    expect(after.auditOnly.length).toBe(1);
+    expect(after.auditOnly[0].reason).toContain("quizAttemptId 一致");
+  });
+});

--- a/scripts/backfill-synthetic-sessions.ts
+++ b/scripts/backfill-synthetic-sessions.ts
@@ -1,0 +1,892 @@
+#!/usr/bin/env npx tsx
+/**
+ * 過去の活動セッション欠落 lesson_session を遡及作成 (#533 Phase 2)
+ *
+ * 背景:
+ * `quiz-attempts.ts` は後方互換のため activeSession=null でもテスト提出を許可する設計
+ * (services/api/src/routes/shared/quiz-attempts.ts:292-294)。
+ * Phase 1 (PR #537) で新規発生は createSyntheticCompletedSession ヘルパーにより予防済み。
+ * 本スクリプトは Phase 1 投入前に発生した過去分 (長遊園テナント 4 件等) を遡及補正する。
+ *
+ * 検出ロジック (categorizeAttempt):
+ *   - status !== "submitted" or isPassed !== true → skip (not relevant)
+ *   - startedAt or submittedAt 欠落 → skip (invalid data, log warn)
+ *   - related lesson_sessions に quizAttemptId === attempt.id の doc が 0 件 → "backfill_target"
+ *   - related lesson_sessions に quizAttemptId 一致 doc あり → "audit_only" (別問題、apply 対象外)
+ *
+ * 書き込み内容 (Phase 1 createSyntheticCompletedSession 相当):
+ *   - doc id: synthetic_{attemptId}  (決定的、tx.create で race-safe + 冪等)
+ *   - entryAt: attempt.startedAt, exitAt: attempt.submittedAt
+ *   - status: "completed", exitReason: "quiz_submitted"
+ *   - isSynthetic: true, sessionVideoCompleted: true
+ *   - sessionToken: synthetic-{attemptId}
+ *   - deadlineAt: entryAt + SESSION_DURATION_MS (completed では未使用だが型は必須)
+ *
+ * 安全機構:
+ *   1. dry-run 既定 (--execute で実行)
+ *   2. expected_count 完全一致ガード (--expected-count=N で対象数が違えば fail)
+ *   3. max_targets 上限 (--max-targets=N、既定 100)
+ *   4. スコープ絞り込み (--tenant-id / --user-id / --user-email、--user-id/-email 排他)
+ *   5. backup JSON (commit SHA / run id / actor / project id / attempt + related sessions snapshot)
+ *   6. tx.create で ALREADY_EXISTS は skip 扱い (race / リトライで安全)
+ *   7. 読み戻し検証 (apply 後の synthetic doc を再取得し全フィールド一致確認)
+ *
+ * 使用方法:
+ *   # audit (検出のみ、件数 + サンプル表示)
+ *   npx tsx scripts/backfill-synthetic-sessions.ts
+ *
+ *   # 特定テナント
+ *   npx tsx scripts/backfill-synthetic-sessions.ts --tenant-id=xxx
+ *
+ *   # 特定ユーザー
+ *   npx tsx scripts/backfill-synthetic-sessions.ts --user-email=foo@bar.com
+ *
+ *   # 実行 (本番では expected-count 必須運用)
+ *   npx tsx scripts/backfill-synthetic-sessions.ts --execute --expected-count=4
+ */
+
+import {
+  initializeApp,
+  cert,
+  applicationDefault,
+  type ServiceAccount,
+} from "firebase-admin/app";
+import { getFirestore, type Firestore } from "firebase-admin/firestore";
+import { readFileSync, writeFileSync } from "fs";
+import { resolve } from "path";
+
+// ============================================================
+// 定数
+// ============================================================
+
+// セッション期間 (ミリ秒)。Phase 1 helper (services/api/src/services/lesson-session.ts) は
+// env SESSION_DURATION_MS を読み、本番 Cloud Run では 10800000 (3h) で稼働。
+// completed session の deadlineAt は意味的に未使用だが、Phase 1 と値を揃えるため env を読む。
+const SESSION_DURATION_MS_FALLBACK = 7_200_000;
+// 上限 24 時間 (86,400,000 ms): セッション 1 日を超える値は誤入力扱いで fallback。
+// Date 範囲外 (例: 1e20 ms ≒ 31.7 京年) で RangeError を防ぐ。
+const SESSION_DURATION_MS_MAX = 86_400_000;
+export function resolveSessionDurationMs(envValue: string | undefined): number {
+  if (!envValue) return SESSION_DURATION_MS_FALLBACK;
+  const n = Number(envValue);
+  if (
+    !Number.isFinite(n) ||
+    !Number.isInteger(n) ||
+    n < 1 ||
+    n > SESSION_DURATION_MS_MAX
+  ) {
+    return SESSION_DURATION_MS_FALLBACK;
+  }
+  return n;
+}
+const DEFAULT_SESSION_DURATION_MS = resolveSessionDurationMs(
+  process.env.SESSION_DURATION_MS
+);
+
+// ============================================================
+// 型定義 (純粋関数 + 永続層共通)
+// ============================================================
+
+export interface AttemptInfo {
+  id: string;
+  status: string;
+  isPassed: boolean | null;
+  startedAt: string | null;
+  submittedAt: string | null;
+  quizId: string;
+  userId: string;
+  attemptNumber: number;
+  score: number | null;
+}
+
+export interface SessionInfo {
+  id: string;
+  userId: string;
+  lessonId: string;
+  courseId: string;
+  videoId: string;
+  status: string;
+  entryAt: string;
+  exitAt: string | null;
+  exitReason: string | null;
+  quizAttemptId: string | null;
+  isSynthetic?: boolean;
+}
+
+export type BackfillCategory = "backfill_target" | "audit_only" | null;
+
+export interface SyntheticSessionData {
+  userId: string;
+  lessonId: string;
+  courseId: string;
+  videoId: string;
+  sessionToken: string;
+  status: "completed";
+  entryAt: string;
+  exitAt: string;
+  exitReason: "quiz_submitted";
+  deadlineAt: string;
+  pauseStartedAt: null;
+  longestPauseSec: 0;
+  sessionVideoCompleted: true;
+  quizAttemptId: string;
+  isSynthetic: true;
+}
+
+/**
+ * Firestore に書き込む完全な payload 形 (タイムスタンプを含む)。
+ * Phase 1 createLessonSessionWithId と一致させるため createdAt/updatedAt は Date オブジェクト
+ * (Firestore admin SDK が自動で Timestamp 型に変換、string 渡しと型が divergent するのを防ぐ)。
+ */
+export interface SyntheticSessionWritePayload extends SyntheticSessionData {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export function buildWritePayload(
+  planned: SyntheticSessionData,
+  now: Date
+): SyntheticSessionWritePayload {
+  return { ...planned, createdAt: now, updatedAt: now };
+}
+
+// ============================================================
+// 純粋関数 (smoke + unit test 対象)
+// ============================================================
+
+/**
+ * attempt の補正カテゴリを判定する純粋関数。
+ *
+ * Codex 指摘反映:
+ *   - status は "passed" ではなく "submitted" + isPassed === true (正しい型)
+ *   - 「quizAttemptId 付き session あり + status=abandoned 等」は audit_only カテゴリで分離、apply 対象外
+ */
+export function categorizeAttempt(
+  attempt: AttemptInfo,
+  relatedSessions: SessionInfo[]
+): BackfillCategory {
+  // 合格提出のみ対象
+  if (attempt.status !== "submitted" || attempt.isPassed !== true) return null;
+  // タイムスタンプ欠落は skip (呼び出し元で warn ログ)
+  if (!attempt.startedAt || !attempt.submittedAt) return null;
+
+  // 同じ attempt に紐づく session が既にあるか
+  const linkedSessions = relatedSessions.filter(
+    (s) => s.quizAttemptId === attempt.id
+  );
+  if (linkedSessions.length > 0) {
+    // 既存 link あり → 別問題 (例: abandoned で残った session)、apply はしない
+    return "audit_only";
+  }
+
+  return "backfill_target";
+}
+
+/**
+ * 合成 session の書き込み内容を構築する純粋関数。
+ * Phase 1 createSyntheticCompletedSession と完全に同じフィールドを生成する。
+ */
+export function buildSyntheticSessionData(
+  attempt: AttemptInfo,
+  lessonId: string,
+  courseId: string,
+  videoId: string,
+  sessionDurationMs: number = DEFAULT_SESSION_DURATION_MS
+): SyntheticSessionData {
+  if (!attempt.startedAt || !attempt.submittedAt) {
+    throw new Error(
+      `buildSyntheticSessionData: attempt ${attempt.id} に startedAt/submittedAt が欠落`
+    );
+  }
+  const startedMs = new Date(attempt.startedAt).getTime();
+  const deadlineAt = new Date(startedMs + sessionDurationMs).toISOString();
+  return {
+    userId: attempt.userId,
+    lessonId,
+    courseId,
+    videoId,
+    sessionToken: `synthetic-${attempt.id}`,
+    status: "completed",
+    entryAt: attempt.startedAt,
+    exitAt: attempt.submittedAt,
+    exitReason: "quiz_submitted",
+    deadlineAt,
+    pauseStartedAt: null,
+    longestPauseSec: 0,
+    sessionVideoCompleted: true,
+    quizAttemptId: attempt.id,
+    isSynthetic: true,
+  };
+}
+
+/**
+ * expected_count 完全一致ガード。
+ * Codex 指摘反映: 本番 apply 時に対象件数が想定と完全一致しなければ fail させる。
+ */
+export function validateExpectedCount(
+  actual: number,
+  expected: number | undefined
+): { ok: boolean; reason?: string } {
+  if (expected === undefined) return { ok: true };
+  if (actual !== expected) {
+    return {
+      ok: false,
+      reason: `expected_count=${expected} だが実際の対象件数は ${actual} 件 (完全一致しないため中断)`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * 読み戻し検証: 書き込んだ synthetic session が期待値と完全一致するかチェック。
+ */
+export function validateReadback(
+  expected: SyntheticSessionData,
+  actual: SessionInfo & {
+    sessionToken?: string;
+    deadlineAt?: string;
+    pauseStartedAt?: string | null;
+    sessionVideoCompleted?: boolean;
+    longestPauseSec?: number;
+  }
+): { ok: boolean; mismatches: string[] } {
+  const mismatches: string[] = [];
+  const fieldsToCheck: Array<keyof SyntheticSessionData> = [
+    "userId",
+    "lessonId",
+    "courseId",
+    "videoId",
+    "sessionToken",
+    "status",
+    "entryAt",
+    "exitAt",
+    "exitReason",
+    "deadlineAt",
+    "pauseStartedAt",
+    "longestPauseSec",
+    "sessionVideoCompleted",
+    "quizAttemptId",
+    "isSynthetic",
+  ];
+  for (const field of fieldsToCheck) {
+    const expectedVal = expected[field];
+    const actualVal = (actual as unknown as Record<string, unknown>)[field];
+    if (expectedVal !== actualVal) {
+      mismatches.push(`${field}: expected=${JSON.stringify(expectedVal)} actual=${JSON.stringify(actualVal)}`);
+    }
+  }
+  return { ok: mismatches.length === 0, mismatches };
+}
+
+// ============================================================
+// CLI 引数パース
+// ============================================================
+
+const KNOWN_FLAGS = [
+  "--execute",
+  "--tenant-id=",
+  "--user-id=",
+  "--user-email=",
+  "--max-targets=",
+  "--expected-count=",
+  "--no-backup",
+];
+
+const isMainEntry = import.meta.url === `file://${process.argv[1]}`;
+
+if (isMainEntry) {
+  void runCli();
+}
+
+interface ParsedArgs {
+  execute: boolean;
+  tenantId?: string;
+  userId?: string;
+  userEmail?: string;
+  noBackup: boolean;
+  maxTargets: number;
+  expectedCount?: number;
+}
+
+function getFlagValue(args: string[], prefix: string): string | undefined {
+  return args.find((a) => a.startsWith(prefix))?.split("=")[1];
+}
+
+export function parseArgs(args: string[]): ParsedArgs {
+  const unknownArgs = args.filter(
+    (a) => !KNOWN_FLAGS.some((k) => a === k || a.startsWith(k))
+  );
+  if (unknownArgs.length > 0) {
+    throw new Error(
+      `未知のフラグ: ${unknownArgs.join(", ")}\n  既知のフラグ: ${KNOWN_FLAGS.join(" / ")}`
+    );
+  }
+
+  const execute = args.includes("--execute");
+  const tenantId = getFlagValue(args, "--tenant-id=");
+  const userId = getFlagValue(args, "--user-id=");
+  const userEmail = getFlagValue(args, "--user-email=")?.trim().toLowerCase();
+  const noBackup = args.includes("--no-backup");
+
+  const rawMaxTargets = getFlagValue(args, "--max-targets=");
+  const maxTargets = rawMaxTargets !== undefined ? Number(rawMaxTargets) : 100;
+  if (!Number.isFinite(maxTargets) || maxTargets < 1) {
+    throw new Error(
+      `--max-targets は 1 以上の数値が必要: 受け取った値="${rawMaxTargets}"`
+    );
+  }
+
+  const rawExpectedCount = getFlagValue(args, "--expected-count=");
+  const expectedCount =
+    rawExpectedCount !== undefined ? Number(rawExpectedCount) : undefined;
+  if (
+    expectedCount !== undefined &&
+    (!Number.isFinite(expectedCount) ||
+      !Number.isInteger(expectedCount) ||
+      expectedCount < 0)
+  ) {
+    throw new Error(
+      `--expected-count は 0 以上の整数が必要: 受け取った値="${rawExpectedCount}"`
+    );
+  }
+
+  if (userId && userEmail) {
+    throw new Error("--user-id と --user-email は同時指定できません");
+  }
+
+  return {
+    execute,
+    tenantId,
+    userId,
+    userEmail,
+    noBackup,
+    maxTargets,
+    expectedCount,
+  };
+}
+
+// ============================================================
+// メインフロー
+// ============================================================
+
+async function runCli(): Promise<void> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(
+      `[FATAL] ${err instanceof Error ? err.message : String(err)}`
+    );
+    process.exit(1);
+  }
+
+  // Firebase 初期化
+  // GOOGLE_APPLICATION_CREDENTIALS には以下のいずれかが入り得る:
+  //   1. type=service_account の JSON (ローカル開発時のサービスアカウントキー) → cert() で初期化
+  //   2. type=external_account の JSON (GitHub Actions WIF 経由) → applicationDefault() で初期化
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  try {
+    if (credPath) {
+      const jsonPath = resolve(process.cwd(), credPath);
+      const credJson = JSON.parse(readFileSync(jsonPath, "utf8")) as {
+        type?: string;
+      };
+      if (credJson.type === "service_account") {
+        initializeApp({ credential: cert(credJson as ServiceAccount) });
+        console.log(`認証: サービスアカウントJSON (${jsonPath})`);
+      } else {
+        initializeApp({ credential: applicationDefault() });
+        console.log(
+          `認証: Application Default Credentials (cred file type=${credJson.type ?? "unknown"})`
+        );
+      }
+    } else {
+      initializeApp({ credential: applicationDefault() });
+      console.log("認証: Application Default Credentials");
+    }
+  } catch (err) {
+    console.error(
+      `[FATAL] Firebase初期化失敗: ${err instanceof Error ? err.message : err}`
+    );
+    process.exit(1);
+  }
+
+  const db = getFirestore();
+  await runMain(db, parsed);
+}
+
+export interface BackfillTarget {
+  tenantId: string;
+  attempt: AttemptInfo;
+  lessonId: string;
+  courseId: string;
+  videoId: string;
+  relatedSessions: SessionInfo[];
+}
+
+export interface AuditOnlyEntry {
+  tenantId: string;
+  attempt: AttemptInfo;
+  relatedSessions: SessionInfo[];
+  reason: string;
+}
+
+/**
+ * Firestore doc.data() の戻り値から SessionInfo に共通フィールドを抽出する。
+ * findBackfillTargets の relatedSessions マッピングと applyBackfill の readback マッピングで共有。
+ */
+function mapDataToSessionInfo(id: string, sd: Record<string, unknown>): SessionInfo {
+  return {
+    id,
+    userId: sd.userId as string,
+    lessonId: sd.lessonId as string,
+    courseId: sd.courseId as string,
+    videoId: sd.videoId as string,
+    status: sd.status as string,
+    entryAt: sd.entryAt as string,
+    exitAt: (sd.exitAt as string | null | undefined) ?? null,
+    exitReason: (sd.exitReason as string | null | undefined) ?? null,
+    quizAttemptId: (sd.quizAttemptId as string | null | undefined) ?? null,
+    isSynthetic: sd.isSynthetic as boolean | undefined,
+  };
+}
+
+export async function runMain(
+  db: Firestore,
+  parsed: ParsedArgs
+): Promise<void> {
+  console.log("=== #533 Phase 2: 合成 session 遡及作成 ===");
+  console.log(
+    `モード: ${parsed.execute ? "EXECUTE (実書き込み)" : "DRY-RUN (検出のみ)"}`
+  );
+  console.log(
+    `スコープ: tenant=${parsed.tenantId ?? "ALL"} userId=${parsed.userId ?? "-"} userEmail=${parsed.userEmail ?? "-"}`
+  );
+  console.log(`最大対象件数: ${parsed.maxTargets}`);
+  console.log(
+    `expected_count: ${parsed.expectedCount ?? "(指定なし)"}${parsed.execute && parsed.expectedCount === undefined ? "  ⚠️  本番 apply では --expected-count 推奨" : ""}`
+  );
+  console.log(`バックアップ: ${parsed.noBackup ? "無効" : "有効"}\n`);
+
+  // ユーザー解決 (--user-email 指定時)
+  let scopedUserId = parsed.userId;
+  let scopedTenantId = parsed.tenantId;
+  if (parsed.userEmail) {
+    const resolved = await resolveUserIdFromEmail(
+      db,
+      parsed.userEmail,
+      scopedTenantId
+    );
+    if (!resolved) {
+      console.error(`[FATAL] ユーザーが見つかりません: ${parsed.userEmail}`);
+      process.exit(1);
+    }
+    scopedUserId = resolved.userId;
+    scopedTenantId = resolved.tenantId;
+    console.log(
+      `ユーザー解決: ${parsed.userEmail} → tenantId=${scopedTenantId} userId=${scopedUserId}\n`
+    );
+  }
+
+  // 対象テナント一覧
+  const tenantsSnap = await db.collection("tenants").get();
+  if (tenantsSnap.empty) {
+    console.error(
+      "[FATAL] tenants コレクションが空です。権限/プロジェクトID 確認してください。"
+    );
+    process.exit(1);
+  }
+  if (scopedTenantId) {
+    const exists = tenantsSnap.docs.some((d) => d.id === scopedTenantId);
+    if (!exists) {
+      console.error(`[FATAL] tenant が見つかりません: ${scopedTenantId}`);
+      process.exit(1);
+    }
+  }
+  const tenantIds = scopedTenantId
+    ? [scopedTenantId]
+    : tenantsSnap.docs.map((d) => d.id);
+
+  // 抽出
+  const { targets, auditOnly } = await findBackfillTargets(
+    db,
+    tenantIds,
+    scopedUserId
+  );
+
+  console.log("=== 抽出結果 ===");
+  console.log(`backfill 対象: ${targets.length} 件`);
+  console.log(`audit_only (apply 対象外): ${auditOnly.length} 件`);
+
+  // expected_count 完全一致ガード (Codex M2)
+  const validation = validateExpectedCount(targets.length, parsed.expectedCount);
+  if (!validation.ok) {
+    console.error(`[FATAL] ${validation.reason}`);
+    process.exit(1);
+  }
+
+  if (auditOnly.length > 0) {
+    console.log("\n=== audit_only サンプル (最大 10 件) ===");
+    for (const e of auditOnly.slice(0, 10)) {
+      console.log(
+        `  tenant=${e.tenantId} attempt=${e.attempt.id} user=${e.attempt.userId} reason=${e.reason} relatedSessions=${e.relatedSessions.length}`
+      );
+    }
+  }
+
+  if (targets.length === 0) {
+    console.log("\nbackfill 対象なし");
+    return;
+  }
+
+  // 件数アサーション (max_targets)
+  if (targets.length > parsed.maxTargets) {
+    console.error(
+      `[FATAL] backfill 対象が ${parsed.maxTargets} 件を超えています (${targets.length} 件)`
+    );
+    console.error(
+      "  --max-targets で上限を上げるか、--tenant-id/--user-id でスコープ絞り込みしてください"
+    );
+    process.exit(1);
+  }
+
+  // backup (apply 前に出力)
+  if (!parsed.noBackup) {
+    const backupPath = `backfill-synthetic-backup-${Date.now()}.json`;
+    const backup = {
+      scriptVersion: "1.0.0",
+      commitSha: process.env.GITHUB_SHA ?? "(local)",
+      githubRunId: process.env.GITHUB_RUN_ID ?? "(local)",
+      githubActor: process.env.GITHUB_ACTOR ?? "(local)",
+      projectId: process.env.GOOGLE_CLOUD_PROJECT ?? "(unknown)",
+      mode: parsed.execute ? "execute" : "dry-run",
+      generatedAt: new Date().toISOString(),
+      targets: targets.map((t) => ({
+        tenantId: t.tenantId,
+        attempt: t.attempt,
+        lessonId: t.lessonId,
+        courseId: t.courseId,
+        videoId: t.videoId,
+        relatedSessions: t.relatedSessions, // pre-existing snapshot (Codex M4)
+        plannedSession: buildSyntheticSessionData(
+          t.attempt,
+          t.lessonId,
+          t.courseId,
+          t.videoId
+        ),
+      })),
+      auditOnly,
+    };
+    writeFileSync(backupPath, JSON.stringify(backup, null, 2));
+    console.log(`バックアップ: ${backupPath}`);
+  } else if (parsed.execute) {
+    console.error(
+      "[FATAL] --execute と --no-backup の組み合わせは禁止 (Codex AC2.9)"
+    );
+    process.exit(1);
+  }
+
+  // backfill 対象サンプル
+  console.log("\n=== backfill 対象サンプル (最大 10 件) ===");
+  for (const t of targets.slice(0, 10)) {
+    console.log(
+      `  tenant=${t.tenantId} attempt=${t.attempt.id} user=${t.attempt.userId} lesson=${t.lessonId} startedAt=${t.attempt.startedAt} submittedAt=${t.attempt.submittedAt}`
+    );
+  }
+
+  if (!parsed.execute) {
+    console.log("\nDRY-RUN: --execute で実行");
+    return;
+  }
+
+  // 実行
+  console.log("\n=== 実行 ===");
+  const result = await applyBackfill(db, targets);
+  console.log("\n=== 完了 ===");
+  console.log(`  created: ${result.created}`);
+  console.log(
+    `  skipped: ${result.skipped} (既存 synthetic doc / 並行作成)`
+  );
+  console.log(`  failed:  ${result.failed}`);
+  console.log(`  readback verified: ${result.readbackVerified}`);
+  if (result.readbackFailed > 0) {
+    console.log(
+      `  ⚠️ readback failed: ${result.readbackFailed} (synthetic doc に期待値との差分あり、backup と diff 確認推奨)`
+    );
+  }
+
+  // readbackFailed も非 0 exit にする (apply 成功扱い → オペレーター見落とし防止)
+  if (result.failed > 0 || result.readbackFailed > 0) {
+    process.exit(1);
+  }
+}
+
+// ============================================================
+// Firestore 連携
+// ============================================================
+
+async function resolveUserIdFromEmail(
+  db: Firestore,
+  email: string,
+  tenantId?: string
+): Promise<{ userId: string; tenantId: string } | null> {
+  const tenants = tenantId
+    ? [tenantId]
+    : (await db.collection("tenants").get()).docs.map((d) => d.id);
+  for (const tid of tenants) {
+    const snap = await db
+      .collection(`tenants/${tid}/users`)
+      .where("email", "==", email)
+      .limit(1)
+      .get();
+    if (!snap.empty) {
+      return { userId: snap.docs[0].id, tenantId: tid };
+    }
+  }
+  return null;
+}
+
+export async function findBackfillTargets(
+  db: Firestore,
+  tenantIds: string[],
+  scopedUserId?: string
+): Promise<{ targets: BackfillTarget[]; auditOnly: AuditOnlyEntry[] }> {
+  const targets: BackfillTarget[] = [];
+  const auditOnly: AuditOnlyEntry[] = [];
+  let skippedInvalid = 0;
+
+  for (const tid of tenantIds) {
+    // status=submitted + isPassed=true で絞り込み (Codex 反映済 status 値)
+    let attemptsQuery = db
+      .collection(`tenants/${tid}/quiz_attempts`)
+      .where("status", "==", "submitted")
+      .where("isPassed", "==", true);
+    if (scopedUserId) {
+      attemptsQuery = attemptsQuery.where("userId", "==", scopedUserId);
+    }
+    const attemptsSnap = await attemptsQuery.get();
+    if (attemptsSnap.empty) continue;
+
+    for (const doc of attemptsSnap.docs) {
+      const data = doc.data();
+      const attempt: AttemptInfo = {
+        id: doc.id,
+        status: data.status,
+        isPassed: data.isPassed ?? null,
+        startedAt: data.startedAt ?? null,
+        submittedAt: data.submittedAt ?? null,
+        quizId: data.quizId,
+        userId: data.userId,
+        attemptNumber: data.attemptNumber,
+        score: data.score ?? null,
+      };
+
+      // タイムスタンプ欠落チェック (build 時の早期エラー回避)
+      if (!attempt.startedAt || !attempt.submittedAt) {
+        console.warn(
+          `[WARN] timestamp 欠落: tenant=${tid} attempt=${attempt.id} startedAt=${attempt.startedAt} submittedAt=${attempt.submittedAt} → skip`
+        );
+        skippedInvalid++;
+        continue;
+      }
+
+      // quiz から lessonId / courseId / videoId を解決
+      const quizDoc = await db
+        .collection(`tenants/${tid}/quizzes`)
+        .doc(attempt.quizId)
+        .get();
+      if (!quizDoc.exists) {
+        console.warn(
+          `[WARN] quiz 削除済み: tenant=${tid} attempt=${attempt.id} quizId=${attempt.quizId} → skip`
+        );
+        skippedInvalid++;
+        continue;
+      }
+      const quizData = quizDoc.data()!;
+      const lessonId = quizData.lessonId as string;
+      const courseId = quizData.courseId as string;
+
+      // lesson から videoId を解決
+      const lessonDoc = await db
+        .collection(`tenants/${tid}/lessons`)
+        .doc(lessonId)
+        .get();
+      if (!lessonDoc.exists) {
+        console.warn(
+          `[WARN] lesson 削除済み: tenant=${tid} attempt=${attempt.id} lessonId=${lessonId} → skip`
+        );
+        skippedInvalid++;
+        continue;
+      }
+      const videoId = lessonDoc.data()!.videoId as string;
+      if (!videoId) {
+        console.warn(
+          `[WARN] videoId 欠落: tenant=${tid} attempt=${attempt.id} lessonId=${lessonId} → skip`
+        );
+        skippedInvalid++;
+        continue;
+      }
+
+      // 関連 sessions 取得 (同 user + 同 lesson)
+      const sessionsSnap = await db
+        .collection(`tenants/${tid}/lesson_sessions`)
+        .where("userId", "==", attempt.userId)
+        .where("lessonId", "==", lessonId)
+        .get();
+
+      const relatedSessions: SessionInfo[] = sessionsSnap.docs.map((d) =>
+        mapDataToSessionInfo(d.id, d.data())
+      );
+
+      const category = categorizeAttempt(attempt, relatedSessions);
+      if (category === "backfill_target") {
+        targets.push({
+          tenantId: tid,
+          attempt,
+          lessonId,
+          courseId,
+          videoId,
+          relatedSessions,
+        });
+      } else if (category === "audit_only") {
+        const linked = relatedSessions.filter(
+          (s) => s.quizAttemptId === attempt.id
+        );
+        auditOnly.push({
+          tenantId: tid,
+          attempt,
+          relatedSessions,
+          reason: `quizAttemptId 一致 session が ${linked.length} 件存在 (status: ${linked.map((s) => s.status).join("/")})`,
+        });
+      }
+    }
+  }
+
+  if (skippedInvalid > 0) {
+    console.warn(`\n[WARN] skipped (invalid data): ${skippedInvalid} 件`);
+  }
+  return { targets, auditOnly };
+}
+
+export interface ApplyResult {
+  created: number;
+  skipped: number;
+  failed: number;
+  readbackVerified: number;
+  readbackFailed: number;
+}
+
+export async function applyBackfill(
+  db: Firestore,
+  targets: BackfillTarget[]
+): Promise<ApplyResult> {
+  const result: ApplyResult = {
+    created: 0,
+    skipped: 0,
+    failed: 0,
+    readbackVerified: 0,
+    readbackFailed: 0,
+  };
+
+  for (const t of targets) {
+    const docId = `synthetic_${t.attempt.id}`;
+    const ref = db
+      .collection(`tenants/${t.tenantId}/lesson_sessions`)
+      .doc(docId);
+    const planned = buildSyntheticSessionData(
+      t.attempt,
+      t.lessonId,
+      t.courseId,
+      t.videoId
+    );
+    // Phase 1 createLessonSessionWithId と同じ Date オブジェクトを渡し Timestamp 型で保存させる
+    // (ISO string 渡しだと同コレクション内で createdAt の型が混在し orderBy 結果が divergent)。
+    const now = new Date();
+
+    // 状態復旧 (apply) を最優先で独立 try/catch (rules/error-handling.md §1)
+    try {
+      const created = await db.runTransaction(async (tx) => {
+        const existing = await tx.get(ref);
+        if (existing.exists) return false;
+        // sanitize: undefined フィールドは Firestore に渡さない (rules/production-data-safety.md §1)
+        const payload = sanitizeForWrite(buildWritePayload(planned, now));
+        tx.create(ref, payload);
+        return true;
+      });
+      if (created) result.created++;
+      else result.skipped++;
+    } catch (err) {
+      // tx.create が race で ALREADY_EXISTS をスローした場合は skip 扱い。
+      // gRPC status code = 6, Firebase Firestore Web SDK の文字列表現は 'already-exists' (lowercase, hyphen)、
+      // admin SDK の文字列表現は 'ALREADY_EXISTS' (uppercase, underscore)。両形式を許容する。
+      // 通常 runTransaction は ABORTED を retry するが、permanent error の場合の retry 後 catch で到達。
+      const errCode = (err as { code?: number | string } | null | undefined)?.code;
+      if (
+        errCode === 6 ||
+        errCode === "ALREADY_EXISTS" ||
+        errCode === "already-exists"
+      ) {
+        result.skipped++;
+        continue;
+      }
+      result.failed++;
+      console.error(
+        `  失敗: tenant=${t.tenantId} attempt=${t.attempt.id}: ${err instanceof Error ? err.message : err}`
+      );
+      continue;
+    }
+
+    // 読み戻し検証 (独立 try/catch)。readbackFailed > 0 は最終的に exit 1 で扱われる
+    // (rules/error-handling.md §1: 状態復旧と検証を独立 try/catch で分離)。
+    try {
+      const readback = await ref.get();
+      if (!readback.exists) {
+        result.readbackFailed++;
+        console.error(
+          `  readback 失敗: tenant=${t.tenantId} attempt=${t.attempt.id} (doc not found)`
+        );
+        continue;
+      }
+      const data = readback.data()!;
+      // SessionInfo の共通部分 + readback で validate する追加フィールド (sessionToken /
+      // deadlineAt / pauseStartedAt / sessionVideoCompleted / longestPauseSec) を merge する。
+      // pauseStartedAt は `?? null` で undefined を丸めるため field 欠落 (本来 null で書かれるべき) は
+      // ここでは検出できない。書き込み payload は常に pauseStartedAt: null を含むため実害は低い
+      // (sanitize 戦略が undefined 除去になっても null は保持される)。
+      const actual = {
+        ...mapDataToSessionInfo(readback.id, data),
+        sessionToken: data.sessionToken as string,
+        deadlineAt: data.deadlineAt as string,
+        pauseStartedAt: (data.pauseStartedAt as string | null | undefined) ?? null,
+        sessionVideoCompleted: data.sessionVideoCompleted as boolean | undefined,
+        longestPauseSec: data.longestPauseSec as number | undefined,
+      };
+      const check = validateReadback(planned, actual);
+      if (check.ok) {
+        result.readbackVerified++;
+      } else {
+        result.readbackFailed++;
+        console.error(
+          `  readback 不一致: tenant=${t.tenantId} attempt=${t.attempt.id} mismatches=${check.mismatches.join(", ")}`
+        );
+      }
+    } catch (err) {
+      result.readbackFailed++;
+      console.error(
+        `  readback 例外: tenant=${t.tenantId} attempt=${t.attempt.id}: ${err instanceof Error ? err.message : err}`
+      );
+    }
+  }
+  return result;
+}
+
+/**
+ * Firestore 書き込み用に undefined フィールドを除去 (rules/production-data-safety.md §1)。
+ */
+export function sanitizeForWrite<T extends Record<string, unknown>>(
+  obj: T
+): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined)
+  ) as Partial<T>;
+}

--- a/scripts/backfill-synthetic-sessions.ts
+++ b/scripts/backfill-synthetic-sessions.ts
@@ -54,30 +54,34 @@ import {
 import { getFirestore, type Firestore } from "firebase-admin/firestore";
 import { readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
+import { parsePositiveDurationMs } from "../services/api/src/utils/env-config.js";
 
 // ============================================================
 // 定数
 // ============================================================
 
-// セッション期間 (ミリ秒)。Phase 1 helper (services/api/src/services/lesson-session.ts) は
-// env SESSION_DURATION_MS を読み、本番 Cloud Run では 10800000 (3h) で稼働。
-// completed session の deadlineAt は意味的に未使用だが、Phase 1 と値を揃えるため env を読む。
+// セッション期間 (ミリ秒)。Phase 1 helper (services/api/src/services/lesson-session.ts:16)
+// は env SESSION_DURATION_MS を parsePositiveDurationMs で読み、本番 Cloud Run では
+// 10800000 (3h) で稼働。本 script も同じ env / helper を用いて Phase 1 と完全に揃える。
+// completed session の deadlineAt は意味的に未使用だが、orderBy 等で混在しないため一致が望ましい。
 const SESSION_DURATION_MS_FALLBACK = 7_200_000;
-// 上限 24 時間 (86,400,000 ms): セッション 1 日を超える値は誤入力扱いで fallback。
-// Date 範囲外 (例: 1e20 ms ≒ 31.7 京年) で RangeError を防ぐ。
+// 24 時間上限: Date 範囲外 (例: 1e20 ms) で RangeError を防ぐ scripts 専用の安全策。
+// Phase 1 ランタイムは Cloud Run env で安定値が入るため上限不要、本 script は環境変数の typo を
+// 監視できないため上限を別途設ける。
 const SESSION_DURATION_MS_MAX = 86_400_000;
 export function resolveSessionDurationMs(envValue: string | undefined): number {
-  if (!envValue) return SESSION_DURATION_MS_FALLBACK;
-  const n = Number(envValue);
-  if (
-    !Number.isFinite(n) ||
-    !Number.isInteger(n) ||
-    n < 1 ||
-    n > SESSION_DURATION_MS_MAX
-  ) {
+  const parsed = parsePositiveDurationMs(
+    envValue,
+    SESSION_DURATION_MS_FALLBACK,
+    "SESSION_DURATION_MS"
+  );
+  if (parsed > SESSION_DURATION_MS_MAX) {
+    console.warn(
+      `[WARN] SESSION_DURATION_MS=${parsed} は 24h (${SESSION_DURATION_MS_MAX}) を超えるため fallback ${SESSION_DURATION_MS_FALLBACK} を使用`
+    );
     return SESSION_DURATION_MS_FALLBACK;
   }
-  return n;
+  return parsed;
 }
 const DEFAULT_SESSION_DURATION_MS = resolveSessionDurationMs(
   process.env.SESSION_DURATION_MS
@@ -412,7 +416,15 @@ async function runCli(): Promise<void> {
   }
 
   const db = getFirestore();
-  await runMain(db, parsed);
+  try {
+    await runMain(db, parsed);
+  } catch (err) {
+    // runMain 内部からの予期せぬエラーを raw stack trace でなく [FATAL] で報告
+    console.error(
+      `[FATAL] 予期しないエラー: ${err instanceof Error ? (err.stack ?? err.message) : err}`
+    );
+    process.exit(1);
+  }
 }
 
 export interface BackfillTarget {
@@ -577,8 +589,16 @@ export async function runMain(
       })),
       auditOnly,
     };
-    writeFileSync(backupPath, JSON.stringify(backup, null, 2));
-    console.log(`バックアップ: ${backupPath}`);
+    try {
+      writeFileSync(backupPath, JSON.stringify(backup, null, 2));
+      console.log(`バックアップ: ${backupPath}`);
+    } catch (err) {
+      // backup 書き込み失敗 → apply 中止 (raw stack trace でなく [FATAL] を出して exit)
+      console.error(
+        `[FATAL] backup 書き込み失敗、apply 中止: ${err instanceof Error ? err.message : err}`
+      );
+      process.exit(1);
+    }
   } else if (parsed.execute) {
     console.error(
       "[FATAL] --execute と --no-backup の組み合わせは禁止 (Codex AC2.9)"
@@ -706,7 +726,7 @@ export async function findBackfillTargets(
       const lessonId = quizData.lessonId as string;
       const courseId = quizData.courseId as string;
 
-      // lesson から videoId を解決
+      // lesson 存在確認 (削除済みなら skip)
       const lessonDoc = await db
         .collection(`tenants/${tid}/lessons`)
         .doc(lessonId)
@@ -718,14 +738,23 @@ export async function findBackfillTargets(
         skippedInvalid++;
         continue;
       }
-      const videoId = lessonDoc.data()!.videoId as string;
-      if (!videoId) {
+
+      // videoId 解決: Phase 1 helper (getVideoByLessonId, firestore.ts:900) と同じ
+      // canonical な videos.lessonId where 検索を使う。lessons.videoId 直接読みは
+      // Phase 1 と divergent するため不可 (一部 lesson に videoId field が無い場合に silent skip)。
+      const videosSnap = await db
+        .collection(`tenants/${tid}/videos`)
+        .where("lessonId", "==", lessonId)
+        .limit(1)
+        .get();
+      if (videosSnap.empty) {
         console.warn(
-          `[WARN] videoId 欠落: tenant=${tid} attempt=${attempt.id} lessonId=${lessonId} → skip`
+          `[WARN] video 未紐付け: tenant=${tid} attempt=${attempt.id} lessonId=${lessonId} → skip`
         );
         skippedInvalid++;
         continue;
       }
+      const videoId = videosSnap.docs[0].id;
 
       // 関連 sessions 取得 (同 user + 同 lesson)
       const sessionsSnap = await db


### PR DESCRIPTION
## Summary

#533 Phase 2: Phase 1 (PR #537) 投入前に発生した活動セッション欠落 4 件 (長遊園テナント、2025-12-15〜2026-01-09) を遡及補正する admin workflow を追加。

- **Phase 1 (PR #537)**: `activeSession=null` 時の合格提出で `createSyntheticCompletedSession` ヘルパーが新規発生を予防
- **Phase 2 (本 PR)**: 過去発生分を `synthetic_{attemptId}` doc id で遡及作成 (destructive migration)
- **Phase 3 (別 PR 予定)**: `isSynthetic` 可視化 (出席レポート FE バッジ)

## Acceptance Criteria

| # | 基準 | 検証 |
|---|------|------|
| AC2.1 | audit モード: 全テナント横断スキャン、対象一覧を artifact 出力 | smoke (5 件) |
| AC2.2 | dry-run: 生成予定 doc 全フィールドを log + artifact、Firestore 書き込みゼロ | smoke |
| AC2.3 | apply: `synthetic_{attemptId}` doc 作成、15 フィールド値検証 | smoke |
| AC2.4 | 冪等性: apply 直後の dry-run 再実行で対象 0 件 | smoke |
| AC2.5 | 件数アサーション: `max_targets` 超過で `process.exit(1)` | unit |
| AC2.6 | スコープ絞り込み: `tenant_id` / `user_email` (排他) | unit |
| AC2.7 | backup artifact: 適用前 attempt + 生成 session JSON、retention 30 days | workflow |
| AC2.8 | エラー耐性: per-attempt try/catch、1 件失敗で全体停止しない | smoke |
| AC2.9 | `execute=true` + `expected_count` 空は workflow 段階で fail | workflow |
| AC2.10 | apply 後の読み戻し検証、`readbackFailed > 0` で exit 1 | smoke |
| AC2.11 | ALREADY_EXISTS (race) は skip 扱い | unit |

## レビュー履歴

### Codex セカンドオピニオン #1 (plan モード) — 反映 5 件
- Blocker 1: `status='passed'` → `'submitted'` + `isPassed===true` (正しい型)
- M1: `audit_only` カテゴリで apply 対象外を分離
- M2: `expected_count` 完全一致ガード (workflow yaml 強制)
- M3: `environment: production` + branch `refs/heads/main` 制限
- M4: backup スキーマ拡張 (commit SHA / run id / actor / pre-existing sessions)

### code-review high — 反映 7 件
| # | 内容 |
|---|------|
| 🔴 1 | `createdAt/updatedAt` を Date オブジェクトで書き込み (Phase 1 と Timestamp 型一致、新型 `SyntheticSessionWritePayload` + `buildWritePayload`) |
| 🔴 2 | workflow yaml で execute=true 時 expected_count 必須 (空なら shell exit 1) |
| 🔴 3 | `readbackFailed > 0` で exit 1 (apply 成功扱い防止) |
| 🔴 4 | tx.create の ALREADY_EXISTS は skip 扱い (catch 内で error code 判定) |
| 🟡 5 | `SESSION_DURATION_MS` env 読み出し (本番 3h と一致、新関数 `resolveSessionDurationMs`) |
| 🟡 6 | `validateReadback` の fieldsToCheck に `pauseStartedAt` 追加 |
| 🟡 7 | `SyntheticSessionWritePayload` 型で createdAt/updatedAt の型保証 |

### Codex セカンドオピニオン #2 (実装 diff review) — 反映 3 件
- M1: `--expected-count` の `Number.isInteger` チェック追加 (件数ガード堅牢化)
- M2: `resolveSessionDurationMs` に 24h 上限追加 (Date 範囲外 RangeError 防止)
- M3: ALREADY_EXISTS 判定に `'already-exists'` (Web SDK lowercase-hyphen) 追加
- 最終信頼度: **High** (本番 apply 着手 OK)

### 別 Issue 候補 (本 PR スコープ外、🟢 LOW)
- `buildSyntheticSessionData` が Phase 1 `createSyntheticCompletedSession` と structural duplication
- `applyBackfill` の sanitize 戦略が `createLessonSessionWithId` と異なる (undefined 除去 vs `?? null`)
- `resolveUserIdFromEmail` が `cleanup-stuck-quiz-attempts.ts` と完全重複

## 安全機構

- ✅ dry-run 既定 (`--execute` で apply)
- ✅ `expected_count` 完全一致ガード (workflow + script)
- ✅ `max_targets` 上限 (default 100)
- ✅ スコープ絞り込み (`--tenant-id` / `--user-id` / `--user-email`、後者 2 つ排他)
- ✅ backup JSON (commit SHA / GitHub run id / actor / pre-existing sessions snapshot)
- ✅ tx.create で ALREADY_EXISTS は skip (race 安全)
- ✅ 書き込み後の読み戻し検証 (15 フィールド一致)
- ✅ `environment: production` (execute=true 時 approval 必須)
- ✅ `if: github.ref == 'refs/heads/main'` (branch 制限)

## Test plan

- [x] vitest 67 件 PASS (純粋関数 + in-memory fake integration + E2E)
- [x] lint 0 error
- [x] type-check 全 4 workspace PASS
- [ ] **dev 環境フルリハーサル** (audit → dry-run → apply、開発者実施)
- [ ] **本番 audit** (件数確認、長遊園 4 件含むこと、開発者実施)
- [ ] **本番 dry-run** (生成内容レビュー、開発者実施)
- [ ] **本番 apply** (`expected_count=4`、開発者 GitHub Actions UI から実行)
- [ ] **本番 dry-run 再実行** (idempotency 検証、開発者実施)

## 実装着手の前提条件

- ✅ Phase 1 (PR #537) deploy 完了
- ⏳ **長遊園様での Phase 1 本番動作確認 OK** (現在開発者確認待ち)

Phase 1 動作確認結果に応じて、本 PR の dev rehearsal → 本番 apply の判断をお願いします。

Refs #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)