### PR TITLE
test(super-attendance): PDF 出力 DOM 操作を pure function 化 + unit test 10 ケース追加

### DIFF
--- a/web/app/super/attendance/__tests__/pdf-print.test.ts
+++ b/web/app/super/attendance/__tests__/pdf-print.test.ts
@@ -1,0 +1,156 @@
+/**
+ * PDF 出力 (window.print()) DOM 操作 helper のテスト。
+ *
+ * Issue #252 (PDF 出力カラム選択) のロジックに対する regression catch。
+ * jsdom 環境で DOM API を直接操作してカバー。
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  applyPdfColumnHide,
+  restorePdfColumnDisplay,
+} from "../_helpers/pdf-print";
+
+const ALL_COLUMNS = [
+  "userName",
+  "courseName",
+  "lessonTitle",
+  "date",
+  "entryAt",
+  "exitAt",
+  "stayDuration",
+  "exitReason",
+  "quizScore",
+  "quizPassed",
+] as const;
+
+/** テーブル構造 (TableHead + 3 行の TableCell) を模した DOM を組み立てる。 */
+function buildTable(): HTMLElement {
+  const root = document.createElement("div");
+  // ヘッダー行 (data-col 付き th 相当の div)
+  for (const key of ALL_COLUMNS) {
+    const th = document.createElement("div");
+    th.setAttribute("data-col", key);
+    th.classList.add("th");
+    th.textContent = `H:${key}`;
+    root.appendChild(th);
+  }
+  // body 3 行 × 全カラム
+  for (let row = 0; row < 3; row += 1) {
+    for (const key of ALL_COLUMNS) {
+      const td = document.createElement("div");
+      td.setAttribute("data-col", key);
+      td.classList.add("td");
+      td.textContent = `R${row}:${key}`;
+      root.appendChild(td);
+    }
+  }
+  return root;
+}
+
+function visibleColumns(root: HTMLElement): string[] {
+  return Array.from(root.querySelectorAll<HTMLElement>("[data-col]"))
+    .filter((el) => el.style.display !== "none")
+    .map((el) => el.getAttribute("data-col") ?? "")
+    .filter((v, i, arr) => arr.indexOf(v) === i);
+}
+
+describe("applyPdfColumnHide", () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = buildTable();
+  });
+
+  it("全カラム選択 → 何も非表示にならず hidden 配列は空", () => {
+    const hidden = applyPdfColumnHide(root, ALL_COLUMNS, new Set(ALL_COLUMNS));
+    expect(hidden).toHaveLength(0);
+    expect(visibleColumns(root)).toEqual([...ALL_COLUMNS]);
+  });
+
+  it("一部選択解除 → 非選択カラムの全要素 (TableHead + 各 TableCell) が非表示", () => {
+    const selected = new Set<string>(["userName", "courseName", "date"]);
+    const hidden = applyPdfColumnHide(root, ALL_COLUMNS, selected);
+
+    // 非選択 7 カラム × 4 要素 (1 ヘッダー + 3 ボディ) = 28 要素が非表示
+    expect(hidden).toHaveLength(28);
+    expect(hidden.every((el) => el.style.display === "none")).toBe(true);
+    expect(visibleColumns(root)).toEqual(["userName", "courseName", "date"]);
+  });
+
+  it("全選択解除 → 全カラム (40 要素) 非表示", () => {
+    const hidden = applyPdfColumnHide(root, ALL_COLUMNS, new Set());
+    expect(hidden).toHaveLength(10 * 4); // 10 cols × 4 (1 head + 3 body)
+    expect(visibleColumns(root)).toEqual([]);
+  });
+
+  it("data-col 値が存在しないカラムキー指定 → エラーなく無視され他カラムに影響なし", () => {
+    const selected = new Set(ALL_COLUMNS);
+    const allWithGhost = [...ALL_COLUMNS, "nonexistent_col"];
+    const hidden = applyPdfColumnHide(root, allWithGhost, selected);
+    expect(hidden).toHaveLength(0);
+    expect(visibleColumns(root)).toEqual([...ALL_COLUMNS]);
+  });
+
+  it("data-col 重複要素 (TableHead + 複数 body row) → すべて非表示にされ hidden 配列に集約", () => {
+    const selected = new Set(ALL_COLUMNS.filter((k) => k !== "quizScore"));
+    const hidden = applyPdfColumnHide(root, ALL_COLUMNS, selected);
+    expect(hidden).toHaveLength(4); // 1 head + 3 body の合計 4 要素
+    expect(hidden.every((el) => el.getAttribute("data-col") === "quizScore")).toBe(true);
+  });
+
+  it("allColumnKeys の指定順に走査する (TableHead が先頭に来る hidden 配列を保証)", () => {
+    // 確認: hidden 配列の順は (col 順) × (DOM 順) になる
+    const selected = new Set<string>();
+    const allKeys = ["entryAt", "exitAt"] as const;
+    const hidden = applyPdfColumnHide(root, allKeys, selected);
+    const colsInOrder = hidden.map((el) => el.getAttribute("data-col"));
+    // entryAt の 4 要素 → exitAt の 4 要素
+    expect(colsInOrder).toEqual([
+      "entryAt", "entryAt", "entryAt", "entryAt",
+      "exitAt", "exitAt", "exitAt", "exitAt",
+    ]);
+  });
+});
+
+describe("restorePdfColumnDisplay", () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = buildTable();
+  });
+
+  it("非表示にした全要素の display を空文字に戻す", () => {
+    const hidden = applyPdfColumnHide(root, ALL_COLUMNS, new Set());
+    expect(hidden.every((el) => el.style.display === "none")).toBe(true);
+
+    restorePdfColumnDisplay(hidden);
+    expect(hidden.every((el) => el.style.display === "")).toBe(true);
+    expect(visibleColumns(root)).toEqual([...ALL_COLUMNS]);
+  });
+
+  it("空配列を渡しても安全 (no-op)", () => {
+    expect(() => restorePdfColumnDisplay([])).not.toThrow();
+  });
+
+  it("idempotent: 復元を 2 回呼んでも DOM 状態が変わらない (afterprint + setTimeout の二重発火対策)", () => {
+    const hidden = applyPdfColumnHide(root, ALL_COLUMNS, new Set(["userName"]));
+    restorePdfColumnDisplay(hidden);
+    const beforeStates = hidden.map((el) => el.style.display);
+
+    restorePdfColumnDisplay(hidden);
+    const afterStates = hidden.map((el) => el.style.display);
+
+    expect(afterStates).toEqual(beforeStates);
+    expect(afterStates.every((d) => d === "")).toBe(true);
+  });
+
+  it("一部要素を後から再度非表示にしても、残りの要素には影響なし (DOM 参照の独立性確認)", () => {
+    const hidden = applyPdfColumnHide(root, ALL_COLUMNS, new Set(["userName"]));
+    restorePdfColumnDisplay(hidden);
+    // 再度 1 要素だけ手動で非表示
+    hidden[0].style.display = "none";
+    expect(hidden[0].style.display).toBe("none");
+    expect(hidden.slice(1).every((el) => el.style.display === "")).toBe(true);
+  });
+});

--- a/web/app/super/attendance/_helpers/pdf-print.ts
+++ b/web/app/super/attendance/_helpers/pdf-print.ts
@@ -1,0 +1,43 @@
+/**
+ * PDF 出力 (window.print()) 時に非選択カラムを一時非表示にする DOM 操作 helper。
+ *
+ * Issue #252 (PDF 出力カラム選択) の `handlePrintPdf` から pure 関数を抽出して unit test 可能にしたもの。
+ * window.print() / afterprint event / setTimeout fallback / requestAnimationFrame 等の
+ * ブラウザ API 依存部分は呼び出し側 (page.tsx) に残し、本 helper は DOM 操作のみを担う。
+ */
+
+/**
+ * `rootEl` 配下の `[data-col="<key>"]` 要素のうち、`selectedColumnKeys` に含まれないものを
+ * `style.display = "none"` で一時非表示にする。
+ *
+ * @param rootEl 探索の起点となる HTMLElement（典型的には表全体を囲む div）
+ * @param allColumnKeys 全カラムキー（既知の data-col 値の列挙、表示順）
+ * @param selectedColumnKeys ユーザーが PDF 出力対象として選んだカラムキー集合
+ * @returns 非表示にした HTMLElement の配列（{@link restorePdfColumnDisplay} に渡して復元する）
+ */
+export function applyPdfColumnHide(
+  rootEl: HTMLElement,
+  allColumnKeys: readonly string[],
+  selectedColumnKeys: ReadonlySet<string>,
+): HTMLElement[] {
+  const hidden: HTMLElement[] = [];
+  for (const key of allColumnKeys) {
+    if (selectedColumnKeys.has(key)) continue;
+    const els = rootEl.querySelectorAll<HTMLElement>(`[data-col="${key}"]`);
+    els.forEach((el) => {
+      el.style.display = "none";
+      hidden.push(el);
+    });
+  }
+  return hidden;
+}
+
+/**
+ * {@link applyPdfColumnHide} で非表示にした要素群の `display` を空文字に戻して復元する。
+ * 空配列を渡しても安全（no-op）。idempotent（複数回呼んでも安全）。
+ */
+export function restorePdfColumnDisplay(hiddenElements: HTMLElement[]): void {
+  hiddenElements.forEach((el) => {
+    el.style.display = "";
+  });
+}

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -49,6 +49,10 @@ import {
   SYNTHETIC_KIND_OPTIONS,
   type SyntheticKind,
 } from "./_helpers/synthetic-filter";
+import {
+  applyPdfColumnHide,
+  restorePdfColumnDisplay,
+} from "./_helpers/pdf-print";
 
 type Tenant = { id: string; name: string };
 
@@ -371,17 +375,12 @@ export default function AttendanceReportPage() {
 
   const handlePrintPdf = () => {
     if (!tableRef.current) return;
-    // 非選択カラムを一時非表示
-    const hidden: HTMLElement[] = [];
-    for (const col of COLUMNS) {
-      if (!pdfColumns.has(col.key)) {
-        const els = tableRef.current.querySelectorAll<HTMLElement>(`[data-col="${col.key}"]`);
-        els.forEach((el) => {
-          el.style.display = "none";
-          hidden.push(el);
-        });
-      }
-    }
+    // 非選択カラムを一時非表示 (DOM 操作は helper に委譲して unit test 可能化)
+    const hidden = applyPdfColumnHide(
+      tableRef.current,
+      COLUMNS.map((c) => c.key),
+      pdfColumns,
+    );
     setPdfDialogOpen(false);
     // 次のフレームで印刷（ダイアログが閉じてから）
     requestAnimationFrame(() => {
@@ -389,7 +388,7 @@ export default function AttendanceReportPage() {
       const restore = () => {
         if (restored) return;
         restored = true;
-        hidden.forEach((el) => { el.style.display = ""; });
+        restorePdfColumnDisplay(hidden);
         window.removeEventListener("afterprint", restore);
       };
       window.addEventListener("afterprint", restore);


### PR DESCRIPTION
## Summary

Issue #533 close 時の最終点検で発覚した gap (PDF 出力ロジック \`handlePrintPdf\` の自動テストカバレッジゼロ) を補強する。

## 動機

- Issue #252 (PDFカラム選択) で実装された \`handlePrintPdf\` (web/app/super/attendance/page.tsx) には自動テストがなく、将来 PDF 機能改修時に regression が自動検出できない状態だった
- testing.md ルール「UI ロジックの網羅はコンポーネントテストで担保」に従い、DOM 操作部分を pure 関数に切り出して unit test 化

## 変更内容

### M1: pure function 切り出し (\`_helpers/pdf-print.ts\` 新規)

- \`applyPdfColumnHide(rootEl, allColumnKeys, selectedColumnKeys): HTMLElement[]\`
- \`restorePdfColumnDisplay(hiddenElements): void\`

window.print() / afterprint / setTimeout / requestAnimationFrame はブラウザ API 依存のため呼び出し側 (page.tsx) に残す。

### M2: page.tsx の handlePrintPdf を helper 呼び出しに置換

挙動変更なし、内部のロジック委譲のみ。

### M3: unit test 10 ケース (\`__tests__/pdf-print.test.ts\` 新規)

- 全選択 / 一部選択 / 全選択解除
- data-col 重複 (TableHead + body rows) → すべて非表示
- 存在しない data-col → エラーなく無視
- 走査順保証 (column 順 × DOM 順)
- 復元: 全要素 display 空文字化
- 空配列 safety
- **idempotency** (afterprint + setTimeout の二重発火対策)
- DOM 参照独立性

## テスト

| スイート | Before | After |
|---------|--------|-------|
| web unit | 292 | **302** (新規 10 ケース) |
| type-check | ✅ | ✅ |

## 関連

- 親 Issue: #533 (CLOSED) の最終点検で発覚した gap
- 既存実装: Issue #252 (CLOSED、PDF カラム選択機能)
- 設計準拠: testing.md「UI ロジックは pure function 化してコンポーネントテストで担保」

## Test plan

- [x] type-check PASS
- [x] web test 302/302 PASS (新規 10 ケース含む)
- [x] 既存挙動変更なし (handlePrintPdf 動作は本日 Playwright MCP で本番確認済、本 PR は内部リファクタのみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)