### PR TITLE
feat(super-attendance): 合成 session に「自動補完」バッジ表示 + フィルタ追加 (#551)

### DIFF
--- a/docs/adr/ADR-027-lesson-session-attendance.md
+++ b/docs/adr/ADR-027-lesson-session-attendance.md
@@ -1,16 +1,24 @@
 # ADR-027: レッスンセッション出席管理
 
 ## ステータス
-承認済み（2026-06-09 改訂: isSynthetic provenance flag 追加 #533 / 2026-05-21 改訂: 再視聴中の完了経験者救済ケース E' / 2026-05-16 改訂: セッション上限を環境変数化）
+承認済み（2026-06-09 改訂: isSynthetic provenance flag 追加 #533 + Phase 3 可視化 #551 / 2026-05-21 改訂: 再視聴中の完了経験者救済ケース E' / 2026-05-16 改訂: セッション上限を環境変数化）
 
 ## 改訂履歴
-- **2026-06-09**: **動機**: `activeSession=null` 時のテスト合格提出（ケース D、後方互換性ケース）で `lesson_sessions` ドキュメントが作成されず、「受講状況管理」では合格扱い・100% 進捗だが「出席・テスト結果レポート」では出席ログが見つからない不整合が発生（#533）。本番運用で 2 テナント計 17 件確認（2026-05-11 〜 2026-06-09 期間、テナント別内訳は 2026-06-09 時点の handoff（Session 70）参照）。
+- **2026-06-09 (Phase 3, #551)**: **動機**: Phase 1/2 で投入された `isSynthetic` provenance flag を運用補助・監査性の観点で出席レポート UI に露出する（設計仕様書 `docs/specs/2026-06-09-phase3-synthetic-session-badge-design.md`）。
+
+  **変更内容**: スーパー管理「出席・テスト結果レポート」(`/super/attendance`) で `isSynthetic=true` の session に「自動補完」バッジ（amber-tone、`entryAt` セル横、`print:` で border + text に切替えて PDF 印字耐性確保）を表示。新規「session 種別」segmented filter（`all` / `synthetic_only` / `actual_only`）を既存「退室理由」フィルタと独立に追加。`SuperAttendanceRecord.isSynthetic: boolean` を `@lms-279/shared-types` で公開し、API layer (`services/api/src/routes/super-admin.ts`) で `data.isSynthetic === true` 比較により Phase 1/2 投入前の既存 doc（フィールド欠落）も `false` に正規化（防御的マッピング）。
+
+  **テスト**: API integration test 4 ケース（response 全 record が boolean、true/false/欠落の正規化）+ FE unit test 6 ケース（`matchesIsSyntheticFilter` pure function）+ manual 確認（Phase 2 補正済 17 件のバッジ表示 / 新規テスト提出経由のバッジ表示 / `window.print()` PDF 印字）。
+
+  **スコープ外（明示記録）**: (i) CSV エクスポート（super attendance は現状 PDF のみ、将来 CSV 機能追加時に `is_synthetic` カラムを含める設計）、(ii) admin 側出席画面（`/admin/analytics/attendance/courses/:courseId`、別系統 API `AdminAttendanceRecord`）、(iii) Firestore index 追加（サーバ側 `isSynthetic` query を行わないため不要）。
+
+- **2026-06-09 (Phase 1/2, #533)**: **動機**: `activeSession=null` 時のテスト合格提出（ケース D、後方互換性ケース）で `lesson_sessions` ドキュメントが作成されず、「受講状況管理」では合格扱い・100% 進捗だが「出席・テスト結果レポート」では出席ログが見つからない不整合が発生（#533）。本番運用で 2 テナント計 17 件確認（2026-05-11 〜 2026-06-09 期間、テナント別内訳は 2026-06-09 時点の handoff（Session 70）参照）。
 
   **変更内容 (Phase 1, PR #537)**: `lesson_sessions` に **`isSynthetic: boolean`** フィールドを追加（`packages/shared-types/src/lesson-session.ts`）。`createSyntheticCompletedSession` ヘルパー（`services/api/src/services/lesson-session.ts`）を追加し、`activeSession=null` の合格提出時に quiz 提出時刻ベースで合成 session を作成（`entryAt=startedAt` / `exitAt=submittedAt` / `status='completed'` / `exitReason='quiz_submitted'` / `isSynthetic=true`）。これにより新規発生分は API 層で自動補完される。
 
   **過去分の遡及補正 (Phase 2, PR #539/#541)**: `scripts/backfill-synthetic-sessions.ts` を追加し、`synthetic_{attemptId}` doc id で transaction `create`（race-safe）により過去 17 件を遡及作成。GitHub Actions workflow（`.github/workflows/backfill-synthetic-sessions.yml`）で workflow_dispatch + WIF + production environment + expected_count 完全一致ガードで本番投入。2026-06-09 apply 完了（workflow run 27200193182、created=17 / readback verified=17）、idempotency 検証 OK（再 audit で対象 0 件）。
 
-  **provenance flag (isSynthetic) の意義**: 実 session（動画再生から自然発生）と合成 session（システム補完）を識別可能にすることで、(a) 監査時に補正済みデータを特定可能、(b) 出席レポート UI で視覚的に区別可能（Phase 3 設計仕様書 `docs/specs/2026-06-09-phase3-synthetic-session-badge-design.md` 参照、未実装）、(c) 将来の分析・データ品質メトリクスで合成データを除外可能。
+  **provenance flag (isSynthetic) の意義**: 実 session（動画再生から自然発生）と合成 session（システム補完）を識別可能にすることで、(a) 監査時に補正済みデータを特定可能、(b) 出席レポート UI で視覚的に区別可能（Phase 3 実装済、本 ADR 上段の 2026-06-09 Phase 3 entry / #551 参照）、(c) 将来の分析・データ品質メトリクスで合成データを除外可能。
 
   **設計上の判断**: ケース D（`activeSession=null` 後方互換性ケース、2026-05-21 entry 参照）は撤廃せず後方互換性を維持。代わりに合成 session を作成することで「合格提出された quiz_attempt には必ず対応する lesson_session が存在する」不変条件を回復。これによりケース D 経由のテスト提出も全件 `lesson_sessions` に記録される状態を担保する。
 

--- a/packages/shared-types/src/attendance.ts
+++ b/packages/shared-types/src/attendance.ts
@@ -58,6 +58,7 @@ export interface SuperAttendanceRecord {
   quizScore: number | null;
   quizPassed: boolean | null;
   quizSubmittedAt: string | null;
+  isSynthetic: boolean;
 }
 
 export interface SuperAttendanceResponse {

--- a/services/api/src/__tests__/integration/attendance-report-synthetic.test.ts
+++ b/services/api/src/__tests__/integration/attendance-report-synthetic.test.ts
@@ -1,0 +1,174 @@
+/**
+ * GET /attendance-report レスポンスの isSynthetic マップ検証
+ *
+ * Issue #533 Phase 3 / #551:
+ *  - lesson_sessions.isSynthetic === true → response.isSynthetic = true
+ *  - lesson_sessions.isSynthetic 欠落 / false / null → response.isSynthetic = false
+ *
+ * 防御的: API layer で `=== true` 比較し boolean 正規化（Phase 1/2 投入前の既存 doc 対応）
+ */
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import supertest from "supertest";
+import express from "express";
+
+// lesson_sessions の固定 fixture（synthetic 1 件 + actual 1 件 + isSynthetic 欠落 1 件）
+const SESSIONS_FIXTURE = [
+  {
+    id: "synth-session-1",
+    data: {
+      userId: "user-1",
+      courseId: "course-1",
+      lessonId: "lesson-1",
+      entryAt: "2026-06-09T01:00:00.000Z",
+      exitAt: "2026-06-09T01:30:00.000Z",
+      exitReason: "quiz_submitted",
+      status: "completed",
+      quizAttemptId: "attempt-1",
+      isSynthetic: true,
+    },
+  },
+  {
+    id: "actual-session-1",
+    data: {
+      userId: "user-1",
+      courseId: "course-1",
+      lessonId: "lesson-1",
+      entryAt: "2026-06-09T02:00:00.000Z",
+      exitAt: "2026-06-09T02:45:00.000Z",
+      exitReason: "quiz_submitted",
+      status: "completed",
+      quizAttemptId: "attempt-2",
+      isSynthetic: false,
+    },
+  },
+  {
+    id: "legacy-session-1",
+    data: {
+      userId: "user-1",
+      courseId: "course-1",
+      lessonId: "lesson-1",
+      entryAt: "2026-06-09T03:00:00.000Z",
+      exitAt: "2026-06-09T03:15:00.000Z",
+      exitReason: "time_limit",
+      status: "force_exited",
+      // isSynthetic フィールド欠落（Phase 1/2 投入前の既存 doc 想定）
+    },
+  },
+];
+
+function makeSnapshot(docs: { id: string; data: Record<string, unknown> }[]) {
+  return {
+    docs: docs.map((d) => ({
+      id: d.id,
+      data: () => d.data,
+    })),
+  };
+}
+
+function makeQuery(snapshot: ReturnType<typeof makeSnapshot>) {
+  const queryObj: Record<string, unknown> = {
+    orderBy: vi.fn(() => queryObj),
+    where: vi.fn(() => queryObj),
+    get: vi.fn(() => Promise.resolve(snapshot)),
+  };
+  return queryObj;
+}
+
+vi.mock("firebase-admin/firestore", () => {
+  return {
+    getFirestore: vi.fn(() => ({
+      collection: vi.fn((path: string) => {
+        // tenants/{tid} 取得
+        if (path === "tenants") {
+          return {
+            doc: vi.fn(() => ({
+              get: vi.fn(() => Promise.resolve({ exists: true, data: () => ({ name: "Test Tenant" }) })),
+            })),
+          };
+        }
+        // tenants/{tid}/lesson_sessions
+        if (path.endsWith("/lesson_sessions")) {
+          return makeQuery(makeSnapshot(SESSIONS_FIXTURE));
+        }
+        // users / quiz_attempts / lessons / courses
+        if (path.endsWith("/users")) {
+          return makeQuery(makeSnapshot([
+            { id: "user-1", data: { name: "受講者1", email: "u1@example.com" } },
+          ]));
+        }
+        if (path.endsWith("/quiz_attempts")) {
+          return makeQuery(makeSnapshot([
+            { id: "attempt-1", data: { score: 100, isPassed: true, submittedAt: "2026-06-09T01:30:00.000Z" } },
+            { id: "attempt-2", data: { score: 80, isPassed: true, submittedAt: "2026-06-09T02:45:00.000Z" } },
+          ]));
+        }
+        if (path.endsWith("/lessons")) {
+          return makeQuery(makeSnapshot([
+            { id: "lesson-1", data: { title: "テストレッスン" } },
+          ]));
+        }
+        if (path.endsWith("/courses")) {
+          return makeQuery(makeSnapshot([
+            { id: "course-1", data: { name: "テストコース" } },
+          ]));
+        }
+        return makeQuery(makeSnapshot([]));
+      }),
+    })),
+  };
+});
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: vi.fn(() => ({
+    verifyIdToken: vi.fn(),
+    getUserByEmail: vi.fn(() => Promise.reject(new Error("not found"))),
+  })),
+}));
+
+vi.mock("../../middleware/super-admin.js", () => ({
+  superAdminAuthMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  getAllSuperAdmins: vi.fn(() => Promise.resolve([])),
+  addSuperAdmin: vi.fn(),
+  removeSuperAdmin: vi.fn(),
+  isSuperAdmin: vi.fn(() => Promise.resolve(false)),
+}));
+
+describe("GET /attendance-report isSynthetic マップ (#533 Phase 3 / #551)", () => {
+  let request: ReturnType<typeof supertest>;
+
+  beforeAll(async () => {
+    const { superAdminRouter } = await import("../../routes/super-admin.js");
+    const app = express();
+    app.use(express.json());
+    app.use(superAdminRouter);
+    request = supertest(app);
+  }, 30_000);
+
+  it("レスポンスの全 record で isSynthetic が boolean になる (AC1)", async () => {
+    const res = await request.get("/tenants/test-tenant/attendance-report");
+    expect(res.status).toBe(200);
+    expect(res.body.records).toHaveLength(3);
+    for (const record of res.body.records) {
+      expect(typeof record.isSynthetic).toBe("boolean");
+    }
+  });
+
+  it("isSynthetic=true の doc は record.isSynthetic=true (AC1)", async () => {
+    const res = await request.get("/tenants/test-tenant/attendance-report");
+    const synthetic = res.body.records.find((r: { id: string }) => r.id === "synth-session-1");
+    expect(synthetic.isSynthetic).toBe(true);
+  });
+
+  it("isSynthetic=false の doc は record.isSynthetic=false (AC1)", async () => {
+    const res = await request.get("/tenants/test-tenant/attendance-report");
+    const actual = res.body.records.find((r: { id: string }) => r.id === "actual-session-1");
+    expect(actual.isSynthetic).toBe(false);
+  });
+
+  it("isSynthetic フィールド欠落の doc は record.isSynthetic=false (AC2: 防御的マップ)", async () => {
+    const res = await request.get("/tenants/test-tenant/attendance-report");
+    const legacy = res.body.records.find((r: { id: string }) => r.id === "legacy-session-1");
+    expect(legacy.isSynthetic).toBe(false);
+  });
+});

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -1056,6 +1056,7 @@ router.get("/tenants/:tenantId/attendance-report", async (req: Request, res: Res
       quizScore: attempt?.score ?? data.quizScore ?? null,
       quizPassed: attempt?.isPassed ?? data.quizPassed ?? null,
       quizSubmittedAt: attempt?.submittedAt ?? null,
+      isSynthetic: data.isSynthetic === true,
     };
   });
 

--- a/web/app/super/attendance/__tests__/synthetic-filter.test.ts
+++ b/web/app/super/attendance/__tests__/synthetic-filter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  matchesIsSyntheticFilter,
+  SYNTHETIC_KIND_OPTIONS,
+} from "../_helpers/synthetic-filter";
+
+describe("SYNTHETIC_KIND_OPTIONS", () => {
+  it("3 つの選択肢 (all / synthetic_only / actual_only) を持つ", () => {
+    expect(SYNTHETIC_KIND_OPTIONS).toHaveLength(3);
+    expect(SYNTHETIC_KIND_OPTIONS.map((o) => o.value)).toEqual([
+      "all",
+      "synthetic_only",
+      "actual_only",
+    ]);
+  });
+});
+
+describe("matchesIsSyntheticFilter", () => {
+  describe("kind=all", () => {
+    it("isSynthetic=true / false どちらも表示する", () => {
+      expect(matchesIsSyntheticFilter(true, "all")).toBe(true);
+      expect(matchesIsSyntheticFilter(false, "all")).toBe(true);
+    });
+  });
+
+  describe("kind=synthetic_only", () => {
+    it("isSynthetic=true のみ表示", () => {
+      expect(matchesIsSyntheticFilter(true, "synthetic_only")).toBe(true);
+    });
+    it("isSynthetic=false は除外", () => {
+      expect(matchesIsSyntheticFilter(false, "synthetic_only")).toBe(false);
+    });
+  });
+
+  describe("kind=actual_only", () => {
+    it("isSynthetic=false のみ表示", () => {
+      expect(matchesIsSyntheticFilter(false, "actual_only")).toBe(true);
+    });
+    it("isSynthetic=true は除外", () => {
+      expect(matchesIsSyntheticFilter(true, "actual_only")).toBe(false);
+    });
+  });
+});

--- a/web/app/super/attendance/_helpers/synthetic-filter.ts
+++ b/web/app/super/attendance/_helpers/synthetic-filter.ts
@@ -1,0 +1,35 @@
+/**
+ * Session 種別フィルタ（合成 session = isSynthetic=true）の判定関数と定数。
+ *
+ * Issue #533 Phase 3 / #551:
+ *   Phase 1 (PR #537) で合成 session 自動作成、Phase 2 (PR #539/#541) で過去 17 件遡及補正後、
+ *   出席レポートで合成 session を視覚識別するための運用補助フィルタ。
+ */
+
+export type SyntheticKind = "all" | "synthetic_only" | "actual_only";
+
+export const SYNTHETIC_KIND_OPTIONS: { value: SyntheticKind; label: string }[] = [
+  { value: "all", label: "すべて" },
+  { value: "synthetic_only", label: "自動補完のみ" },
+  { value: "actual_only", label: "実 session のみ" },
+];
+
+/** 純粋関数: SyntheticKind フィルタ値とレコードの isSynthetic を突き合わせて表示すべきか判定。 */
+export function matchesIsSyntheticFilter(
+  recordIsSynthetic: boolean,
+  kind: SyntheticKind,
+): boolean {
+  switch (kind) {
+    case "all":
+      return true;
+    case "synthetic_only":
+      return recordIsSynthetic === true;
+    case "actual_only":
+      return recordIsSynthetic === false;
+    default: {
+      // SyntheticKind に新しい値が追加された際、TypeScript が網羅漏れを検出する
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
+  }
+}

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -43,6 +44,11 @@ import {
   calculateStayDurationMs,
   formatStayDuration,
 } from "./_helpers/stay-duration";
+import {
+  matchesIsSyntheticFilter,
+  SYNTHETIC_KIND_OPTIONS,
+  type SyntheticKind,
+} from "./_helpers/synthetic-filter";
 
 type Tenant = { id: string; name: string };
 
@@ -134,6 +140,7 @@ export default function AttendanceReportPage() {
   const [filterLessons, setFilterLessons] = useState<Set<string>>(new Set());
   const [filterExitReasons, setFilterExitReasons] = useState<Set<string>>(new Set());
   const [filterQuizPassed, setFilterQuizPassed] = useState<Set<string>>(new Set());
+  const [filterSyntheticKind, setFilterSyntheticKind] = useState<SyntheticKind>("all");
 
   // ソート
   const [sortKey, setSortKey] = useState<SortKey | null>(null);
@@ -189,6 +196,7 @@ export default function AttendanceReportPage() {
       setFilterLessons(new Set());
       setFilterExitReasons(new Set());
       setFilterQuizPassed(new Set());
+      setFilterSyntheticKind("all");
       setSortKey(null);
       setSortDir(null);
     } else {
@@ -278,6 +286,9 @@ export default function AttendanceReportPage() {
         return false;
       });
     }
+    if (filterSyntheticKind !== "all") {
+      records = records.filter((r) => matchesIsSyntheticFilter(r.isSynthetic, filterSyntheticKind));
+    }
 
     // ソート
     if (sortKey && sortDir) {
@@ -304,7 +315,7 @@ export default function AttendanceReportPage() {
     }
 
     return records;
-  }, [report, filterUsers, filterCourses, filterLessons, filterExitReasons, filterQuizPassed, sortKey, sortDir]);
+  }, [report, filterUsers, filterCourses, filterLessons, filterExitReasons, filterQuizPassed, filterSyntheticKind, sortKey, sortDir]);
 
   const openEdit = (record: SuperAttendanceRecord) => {
     setEditRecord(record);
@@ -468,7 +479,7 @@ export default function AttendanceReportPage() {
               selected={filterQuizPassed}
               onChange={setFilterQuizPassed}
             />
-            {(filterUsers.size > 0 || filterCourses.size > 0 || filterLessons.size > 0 || filterExitReasons.size > 0 || filterQuizPassed.size > 0) && (
+            {(filterUsers.size > 0 || filterCourses.size > 0 || filterLessons.size > 0 || filterExitReasons.size > 0 || filterQuizPassed.size > 0 || filterSyntheticKind !== "all") && (
               <Button
                 variant="ghost"
                 size="sm"
@@ -479,11 +490,44 @@ export default function AttendanceReportPage() {
                   setFilterLessons(new Set());
                   setFilterExitReasons(new Set());
                   setFilterQuizPassed(new Set());
+                  setFilterSyntheticKind("all");
                 }}
               >
                 フィルタ解除
               </Button>
             )}
+          </div>
+
+          {/* session 種別フィルタ (#533 Phase 3 / #551): 既存「退室理由」フィルタとは独立 */}
+          <div className="flex flex-wrap items-center gap-2 mb-3 print:hidden">
+            <span className="text-xs text-muted-foreground">session 種別:</span>
+            <div
+              role="radiogroup"
+              aria-label="session 種別"
+              className="inline-flex rounded-md border"
+            >
+              {SYNTHETIC_KIND_OPTIONS.map((opt, i) => {
+                const active = filterSyntheticKind === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={active}
+                    onClick={() => setFilterSyntheticKind(opt.value)}
+                    className={`px-3 py-1 text-xs transition-colors ${
+                      active
+                        ? "bg-secondary text-secondary-foreground"
+                        : "hover:bg-muted/50"
+                    } ${i === 0 ? "rounded-l-md" : ""} ${
+                      i === SYNTHETIC_KIND_OPTIONS.length - 1 ? "rounded-r-md" : ""
+                    } ${i > 0 ? "border-l" : ""}`}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
           </div>
 
           {filteredRecords.length === 0 ? (
@@ -519,7 +563,18 @@ export default function AttendanceReportPage() {
                       <TableCell data-col="courseName" className="text-sm">{r.courseName}</TableCell>
                       <TableCell data-col="lessonTitle" className="max-w-[200px] truncate text-sm">{r.lessonTitle}</TableCell>
                       <TableCell data-col="date" className="whitespace-nowrap text-sm">{formatDate(r.entryAt)}</TableCell>
-                      <TableCell data-col="entryAt" className="whitespace-nowrap text-sm">{formatTime(r.entryAt)}</TableCell>
+                      <TableCell data-col="entryAt" className="whitespace-nowrap text-sm">
+                        {formatTime(r.entryAt)}
+                        {r.isSynthetic && (
+                          <Badge
+                            variant="outline"
+                            className="ml-1 border-amber-400 text-amber-700 print:border-black print:text-black"
+                            title="このセッションは合格提出から自動補完されました (#533 Phase 1/2)"
+                          >
+                            自動補完
+                          </Badge>
+                        )}
+                      </TableCell>
                       <TableCell data-col="exitAt" className="whitespace-nowrap text-sm">{formatTime(r.exitAt)}</TableCell>
                       <TableCell data-col="stayDuration" className="whitespace-nowrap text-sm">
                         {formatStayDuration(calculateStayDurationMs(r.entryAt, r.exitAt))}


### PR DESCRIPTION
## Summary

Issue #533 の **Phase 3 完結ピース**。Phase 1/2 で導入された `isSynthetic` provenance flag を出席レポート UI に露出し、運用補助・監査性を確保する。

- **背景**: Phase 1 (PR #537) で新規発生予防、Phase 2 (PR #539/#541) で過去 17 件遡及補正済。本 PR は補正済 session を視覚識別可能にする最終段階。
- **設計仕様書**: \`docs/specs/2026-06-09-phase3-synthetic-session-badge-design.md\` (PR #540 merged、Codex review 経由)

## 実装内容

### M1: shared-types (1 行)
- \`SuperAttendanceRecord.isSynthetic: boolean\` 追加

### M2: API (1 行 + integration test 4 ケース)
- \`super-admin.ts\` record builder: \`isSynthetic: data.isSynthetic === true\`
- **防御的マッピング**: Phase 1/2 投入前の既存 doc（フィールド欠落）は \`false\` に正規化

### M3: FE (~85 行 + unit test 6 ケース)
- \`entryAt\` セル横に「自動補完」バッジ（amber-tone、\`print:\` で border + text に切替で **PDF 印字耐性**確保）
- 新規「session 種別」segmented filter（\`all\` / \`synthetic_only\` / \`actual_only\`）— 既存「退室理由」フィルタとは独立
- \`matchesIsSyntheticFilter\` pure function + **\`never\` 型 exhaustive guard**（将来 \`SyntheticKind\` 拡張時の網羅漏れ検出、evaluator 指摘反映）

### M4: ~~Playwright UI E2E~~ → manual 確認に振替
- testing.md ルール「E2E は致命的ビジネス導線のみ、UI ロジックはコンポーネントテスト」に従い縮小
- 代替カバレッジ: M2 integration test (4 ケース) + M3 unit test (6 ケース) で API 整合性・フィルタロジックを担保
- バッジ表示 / PDF 印字は Test Plan の manual 確認で確認

### M5: ADR-027 改訂履歴に Phase 3 entry 追記

## 品質ゲート実行

- ✅ \`/safe-refactor\`: 問題 0 件 (HIGH/MED/LOW 全 0)
- ✅ \`/code-review medium\`: findings 0 件
- ✅ Evaluator 分離 (5+ ファイル発動): APPROVE、全 AC PASS。MEDIUM 1 件 (\`never\` exhaustive guard) → **修正反映済**

## テスト結果

| スイート | 結果 |
|---------|------|
| api unit/integration | **1658/1658** PASS (新規 4 ケース含む) |
| web unit | **298/298** PASS (新規 6 ケース含む) |
| type-check (api/web/shared-types) | ✅ PASS |

## スコープ外（明示記録）

- CSV エクスポート（super attendance は現状 PDF のみ）
- admin 側出席画面 (\`/admin/analytics/attendance/courses/:courseId\`、別系統 API)
- Firestore index 追加（サーバ側 \`isSynthetic\` query なし）
- フィルタ解除ボタンの DOM 配置最適化（evaluator LOW 指摘、UX 改善で本 PR スコープ外）

## Test plan

- [ ] CI (lint + test + type-check + build) PASS
- [ ] 本番 deploy 後、\`/super/attendance\` で Phase 2 補正済テナント (17 件) を表示し「自動補完」バッジが entryAt 横に表示されることを目視確認
- [ ] 「session 種別」フィルタで \`synthetic_only\` / \`actual_only\` の絞り込みが動作することを目視確認
- [ ] \`window.print()\` (PDF 出力) でバッジが border + text 色で印字されることを目視確認
- [ ] 新規テスト提出 (Phase 1 経由) で synthetic session が作成され、バッジ表示されることを目視確認（タイミングは開発者領分）

## 関連

- Closes #551
- Refs #533 (Phase 3 完結により本 Issue close 可能性あり、Phase 3 動作確認後に判断)
- 親 ADR: ADR-027-lesson-session-attendance.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)