### PR TITLE
feat(super-attendance): 編集時の元データ snapshot 保持 + 「編集済」バッジ表示 (#556)

### DIFF
--- a/docs/adr/ADR-027-lesson-session-attendance.md
+++ b/docs/adr/ADR-027-lesson-session-attendance.md
@@ -10,7 +10,13 @@
 
   **データ保管方式の判断根拠**: A. snapshot のみ（採用）/ B. edit_log サブコレクション（将来複数管理者・コンプライアンス要件出現時に検討）/ C. A + B ハイブリッド（完全監査要件時）の 3 案を検討し、現状スーパー管理者は単一（`system@279279.net`）で複数管理者・編集理由記録の運用要件がないため、最小工数で「最初の値」を温存する A 案を採用。将来 B が必要になった際は snapshot を「最初の編集前の値」として保持しつつ edit_log を追加できる構造を維持。
 
-  **テスト**: API integration test 5 ケース（初回 snapshot 保存 / 2 回目以降 immutable / quiz_attempts fallback fetch / GET レスポンスで original + editedAt 返却 / 既存データ original 欠落時の防御マップ）+ FE unit test 8 ケース（`hasOriginalSnapshot` / `formatOriginalTooltip`、JST 時刻表示 / 不合格 / 未受験 / null 値）+ manual 確認（Playwright MCP で画面表示 + print emulate）。
+  **transaction 化（Codex review BLOCK MERGE → 修正反映）**: 当初 `sessionRef.get()` → `quiz_attempts` fallback fetch → `sessionRef.update()` → `attemptRef.update()` を逐次実行していたが、Codex review が並列 PATCH での race condition を指摘（2 つの PATCH が同時に `original` 欠落状態を読み、片方の snapshot を後勝ちで上書きできてしまう）。本実装では PATCH 全体を `db.runTransaction` 内で atomic 実行し、Firestore 内部の楽観ロック + 自動 retry により先行 PATCH が `original` を書いた場合は再実行で `isFirstEdit=false` として正しく扱われる。これにより「初回値 immutable」の audit 前提を保証。
+
+  **最終時刻整合性検証（Codex review Medium → 修正反映）**: 既存 validation は `entryAt` と `exitAt` 両方を含む PATCH のみで `entryAt <= exitAt` を検証していたが、片方だけ送信時に既存値と組み合わせて不正な時系列（entryAt > 既存 exitAt 等）になるケースがあった。transaction 内で `finalEntryAt = req.entryAt ?? current.entryAt` / `finalExitAt = req.exitAt ?? current.exitAt` を組み立てて `finalEntryAt > finalExitAt` を検出し 400 で reject する。行政提出データの整合性確保。
+
+  **PDF 出力時のフィルタ条件明示（Codex review Low → 修正反映）**: 既存の印刷専用ヘッダー（`print:block hidden`）に対象件数・抽出条件のサマリーを追加。フィルタ UI 自体は `print:hidden` のままだが、PDF 上で「全件か抽出か」「どの条件で抽出したか」が明示されるため、提出資料としての中立性が高まる。
+
+  **テスト**: API integration test 9 ケース（初回 snapshot 保存 / 2 回目以降 immutable / null 直書き判定 / quizAttemptId なし / quiz_attempts fallback fetch / GET レスポンスで original + editedAt 返却 / 既存データ original 欠落時の防御マップ / entryAt のみ送信時の時刻整合性 / exitAt のみ送信時の時刻整合性）+ FE unit test 9 ケース（`hasOriginalSnapshot` 4 + `formatOriginalTooltip` 5、JST 時刻表示 / 不合格 / 未受験 / null 値 / 型述語 narrowing）+ manual 確認（Playwright MCP で編集 → バッジ表示 + tooltip + print emulate）。
 
 - **2026-06-10 (Phase 3 follow-up, #533)**: **動機**: Phase 3 で導入した「自動補完」バッジが PDF 出力 (`window.print()`) 時にも印字されることが、外部 (行政等) への提出資料として用いる際に「補正データである」ことを過剰に明示してしまい、提出物の正当性に疑念を生じさせる懸念が判明（補正データは実際にテスト合格した受講者の正規記録だが、PDF 上で「自動補完」と注記されると行政側に「実際の入室記録ではない」と誤解される可能性）。
 

--- a/docs/adr/ADR-027-lesson-session-attendance.md
+++ b/docs/adr/ADR-027-lesson-session-attendance.md
@@ -1,9 +1,17 @@
 # ADR-027: レッスンセッション出席管理
 
 ## ステータス
-承認済み（2026-06-10 改訂: PDF 印字時バッジ非表示化 #533 follow-up / 2026-06-09 改訂: isSynthetic provenance flag 追加 #533 + Phase 3 可視化 #551 / 2026-05-21 改訂: 再視聴中の完了経験者救済ケース E' / 2026-05-16 改訂: セッション上限を環境変数化）
+承認済み（2026-06-10 改訂: 編集前 original snapshot 保持 #556 / 2026-06-10 改訂: PDF 印字時バッジ非表示化 #533 follow-up / 2026-06-09 改訂: isSynthetic provenance flag 追加 #533 + Phase 3 可視化 #551 / 2026-05-21 改訂: 再視聴中の完了経験者救済ケース E' / 2026-05-16 改訂: セッション上限を環境変数化）
 
 ## 改訂履歴
+- **2026-06-10 (Phase 3 follow-up #2, #556)**: **動機**: 出席・テスト結果レポートを行政提出資料として PDF 出力する運用において、不自然な滞在時間（補正データの 0 分、`time_limit` 強制退出の数十時間等）を手動編集する需要が判明。既存の編集機能 (`PATCH /super/tenants/:tenantId/attendance-report/:sessionId`) は実装済みだが、編集後は元の値が完全に上書きされ、データの真実性追跡が失われる課題があった。
+
+  **変更内容**: `lesson_sessions` に **`original: { entryAt, exitAt, quizScore, quizPassed }`** フィールド（編集前 immutable snapshot）と **`editedAt: string`**（最後の編集時刻）を追加。初回 PATCH 時に `original` が未設定なら現在値を snapshot として保存し、以降の PATCH では `original` を変更しない（immutable）。quiz 値は session 側に書かれていないケースが多いため、`quizAttemptId` から quiz_attempts ドキュメントを fallback fetch して snapshot に含める。FE は `SuperAttendanceRecord.original?` / `editedAt?` を利用して「編集済」バッジ（sky-tone、`entryAt` セル横、「自動補完」バッジと並列表示可）を表示、tooltip で元データ（編集前の入退室時刻 / 点数 / 合否）を提示。`print:hidden` で PDF 出力時はバッジ非表示（Phase 3 follow-up と同方針、行政提出時の中立性確保）。
+
+  **データ保管方式の判断根拠**: A. snapshot のみ（採用）/ B. edit_log サブコレクション（将来複数管理者・コンプライアンス要件出現時に検討）/ C. A + B ハイブリッド（完全監査要件時）の 3 案を検討し、現状スーパー管理者は単一（`system@279279.net`）で複数管理者・編集理由記録の運用要件がないため、最小工数で「最初の値」を温存する A 案を採用。将来 B が必要になった際は snapshot を「最初の編集前の値」として保持しつつ edit_log を追加できる構造を維持。
+
+  **テスト**: API integration test 5 ケース（初回 snapshot 保存 / 2 回目以降 immutable / quiz_attempts fallback fetch / GET レスポンスで original + editedAt 返却 / 既存データ original 欠落時の防御マップ）+ FE unit test 8 ケース（`hasOriginalSnapshot` / `formatOriginalTooltip`、JST 時刻表示 / 不合格 / 未受験 / null 値）+ manual 確認（Playwright MCP で画面表示 + print emulate）。
+
 - **2026-06-10 (Phase 3 follow-up, #533)**: **動機**: Phase 3 で導入した「自動補完」バッジが PDF 出力 (`window.print()`) 時にも印字されることが、外部 (行政等) への提出資料として用いる際に「補正データである」ことを過剰に明示してしまい、提出物の正当性に疑念を生じさせる懸念が判明（補正データは実際にテスト合格した受講者の正規記録だが、PDF 上で「自動補完」と注記されると行政側に「実際の入室記録ではない」と誤解される可能性）。
 
   **変更内容**: バッジ className に Tailwind `print:hidden` を追加し、`@media print` 時にバッジ要素全体を `display: none` にする。画面表示時 (内部監査・運用補助) は引き続きバッジ表示を維持。`print:border-black` / `print:text-black` (Phase 3 で追加した PDF 印字耐性スタイル) は不要となるため削除しシンプル化。

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -160,6 +160,8 @@ questions配列の各要素:
 | sessionVideoCompleted | boolean | セッション内で動画完了したか |
 | quizAttemptId | string? | 完了時のテストattempt ID |
 | isSynthetic | boolean? | provenance flag。`true` の場合、`activeSession=null` の合格提出時にシステムが自動補完した合成 session であることを示す（ADR-027 §改訂履歴 2026-06-09 / #533 Phase 1/2）。doc id 規約: 合成は `synthetic_{attemptId}`、実 session は Firestore 自動採番 |
+| original | object? | 編集前 immutable snapshot。初回 PATCH 時に `{ entryAt, exitAt, quizScore, quizPassed }` を記録、以降の編集では不変。未編集なら欠落。UI 上「編集済」バッジの表示判定・tooltip 元データ表示に使用（ADR-027 §改訂履歴 2026-06-10 / #556） |
+| editedAt | string? (ISO8601) | 最後の編集時刻。各 PATCH ごとに更新される。未編集なら欠落（#556） |
 | createdAt | Timestamp | 作成日時 |
 | updatedAt | Timestamp | 更新日時 |
 

--- a/packages/shared-types/src/attendance.ts
+++ b/packages/shared-types/src/attendance.ts
@@ -59,6 +59,18 @@ export interface SuperAttendanceRecord {
   quizPassed: boolean | null;
   quizSubmittedAt: string | null;
   isSynthetic: boolean;
+  /**
+   * 編集前の値の immutable snapshot（初回 PATCH 時に記録、以降不変）。Issue #556。
+   * フィールドが存在しない場合 (`undefined`)、当該レコードは未編集または Phase 3 follow-up 投入前データ。
+   */
+  original?: {
+    entryAt: string | null;
+    exitAt: string | null;
+    quizScore: number | null;
+    quizPassed: boolean | null;
+  };
+  /** 最後の編集時刻 (ISO8601)。未編集の場合 `undefined`。Issue #556。 */
+  editedAt?: string;
 }
 
 export interface SuperAttendanceResponse {

--- a/services/api/src/__tests__/integration/attendance-original-snapshot.test.ts
+++ b/services/api/src/__tests__/integration/attendance-original-snapshot.test.ts
@@ -2,9 +2,11 @@
  * PATCH /attendance-report/:sessionId の original snapshot 保存ロジックと
  * GET レスポンスの original / editedAt 返却を検証する。
  *
- * Issue #556: 編集時に元データを immutable snapshot として保持する。
+ * Issue #556 + Codex review:
  *   - 初回 PATCH: original 未設定 → 現在値を snapshot 保存 + editedAt 記録
  *   - 2 回目以降 PATCH: original 不変 (immutable)、editedAt のみ更新
+ *   - PATCH 全体が Firestore transaction 内で atomic 実行 (race condition 対策)
+ *   - 最終 entryAt/exitAt の整合性検証 (片方だけ送信時も既存値と比較)
  *   - 既存データ (original 欠落): GET レスポンスで undefined を返す
  */
 
@@ -12,18 +14,16 @@ import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import supertest from "supertest";
 import express from "express";
 
-// PATCH 経由で update が呼ばれた引数を記録するための spy
-const sessionUpdateSpy = vi.fn(() => Promise.resolve());
-const attemptUpdateSpy = vi.fn(() => Promise.resolve());
+// transaction 内の tx.get / tx.update が呼ばれた引数を記録する spy
+const txUpdateSpy = vi.fn();
+const txGetSpy = vi.fn();
 
-// session ドキュメントの可変状態（テストごとに beforeEach でリセット）
+// session ドキュメントの可変状態 (テストごとに beforeEach でリセット)
 type SessionDocState = {
   exists: boolean;
   data: Record<string, unknown>;
 };
 let sessionDocState: SessionDocState;
-
-// quiz_attempts ドキュメントの可変状態
 let attemptDocState: SessionDocState;
 
 // GET レスポンス用 lesson_sessions snapshot
@@ -49,6 +49,24 @@ function makeQuery(snapshot: ReturnType<typeof makeSnapshot>) {
 
 vi.mock("firebase-admin/firestore", () => ({
   getFirestore: vi.fn(() => ({
+    runTransaction: vi.fn(async (callback: (tx: { get: typeof txGetSpy; update: typeof txUpdateSpy }) => Promise<void>) => {
+      // tx.get は ref のパスから判定して session/attempt の状態を返す
+      txGetSpy.mockImplementation(async (ref: unknown) => {
+        const path = (ref as { _path?: string })._path ?? "";
+        if (path.includes("/quiz_attempts/")) {
+          return {
+            exists: attemptDocState.exists,
+            data: () => attemptDocState.data,
+          };
+        }
+        // session doc 扱い
+        return {
+          exists: sessionDocState.exists,
+          data: () => sessionDocState.data,
+        };
+      });
+      await callback({ get: txGetSpy, update: txUpdateSpy });
+    }),
     collection: vi.fn((path: string) => {
       if (path === "tenants") {
         return {
@@ -65,23 +83,15 @@ vi.mock("firebase-admin/firestore", () => ({
             }),
             get: vi.fn(() => Promise.resolve(makeSnapshot(sessionsSnapshotDocs))),
           })),
-          doc: vi.fn(() => ({
-            get: vi.fn(() => Promise.resolve({
-              exists: sessionDocState.exists,
-              data: () => sessionDocState.data,
-            })),
-            update: sessionUpdateSpy,
+          doc: vi.fn((sid: string) => ({
+            _path: `${path}/${sid}`,
           })),
         };
       }
       if (path.endsWith("/quiz_attempts")) {
         return {
-          doc: vi.fn(() => ({
-            get: vi.fn(() => Promise.resolve({
-              exists: attemptDocState.exists,
-              data: () => attemptDocState.data,
-            })),
-            update: attemptUpdateSpy,
+          doc: vi.fn((aid: string) => ({
+            _path: `${path}/${aid}`,
           })),
           where: vi.fn(() => ({
             get: vi.fn(() => Promise.resolve(makeSnapshot([]))),
@@ -111,7 +121,16 @@ vi.mock("../../middleware/super-admin.js", () => ({
   isSuperAdmin: vi.fn(() => Promise.resolve(false)),
 }));
 
-describe("PATCH original snapshot 保存 (#556 Issue)", () => {
+/** txUpdateSpy の calls から session 更新 (path に /lesson_sessions/ を含む) の引数を抽出する。 */
+function getSessionUpdateArg(): Record<string, unknown> | undefined {
+  const call = txUpdateSpy.mock.calls.find((c) => {
+    const ref = c[0] as { _path?: string };
+    return ref._path?.includes("/lesson_sessions/");
+  });
+  return call?.[1] as Record<string, unknown> | undefined;
+}
+
+describe("PATCH original snapshot 保存 + transaction (#556 + Codex review)", () => {
   let request: ReturnType<typeof supertest>;
 
   beforeAll(async () => {
@@ -123,8 +142,8 @@ describe("PATCH original snapshot 保存 (#556 Issue)", () => {
   }, 30_000);
 
   beforeEach(() => {
-    sessionUpdateSpy.mockClear();
-    attemptUpdateSpy.mockClear();
+    txUpdateSpy.mockClear();
+    txGetSpy.mockClear();
   });
 
   it("AC1: 初回編集時 → 現在値を original snapshot として保存 + editedAt 記録", async () => {
@@ -137,7 +156,6 @@ describe("PATCH original snapshot 保存 (#556 Issue)", () => {
         quizScore: 100,
         quizPassed: true,
         quizAttemptId: "attempt-1",
-        // original 未設定
       },
     };
     attemptDocState = { exists: false, data: {} };
@@ -147,16 +165,15 @@ describe("PATCH original snapshot 保存 (#556 Issue)", () => {
       .send({ entryAt: "2026-06-09T01:00:00.000Z", exitAt: "2026-06-09T01:45:00.000Z" });
 
     expect(res.status).toBe(200);
-    expect(sessionUpdateSpy).toHaveBeenCalled();
-    const updateArg = sessionUpdateSpy.mock.calls[0][0] as Record<string, unknown>;
-    expect(updateArg.original).toEqual({
+    const updateArg = getSessionUpdateArg();
+    expect(updateArg?.original).toEqual({
       entryAt: "2026-06-09T01:00:00.000Z",
       exitAt: "2026-06-09T01:30:00.000Z",
       quizScore: 100,
       quizPassed: true,
     });
-    expect(typeof updateArg.editedAt).toBe("string");
-    expect(updateArg.exitAt).toBe("2026-06-09T01:45:00.000Z");
+    expect(typeof updateArg?.editedAt).toBe("string");
+    expect(updateArg?.exitAt).toBe("2026-06-09T01:45:00.000Z");
   });
 
   it("AC2: 2 回目以降 PATCH → original を更新フィールドに含めない (immutable)、editedAt のみ更新", async () => {
@@ -182,10 +199,10 @@ describe("PATCH original snapshot 保存 (#556 Issue)", () => {
       .send({ exitAt: "2026-06-09T02:45:00.000Z" });
 
     expect(res.status).toBe(200);
-    const updateArg = sessionUpdateSpy.mock.calls[0][0] as Record<string, unknown>;
-    expect("original" in updateArg).toBe(false);
-    expect(typeof updateArg.editedAt).toBe("string");
-    expect(updateArg.editedAt).not.toBe("2026-06-09T10:00:00.000Z");
+    const updateArg = getSessionUpdateArg();
+    expect(updateArg && "original" in updateArg).toBe(false);
+    expect(typeof updateArg?.editedAt).toBe("string");
+    expect(updateArg?.editedAt).not.toBe("2026-06-09T10:00:00.000Z");
   });
 
   it("Evaluator 指摘: original=null の doc は初回扱い (== null 判定で undefined と null 両対応)", async () => {
@@ -195,7 +212,7 @@ describe("PATCH original snapshot 保存 (#556 Issue)", () => {
         userId: "user-1",
         entryAt: "2026-06-09T01:00:00.000Z",
         exitAt: "2026-06-09T01:30:00.000Z",
-        original: null, // 手動 null 直書きされたケース
+        original: null,
       },
     };
     attemptDocState = { exists: false, data: {} };
@@ -205,9 +222,8 @@ describe("PATCH original snapshot 保存 (#556 Issue)", () => {
       .send({ exitAt: "2026-06-09T01:45:00.000Z" });
 
     expect(res.status).toBe(200);
-    const updateArg = sessionUpdateSpy.mock.calls[0][0] as Record<string, unknown>;
-    // null の場合も初回扱いで snapshot が保存される (Evaluator 検出: === undefined のみだとすり抜ける)
-    expect(updateArg.original).toBeDefined();
+    const updateArg = getSessionUpdateArg();
+    expect(updateArg?.original).toBeDefined();
   });
 
   it("Evaluator 指摘: quizAttemptId なし + quiz 値 null の初回 PATCH → snapshot の quiz 値は null のまま保存", async () => {
@@ -217,7 +233,6 @@ describe("PATCH original snapshot 保存 (#556 Issue)", () => {
         userId: "user-1",
         entryAt: "2026-06-09T01:00:00.000Z",
         exitAt: "2026-06-09T01:30:00.000Z",
-        // quizAttemptId なし、quizScore/quizPassed も未設定
       },
     };
     attemptDocState = { exists: false, data: {} };
@@ -227,8 +242,8 @@ describe("PATCH original snapshot 保存 (#556 Issue)", () => {
       .send({ entryAt: "2026-06-09T00:30:00.000Z" });
 
     expect(res.status).toBe(200);
-    const updateArg = sessionUpdateSpy.mock.calls[0][0] as Record<string, unknown>;
-    expect(updateArg.original).toEqual({
+    const updateArg = getSessionUpdateArg();
+    expect(updateArg?.original).toEqual({
       entryAt: "2026-06-09T01:00:00.000Z",
       exitAt: "2026-06-09T01:30:00.000Z",
       quizScore: null,
@@ -256,13 +271,51 @@ describe("PATCH original snapshot 保存 (#556 Issue)", () => {
       .send({ exitAt: "2026-06-09T03:30:00.000Z" });
 
     expect(res.status).toBe(200);
-    const updateArg = sessionUpdateSpy.mock.calls[0][0] as Record<string, unknown>;
-    expect(updateArg.original).toEqual({
+    const updateArg = getSessionUpdateArg();
+    expect(updateArg?.original).toEqual({
       entryAt: "2026-06-09T03:00:00.000Z",
       exitAt: "2026-06-09T03:15:00.000Z",
       quizScore: 90,
       quizPassed: true,
     });
+  });
+
+  it("Codex Medium: entryAt のみ送信で既存 exitAt より後ろになる → 400 invalid_time_range", async () => {
+    sessionDocState = {
+      exists: true,
+      data: {
+        userId: "user-1",
+        entryAt: "2026-06-09T01:00:00.000Z",
+        exitAt: "2026-06-09T02:00:00.000Z",
+      },
+    };
+    attemptDocState = { exists: false, data: {} };
+
+    const res = await request
+      .patch("/tenants/test-tenant/attendance-report/sess-4")
+      .send({ entryAt: "2026-06-09T03:00:00.000Z" }); // exitAt より後ろ
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_time_range");
+  });
+
+  it("Codex Medium: exitAt のみ送信で既存 entryAt より前になる → 400 invalid_time_range", async () => {
+    sessionDocState = {
+      exists: true,
+      data: {
+        userId: "user-1",
+        entryAt: "2026-06-09T02:00:00.000Z",
+        exitAt: "2026-06-09T03:00:00.000Z",
+      },
+    };
+    attemptDocState = { exists: false, data: {} };
+
+    const res = await request
+      .patch("/tenants/test-tenant/attendance-report/sess-5")
+      .send({ exitAt: "2026-06-09T01:00:00.000Z" }); // entryAt より前
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_time_range");
   });
 });
 
@@ -319,7 +372,6 @@ describe("GET /attendance-report レスポンスの original/editedAt 返却 (#5
         entryAt: "2026-06-09T06:00:00.000Z",
         exitAt: "2026-06-09T06:30:00.000Z",
         status: "completed",
-        // original / editedAt 欠落
       },
     }];
 

--- a/services/api/src/__tests__/integration/attendance-original-snapshot.test.ts
+++ b/services/api/src/__tests__/integration/attendance-original-snapshot.test.ts
@@ -1,0 +1,332 @@
+/**
+ * PATCH /attendance-report/:sessionId の original snapshot 保存ロジックと
+ * GET レスポンスの original / editedAt 返却を検証する。
+ *
+ * Issue #556: 編集時に元データを immutable snapshot として保持する。
+ *   - 初回 PATCH: original 未設定 → 現在値を snapshot 保存 + editedAt 記録
+ *   - 2 回目以降 PATCH: original 不変 (immutable)、editedAt のみ更新
+ *   - 既存データ (original 欠落): GET レスポンスで undefined を返す
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import supertest from "supertest";
+import express from "express";
+
+// PATCH 経由で update が呼ばれた引数を記録するための spy
+const sessionUpdateSpy = vi.fn(() => Promise.resolve());
+const attemptUpdateSpy = vi.fn(() => Promise.resolve());
+
+// session ドキュメントの可変状態（テストごとに beforeEach でリセット）
+type SessionDocState = {
+  exists: boolean;
+  data: Record<string, unknown>;
+};
+let sessionDocState: SessionDocState;
+
+// quiz_attempts ドキュメントの可変状態
+let attemptDocState: SessionDocState;
+
+// GET レスポンス用 lesson_sessions snapshot
+let sessionsSnapshotDocs: { id: string; data: Record<string, unknown> }[] = [];
+
+function makeSnapshot(docs: { id: string; data: Record<string, unknown> }[]) {
+  return {
+    docs: docs.map((d) => ({
+      id: d.id,
+      data: () => d.data,
+    })),
+  };
+}
+
+function makeQuery(snapshot: ReturnType<typeof makeSnapshot>) {
+  const queryObj: Record<string, unknown> = {
+    orderBy: vi.fn(() => queryObj),
+    where: vi.fn(() => queryObj),
+    get: vi.fn(() => Promise.resolve(snapshot)),
+  };
+  return queryObj;
+}
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: vi.fn(() => ({
+    collection: vi.fn((path: string) => {
+      if (path === "tenants") {
+        return {
+          doc: vi.fn(() => ({
+            get: vi.fn(() => Promise.resolve({ exists: true, data: () => ({ name: "Test Tenant" }) })),
+          })),
+        };
+      }
+      if (path.endsWith("/lesson_sessions")) {
+        return {
+          orderBy: vi.fn(() => ({
+            where: vi.fn(function (this: unknown) {
+              return this;
+            }),
+            get: vi.fn(() => Promise.resolve(makeSnapshot(sessionsSnapshotDocs))),
+          })),
+          doc: vi.fn(() => ({
+            get: vi.fn(() => Promise.resolve({
+              exists: sessionDocState.exists,
+              data: () => sessionDocState.data,
+            })),
+            update: sessionUpdateSpy,
+          })),
+        };
+      }
+      if (path.endsWith("/quiz_attempts")) {
+        return {
+          doc: vi.fn(() => ({
+            get: vi.fn(() => Promise.resolve({
+              exists: attemptDocState.exists,
+              data: () => attemptDocState.data,
+            })),
+            update: attemptUpdateSpy,
+          })),
+          where: vi.fn(() => ({
+            get: vi.fn(() => Promise.resolve(makeSnapshot([]))),
+          })),
+        };
+      }
+      if (path.endsWith("/users") || path.endsWith("/lessons") || path.endsWith("/courses")) {
+        return makeQuery(makeSnapshot([]));
+      }
+      return makeQuery(makeSnapshot([]));
+    }),
+  })),
+}));
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: vi.fn(() => ({
+    verifyIdToken: vi.fn(),
+    getUserByEmail: vi.fn(() => Promise.reject(new Error("not found"))),
+  })),
+}));
+
+vi.mock("../../middleware/super-admin.js", () => ({
+  superAdminAuthMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  getAllSuperAdmins: vi.fn(() => Promise.resolve([])),
+  addSuperAdmin: vi.fn(),
+  removeSuperAdmin: vi.fn(),
+  isSuperAdmin: vi.fn(() => Promise.resolve(false)),
+}));
+
+describe("PATCH original snapshot 保存 (#556 Issue)", () => {
+  let request: ReturnType<typeof supertest>;
+
+  beforeAll(async () => {
+    const { superAdminRouter } = await import("../../routes/super-admin.js");
+    const app = express();
+    app.use(express.json());
+    app.use(superAdminRouter);
+    request = supertest(app);
+  }, 30_000);
+
+  beforeEach(() => {
+    sessionUpdateSpy.mockClear();
+    attemptUpdateSpy.mockClear();
+  });
+
+  it("AC1: 初回編集時 → 現在値を original snapshot として保存 + editedAt 記録", async () => {
+    sessionDocState = {
+      exists: true,
+      data: {
+        userId: "user-1",
+        entryAt: "2026-06-09T01:00:00.000Z",
+        exitAt: "2026-06-09T01:30:00.000Z",
+        quizScore: 100,
+        quizPassed: true,
+        quizAttemptId: "attempt-1",
+        // original 未設定
+      },
+    };
+    attemptDocState = { exists: false, data: {} };
+
+    const res = await request
+      .patch("/tenants/test-tenant/attendance-report/sess-1")
+      .send({ entryAt: "2026-06-09T01:00:00.000Z", exitAt: "2026-06-09T01:45:00.000Z" });
+
+    expect(res.status).toBe(200);
+    expect(sessionUpdateSpy).toHaveBeenCalled();
+    const updateArg = sessionUpdateSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(updateArg.original).toEqual({
+      entryAt: "2026-06-09T01:00:00.000Z",
+      exitAt: "2026-06-09T01:30:00.000Z",
+      quizScore: 100,
+      quizPassed: true,
+    });
+    expect(typeof updateArg.editedAt).toBe("string");
+    expect(updateArg.exitAt).toBe("2026-06-09T01:45:00.000Z");
+  });
+
+  it("AC2: 2 回目以降 PATCH → original を更新フィールドに含めない (immutable)、editedAt のみ更新", async () => {
+    sessionDocState = {
+      exists: true,
+      data: {
+        userId: "user-1",
+        entryAt: "2026-06-09T02:00:00.000Z",
+        exitAt: "2026-06-09T02:30:00.000Z",
+        original: {
+          entryAt: "2026-06-09T01:00:00.000Z",
+          exitAt: "2026-06-09T01:30:00.000Z",
+          quizScore: 80,
+          quizPassed: true,
+        },
+        editedAt: "2026-06-09T10:00:00.000Z",
+      },
+    };
+    attemptDocState = { exists: false, data: {} };
+
+    const res = await request
+      .patch("/tenants/test-tenant/attendance-report/sess-2")
+      .send({ exitAt: "2026-06-09T02:45:00.000Z" });
+
+    expect(res.status).toBe(200);
+    const updateArg = sessionUpdateSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect("original" in updateArg).toBe(false);
+    expect(typeof updateArg.editedAt).toBe("string");
+    expect(updateArg.editedAt).not.toBe("2026-06-09T10:00:00.000Z");
+  });
+
+  it("Evaluator 指摘: original=null の doc は初回扱い (== null 判定で undefined と null 両対応)", async () => {
+    sessionDocState = {
+      exists: true,
+      data: {
+        userId: "user-1",
+        entryAt: "2026-06-09T01:00:00.000Z",
+        exitAt: "2026-06-09T01:30:00.000Z",
+        original: null, // 手動 null 直書きされたケース
+      },
+    };
+    attemptDocState = { exists: false, data: {} };
+
+    const res = await request
+      .patch("/tenants/test-tenant/attendance-report/sess-null")
+      .send({ exitAt: "2026-06-09T01:45:00.000Z" });
+
+    expect(res.status).toBe(200);
+    const updateArg = sessionUpdateSpy.mock.calls[0][0] as Record<string, unknown>;
+    // null の場合も初回扱いで snapshot が保存される (Evaluator 検出: === undefined のみだとすり抜ける)
+    expect(updateArg.original).toBeDefined();
+  });
+
+  it("Evaluator 指摘: quizAttemptId なし + quiz 値 null の初回 PATCH → snapshot の quiz 値は null のまま保存", async () => {
+    sessionDocState = {
+      exists: true,
+      data: {
+        userId: "user-1",
+        entryAt: "2026-06-09T01:00:00.000Z",
+        exitAt: "2026-06-09T01:30:00.000Z",
+        // quizAttemptId なし、quizScore/quizPassed も未設定
+      },
+    };
+    attemptDocState = { exists: false, data: {} };
+
+    const res = await request
+      .patch("/tenants/test-tenant/attendance-report/sess-no-quiz")
+      .send({ entryAt: "2026-06-09T00:30:00.000Z" });
+
+    expect(res.status).toBe(200);
+    const updateArg = sessionUpdateSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(updateArg.original).toEqual({
+      entryAt: "2026-06-09T01:00:00.000Z",
+      exitAt: "2026-06-09T01:30:00.000Z",
+      quizScore: null,
+      quizPassed: null,
+    });
+  });
+
+  it("AC1 拡張: session に quiz 値なし + quiz_attempts に値あり → attempt から fallback 取得して snapshot", async () => {
+    sessionDocState = {
+      exists: true,
+      data: {
+        userId: "user-1",
+        entryAt: "2026-06-09T03:00:00.000Z",
+        exitAt: "2026-06-09T03:15:00.000Z",
+        quizAttemptId: "attempt-2",
+      },
+    };
+    attemptDocState = {
+      exists: true,
+      data: { score: 90, isPassed: true },
+    };
+
+    const res = await request
+      .patch("/tenants/test-tenant/attendance-report/sess-3")
+      .send({ exitAt: "2026-06-09T03:30:00.000Z" });
+
+    expect(res.status).toBe(200);
+    const updateArg = sessionUpdateSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(updateArg.original).toEqual({
+      entryAt: "2026-06-09T03:00:00.000Z",
+      exitAt: "2026-06-09T03:15:00.000Z",
+      quizScore: 90,
+      quizPassed: true,
+    });
+  });
+});
+
+describe("GET /attendance-report レスポンスの original/editedAt 返却 (#556)", () => {
+  let request: ReturnType<typeof supertest>;
+
+  beforeAll(async () => {
+    const { superAdminRouter } = await import("../../routes/super-admin.js");
+    const app = express();
+    app.use(express.json());
+    app.use(superAdminRouter);
+    request = supertest(app);
+  }, 30_000);
+
+  it("AC3: 編集済 doc (original あり) → レスポンスに original + editedAt が含まれる", async () => {
+    sessionsSnapshotDocs = [{
+      id: "sess-edited",
+      data: {
+        userId: "user-1",
+        courseId: "course-1",
+        lessonId: "lesson-1",
+        entryAt: "2026-06-09T05:00:00.000Z",
+        exitAt: "2026-06-09T05:30:00.000Z",
+        status: "completed",
+        original: {
+          entryAt: "2026-06-09T04:00:00.000Z",
+          exitAt: "2026-06-09T04:05:00.000Z",
+          quizScore: 100,
+          quizPassed: true,
+        },
+        editedAt: "2026-06-09T20:00:00.000Z",
+      },
+    }];
+
+    const res = await request.get("/tenants/test-tenant/attendance-report");
+    expect(res.status).toBe(200);
+    const record = res.body.records[0];
+    expect(record.original).toEqual({
+      entryAt: "2026-06-09T04:00:00.000Z",
+      exitAt: "2026-06-09T04:05:00.000Z",
+      quizScore: 100,
+      quizPassed: true,
+    });
+    expect(record.editedAt).toBe("2026-06-09T20:00:00.000Z");
+  });
+
+  it("AC4: 未編集 doc (original 欠落) → レスポンスで original / editedAt は undefined", async () => {
+    sessionsSnapshotDocs = [{
+      id: "sess-unedited",
+      data: {
+        userId: "user-1",
+        courseId: "course-1",
+        lessonId: "lesson-1",
+        entryAt: "2026-06-09T06:00:00.000Z",
+        exitAt: "2026-06-09T06:30:00.000Z",
+        status: "completed",
+        // original / editedAt 欠落
+      },
+    }];
+
+    const res = await request.get("/tenants/test-tenant/attendance-report");
+    expect(res.status).toBe(200);
+    const record = res.body.records[0];
+    expect(record.original).toBeUndefined();
+    expect(record.editedAt).toBeUndefined();
+  });
+});

--- a/services/api/src/__tests__/integration/attendance-validation.test.ts
+++ b/services/api/src/__tests__/integration/attendance-validation.test.ts
@@ -10,8 +10,16 @@ import supertest from "supertest";
 import express from "express";
 
 // Firebase Admin SDKのモック（super-admin.tsがimport時にgetFirestore()を使うため）
+// Issue #556 Codex review 反映で PATCH を runTransaction 化したため、transaction 内の tx.get も対応する
 vi.mock("firebase-admin/firestore", () => ({
   getFirestore: vi.fn(() => ({
+    runTransaction: vi.fn(async (callback: (tx: { get: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> }) => Promise<void>) => {
+      const tx = {
+        get: vi.fn(() => Promise.resolve({ exists: false, data: () => ({}) })),
+        update: vi.fn(),
+      };
+      await callback(tx);
+    }),
     collection: vi.fn(() => ({
       doc: vi.fn(() => ({
         get: vi.fn(() => Promise.resolve({ exists: false })),

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -1121,76 +1121,102 @@ router.patch("/tenants/:tenantId/attendance-report/:sessionId", async (req: Requ
 
   const basePath = `tenants/${tenantId}`;
   const sessionRef = db.collection(`${basePath}/lesson_sessions`).doc(sessionId);
-  const sessionDoc = await sessionRef.get();
 
-  if (!sessionDoc.exists) {
+  // Issue #556 + Codex review: 並列 PATCH での original snapshot 汚染 (race condition) を防ぐため
+  // session 読込・snapshot 作成・quiz fallback fetch・session/quiz 更新を Firestore transaction 内で一貫実行する。
+  // Firestore は内部で楽観ロック + 自動 retry を行うため、先行 PATCH が original を書いた場合は再実行で
+  // sessionData.original を読み直し、isFirstEdit=false として snapshot 上書きを回避できる。
+  const now = new Date().toISOString();
+  // closure 内で代入するため、TypeScript の type narrowing を回避するために string 型を採用
+  let txStatus: string = "ok";
+
+  await db.runTransaction(async (tx) => {
+    const sessionDoc = await tx.get(sessionRef);
+    if (!sessionDoc.exists) {
+      txStatus = "not_found";
+      return;
+    }
+
+    const sessionData = sessionDoc.data() ?? {};
+
+    // Codex Medium: PATCH 後の最終 entryAt/exitAt 整合性を検証 (片方だけ送信時も）。
+    // 既存値を JST 文字列等の Timestamp / string 混在から ISO 8601 に正規化してから比較する。
+    const currentEntryAtIso = sessionData.entryAt?.toDate?.().toISOString?.() ?? sessionData.entryAt ?? null;
+    const currentExitAtIso = sessionData.exitAt?.toDate?.().toISOString?.() ?? sessionData.exitAt ?? null;
+    const finalEntryAt = entryAt ?? currentEntryAtIso;
+    const finalExitAt = exitAt ?? currentExitAtIso;
+    if (finalEntryAt && finalExitAt && new Date(finalEntryAt as string).getTime() > new Date(finalExitAt as string).getTime()) {
+      txStatus = "invalid_time_range";
+      return;
+    }
+
+    // 初回編集時のみ原データを original snapshot として保存 (以降 immutable)。Issue #556。
+    // null + undefined 両対応 (`== null`): Firestore からの欠落と、手動で null 直書きされたケース両方を初回扱いに。
+    const isFirstEdit = sessionData.original == null;
+    let originalSnapshot: {
+      entryAt: string | null;
+      exitAt: string | null;
+      quizScore: number | null;
+      quizPassed: boolean | null;
+    } | undefined;
+    if (isFirstEdit) {
+      let originalQuizScore: number | null = sessionData.quizScore ?? null;
+      let originalQuizPassed: boolean | null = sessionData.quizPassed ?? null;
+      // quiz_attempts fallback fetch は snapshot 取得補助のみが目的のため、エラーで PATCH 本体を巻き込まない。
+      // fetch 失敗時は quiz 値を null のまま snapshot 保存し、PATCH 本体の入退室時刻更新を継続する
+      // (rules/error-handling.md §1「各ステップを独立 try-catch で囲む」原則)。
+      if (sessionData.quizAttemptId && (originalQuizScore === null || originalQuizPassed === null)) {
+        try {
+          const attemptDoc = await tx.get(db.collection(`${basePath}/quiz_attempts`).doc(sessionData.quizAttemptId));
+          if (attemptDoc.exists) {
+            const attemptData = attemptDoc.data();
+            if (originalQuizScore === null) originalQuizScore = attemptData?.score ?? null;
+            if (originalQuizPassed === null) originalQuizPassed = attemptData?.isPassed ?? null;
+          }
+        } catch (e) {
+          console.error("[attendance-report PATCH] quiz_attempts fallback fetch failed", { sessionId, quizAttemptId: sessionData.quizAttemptId, error: e });
+        }
+      }
+      originalSnapshot = {
+        entryAt: currentEntryAtIso,
+        exitAt: currentExitAtIso,
+        quizScore: originalQuizScore,
+        quizPassed: originalQuizPassed,
+      };
+    }
+
+    // セッション更新
+    const sessionUpdate: Record<string, unknown> = { updatedAt: now, editedAt: now };
+    if (originalSnapshot !== undefined) sessionUpdate.original = originalSnapshot;
+    if (entryAt !== undefined) sessionUpdate.entryAt = entryAt;
+    if (exitAt !== undefined) sessionUpdate.exitAt = exitAt;
+    if (exitReason !== undefined) sessionUpdate.exitReason = exitReason;
+
+    // テスト結果更新 (transaction 内で session/quiz_attempts を atomic に更新)
+    if (quizScore !== undefined || quizPassed !== undefined) {
+      const quizAttemptId = sessionData.quizAttemptId;
+      if (quizAttemptId) {
+        const attemptRef = db.collection(`${basePath}/quiz_attempts`).doc(quizAttemptId);
+        const attemptUpdate: Record<string, unknown> = {};
+        if (quizScore !== undefined) attemptUpdate.score = quizScore;
+        if (quizPassed !== undefined) attemptUpdate.isPassed = quizPassed;
+        tx.update(attemptRef, attemptUpdate);
+      }
+      // セッションにも直接保存 (quizAttemptId がない場合のフォールバック)
+      if (quizScore !== undefined) sessionUpdate.quizScore = quizScore;
+      if (quizPassed !== undefined) sessionUpdate.quizPassed = quizPassed;
+    }
+
+    tx.update(sessionRef, sessionUpdate);
+  });
+
+  if (txStatus === "not_found") {
     res.status(404).json({ error: "not_found", message: "Session not found" });
     return;
   }
-
-  const sessionData = sessionDoc.data() ?? {};
-  const now = new Date().toISOString();
-
-  // 初回編集時のみ原データを original snapshot として保存（以降 immutable）。Issue #556。
-  // null + undefined 両対応 (`== null`): Firestore からの欠落と、手動で null 直書きされたケース両方を初回扱いに。
-  // quiz 値は session 側に書かれていないケースが多いため quiz_attempts から fallback fetch する。
-  const isFirstEdit = sessionData.original == null;
-  let originalSnapshot: {
-    entryAt: string | null;
-    exitAt: string | null;
-    quizScore: number | null;
-    quizPassed: boolean | null;
-  } | undefined;
-  if (isFirstEdit) {
-    let originalQuizScore: number | null = sessionData.quizScore ?? null;
-    let originalQuizPassed: boolean | null = sessionData.quizPassed ?? null;
-    // quiz_attempts fallback fetch は snapshot 取得補助のみが目的のため、エラーで PATCH 本体を巻き込まない。
-    // fetch 失敗時は quiz 値を null のまま snapshot 保存し、PATCH 本体の入退室時刻更新を継続する
-    // (rules/error-handling.md §1「各ステップを独立 try-catch で囲む」原則)。
-    if (sessionData.quizAttemptId && (originalQuizScore === null || originalQuizPassed === null)) {
-      try {
-        const attemptDoc = await db.collection(`${basePath}/quiz_attempts`).doc(sessionData.quizAttemptId).get();
-        if (attemptDoc.exists) {
-          const attemptData = attemptDoc.data();
-          if (originalQuizScore === null) originalQuizScore = attemptData?.score ?? null;
-          if (originalQuizPassed === null) originalQuizPassed = attemptData?.isPassed ?? null;
-        }
-      } catch (e) {
-        console.error("[attendance-report PATCH] quiz_attempts fallback fetch failed", { sessionId, quizAttemptId: sessionData.quizAttemptId, error: e });
-      }
-    }
-    originalSnapshot = {
-      entryAt: sessionData.entryAt?.toDate?.().toISOString?.() ?? sessionData.entryAt ?? null,
-      exitAt: sessionData.exitAt?.toDate?.().toISOString?.() ?? sessionData.exitAt ?? null,
-      quizScore: originalQuizScore,
-      quizPassed: originalQuizPassed,
-    };
-  }
-
-  // セッション更新
-  const sessionUpdate: Record<string, unknown> = { updatedAt: now, editedAt: now };
-  if (originalSnapshot !== undefined) sessionUpdate.original = originalSnapshot;
-  if (entryAt !== undefined) sessionUpdate.entryAt = entryAt;
-  if (exitAt !== undefined) sessionUpdate.exitAt = exitAt;
-  if (exitReason !== undefined) sessionUpdate.exitReason = exitReason;
-  await sessionRef.update(sessionUpdate);
-
-  // テスト結果更新
-  if (quizScore !== undefined || quizPassed !== undefined) {
-    const quizAttemptId = sessionDoc.data()?.quizAttemptId;
-    if (quizAttemptId) {
-      // quiz_attemptsドキュメントを更新
-      const attemptRef = db.collection(`${basePath}/quiz_attempts`).doc(quizAttemptId);
-      const attemptUpdate: Record<string, unknown> = {};
-      if (quizScore !== undefined) attemptUpdate.score = quizScore;
-      if (quizPassed !== undefined) attemptUpdate.isPassed = quizPassed;
-      await attemptRef.update(attemptUpdate);
-    }
-    // セッションにも直接保存（quizAttemptIdがない場合のフォールバック）
-    const quizUpdate: Record<string, unknown> = {};
-    if (quizScore !== undefined) quizUpdate.quizScore = quizScore;
-    if (quizPassed !== undefined) quizUpdate.quizPassed = quizPassed;
-    await sessionRef.update(quizUpdate);
+  if (txStatus === "invalid_time_range") {
+    res.status(400).json({ error: "invalid_time_range", message: "Final entryAt must be before exitAt (considering existing values)" });
+    return;
   }
 
   res.json({ message: "updated" });

--- a/services/api/src/routes/super-admin.ts
+++ b/services/api/src/routes/super-admin.ts
@@ -1057,6 +1057,9 @@ router.get("/tenants/:tenantId/attendance-report", async (req: Request, res: Res
       quizPassed: attempt?.isPassed ?? data.quizPassed ?? null,
       quizSubmittedAt: attempt?.submittedAt ?? null,
       isSynthetic: data.isSynthetic === true,
+      // Issue #556: 初回編集時の immutable snapshot を返却（未編集なら undefined）
+      original: data.original ?? undefined,
+      editedAt: data.editedAt?.toDate?.().toISOString?.() ?? data.editedAt ?? undefined,
     };
   });
 
@@ -1125,8 +1128,48 @@ router.patch("/tenants/:tenantId/attendance-report/:sessionId", async (req: Requ
     return;
   }
 
+  const sessionData = sessionDoc.data() ?? {};
+  const now = new Date().toISOString();
+
+  // 初回編集時のみ原データを original snapshot として保存（以降 immutable）。Issue #556。
+  // null + undefined 両対応 (`== null`): Firestore からの欠落と、手動で null 直書きされたケース両方を初回扱いに。
+  // quiz 値は session 側に書かれていないケースが多いため quiz_attempts から fallback fetch する。
+  const isFirstEdit = sessionData.original == null;
+  let originalSnapshot: {
+    entryAt: string | null;
+    exitAt: string | null;
+    quizScore: number | null;
+    quizPassed: boolean | null;
+  } | undefined;
+  if (isFirstEdit) {
+    let originalQuizScore: number | null = sessionData.quizScore ?? null;
+    let originalQuizPassed: boolean | null = sessionData.quizPassed ?? null;
+    // quiz_attempts fallback fetch は snapshot 取得補助のみが目的のため、エラーで PATCH 本体を巻き込まない。
+    // fetch 失敗時は quiz 値を null のまま snapshot 保存し、PATCH 本体の入退室時刻更新を継続する
+    // (rules/error-handling.md §1「各ステップを独立 try-catch で囲む」原則)。
+    if (sessionData.quizAttemptId && (originalQuizScore === null || originalQuizPassed === null)) {
+      try {
+        const attemptDoc = await db.collection(`${basePath}/quiz_attempts`).doc(sessionData.quizAttemptId).get();
+        if (attemptDoc.exists) {
+          const attemptData = attemptDoc.data();
+          if (originalQuizScore === null) originalQuizScore = attemptData?.score ?? null;
+          if (originalQuizPassed === null) originalQuizPassed = attemptData?.isPassed ?? null;
+        }
+      } catch (e) {
+        console.error("[attendance-report PATCH] quiz_attempts fallback fetch failed", { sessionId, quizAttemptId: sessionData.quizAttemptId, error: e });
+      }
+    }
+    originalSnapshot = {
+      entryAt: sessionData.entryAt?.toDate?.().toISOString?.() ?? sessionData.entryAt ?? null,
+      exitAt: sessionData.exitAt?.toDate?.().toISOString?.() ?? sessionData.exitAt ?? null,
+      quizScore: originalQuizScore,
+      quizPassed: originalQuizPassed,
+    };
+  }
+
   // セッション更新
-  const sessionUpdate: Record<string, unknown> = { updatedAt: new Date().toISOString() };
+  const sessionUpdate: Record<string, unknown> = { updatedAt: now, editedAt: now };
+  if (originalSnapshot !== undefined) sessionUpdate.original = originalSnapshot;
   if (entryAt !== undefined) sessionUpdate.entryAt = entryAt;
   if (exitAt !== undefined) sessionUpdate.exitAt = exitAt;
   if (exitReason !== undefined) sessionUpdate.exitReason = exitReason;

--- a/web/app/super/attendance/__tests__/edit-history.test.ts
+++ b/web/app/super/attendance/__tests__/edit-history.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatOriginalTooltip,
+  hasOriginalSnapshot,
+} from "../_helpers/edit-history";
+
+describe("hasOriginalSnapshot", () => {
+  it("original あり → true", () => {
+    const original = { entryAt: "2026-06-09T01:00:00.000Z", exitAt: null, quizScore: 100, quizPassed: true };
+    expect(hasOriginalSnapshot({ original })).toBe(true);
+  });
+
+  it("original なし (undefined) → false", () => {
+    expect(hasOriginalSnapshot({ original: undefined })).toBe(false);
+  });
+
+  it("original が空オブジェクト風だが存在する → true", () => {
+    const original = { entryAt: null, exitAt: null, quizScore: null, quizPassed: null };
+    expect(hasOriginalSnapshot({ original })).toBe(true);
+  });
+
+  it("型述語: true 分岐で original の non-null 型推論が効く (Evaluator 指摘の non-null assertion 削除)", () => {
+    const record = {
+      original: { entryAt: null, exitAt: null, quizScore: 100, quizPassed: true },
+    };
+    if (hasOriginalSnapshot(record)) {
+      // この分岐内では record.original の type narrowing が効く
+      const score: number | null = record.original.quizScore;
+      expect(score).toBe(100);
+    }
+  });
+});
+
+describe("formatOriginalTooltip", () => {
+  it("全フィールドありの正常系: 入退室時刻 / 点数 / 合否 が表示", () => {
+    const tooltip = formatOriginalTooltip({
+      entryAt: "2026-06-09T01:30:00.000Z", // JST 10:30
+      exitAt: "2026-06-09T03:45:00.000Z",  // JST 12:45
+      quizScore: 100,
+      quizPassed: true,
+    });
+    expect(tooltip).toContain("編集前:");
+    expect(tooltip).toContain("入室 10:30");
+    expect(tooltip).toContain("退室 12:45");
+    expect(tooltip).toContain("100点");
+    expect(tooltip).toContain("合格");
+  });
+
+  it("不合格 → '不合格' 表示", () => {
+    const tooltip = formatOriginalTooltip({
+      entryAt: "2026-06-09T01:00:00.000Z",
+      exitAt: "2026-06-09T02:00:00.000Z",
+      quizScore: 50,
+      quizPassed: false,
+    });
+    expect(tooltip).toContain("50点");
+    expect(tooltip).toContain("不合格");
+  });
+
+  it("quizPassed=null (未受験) → '未受験' 表示", () => {
+    const tooltip = formatOriginalTooltip({
+      entryAt: "2026-06-09T01:00:00.000Z",
+      exitAt: "2026-06-09T02:00:00.000Z",
+      quizScore: null,
+      quizPassed: null,
+    });
+    expect(tooltip).toContain("未受験");
+    expect(tooltip).toContain("—");
+  });
+
+  it("entryAt / exitAt null → '—' 表示 (在室中/未確定セッションの編集等)", () => {
+    const tooltip = formatOriginalTooltip({
+      entryAt: null,
+      exitAt: null,
+      quizScore: 80,
+      quizPassed: true,
+    });
+    expect(tooltip).toContain("入室 —");
+    expect(tooltip).toContain("退室 —");
+  });
+
+  it("JST タイムゾーンで時刻表示 (UTC からの変換)", () => {
+    // UTC 00:00 → JST 09:00
+    const tooltip = formatOriginalTooltip({
+      entryAt: "2026-06-09T00:00:00.000Z",
+      exitAt: "2026-06-09T00:30:00.000Z",
+      quizScore: 100,
+      quizPassed: true,
+    });
+    expect(tooltip).toContain("入室 09:00");
+    expect(tooltip).toContain("退室 09:30");
+  });
+});

--- a/web/app/super/attendance/_helpers/edit-history.ts
+++ b/web/app/super/attendance/_helpers/edit-history.ts
@@ -1,0 +1,43 @@
+/**
+ * 編集履歴 (Issue #556) の判定・表示ヘルパー。
+ *
+ * 初回 PATCH 時に `lesson_sessions.original` フィールドへ immutable snapshot を保存し、
+ * `editedAt` で編集時刻を記録する。本ヘルパーは UI 側で「編集済」バッジを出すか判定し、
+ * tooltip に表示する元データ文字列を組み立てる。
+ */
+
+import type { SuperAttendanceRecord } from "@lms-279/shared-types";
+
+type OriginalSnapshot = NonNullable<SuperAttendanceRecord["original"]>;
+
+/** record に `original` snapshot が存在するか (= 編集済か) を判定する。型述語版で呼び出し側の non-null assertion を不要化。 */
+export function hasOriginalSnapshot<T extends Pick<SuperAttendanceRecord, "original">>(
+  record: T,
+): record is T & { original: OriginalSnapshot } {
+  return record.original !== undefined && record.original !== null;
+}
+
+/** ISO8601 文字列を JST `HH:mm` 表記に変換 (null → `—`)。バッジ tooltip 用の簡易フォーマット。 */
+function formatTimeJST(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleTimeString("ja-JP", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Asia/Tokyo",
+  });
+}
+
+/**
+ * 元データ snapshot を tooltip 用に整形した複数行文字列を返す。
+ * 例:
+ *   編集前:
+ *   入室 14:30 / 退室 16:45
+ *   点数 100点 / 合格
+ */
+export function formatOriginalTooltip(original: OriginalSnapshot): string {
+  const entry = formatTimeJST(original.entryAt);
+  const exit = formatTimeJST(original.exitAt);
+  const score = original.quizScore !== null ? `${original.quizScore}点` : "—";
+  const passed = original.quizPassed === null ? "未受験" : original.quizPassed ? "合格" : "不合格";
+  return `編集前:\n入室 ${entry} / 退室 ${exit}\n点数 ${score} / ${passed}`;
+}

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -53,6 +53,10 @@ import {
   applyPdfColumnHide,
   restorePdfColumnDisplay,
 } from "./_helpers/pdf-print";
+import {
+  formatOriginalTooltip,
+  hasOriginalSnapshot,
+} from "./_helpers/edit-history";
 
 type Tenant = { id: string; name: string };
 
@@ -571,6 +575,15 @@ export default function AttendanceReportPage() {
                             title="このセッションは合格提出から自動補完されました (#533 Phase 1/2)"
                           >
                             自動補完
+                          </Badge>
+                        )}
+                        {hasOriginalSnapshot(r) && (
+                          <Badge
+                            variant="outline"
+                            className="ml-1 border-sky-400 text-sky-700 print:hidden"
+                            title={formatOriginalTooltip(r.original)}
+                          >
+                            編集済
                           </Badge>
                         )}
                       </TableCell>

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -435,12 +435,34 @@ export default function AttendanceReportPage() {
 
       {report && !loading && (
         <div ref={tableRef}>
-          {/* 印刷用ヘッダー */}
+          {/* 印刷用ヘッダー (#557 Codex Low: PDF 出力時に抽出条件を明示) */}
           <div className="print:block hidden mb-4">
             <h2 className="text-xl font-bold">{report.tenantName} — 出席・テスト結果レポート</h2>
             <p className="text-sm text-muted-foreground">
               出力日: {new Date().toLocaleDateString("ja-JP")}
             </p>
+            <p className="text-sm text-muted-foreground">
+              対象件数: {filteredRecords.length} 件
+              {filteredRecords.length !== report.totalRecords && ` (全 ${report.totalRecords} 件のうち抽出)`}
+            </p>
+            {(filterUsers.size > 0 || filterCourses.size > 0 || filterLessons.size > 0
+              || filterExitReasons.size > 0 || filterQuizPassed.size > 0
+              || filterSyntheticKind !== "all") && (
+              <p className="text-sm text-muted-foreground">
+                抽出条件:{" "}
+                {[
+                  filterUsers.size > 0 && `受講者 ${filterUsers.size} 名`,
+                  filterCourses.size > 0 && `コース ${filterCourses.size} 件`,
+                  filterLessons.size > 0 && `レッスン ${filterLessons.size} 件`,
+                  filterExitReasons.size > 0 && `退室理由 ${filterExitReasons.size} 件`,
+                  filterQuizPassed.size > 0 && `合否 ${filterQuizPassed.size} 件`,
+                  filterSyntheticKind === "synthetic_only" && "session 種別: 自動補完のみ",
+                  filterSyntheticKind === "actual_only" && "session 種別: 実 session のみ",
+                ]
+                  .filter(Boolean)
+                  .join(" / ")}
+              </p>
+            )}
           </div>
 
           <p className="text-sm text-muted-foreground mb-2">


### PR DESCRIPTION
## Summary

出席レポートを行政提出資料として PDF 出力する運用において、不自然な滞在時間を手動編集する需要に対し、編集前データの追跡性を確保しつつ「編集後の値で印刷」「画面上では編集済みであることが識別可能」を両立する。

## 動機

- 既存編集機能 (\`PATCH /super/tenants/:tenantId/attendance-report/:sessionId\`) は実装済みだが、編集後は元の値が完全に上書きされ、データの真実性追跡が失われる
- 行政提出 PDF では編集後の値で印字したい、しかし内部監査時には「いつ・どの値が編集されたか」を追跡したい

## 設計確定

開発者承認:
- **データ保管**: A. snapshot のみ (初回値 immutable)
- **閲覧場所**: 1. 「編集済」バッジ + tooltip

## 変更内容

### M1: shared-types
\`SuperAttendanceRecord.original?: { entryAt, exitAt, quizScore, quizPassed }\` + \`editedAt?: string\` 追加

### M2: API
- PATCH endpoint: 初回 snapshot 保存 + \`editedAt\` 記録 + quiz_attempts fallback fetch
- GET response: \`original?\` / \`editedAt?\` 返却
- 防御的マッピング (\`data.original ?? undefined\`)

### M3: FE
- \`_helpers/edit-history.ts\` (新規): \`hasOriginalSnapshot\` (型述語) + \`formatOriginalTooltip\`
- page.tsx: 「編集済」バッジ (sky-tone、\`entryAt\` セル横、\`print:hidden\` で PDF 非表示)

### M4: ドキュメント
- ADR-027 改訂履歴に Phase 3 follow-up #2 entry (A/B/C 案検討経緯)
- data-model.md に \`original\` / \`editedAt\` 追記

## Evaluator 指摘反映 (REQUEST_CHANGES → 全修正済)

| 重要度 | 指摘 | 修正 |
|--------|------|------|
| MEDIUM | \`isFirstEdit\` 判定が \`=== undefined\` のみで \`null\` 値直書きをすり抜ける | \`== null\` で undefined + null 両対応 |
| LOW | quiz_attempts fallback fetch がエラー時に PATCH 本体を巻き込む | 独立 try-catch で snapshot 取得失敗時も PATCH 継続 |
| LOW | \`r.original!\` non-null assertion | \`hasOriginalSnapshot\` を型述語化 (\`record is T & { original: OriginalSnapshot }\`) |

エッジケーステストも追加 (Evaluator 指摘 null 値 / quizAttemptId なし)。

## テスト

| スイート | Before | After |
|---------|--------|-------|
| api integration | 1658 | **1665** (新規 7 ケース) |
| web unit | 302 | **311** (新規 9 ケース) |
| type-check | ✅ | ✅ |

## 「自動補完」バッジ (Phase 3 / #552) との両立

- \`isSynthetic\` (Firestore field) と \`original\` (Firestore field) は独立、両方表示可
- 「自動補完」(amber) + 「編集済」(sky) が同セル内に並列表示
- 両方とも \`print:hidden\` で PDF 出力時は消える (#555 と同方針)

## スコープ外 (明示記録)

- edit_log フルログ (将来複数管理者・コンプライアンス要件時に検討)
- 編集者記録 / 編集理由
- 専用「編集監査」画面
- CSV エクスポート

## Test plan

- [x] api 1665/1665 + web 311/311 PASS
- [x] type-check ✅
- [x] Evaluator REQUEST_CHANGES → 全指摘修正済
- [ ] deploy 後の本番動作確認 (Playwright MCP で編集 → バッジ表示 + tooltip + print emulate でバッジ非表示)

## 関連

- Closes #556
- 親 Issue: #533 (Phase 1/2/3 完結)
- Phase 3 元 PR: #552 (「自動補完」バッジ実装、本 PR と並列表示)
- Phase 3 follow-up: #555 (print:hidden パターン継承)

🤖 Generated with [Claude Code](https://claude.com/claude-code)