### PR TITLE
ci(backfill): bump actions/upload-artifact from 4 to 7

### DIFF
--- a/.github/workflows/backfill-synthetic-sessions.yml
+++ b/.github/workflows/backfill-synthetic-sessions.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload backup artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: backfill-synthetic-backup-${{ github.run_id }}
           path: backfill-synthetic-backup-*.json


### PR DESCRIPTION
## Summary

`backfill-synthetic-sessions.yml` の `actions/upload-artifact@v4` を `@v7` に bump。

## なぜこの PR が必要か

PR #500 (dependabot 自動) は v4→v7 bump を 4 workflow に適用するが、本セッションで新規追加した `backfill-synthetic-sessions.yml` を含まない (dependabot 検出時点で存在しなかったため)。

Node.js 20 actions deprecation 期限が 2026-06-16 (約 1 週間後) で、次回 dependabot 検出を待つと間に合わない可能性がある。本 PR で先回り対応。

## 互換性

- v4 → v7 で **breaking change なし** (ESM 化のみ、[v7 release notes 確認](https://github.com/actions/upload-artifact/issues/776))
- v4 から導入された behavioral differences (artifact 不変性 / unique 名前) は v7 でも維持
- 当 workflow は `run_id` ベースの unique artifact name を使用 (`backfill-synthetic-backup-${{ github.run_id }}`) → v4 制約満たし済

## 関連

- 連動: PR #500 (dependabot、cleanup/dispatch 系 4 workflow の v4→v7 bump)
- 期限: 2026-06-16 Node.js 20 actions deprecation (実行時 warning は backfill workflow run 27200193182 等の annotation で確認済)

## Test plan

- [x] yaml 構文確認 (cat で目視、変更 1 行のみ)
- [x] CI pass 確認
- [ ] (次回 backfill workflow 実行時に動作確認、ただし apply は当面予定なし → audit run で代替確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)