### PR TITLE
docs(data-model): lesson_sessions に isSynthetic フィールドを追記 (#533)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -159,6 +159,7 @@ questions配列の各要素:
 | longestPauseSec | number | セッション中の最長一時停止秒数 |
 | sessionVideoCompleted | boolean | セッション内で動画完了したか |
 | quizAttemptId | string? | 完了時のテストattempt ID |
+| isSynthetic | boolean? | provenance flag。`true` の場合、`activeSession=null` の合格提出時にシステムが自動補完した合成 session であることを示す（ADR-027 §改訂履歴 2026-06-09 / #533 Phase 1/2）。doc id 規約: 合成は `synthetic_{attemptId}`、実 session は Firestore 自動採番 |
 | createdAt | Timestamp | 作成日時 |
 | updatedAt | Timestamp | 更新日時 |
 


### PR DESCRIPTION
## Summary

Phase 1/2 (PR #537/#539/#541) で導入した `lesson_sessions.isSynthetic` フィールドを `docs/data-model.md` の公式スキーマ記述に反映。

- `isSynthetic: boolean?` 追記
- provenance flag の意味記載
- doc id 規約 (合成: `synthetic_{attemptId}` / 実 session: 自動採番) も記載
- 詳細根拠は ADR-027 改訂履歴 2026-06-09 entry を参照

## なぜ追記が必要か

Phase 1/2 で Firestore スキーマに新フィールドを追加したが、公式ドキュメント (data-model.md) に反映漏れがあった。CLAUDE.md「ドキュメント更新ルール」MUST 違反の予防。

## Test plan

- [x] markdown 構文確認 (cat で目視)
- [x] lesson_sessions テーブル内の他フィールドとの整合性確認 (`?` 記法統一)
- [x] ADR-027 / Issue #533 への cross-link

🤖 Generated with [Claude Code](https://claude.com/claude-code)