### PR TITLE
fix(super-attendance): 自動補完 session の滞在時間表示分離 (#533 Phase 3 follow-up #3)

### DIFF
--- a/docs/adr/ADR-027-lesson-session-attendance.md
+++ b/docs/adr/ADR-027-lesson-session-attendance.md
@@ -1,9 +1,25 @@
 # ADR-027: レッスンセッション出席管理
 
 ## ステータス
-承認済み（2026-06-10 改訂: 編集前 original snapshot 保持 #556 / 2026-06-10 改訂: PDF 印字時バッジ非表示化 #533 follow-up / 2026-06-09 改訂: isSynthetic provenance flag 追加 #533 + Phase 3 可視化 #551 / 2026-05-21 改訂: 再視聴中の完了経験者救済ケース E' / 2026-05-16 改訂: セッション上限を環境変数化）
+承認済み（2026-06-10 改訂: 自動補完 session 滞在時間カラム表示分離 #533 follow-up #3 / 2026-06-10 改訂: 編集前 original snapshot 保持 #556 / 2026-06-10 改訂: PDF 印字時バッジ非表示化 #533 follow-up / 2026-06-09 改訂: isSynthetic provenance flag 追加 #533 + Phase 3 可視化 #551 / 2026-05-21 改訂: 再視聴中の完了経験者救済ケース E' / 2026-05-16 改訂: セッション上限を環境変数化）
 
 ## 改訂履歴
+- **2026-06-10 (Phase 3 follow-up #3, #533)**: **動機**: 現場から「合格のみで抽出した PDF」に **自動補完 session の滞在時間 1 分の合格行が混入** するとのフィードバック (前田さよりさん 2026/05/30 レッスン 2 等)。`createSyntheticCompletedSession` (PR #537) は `entryAt = quiz.startedAt` / `exitAt = quiz.submittedAt` で session を作成しており、quiz 解答時間 (1〜2 分) が滞在時間カラムに表示される構造的問題。行政提出資料として違和感を招く。
+
+  **当初検討した案 (B 案、不採用)**: backfill 再実行で過去 17 件含め `entryAt = submittedAt - SESSION_DURATION_MS` (本番 3h) に上書きし「3 時間滞在」で統一する案。Codex セカンドオピニオン (thread 019eaf6b-6b25-7011-be78-aaaa02ced8d2) で **No-Go 判定**: (1) `entryAt - 3h` は実打刻でも quiz 開始時刻でもなく運用上限値からの逆算で「3 時間滞在」と読める値の捏造、(2) PR #555 でバッジを PDF 非表示化済のため行政提出時に provenance が伝わらない、(3) 旧 entryAt が GitHub Actions artifact (90 日) + ローカル backup JSON にしか残らず Firestore からは消える、(4) `SESSION_DURATION_MS` (runtime config) を履歴データ改変の根拠にすると将来 3h→4h 変更時に説明不能、(5) `entryAt` 3 時間前移動で日付境界をまたぐ集計に副作用。
+
+  **採用案 (A 案、本変更)**: UI 表示層のみで対応。Firestore データは一切変更せず、出席レポート (`/super/attendance`) の滞在時間カラム表示を `isSynthetic=true` 時に `"— (テストのみ)"` (定数 `SYNTHETIC_STAY_DURATION_LABEL`) に変える。ソート時は実滞在時間ではないため null 同等で末尾配置。PDF 出力は画面 DOM をそのまま印刷するため自動同期、追加変更不要。
+
+  **変更内容**: `web/app/super/attendance/_helpers/stay-duration.ts` に `formatRecordStayDuration(record)` と `SYNTHETIC_STAY_DURATION_LABEL` を追加 / `web/app/super/attendance/page.tsx` の滞在時間カラム表示で新関数利用 + ソート時 isSynthetic 末尾配置。
+
+  **編集機能 (#557) との整合性**: 編集機能で synthetic record の `entryAt/exitAt` を実時刻に修正した場合のみ通常計算で滞在時間を表示する。判定は **`original` snapshot (#556) との差分** で行う (`record.entryAt !== record.original?.entryAt || record.exitAt !== record.original?.exitAt`)。`editedAt` 単独判定は使えない理由: PATCH endpoint (`super-admin.ts:1189`) は **quizScore/quizPassed/exitReason のみの編集でも無条件に `editedAt` を付与** するため、時刻未編集でも `editedAt` が立ち、滞在時間 1 分が表示される問題が起きる (Evaluator 第 2 ラウンド HIGH 指摘反映)。`isStayTimeEdited` ヘルパーで「entryAt/exitAt の実差分」のみを判定基準とし、quizScore のみ編集ケースは `SYNTHETIC_STAY_DURATION_LABEL` 表示を維持する。`SuperAttendanceRecord.original` は既存フィールド (#556) のため BE 変更なし。
+
+  **判断根拠**: 一次データ書き換えなし = 真実性・監査証跡・env 依存・日付フィルタ副作用のリスクすべて回避。過去 17 件 + 今後の自動補完すべてに条件分岐なしで即時自動適用。「自動補完」バッジ (Phase 3 / #551) と組み合わせ、画面では内部監査可視性、PDF では中立的な `"— (テストのみ)"` 表示で行政提出資料の説明可能性を確保。
+
+  **設計仕様書**: `docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md`
+
+  **テスト**: FE unit test 6 ケース追加 (formatRecordStayDuration: isSynthetic=true / true+null / false 1h22m / false null / false 異常時刻 / ラベル定数固定)。本番動作確認 (Playwright MCP) で前田さよりさんレッスン 2 含む画面確認予定。
+
 - **2026-06-10 (Phase 3 follow-up #2, #556)**: **動機**: 出席・テスト結果レポートを行政提出資料として PDF 出力する運用において、不自然な滞在時間（補正データの 0 分、`time_limit` 強制退出の数十時間等）を手動編集する需要が判明。既存の編集機能 (`PATCH /super/tenants/:tenantId/attendance-report/:sessionId`) は実装済みだが、編集後は元の値が完全に上書きされ、データの真実性追跡が失われる課題があった。
 
   **変更内容**: `lesson_sessions` に **`original: { entryAt, exitAt, quizScore, quizPassed }`** フィールド（編集前 immutable snapshot）と **`editedAt: string`**（最後の編集時刻）を追加。初回 PATCH 時に `original` が未設定なら現在値を snapshot として保存し、以降の PATCH では `original` を変更しない（immutable）。quiz 値は session 側に書かれていないケースが多いため、`quizAttemptId` から quiz_attempts ドキュメントを fallback fetch して snapshot に含める。FE は `SuperAttendanceRecord.original?` / `editedAt?` を利用して「編集済」バッジ（sky-tone、`entryAt` セル横、「自動補完」バッジと並列表示可）を表示、tooltip で元データ（編集前の入退室時刻 / 点数 / 合否）を提示。`print:hidden` で PDF 出力時はバッジ非表示（Phase 3 follow-up と同方針、行政提出時の中立性確保）。

--- a/docs/adr/ADR-027-lesson-session-attendance.md
+++ b/docs/adr/ADR-027-lesson-session-attendance.md
@@ -18,7 +18,7 @@
 
   **設計仕様書**: `docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md`
 
-  **テスト**: FE unit test 6 ケース追加 (formatRecordStayDuration: isSynthetic=true / true+null / false 1h22m / false null / false 異常時刻 / ラベル定数固定)。本番動作確認 (Playwright MCP) で前田さよりさんレッスン 2 含む画面確認予定。
+  **テスト**: FE unit test 多数追加 — `formatRecordStayDuration` 9 ケース (isSynthetic / editedAt / original 差分マトリクス)、`isStayTimeEdited` 5 ケース、`stayDurationSortValue` 6 ケース (ソート挙動、編集済 synthetic を通常順序に混在させる検証含む)、`buildEditPatchBody` 11 ケース (dirty 判定、quizScore のみ編集時に entryAt/exitAt 不含、score=0 を未編集と混同しない 等、Codex BLOCK MERGE 反映)。本番動作確認 (Playwright MCP) で前田さよりさんレッスン 2 含む画面確認予定。
 
 - **2026-06-10 (Phase 3 follow-up #2, #556)**: **動機**: 出席・テスト結果レポートを行政提出資料として PDF 出力する運用において、不自然な滞在時間（補正データの 0 分、`time_limit` 強制退出の数十時間等）を手動編集する需要が判明。既存の編集機能 (`PATCH /super/tenants/:tenantId/attendance-report/:sessionId`) は実装済みだが、編集後は元の値が完全に上書きされ、データの真実性追跡が失われる課題があった。
 

--- a/docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md
+++ b/docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md
@@ -126,18 +126,20 @@ export function isStayTimeEdited(record: {
 
 ### 5.3 ソート対応
 
-該当箇所 (`page.tsx:305-313`):
+`stayDurationSortValue` ヘルパーで isSynthetic + 編集判定を内包。該当箇所:
+
 ```typescript
 if (sortKey === "stayDuration") {
-  // isSynthetic=true は実滞在時間ではないため末尾 (null と同等扱い)
-  const av = a.isSynthetic ? null : calculateStayDurationMs(a.entryAt, a.exitAt);
-  const bv = b.isSynthetic ? null : calculateStayDurationMs(b.entryAt, b.exitAt);
+  const av = stayDurationSortValue(a);
+  const bv = stayDurationSortValue(b);
   if (av === null && bv === null) return 0;
   if (av === null) return 1;
   if (bv === null) return -1;
   return (av - bv) * dir;
 }
 ```
+
+`stayDurationSortValue` は `isSynthetic && !isStayTimeEdited` の場合 null (= 末尾)、それ以外は `calculateStayDurationMs` 結果を返す。これにより編集済 synthetic は通常順序に混在し、未編集 synthetic のみ末尾配置される。
 
 ### 5.4 PDF 出力
 
@@ -156,8 +158,9 @@ PR #554 で導入された `applyPdfColumnHide` (`_helpers/pdf-print.ts`) は da
 | AC5 | Firestore データ変更ゼロ (本番含め一切書き込まない) | grep / コードレビュー |
 | AC6 | 過去 17 件 + 今後の自動補完すべてに自動適用 (条件分岐なし) | Playwright MCP 本番確認 |
 | AC7 | `formatRecordStayDuration` 関数の境界値テスト (isSynthetic=true/false × entryAt/exitAt null/非 null の組み合わせ) | unit test |
-| AC8 | 編集済 synthetic (isSynthetic=true + editedAt あり) は通常計算で表示される (Evaluator 指摘反映) | unit test |
-| AC9 | 編集済 synthetic はソート時も末尾配置から外れ、通常 session と同じ順序で並ぶ | page.tsx ロジックレビュー + Playwright MCP |
+| AC8 | 編集済 synthetic (`isSynthetic=true` + `original` snapshot との entryAt/exitAt 差分あり) は通常計算で表示される (Evaluator 第 2 ラウンド HIGH 指摘反映) | unit test |
+| AC9 | 編集済 synthetic はソート時も末尾配置から外れ、通常 session と同じ順序で並ぶ | `stayDurationSortValue` unit test + Playwright MCP |
+| AC10 | 編集ダイアログで quizScore のみ編集した場合、entryAt/exitAt は PATCH body に含まれない (Codex BLOCK MERGE 指摘反映、`buildEditPatchBody` の dirty 判定) | `edit-patch.test.ts` unit test |
 
 ---
 

--- a/docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md
+++ b/docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md
@@ -1,0 +1,187 @@
+# Phase 3 follow-up #3 設計仕様書: 自動補完 session の滞在時間表示分離
+
+**作成日**: 2026-06-10
+**Issue**: #533 Phase 3 follow-up #3 (現場フィードバック起因)
+**前提**: Phase 1 (PR #537) / Phase 2 (PR #539, #541) / Phase 3 (PR #552, #555, #557) 完了後
+
+---
+
+## 1. 背景
+
+### 現場フィードバック
+2026-06-10、現場から「合格のみで抽出した PDF」に**滞在時間 1 分の合格行が混入**するとのフィードバック。具体例:
+
+- 受講者「前田さより」さん 2026/05/30 のレッスン 2「Google ドライブの活用」
+- 入室 08:41 / 退室 08:42 / 滞在時間 1 分 / テスト合格 100 点 / 「自動補完」バッジ表示
+- 行政提出資料として「1 分で合格」は不自然に見える
+
+### 構造的原因
+`createSyntheticCompletedSession` (PR #537、`services/api/src/services/lesson-session.ts:449-484`) は `entryAt = quiz.startedAt` / `exitAt = quiz.submittedAt` で session を作成。これは「quiz 解答時間 = 1〜2 分」をそのまま session 滞在時間として記録する。これ自体は**正しい一次データ** (quiz 開始 → 提出の時刻記録) だが、出席レポート UI でこれを通常 session と同じ「滞在時間」カラムで表示すると違和感が出る。
+
+---
+
+## 2. 方針判断経緯
+
+### 当初検討された案 (B 案)
+- entryAt を `submittedAt - SESSION_DURATION_MS` (本番 3h) に書き換え、過去 17 件も backfill 再実行で統一
+- ユーザー (開発者) も一度承認
+
+### Codex セカンドオピニオン (`feedback_destructive_migration_codex_review.md` 準拠) で **No-Go 判定**
+1. **真実性リスク**: `entryAt = submittedAt - 3h` は実打刻でも quiz 開始時刻でもなく、運用上限値からの逆算 = 「3 時間滞在した」と読める値の捏造。「自動補完」バッジは PR #555 で **PDF 非表示**なので、行政提出時に provenance が伝わらない
+2. **監査証跡の弱さ**: 旧 entryAt は GitHub Actions artifact (90 日) + ローカルの backup JSON にしか残らず、Firestore からは消える
+3. **`SESSION_DURATION_MS` 依存の不安定性**: runtime config を履歴データ改変の根拠に使うと、将来 3h → 4h 変更時に「過去 17 件はどっち？」が説明不能
+4. **race condition / 日付フィルタ副作用**: dry-run と execute の間で PATCH 可能 / `entryAt` 3 時間前移動で日付境界をまたぐ集計に副作用
+5. **本質**: 「synthetic を通常 session と同じカラムで扱っている」のが問題。一次データ書き換え不要
+
+### 採用案 (A 案)
+**UI 表示層のみで対応**。Firestore データは一切変更せず、`isSynthetic=true` の record の滞在時間カラム表示を `"— (テストのみ)"` に変える。
+
+---
+
+## 3. ゴール
+
+- 出席レポート画面 (`/super/attendance`) で `isSynthetic=true` record の滞在時間カラム表示を `"— (テストのみ)"` に変更
+- PDF 出力時も同表示 (画面 DOM をそのまま印刷するため自動で同期)
+- データ改変ゼロ、過去 17 件 + 今後の自動補完 すべて即時自動適用
+- ソート時 synthetic record は末尾配置 (実滞在時間ではないため数値比較対象外)
+
+---
+
+## 4. スコープ
+
+### IN
+- `web/app/super/attendance/_helpers/stay-duration.ts` に synthetic 対応関数追加
+- `web/app/super/attendance/page.tsx` 滞在時間カラム表示変更
+- ソートロジックの synthetic 末尾配置対応
+- 単体テスト追加 (新ヘルパー関数)
+- ADR-027 改訂履歴に Phase 3 follow-up #3 entry 追記
+
+### OUT
+- Firestore データ書き換え (一切なし)
+- API レスポンス変更 (なし、`isSynthetic` は既存フィールド)
+- shared-types 変更 (なし)
+- 他画面の表示変更 (該当画面 = `/super/attendance` のみ)
+- backfill script 改修 (B 案で計画したが採用案では不要)
+- `createSyntheticCompletedSession` ヘルパー改修 (なし、一次データ生成は現行維持)
+
+---
+
+## 5. 実装詳細
+
+### 5.1 stay-duration.ts ヘルパー拡張
+
+新関数 `formatRecordStayDuration` + `isStayTimeEdited` を追加:
+
+```typescript
+/**
+ * record 単位の滞在時間表示。isSynthetic=true && entryAt/exitAt 未編集 (original snapshot との差分なし)
+ * は実滞在時間ではないため「— (テストのみ)」表示。entryAt/exitAt 編集済は通常計算。
+ * editedAt 単独では quizScore のみ編集でも付与されるため使えない (HIGH 指摘反映)。
+ */
+export function formatRecordStayDuration(record: {
+  isSynthetic: boolean;
+  entryAt: string | null;
+  exitAt: string | null;
+  original?: { entryAt: string | null; exitAt: string | null };
+}): string {
+  if (record.isSynthetic && !isStayTimeEdited(record)) return "— (テストのみ)";
+  return formatStayDuration(calculateStayDurationMs(record.entryAt, record.exitAt));
+}
+
+export function isStayTimeEdited(record: {
+  entryAt: string | null;
+  exitAt: string | null;
+  original?: { entryAt: string | null; exitAt: string | null };
+}): boolean {
+  if (!record.original) return false;
+  return (
+    record.entryAt !== record.original.entryAt ||
+    record.exitAt !== record.original.exitAt
+  );
+}
+```
+
+### 5.1.1 編集機能 (#557) との整合性
+
+`PATCH /super/tenants/:tenantId/attendance-report/:sessionId` は `entryAt/exitAt/exitReason/quizScore/quizPassed` を編集可能で、**いずれを編集しても `editedAt` が無条件付与される** (`super-admin.ts:1189`)。`isSynthetic` は不変 (provenance flag)。本関数は **entryAt/exitAt の `original` snapshot との差分** で判定 (`editedAt` 単独判定では quizScore のみ編集ケースで「1 分滞在」が再出現するため使わない、HIGH 指摘反映):
+
+| isSynthetic | entryAt/exitAt 編集 | original | 表示 | 意味 |
+|-------------|---------------------|----------|------|------|
+| false | - | - | 通常計算 | 通常 session (現状維持) |
+| true | なし | undefined | `"— (テストのみ)"` | 過去 17 件 + 今後の自動補完 (本変更の主目的) |
+| true | なし | あり + 同値 | `"— (テストのみ)"` | quizScore/quizPassed のみ編集 (HIGH 指摘反映) |
+| **true** | **あり** | **あり + 差分** | **通常計算** | **entryAt/exitAt を実時刻に修正 = 管理者確認** |
+
+### 5.2 page.tsx 表示変更
+
+該当箇所 (`page.tsx:613-615`):
+```diff
+- <TableCell data-col="stayDuration" className="whitespace-nowrap text-sm">
+-   {formatStayDuration(calculateStayDurationMs(r.entryAt, r.exitAt))}
+- </TableCell>
++ <TableCell data-col="stayDuration" className="whitespace-nowrap text-sm">
++   {formatRecordStayDuration(r)}
++ </TableCell>
+```
+
+### 5.3 ソート対応
+
+該当箇所 (`page.tsx:305-313`):
+```typescript
+if (sortKey === "stayDuration") {
+  // isSynthetic=true は実滞在時間ではないため末尾 (null と同等扱い)
+  const av = a.isSynthetic ? null : calculateStayDurationMs(a.entryAt, a.exitAt);
+  const bv = b.isSynthetic ? null : calculateStayDurationMs(b.entryAt, b.exitAt);
+  if (av === null && bv === null) return 0;
+  if (av === null) return 1;
+  if (bv === null) return -1;
+  return (av - bv) * dir;
+}
+```
+
+### 5.4 PDF 出力
+
+PR #554 で導入された `applyPdfColumnHide` (`_helpers/pdf-print.ts`) は data-col 単位の表示/非表示制御。本変更は滞在時間セルの**中身の文字列のみ変更**するため PDF 出力ロジックに変更不要 (画面表示 = `"— (テストのみ)"` がそのまま PDF にも印字される)。
+
+---
+
+## 6. Acceptance Criteria
+
+| # | 基準 | 検証方法 |
+|---|------|---------|
+| AC1 | `isSynthetic=true` record の滞在時間カラムが `"— (テストのみ)"` 表示 | unit test + Playwright MCP |
+| AC2 | `isSynthetic=false` record は従来通り `formatStayDuration` 結果表示 | unit test |
+| AC3 | 滞在時間カラムでソート時、synthetic record は末尾配置 (昇順/降順とも) | unit test + Playwright MCP |
+| AC4 | PDF 出力時も `"— (テストのみ)"` がそのまま印字 (バッジは非表示維持) | Playwright MCP (print emulate) |
+| AC5 | Firestore データ変更ゼロ (本番含め一切書き込まない) | grep / コードレビュー |
+| AC6 | 過去 17 件 + 今後の自動補完すべてに自動適用 (条件分岐なし) | Playwright MCP 本番確認 |
+| AC7 | `formatRecordStayDuration` 関数の境界値テスト (isSynthetic=true/false × entryAt/exitAt null/非 null の組み合わせ) | unit test |
+| AC8 | 編集済 synthetic (isSynthetic=true + editedAt あり) は通常計算で表示される (Evaluator 指摘反映) | unit test |
+| AC9 | 編集済 synthetic はソート時も末尾配置から外れ、通常 session と同じ順序で並ぶ | page.tsx ロジックレビュー + Playwright MCP |
+
+---
+
+## 7. リスクと緩和
+
+| リスク | 緩和策 |
+|--------|--------|
+| 表示変更だけで現場の問題が解消しない | A 案不採用時に C 案 (PDF 別セクション分離) に escalate 可能、ADR-027 に判断経緯記録 |
+| ソート時 synthetic 末尾が現場の意図と異なる | Playwright MCP で本番確認、現場から再フィードバックあれば挙動変更 |
+| `"— (テストのみ)"` の文言が長すぎてカラム幅破壊 | whitespace-nowrap で 1 行強制、必要なら CSS truncate |
+
+---
+
+## 8. ADR-027 改訂履歴 entry (案)
+
+```
+- **2026-06-10 (Phase 3 follow-up #3, #533)**: **動機**: 行政提出 PDF で「合格のみ」抽出した際、自動補完 session の滞在時間 1 分が不自然に見えるとの現場フィードバック。**当初検討した entryAt 書き換え案 (B 案: entryAt = submittedAt - SESSION_DURATION_MS)** は Codex セカンドオピニオンで No-Go 判定 (行政提出データの真実性リスク / 監査証跡の弱さ / `SESSION_DURATION_MS` 依存の不安定性 / 日付フィルタ副作用)。**採用案 (A 案)**: UI 表示層のみで対応、Firestore データは維持し、出席レポートの滞在時間カラムを `isSynthetic=true` 時に `"— (テストのみ)"` 表示。データ改変ゼロ + 過去 17 件含め即時自動適用。
+```
+
+---
+
+## 9. 関連ドキュメント
+
+- ADR-027: `docs/adr/ADR-027-lesson-session-attendance.md`
+- Phase 3 設計仕様書 (#551): `docs/specs/2026-06-09-phase3-synthetic-session-badge-design.md`
+- Codex セカンドオピニオン thread: 019eaf6b-6b25-7011-be78-aaaa02ced8d2
+- 前 session handoff: `docs/handoff/LATEST.md` (Session 72)

--- a/web/app/super/attendance/__tests__/edit-patch.test.ts
+++ b/web/app/super/attendance/__tests__/edit-patch.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { buildEditPatchBody, dateTimeJSTtoISO } from "../_helpers/edit-patch";
+
+describe("dateTimeJSTtoISO", () => {
+  it("JST 08:41 → UTC 23:41 (前日)", () => {
+    expect(dateTimeJSTtoISO("2026-05-30", "08:41")).toBe("2026-05-29T23:41:00.000Z");
+  });
+
+  it("秒は :00 で丸める (分精度)", () => {
+    const iso = dateTimeJSTtoISO("2026-05-30", "10:14");
+    expect(iso.endsWith(":00.000Z")).toBe(true);
+  });
+});
+
+describe("buildEditPatchBody", () => {
+  const initial = {
+    editDate: "2026-05-30",
+    editEntryTime: "08:41",
+    editExitTime: "08:42",
+    initialEditDate: "2026-05-30",
+    initialEditEntryTime: "08:41",
+    initialEditExitTime: "08:42",
+    editScore: "",
+    editPassed: "",
+  };
+
+  it("全フィールド未変更 → 空 body (時刻 / score / passed すべて送らない)", () => {
+    expect(buildEditPatchBody(initial)).toEqual({});
+  });
+
+  it("Phase 3 follow-up #3 回帰防止: synthetic record の quizScore のみ編集 → entryAt/exitAt 不含 (Codex BLOCK MERGE 反映)", () => {
+    const body = buildEditPatchBody({ ...initial, editScore: "100" });
+    expect(body).toEqual({ quizScore: 100 });
+    expect(body.entryAt).toBeUndefined();
+    expect(body.exitAt).toBeUndefined();
+  });
+
+  it("quizPassed のみ編集 → entryAt/exitAt 不含", () => {
+    const body = buildEditPatchBody({ ...initial, editPassed: "true" });
+    expect(body).toEqual({ quizPassed: true });
+    expect(body.entryAt).toBeUndefined();
+    expect(body.exitAt).toBeUndefined();
+  });
+
+  it("editEntryTime 変更 → entryAt のみ含む、exitAt 不含", () => {
+    const body = buildEditPatchBody({ ...initial, editEntryTime: "09:00" });
+    expect(body.entryAt).toBe("2026-05-30T00:00:00.000Z");
+    expect(body.exitAt).toBeUndefined();
+  });
+
+  it("editExitTime 変更 → exitAt のみ含む、entryAt 不含", () => {
+    const body = buildEditPatchBody({ ...initial, editExitTime: "11:00" });
+    expect(body.exitAt).toBe("2026-05-30T02:00:00.000Z");
+    expect(body.entryAt).toBeUndefined();
+  });
+
+  it("editDate 変更 → entryAt/exitAt 両方含む (日付は両方の ISO に影響)", () => {
+    const body = buildEditPatchBody({ ...initial, editDate: "2026-05-31" });
+    expect(body.entryAt).toBe("2026-05-30T23:41:00.000Z");
+    expect(body.exitAt).toBe("2026-05-30T23:42:00.000Z");
+  });
+
+  it("editDate + editEntryTime + editExitTime 全変更 + score + passed → 全フィールド含む", () => {
+    const body = buildEditPatchBody({
+      editDate: "2026-05-31",
+      editEntryTime: "09:00",
+      editExitTime: "11:00",
+      initialEditDate: "2026-05-30",
+      initialEditEntryTime: "08:41",
+      initialEditExitTime: "08:42",
+      editScore: "80",
+      editPassed: "true",
+    });
+    expect(body).toEqual({
+      entryAt: "2026-05-31T00:00:00.000Z",
+      exitAt: "2026-05-31T02:00:00.000Z",
+      quizScore: 80,
+      quizPassed: true,
+    });
+  });
+
+  it("editDate 空文字 → 時刻フィールド変更があっても entryAt/exitAt 不含 (anti-NaN ガード)", () => {
+    const body = buildEditPatchBody({
+      ...initial,
+      editDate: "",
+      editEntryTime: "09:00",
+    });
+    expect(body.entryAt).toBeUndefined();
+    expect(body.exitAt).toBeUndefined();
+  });
+
+  it("editEntryTime 空文字 → entryAt 不含 (但し exitAt は exitTime あれば送信可)", () => {
+    const body = buildEditPatchBody({
+      ...initial,
+      editEntryTime: "",
+      editExitTime: "11:00",
+    });
+    expect(body.entryAt).toBeUndefined();
+    expect(body.exitAt).toBe("2026-05-30T02:00:00.000Z");
+  });
+
+  it("editScore='' → quizScore 不含 (デフォルト空文字は『未編集』扱い)", () => {
+    const body = buildEditPatchBody({ ...initial, editScore: "" });
+    expect(body.quizScore).toBeUndefined();
+  });
+
+  it("editScore='0' → quizScore=0 含む (0 を未編集と混同しない)", () => {
+    const body = buildEditPatchBody({ ...initial, editScore: "0" });
+    expect(body.quizScore).toBe(0);
+  });
+});

--- a/web/app/super/attendance/__tests__/stay-duration.test.ts
+++ b/web/app/super/attendance/__tests__/stay-duration.test.ts
@@ -4,6 +4,7 @@ import {
   formatStayDuration,
   formatRecordStayDuration,
   isStayTimeEdited,
+  stayDurationSortValue,
   SYNTHETIC_STAY_DURATION_LABEL,
 } from "../_helpers/stay-duration";
 
@@ -272,5 +273,92 @@ describe("isStayTimeEdited", () => {
         original: { entryAt: null, exitAt: null },
       }),
     ).toBe(false);
+  });
+});
+
+describe("stayDurationSortValue", () => {
+  it("isSynthetic=true + 未編集 (original なし) → null (= 末尾配置)", () => {
+    expect(
+      stayDurationSortValue({
+        isSynthetic: true,
+        entryAt: "2026-05-30T01:14:10.258Z",
+        exitAt: "2026-05-30T01:15:10.258Z",
+      }),
+    ).toBeNull();
+  });
+
+  it("isSynthetic=true + original 同値 (quizScore のみ編集) → null (= 末尾配置、HIGH 指摘反映)", () => {
+    expect(
+      stayDurationSortValue({
+        isSynthetic: true,
+        entryAt: "2026-05-30T01:14:10.258Z",
+        exitAt: "2026-05-30T01:15:10.258Z",
+        original: {
+          entryAt: "2026-05-30T01:14:10.258Z",
+          exitAt: "2026-05-30T01:15:10.258Z",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("isSynthetic=true + original 差分あり (時刻編集済) → ms 値 (通常順序)", () => {
+    expect(
+      stayDurationSortValue({
+        isSynthetic: true,
+        entryAt: "2026-05-30T01:14:10.258Z",
+        exitAt: "2026-05-30T02:36:29.496Z",
+        original: {
+          entryAt: "2026-05-30T02:35:00.000Z",
+          exitAt: "2026-05-30T02:36:29.496Z",
+        },
+      }),
+    ).toBeGreaterThan(0);
+  });
+
+  it("isSynthetic=false → ms 値 (通常 session、calculateStayDurationMs の生の ms 差分)", () => {
+    // entry: 2026-05-30T01:14:10.258Z, exit: 2026-05-30T02:36:29.496Z → 4939238 ms (約 82 分)
+    expect(
+      stayDurationSortValue({
+        isSynthetic: false,
+        entryAt: "2026-05-30T01:14:10.258Z",
+        exitAt: "2026-05-30T02:36:29.496Z",
+      }),
+    ).toBe(4939238);
+  });
+
+  it("isSynthetic=false + entryAt/exitAt null → null (異常データは末尾)", () => {
+    expect(
+      stayDurationSortValue({
+        isSynthetic: false,
+        entryAt: null,
+        exitAt: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("ソート挙動: 未編集 synthetic は実 session 後ろ、編集済 synthetic は通常順序に混在", () => {
+    const records = [
+      // 編集済 synthetic 1h22m
+      { isSynthetic: true, entryAt: "2026-05-30T01:14:10.258Z", exitAt: "2026-05-30T02:36:29.496Z",
+        original: { entryAt: "2026-05-30T02:35:00.000Z", exitAt: "2026-05-30T02:36:29.496Z" } },
+      // 未編集 synthetic
+      { isSynthetic: true, entryAt: "2026-05-30T08:41:00.000Z", exitAt: "2026-05-30T08:42:00.000Z" },
+      // 通常 session 30 分
+      { isSynthetic: false, entryAt: "2026-05-30T10:00:00.000Z", exitAt: "2026-05-30T10:30:00.000Z" },
+    ];
+    const sorted = [...records].sort((a, b) => {
+      const av = stayDurationSortValue(a);
+      const bv = stayDurationSortValue(b);
+      if (av === null && bv === null) return 0;
+      if (av === null) return 1;
+      if (bv === null) return -1;
+      return av - bv;
+    });
+    // 順序: 通常 30 分 → 編集済 synthetic 1h22m → 未編集 synthetic (末尾)
+    expect(sorted[0].isSynthetic).toBe(false);
+    expect(sorted[1].isSynthetic).toBe(true);
+    expect(sorted[1].original).toBeDefined();
+    expect(sorted[2].isSynthetic).toBe(true);
+    expect(sorted[2].original).toBeUndefined();
   });
 });

--- a/web/app/super/attendance/__tests__/stay-duration.test.ts
+++ b/web/app/super/attendance/__tests__/stay-duration.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   calculateStayDurationMs,
   formatStayDuration,
+  formatRecordStayDuration,
+  isStayTimeEdited,
+  SYNTHETIC_STAY_DURATION_LABEL,
 } from "../_helpers/stay-duration";
 
 describe("calculateStayDurationMs", () => {
@@ -92,5 +95,182 @@ describe("formatStayDuration", () => {
   it("極大値 54 時間 → '54時間XX分'", () => {
     const ms = (54 * 60 + 36) * 60_000;
     expect(formatStayDuration(ms)).toBe("54時間36分");
+  });
+});
+
+describe("formatRecordStayDuration", () => {
+  it("isSynthetic=true → SYNTHETIC_STAY_DURATION_LABEL (entryAt/exitAt 値に関わらず)", () => {
+    expect(
+      formatRecordStayDuration({
+        isSynthetic: true,
+        entryAt: "2026-05-30T01:14:10.258Z",
+        exitAt: "2026-05-30T01:15:10.258Z",
+      }),
+    ).toBe(SYNTHETIC_STAY_DURATION_LABEL);
+  });
+
+  it("isSynthetic=true + entryAt/exitAt null でも SYNTHETIC_STAY_DURATION_LABEL を維持", () => {
+    expect(
+      formatRecordStayDuration({ isSynthetic: true, entryAt: null, exitAt: null }),
+    ).toBe(SYNTHETIC_STAY_DURATION_LABEL);
+  });
+
+  it("isSynthetic=false: 通常 session は formatStayDuration 結果と一致 (1 時間 22 分例)", () => {
+    const result = formatRecordStayDuration({
+      isSynthetic: false,
+      entryAt: "2026-05-30T01:14:10.258Z",
+      exitAt: "2026-05-30T02:36:29.496Z",
+    });
+    expect(result).toBe("1時間22分");
+  });
+
+  it("isSynthetic=false + entryAt null → '—' (formatStayDuration の null 経路)", () => {
+    expect(
+      formatRecordStayDuration({ isSynthetic: false, entryAt: null, exitAt: null }),
+    ).toBe("—");
+  });
+
+  it("isSynthetic=false + exit < entry (異常) → '—'", () => {
+    expect(
+      formatRecordStayDuration({
+        isSynthetic: false,
+        entryAt: "2026-05-30T02:36:29.496Z",
+        exitAt: "2026-05-30T01:14:10.258Z",
+      }),
+    ).toBe("—");
+  });
+
+  it("ラベルは「— (テストのみ)」固定 (表示文字列の回帰防止)", () => {
+    expect(SYNTHETIC_STAY_DURATION_LABEL).toBe("— (テストのみ)");
+  });
+
+  it("isSynthetic=true + entryAt 編集済 (original 差分あり) → 通常計算", () => {
+    // 編集機能で entryAt/exitAt を実時刻に修正した synthetic record。
+    // provenance としての isSynthetic は維持されるが、滞在時間は編集後の値を表示する。
+    const result = formatRecordStayDuration({
+      isSynthetic: true,
+      entryAt: "2026-05-30T01:14:10.258Z",
+      exitAt: "2026-05-30T02:36:29.496Z",
+      original: {
+        entryAt: "2026-05-30T02:35:00.000Z", // 初回 = quiz.startedAt (1 分前)
+        exitAt: "2026-05-30T02:36:29.496Z",
+      },
+    });
+    expect(result).toBe("1時間22分");
+  });
+
+  it("isSynthetic=true + exitAt のみ編集済 (original 差分あり) → 通常計算", () => {
+    const result = formatRecordStayDuration({
+      isSynthetic: true,
+      entryAt: "2026-05-30T01:14:10.258Z",
+      exitAt: "2026-05-30T02:36:29.496Z",
+      original: {
+        entryAt: "2026-05-30T01:14:10.258Z",
+        exitAt: "2026-05-30T01:15:10.258Z", // 初回 = quiz.submittedAt (1 分後)
+      },
+    });
+    expect(result).toBe("1時間22分");
+  });
+
+  it("isSynthetic=true + original なし → SYNTHETIC_STAY_DURATION_LABEL (PR #557 投入前 / 未編集)", () => {
+    // 過去 17 件 + 今後の自動補完すべて該当 (original snapshot 未付与)
+    expect(
+      formatRecordStayDuration({
+        isSynthetic: true,
+        entryAt: "2026-05-30T01:14:10.258Z",
+        exitAt: "2026-05-30T01:15:10.258Z",
+        original: undefined,
+      }),
+    ).toBe(SYNTHETIC_STAY_DURATION_LABEL);
+  });
+
+  it("isSynthetic=true + original あり + entryAt/exitAt 同一値 (quizScore のみ編集等) → SYNTHETIC_STAY_DURATION_LABEL (HIGH 指摘反映)", () => {
+    // quizScore/quizPassed のみ編集すると editedAt が付くが entryAt/exitAt は不変。
+    // editedAt 単独判定だと「1 分滞在」が表示される問題を original 差分判定で防ぐ。
+    expect(
+      formatRecordStayDuration({
+        isSynthetic: true,
+        entryAt: "2026-05-30T01:14:10.258Z",
+        exitAt: "2026-05-30T01:15:10.258Z",
+        original: {
+          entryAt: "2026-05-30T01:14:10.258Z", // 同値 = 未編集
+          exitAt: "2026-05-30T01:15:10.258Z",
+        },
+      }),
+    ).toBe(SYNTHETIC_STAY_DURATION_LABEL);
+  });
+
+  it("isSynthetic=false + original あり → 通常計算 (#557 編集済通常 session)", () => {
+    const result = formatRecordStayDuration({
+      isSynthetic: false,
+      entryAt: "2026-05-30T01:14:10.258Z",
+      exitAt: "2026-05-30T02:36:29.496Z",
+      original: {
+        entryAt: "2026-05-30T01:00:00.000Z",
+        exitAt: "2026-05-30T02:30:00.000Z",
+      },
+    });
+    expect(result).toBe("1時間22分");
+  });
+});
+
+describe("isStayTimeEdited", () => {
+  it("original なし → false", () => {
+    expect(
+      isStayTimeEdited({
+        entryAt: "2026-05-30T01:14:10.258Z",
+        exitAt: "2026-05-30T01:15:10.258Z",
+        original: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("original あり + entryAt/exitAt 一致 → false (quizScore のみ編集等)", () => {
+    expect(
+      isStayTimeEdited({
+        entryAt: "2026-05-30T01:14:10.258Z",
+        exitAt: "2026-05-30T01:15:10.258Z",
+        original: {
+          entryAt: "2026-05-30T01:14:10.258Z",
+          exitAt: "2026-05-30T01:15:10.258Z",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("entryAt のみ差分 → true", () => {
+    expect(
+      isStayTimeEdited({
+        entryAt: "2026-05-30T00:00:00.000Z",
+        exitAt: "2026-05-30T01:15:10.258Z",
+        original: {
+          entryAt: "2026-05-30T01:14:10.258Z",
+          exitAt: "2026-05-30T01:15:10.258Z",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("exitAt のみ差分 → true", () => {
+    expect(
+      isStayTimeEdited({
+        entryAt: "2026-05-30T01:14:10.258Z",
+        exitAt: "2026-05-30T03:00:00.000Z",
+        original: {
+          entryAt: "2026-05-30T01:14:10.258Z",
+          exitAt: "2026-05-30T01:15:10.258Z",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("null 値が初回値と一致 (両 null) → false", () => {
+    expect(
+      isStayTimeEdited({
+        entryAt: null,
+        exitAt: null,
+        original: { entryAt: null, exitAt: null },
+      }),
+    ).toBe(false);
   });
 });

--- a/web/app/super/attendance/_helpers/edit-patch.ts
+++ b/web/app/super/attendance/_helpers/edit-patch.ts
@@ -1,0 +1,47 @@
+/**
+ * 出席レポート編集ダイアログの PATCH body 生成 pure function。
+ *
+ * Phase 3 follow-up #3 (#533): 時刻フィールドが実際に変更された場合のみ entryAt/exitAt を含める。
+ * 未変更で送ると `dateTimeJSTtoISO` の分精度丸めで秒情報が失われ、original snapshot との差分が
+ * 発生し `isStayTimeEdited=true` になる回帰を防ぐ (Codex セカンドオピニオン BLOCK MERGE 指摘)。
+ */
+
+/** 日付(yyyy-MM-dd) + 時刻(HH:mm) をJSTとしてISO UTC文字列に変換 (分精度、秒は :00) */
+export function dateTimeJSTtoISO(date: string, time: string): string {
+  return new Date(`${date}T${time}:00+09:00`).toISOString();
+}
+
+export interface EditPatchInput {
+  editDate: string;
+  editEntryTime: string;
+  editExitTime: string;
+  initialEditDate: string;
+  initialEditEntryTime: string;
+  initialEditExitTime: string;
+  editScore: string;
+  editPassed: string;
+}
+
+/**
+ * 編集ダイアログの form state から PATCH body を生成する。
+ * 時刻フィールドは「日付 or 該当時刻が初期値から変更された場合のみ」body に含める (dirty 判定)。
+ */
+export function buildEditPatchBody(input: EditPatchInput): Record<string, unknown> {
+  const dateChanged = input.editDate !== input.initialEditDate;
+  const entryTimeChanged = input.editEntryTime !== input.initialEditEntryTime;
+  const exitTimeChanged = input.editExitTime !== input.initialEditExitTime;
+  const body: Record<string, unknown> = {};
+  if (input.editDate && input.editEntryTime && (dateChanged || entryTimeChanged)) {
+    body.entryAt = dateTimeJSTtoISO(input.editDate, input.editEntryTime);
+  }
+  if (input.editDate && input.editExitTime && (dateChanged || exitTimeChanged)) {
+    body.exitAt = dateTimeJSTtoISO(input.editDate, input.editExitTime);
+  }
+  if (input.editScore !== "") {
+    body.quizScore = Number(input.editScore);
+  }
+  if (input.editPassed !== "") {
+    body.quizPassed = input.editPassed === "true";
+  }
+  return body;
+}

--- a/web/app/super/attendance/_helpers/stay-duration.ts
+++ b/web/app/super/attendance/_helpers/stay-duration.ts
@@ -79,3 +79,18 @@ export function isStayTimeEdited(record: {
     record.exitAt !== record.original.exitAt
   );
 }
+
+/**
+ * ソート用の滞在時間値 (ms)。`isSynthetic=true` かつ未編集なら null (= 末尾配置)、
+ * それ以外は通常の `calculateStayDurationMs` 結果。
+ * Phase 3 follow-up #3 (#533): 編集済 synthetic は実時刻として通常順序に戻す。
+ */
+export function stayDurationSortValue(record: {
+  isSynthetic: boolean;
+  entryAt: string | null;
+  exitAt: string | null;
+  original?: { entryAt: string | null; exitAt: string | null };
+}): number | null {
+  if (record.isSynthetic && !isStayTimeEdited(record)) return null;
+  return calculateStayDurationMs(record.entryAt, record.exitAt);
+}

--- a/web/app/super/attendance/_helpers/stay-duration.ts
+++ b/web/app/super/attendance/_helpers/stay-duration.ts
@@ -35,3 +35,47 @@ export function formatStayDuration(ms: number | null): string {
   const minutes = totalMinutes % 60;
   return hours > 0 ? `${hours}時間${minutes}分` : `${minutes}分`;
 }
+
+/** 自動補完 session の滞在時間カラム表示文字列。Firestore 一次データは維持し表示層のみで分離する。 */
+export const SYNTHETIC_STAY_DURATION_LABEL = "— (テストのみ)";
+
+/**
+ * record 単位の滞在時間表示。
+ * `isSynthetic=true` は quiz 開始〜提出の所要時間 (= 1〜2 分) が記録されているが、実滞在時間ではないため
+ * `SYNTHETIC_STAY_DURATION_LABEL` で表示し、通常 session と数値カラムを混在させない。
+ * Phase 3 follow-up #3 (#533): entryAt 書き換え案 (B) は Codex No-Go 判定により表示層分離 (A) を採用。
+ *
+ * 例外: `entryAt/exitAt` が実際に編集されている場合 (`original` snapshot との差分検知、PR #557) は
+ * 管理者が確認した実時刻のため通常計算で表示する。`editedAt` 単独では quizScore/quizPassed のみの
+ * 編集でも付与されるため判定材料に使えない (HIGH 指摘反映)。
+ * provenance としての `isSynthetic` バッジは UI 側で表示維持されるが、滞在時間は編集後の値を反映する。
+ */
+export function formatRecordStayDuration(record: {
+  isSynthetic: boolean;
+  entryAt: string | null;
+  exitAt: string | null;
+  original?: {
+    entryAt: string | null;
+    exitAt: string | null;
+  };
+}): string {
+  if (record.isSynthetic && !isStayTimeEdited(record)) return SYNTHETIC_STAY_DURATION_LABEL;
+  return formatStayDuration(calculateStayDurationMs(record.entryAt, record.exitAt));
+}
+
+/**
+ * `entryAt/exitAt` が初回値 (`original` snapshot) から実際に変更されたか判定。
+ * `original` が undefined (PR #557 投入前データ) や entryAt/exitAt が初回値と一致の場合は false。
+ * ソート判定にも使うため export。
+ */
+export function isStayTimeEdited(record: {
+  entryAt: string | null;
+  exitAt: string | null;
+  original?: { entryAt: string | null; exitAt: string | null };
+}): boolean {
+  if (!record.original) return false;
+  return (
+    record.entryAt !== record.original.entryAt ||
+    record.exitAt !== record.original.exitAt
+  );
+}

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -41,10 +41,10 @@ import {
   matchesExitReasonFilter,
 } from "./_helpers/exit-reason-filter";
 import {
-  calculateStayDurationMs,
   formatRecordStayDuration,
-  isStayTimeEdited,
+  stayDurationSortValue,
 } from "./_helpers/stay-duration";
+import { buildEditPatchBody } from "./_helpers/edit-patch";
 import {
   matchesIsSyntheticFilter,
   SYNTHETIC_KIND_OPTIONS,
@@ -98,12 +98,6 @@ function isoToTimeJST(iso: string | null): string {
     hour: "2-digit",
     minute: "2-digit",
   });
-}
-
-/** 日付(yyyy-MM-dd) + 時刻(HH:mm) をJSTとしてISO UTC文字列に変換 */
-function dateTimeJSTtoISO(date: string, time: string): string {
-  // JSTオフセット (+09:00) を付与して正しいUTCに変換
-  return new Date(`${date}T${time}:00+09:00`).toISOString();
 }
 
 const EXIT_REASON_LABELS: Record<string, string> = {
@@ -161,6 +155,12 @@ export default function AttendanceReportPage() {
   const [editDate, setEditDate] = useState("");
   const [editEntryTime, setEditEntryTime] = useState("");
   const [editExitTime, setEditExitTime] = useState("");
+  // dirty 判定用: openEdit 時の初期値 snapshot (時刻フィールド未変更時に PATCH body 送信を抑止)。
+  // Phase 3 follow-up #3 (#533): dateTimeJSTtoISO が秒を `:00` に丸めるため、未編集でも
+  // 元 ISO と新 ISO が「秒精度」で差分発生し isStayTimeEdited=true になる回帰を防ぐ。
+  const [initialEditDate, setInitialEditDate] = useState("");
+  const [initialEditEntryTime, setInitialEditEntryTime] = useState("");
+  const [initialEditExitTime, setInitialEditExitTime] = useState("");
   const [editScore, setEditScore] = useState("");
   const [editPassed, setEditPassed] = useState("");
   const [editLoading, setEditLoading] = useState(false);
@@ -303,15 +303,11 @@ export default function AttendanceReportPage() {
     if (sortKey && sortDir) {
       const dir = sortDir === "asc" ? 1 : -1;
       records = [...records].sort((a, b) => {
-        // stayDuration は計算フィールド: ms 数値で比較 (null は末尾)。
-        // isSynthetic は実滞在時間ではないため null 同等で末尾配置 (Phase 3 follow-up #3)。
-        // 例外: entryAt/exitAt が編集された (original snapshot との差分あり) 場合は通常順序。
-        // editedAt 単独判定だと quizScore のみ編集でも通常順序に戻ってしまうため original を見る。
+        // stayDuration は計算フィールド: stayDurationSortValue で synthetic 末尾配置 + 編集済例外を扱う
+        // (Phase 3 follow-up #3)。null 同等で末尾固定。
         if (sortKey === "stayDuration") {
-          const aTreatAsSynthetic = a.isSynthetic && !isStayTimeEdited(a);
-          const bTreatAsSynthetic = b.isSynthetic && !isStayTimeEdited(b);
-          const av = aTreatAsSynthetic ? null : calculateStayDurationMs(a.entryAt, a.exitAt);
-          const bv = bTreatAsSynthetic ? null : calculateStayDurationMs(b.entryAt, b.exitAt);
+          const av = stayDurationSortValue(a);
+          const bv = stayDurationSortValue(b);
           if (av === null && bv === null) return 0;
           if (av === null) return 1;
           if (bv === null) return -1;
@@ -333,9 +329,15 @@ export default function AttendanceReportPage() {
 
   const openEdit = (record: SuperAttendanceRecord) => {
     setEditRecord(record);
-    setEditDate(isoToDateJST(record.entryAt));
-    setEditEntryTime(isoToTimeJST(record.entryAt));
-    setEditExitTime(isoToTimeJST(record.exitAt));
+    const dateInit = isoToDateJST(record.entryAt);
+    const entryInit = isoToTimeJST(record.entryAt);
+    const exitInit = isoToTimeJST(record.exitAt);
+    setEditDate(dateInit);
+    setEditEntryTime(entryInit);
+    setEditExitTime(exitInit);
+    setInitialEditDate(dateInit);
+    setInitialEditEntryTime(entryInit);
+    setInitialEditExitTime(exitInit);
     setEditScore(record.quizScore?.toString() ?? "");
     setEditPassed(record.quizPassed === null ? "" : record.quizPassed ? "true" : "false");
     setEditError(null);
@@ -347,17 +349,11 @@ export default function AttendanceReportPage() {
     setEditLoading(true);
     setEditError(null);
     try {
-      const body: Record<string, unknown> = {};
-      if (editDate && editEntryTime) {
-        body.entryAt = dateTimeJSTtoISO(editDate, editEntryTime);
-      }
-      if (editDate && editExitTime) {
-        body.exitAt = dateTimeJSTtoISO(editDate, editExitTime);
-      }
-      if (editScore !== "") {
-        body.quizScore = Number(editScore);
-      }
-      if (editPassed !== "") body.quizPassed = editPassed === "true";
+      const body = buildEditPatchBody({
+        editDate, editEntryTime, editExitTime,
+        initialEditDate, initialEditEntryTime, initialEditExitTime,
+        editScore, editPassed,
+      });
 
       await superFetch(
         `/api/v2/super/tenants/${selectedTenant}/attendance-report/${editRecord.id}`,

--- a/web/app/super/attendance/page.tsx
+++ b/web/app/super/attendance/page.tsx
@@ -42,7 +42,8 @@ import {
 } from "./_helpers/exit-reason-filter";
 import {
   calculateStayDurationMs,
-  formatStayDuration,
+  formatRecordStayDuration,
+  isStayTimeEdited,
 } from "./_helpers/stay-duration";
 import {
   matchesIsSyntheticFilter,
@@ -302,10 +303,15 @@ export default function AttendanceReportPage() {
     if (sortKey && sortDir) {
       const dir = sortDir === "asc" ? 1 : -1;
       records = [...records].sort((a, b) => {
-        // stayDuration は計算フィールド: ms 数値で比較 (null は末尾)
+        // stayDuration は計算フィールド: ms 数値で比較 (null は末尾)。
+        // isSynthetic は実滞在時間ではないため null 同等で末尾配置 (Phase 3 follow-up #3)。
+        // 例外: entryAt/exitAt が編集された (original snapshot との差分あり) 場合は通常順序。
+        // editedAt 単独判定だと quizScore のみ編集でも通常順序に戻ってしまうため original を見る。
         if (sortKey === "stayDuration") {
-          const av = calculateStayDurationMs(a.entryAt, a.exitAt);
-          const bv = calculateStayDurationMs(b.entryAt, b.exitAt);
+          const aTreatAsSynthetic = a.isSynthetic && !isStayTimeEdited(a);
+          const bTreatAsSynthetic = b.isSynthetic && !isStayTimeEdited(b);
+          const av = aTreatAsSynthetic ? null : calculateStayDurationMs(a.entryAt, a.exitAt);
+          const bv = bTreatAsSynthetic ? null : calculateStayDurationMs(b.entryAt, b.exitAt);
           if (av === null && bv === null) return 0;
           if (av === null) return 1;
           if (bv === null) return -1;
@@ -611,7 +617,7 @@ export default function AttendanceReportPage() {
                       </TableCell>
                       <TableCell data-col="exitAt" className="whitespace-nowrap text-sm">{formatTime(r.exitAt)}</TableCell>
                       <TableCell data-col="stayDuration" className="whitespace-nowrap text-sm">
-                        {formatStayDuration(calculateStayDurationMs(r.entryAt, r.exitAt))}
+                        {formatRecordStayDuration(r)}
                       </TableCell>
                       <TableCell data-col="exitReason" className="text-sm">
                         {r.exitReason ? (EXIT_REASON_LABELS[r.exitReason] ?? r.exitReason) : "—"}


### PR DESCRIPTION
## Summary

- 現場フィードバック「合格のみで抽出した PDF に滞在時間 1 分が混入する」問題に対応
- 自動補完 session (`isSynthetic=true`) の滞在時間カラムを `"— (テストのみ)"` 表示に分離
- Firestore データは一切変更せず、UI 表示層のみで対応 (Codex No-Go の B 案を回避)
- 編集機能 (#557) で entryAt/exitAt を実時刻に修正した場合は通常計算 (Evaluator HIGH 指摘反映)

## 設計判断経緯

### B 案 (不採用): backfill 再実行で entryAt=submittedAt-SESSION_DURATION_MS に統一
Codex セカンドオピニオン (thread `019eaf6b-6b25-7011-be78-aaaa02ced8d2`) で **No-Go 判定**:
1. `entryAt - 3h` は実打刻でも quiz 開始時刻でもない = 真実性リスク
2. PR #555 でバッジ PDF 非表示化済 = provenance が行政提出時に伝わらない
3. `SESSION_DURATION_MS` (runtime config) を履歴データ改変根拠にすると将来変更時に説明不能
4. `entryAt` 3 時間前移動で日付境界をまたぐ集計に副作用

### A 案 (採用): UI 表示層のみで対応
- Firestore データ改変ゼロ、過去 17 件 + 今後の自動補完すべて即時自動適用
- 「自動補完」バッジ (#551) と組み合わせ、画面は内部監査可視性 / PDF は中立的な `"— (テストのみ)"` 表示

## 編集機能 (#557) との整合性 (Evaluator 2 ラウンド HIGH 指摘反映)

| isSynthetic | entryAt/exitAt 編集 | original | 表示 |
|-------------|---------------------|----------|------|
| false | - | - | 通常計算 |
| true | なし | undefined | `"— (テストのみ)"` |
| true | なし | あり + 同値 | `"— (テストのみ)"` (quizScore のみ編集) |
| **true** | **あり** | **あり + 差分** | **通常計算 (管理者確認)** |

`PATCH endpoint` は quizScore のみ編集でも `editedAt` を無条件付与するため、`editedAt` 単独判定は使えない (「1 分滞在」再出現問題)。`original` snapshot (#556) との entryAt/exitAt **実差分** で判定する。

## 変更ファイル

- `web/app/super/attendance/_helpers/stay-duration.ts`: `formatRecordStayDuration` + `isStayTimeEdited` + `SYNTHETIC_STAY_DURATION_LABEL`
- `web/app/super/attendance/page.tsx`: 表示 + ソートロジック変更
- `web/app/super/attendance/__tests__/stay-duration.test.ts`: 12 ケース追加
- `docs/adr/ADR-027-lesson-session-attendance.md`: Phase 3 follow-up #3 entry + 編集機能整合性
- `docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md`: 新規設計仕様書

## 品質ゲート

- ✅ safe-refactor: findings 0
- ✅ code-review medium: findings 0
- ✅ Evaluator 分離プロトコル: 2 ラウンド (MEDIUM → HIGH 指摘反映)
- ✅ 単体テスト 67 件全 PASS (新規 12 件)
- ✅ 型チェック / lint 全 PASS
- ⏳ Codex セカンドオピニオン (PR 作成後実施予定)

## Test plan

- [x] 単体テスト 67 件全 PASS (vitest)
- [x] 型チェック全 PASS (tsc)
- [x] lint 全 PASS
- [ ] CI 全 PASS
- [ ] Codex セカンドオピニオン (PR review モード)
- [ ] Playwright MCP で本番動作確認 (前田さよりさんの 2026/05/30 レッスン 2 含む画面で `"— (テストのみ)"` 表示確認、PDF 出力でも同様)

Refs #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)