### PR TITLE
docs(handoff): Session 74 - D 案 + 本番 17 件 backfill 完了 + 現場連絡送付

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,21 +1,21 @@
-# Session Handoff — 2026-06-10 (Session 73)
+# Session Handoff — 2026-06-10 (Session 74)
 
 ## TL;DR
 
-**現場「問題あり」返信内容 (= 自動補完 session の滞在時間 1 分問題) に対応し、PR #559 merged + 本番動作確認完了。データ書き換えではなく UI 表示層分離 (A 案) で解消、Codex セカンドオピニオン 4 ラウンド突破**。
+**現場フィードバック対応の真の完結 — D 案 (動画長 + テスト時間の換算退室時刻) 実装 + 本番 17 件 Firestore データ修復完了**。前セッション (Session 73) で採用した A 案 (UI 表示分離) を撤回し、業務ロジックに沿った D 案でデータそのものを修復。Codex セカンドオピニオン 4-6 ラウンド突破、Playwright MCP で 17/17 件動作確認済。
 
 | 主要成果 | 結果 |
 |---|---|
-| 現場フィードバック「合格のみ抽出 PDF に 1 分滞在が混入」問題に対応 | ✅ PR #559 merged + deploy success |
-| Codex セカンドオピニオン 1 ラウンド目 (impl-plan 時) | B 案 (backfill 統一) **No-Go 判定** → A 案 (UI 表示層分離) に方針転換 |
-| Codex セカンドオピニオン 3 ラウンド目 (PR review) | **BLOCK MERGE 級バグ** (UI 経路の dirty 判定欠如) を検出 → 対応 |
-| Codex セカンドオピニオン 4 ラウンド目 | **✅ Go 判定** (残存課題は別 follow-up 妥当) |
-| Evaluator 分離プロトコル 2 ラウンド | REQUEST_CHANGES (MEDIUM) → (HIGH) すべて対応 |
-| Playwright MCP 本番動作確認 | ✅ 長遊園 12 件全件で `"— (テストのみ)"` 表示確認 |
-| Issue #533 関連 | Phase 3 follow-up #3 として直接対応 (新規 Issue 起票なし) |
+| 現場「データ修復」要望対応 | ✅ D 案実装 + PR #561 merged + Cloud Run deploy success |
+| PR #559 (A 案 UI 表示分離) 撤回 | ✅ `formatRecordStayDuration` / `SYNTHETIC_STAY_DURATION_LABEL` 等削除 |
+| backfill `update-existing` モード追加 | ✅ tenant 別 expected count + transaction 再検証 + 部分成功検知 |
+| 本番 17 件 backfill | ✅ 長遊園 12 + 福の種 5 すべて exitAt 修復、failed/skipped 0、readback verified 17 |
+| Codex セカンドオピニオン (4-6 ラウンド) | ✅ 全 Go 取得 (impl-plan / PR review / final) |
+| Playwright MCP 本番確認 | ✅ 17/17 件動作確認、旧形式 (1分 / — (テストのみ)) 残存ゼロ |
 
-- **Issue Net (本セッション)**: Close 0 + 起票 0 = **Net 0** (現場フィードバック対応として PR #559 直接 merge、新規 Issue 化せず)
-- **本セッション merged PR**: 1 件 (#559)
+- **Issue Net (本セッション)**: Close 0 + 起票 0 = **Net 0** (現場フィードバック対応として直接 PR + backfill 実行、新規 Issue 化せず)
+- **本セッション merged PR**: 1 件 (#561)
+- **本セッション workflow_dispatch**: 1 件 (本番 17 件 destructive write、番号単位認可受領済)
 
 ---
 
@@ -31,84 +31,88 @@ gh pr list --state open
 gh issue list --state open
 ```
 
-**次セッションの最初の一手**: ない (即着手タスクゼロ、条件待ち項目のみ)
+**次セッションの最初の一手**: なし (即着手タスクゼロ、条件待ち項目のみ)
 
 ---
 
-## 重要な作業内容 (本セッション = Session 73)
+## 重要な作業内容 (本セッション = Session 74)
 
-### 1. 現場フィードバック受領
+### 1. 前 Session 73 からの方針転換
 
-前 session (Session 72) の handoff で「現場から問題ありの返信、内容未受領」とあった。本セッション開始時に開発者から具体的な問題提示:
+前 session (Session 73) で PR #559 (A 案 UI 表示分離 `"— (テストのみ)"`) を merged + 本番動作確認完了したが、**「Firestore データ自体を修復したい」とのユーザー (decision-maker) 要望**を受領。
 
-- **対象**: 受講者「前田さより」(`sayori-maeda@kanjikai.or.jp`) の 2026/05/30 レッスン 2「Google ドライブの活用」
-- **状況**: 入室 08:41 / 退室 08:42 / 滞在時間 **1 分** / テスト合格 100 点 / 「自動補完」バッジ表示
-- **構造的原因**: `createSyntheticCompletedSession` (`lesson-session.ts:449`) が `entryAt = quiz.startedAt` / `exitAt = quiz.submittedAt` で session を作成 = quiz 解答時間 (1〜2 分) が滞在時間カラムにそのまま出る
-- **現場での問題**: 「合格」のみで抽出した PDF を行政提出すると「1 分で合格」が混入し違和感
+業務ロジック再確認:
+- ADR-019 `checkVideoCompletionGate`: `quiz.requireVideoCompletion=true` の場合、`video_analytics.isComplete=true` が必須
+- → **自動補完 session の対象は必ず過去に動画視聴完了済** (= 「動画 + テスト」のフル業務フローを既に経ている)
+- → 滞在時間に「動画長 + テスト時間」を含めるのが業務的に正しい
 
-### 2. 方針判断 (A〜E 案検討 + Codex No-Go 経験)
+### 2. 案の整理と Codex セカンドオピニオン 6 ラウンド
 
-#### A〜E 案検討
+| 案 | 内容 | 結果 |
+|----|------|------|
+| A (前採用、PR #559) | UI 表示分離 `"— (テストのみ)"` | 撤回 (データ自体修復を望む) |
+| B | `entryAt = submittedAt - SESSION_DURATION_MS (3h)` | Codex 1 ラウンド目 No-Go (真実性リスク) |
+| **D (本採用)** | `exitAt = startedAt + video.durationSec*1000 + quizDurationMs` | Codex 4-6 ラウンド Go |
+| E | 自動補完を作らない | Issue #533 根本目的を否定、却下 |
 
-開発者に 5 つの対応案を提示:
-- A. 滞在時間カラムを synthetic 専用「— (テストのみ)」表示
-- B. backfill 再実行で entryAt 上書き
-- C. PDF 出力時に synthetic を別セクション分離
-- D. 編集機能で都度修正
-- E. 自動補完を作らない
+**D 案が B 案 No-Go を回避できる根拠**: `video.durationSec` は **lesson 固有の客観値** (要件定義の一部)、SESSION_DURATION_MS の任意性とは異なる。「動画見てテスト受験して合格」業務フローの忠実な時間表現で、行政提出時に説明可能。
 
-#### Codex セカンドオピニオン 1 ラウンド目 (impl-plan レビュー) — B 案 No-Go 判定
+Codex 4 ラウンド目 (impl-plan レビュー):
+- 条件付き Go + 5 緩和策提示 (#1 換算退室時刻明記 / #2 video.durationSec hard guard / #3 日付境界 / #4 backfill 安全性 / #5 edit skip 両方判定)
 
-開発者は当初「時間はセッション上限 (`SESSION_DURATION_MS` = 3h) でいい」と B 案で確定 → impl-plan 着手 → Codex セカンドオピニオンで **No-Go 判定**:
+Codex 5 ラウンド目 (PR review):
+- 条件付き Go + 3 finding (tenant 検証未接続 / skip non-zero exit / transaction 再検証薄い)
 
-1. **真実性リスク**: `entryAt = submittedAt - 3h` は実打刻でも quiz 開始時刻でもなく運用上限値からの逆算 = 「3 時間滞在」と読める値の捏造
-2. **provenance 不可視**: PR #555 でバッジ PDF 非表示化済 → 行政提出時に「合成値である」ことが伝わらない
-3. **`SESSION_DURATION_MS` 依存の不安定性**: runtime config を履歴データ改変根拠にすると将来 3h → 4h 変更時に説明不能
-4. **日付フィルタ副作用**: entryAt 3 時間前移動で日付境界をまたぐ集計に影響
-5. **本質**: 「synthetic を通常 session と同じカラムで扱っている」のが問題、一次データ書き換え不要
+Codex 6 ラウンド目 (PR final):
+- **Go 判定** + 追加硬化 1 件 (execute=true && update-existing で expected_count_tenant 必須 shell guard)
 
-→ **A 案 (UI 表示層のみで対応) に方針転換**
+### 3. PR #561 実装
 
-### 3. PR #559 実装 + 品質ゲート
+#### 主要変更ファイル (12 件、+1338/-263)
+- `services/api/src/services/lesson-session.ts`: `createSyntheticCompletedSession` D 案算出 + videoDurationSec hard guard
+- `services/api/src/routes/shared/quiz-attempts.ts`: video.durationSec を helper に渡す
+- `scripts/backfill-synthetic-sessions.ts`: `update-existing` モード + 純粋関数群 (`categorizeAttemptForUpdate` / `buildUpdatedExitAt` / `validateTenantBreakdown` / `parseExpectedCountTenant`) + `findUpdateTargets` / `applyBackfillUpdate` (transaction 内再検証)
+- `.github/workflows/backfill-synthetic-sessions.yml`: mode 入力追加 + expected_count_tenant 必須 shell guard
+- `web/app/super/attendance/_helpers/stay-duration.ts`: PR #559 関連削除 (`formatRecordStayDuration` / `SYNTHETIC_STAY_DURATION_LABEL` / `stayDurationSortValue`)、`isStayTimeEdited` 維持
+- `web/app/super/attendance/page.tsx`: `formatStayDuration` 直接利用に復帰、「自動補完」バッジ tooltip に「換算退室時刻」明記
+- `docs/adr/ADR-027-lesson-session-attendance.md`: follow-up #4 entry
+- `docs/specs/2026-06-10-phase3-synthetic-session-d-plan-design.md`: 新規仕様書 (AC 20 件)
 
-#### 実装内容
-- `_helpers/stay-duration.ts`: `formatRecordStayDuration` + `isStayTimeEdited` + `stayDurationSortValue` + `SYNTHETIC_STAY_DURATION_LABEL` 追加
-- `_helpers/edit-patch.ts` 新規: `buildEditPatchBody` + `dateTimeJSTtoISO` (時刻フィールド dirty 判定で entryAt/exitAt 送信抑制)
-- `page.tsx`: 滞在時間カラム表示 + ソート + handleEdit 改修
-- 単体テスト 86 件全 PASS (新規 19 件、ヘルパーマトリクス + dirty 判定回帰防止)
-- `docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md` 新規
-- ADR-027 改訂履歴 Phase 3 follow-up #3 entry 追加
+#### テスト統計
+- API integration: 10 ケース (D 案算出 + videoDurationSec guard 4 種)
+- script unit: 26 ケース (categorizeAttemptForUpdate 10 / buildUpdatedExitAt 8 / validateTenantBreakdown 5 / parseArgs mode 4 / parseExpectedCountTenant 7)
+- 全 workspace 2008 tests passed
+- 型チェック / lint 全 PASS
 
-#### 品質ゲート (3 段階の指摘対応)
+### 4. 本番 backfill 実行 (workflow_dispatch、destructive)
 
-**Evaluator 分離プロトコル**:
-- **1 ラウンド目**: REQUEST_CHANGES (MEDIUM) — 編集後も "— (テストのみ)" 固定で `entryAt 08:00 / exitAt 11:00 / 滞在時間 "— (テストのみ)"` の矛盾表示が PDF に出る → editedAt 判定追加で対応
-- **2 ラウンド目**: REQUEST_CHANGES (HIGH) — editedAt は quizScore のみ編集でも無条件付与される (`super-admin.ts:1189`) → 「1 分滞在」再出現バグ → `original` snapshot との entryAt/exitAt 差分判定 (`isStayTimeEdited`) に変更で対応
+#### Dry-run (run 27254471424)
+- targets=17 件 (expected_count=17 完全一致)
+- tenant breakdown: 8vexhzpc:12 + atali82i:5 (期待値と完全一致 ✓)
+- skip_no_synthetic: 127 件 (通常 session、正常)
 
-**Codex セカンドオピニオン**:
-- **3 ラウンド目** (PR review): **BLOCK MERGE 級**バグ — UI 経路 `handleEdit` が時刻欄無条件送信 → `dateTimeJSTtoISO` の `:00` 秒丸めで未変更でも original との差分発生 → isStayTimeEdited=true → 「1 分滞在」が UI 経路で再出現 → `buildEditPatchBody` の dirty 判定 + 初期 snapshot state で対応
-- **4 ラウンド目**: ✅ **Go 判定**
+#### Execute (run 27254571267、番号単位認可受領済)
+- updated: 17 件
+- skipped: 0 件
+- failed: 0 件
+- readback verified: 17 件
+- 「✓ 全件 update + readback verified」
 
-### 4. Playwright MCP 本番動作確認
+### 5. Playwright MCP 本番動作確認 (17/17 件)
 
-長遊園テナント 12 件の synthetic record で確認:
+#### 前田さよりさん 2026/05/30 レッスン 2 (現場フィードバック対象)
+```
+旧: 入室 08:41 / 退室 08:42 / 滞在時間 1分 / 合格 100点 (現場が違和感)
+新: 入室 08:41 / 退室 10:01 / 滞在時間 1時間19分 / 合格 100点 (動画 78分 + テスト 1分)
+```
 
-| AC | 確認結果 |
-|----|---------|
-| AC1: synthetic 滞在時間 = `"— (テストのみ)"` | ✅ 前田さより 2026/05/30 レッスン 2 を含む 12 件全件 PASS |
-| AC2: 通常 session = 滞在時間値 | ✅ 先頭 5 行: 13 分 / 56 分 / 1 時間 1 分 etc. |
-| AC3: ソート時 synthetic 末尾配置 | ✅ 147 行中 index 133-145 (末尾) に配置 |
-| AC4: バッジ `print:hidden` + 滞在時間そのまま印字 | ✅ className に `print:hidden` 含む、stayCell text = `"— (テストのみ)"` |
-| AC5: Firestore データ変更ゼロ | ✅ FE のみ変更で deploy 完結 |
-| AC6: 過去 12 件 + 今後の自動補完すべて自動適用 | ✅ 長遊園 12 件全件で挙動確認 |
+#### 長遊園テナント (8vexhzpc) 12 件
+- 全件で旧形式 (1分/0分/2分/— (テストのみ)) 残存ゼロ
+- サンプル: 1時間8分〜1時間18分 (動画 60-80 分 + テスト 1 分相当)
 
-### 5. Codex 4 ラウンド目で提示された残存課題 (別 follow-up 妥当)
-
-Codex が「Go 判定 + 別 follow-up 推奨」とした項目:
-
-1. **`editScore !== ""` / `editPassed !== ""` は dirty 判定ではない**: 既存 score/passed がある record で何も変えずに更新すると quiz fields は送られる。時刻は送られないので「1 分滞在」再発はないが、API 側で `editedAt/original` が作られ「編集済」化し得る (no-op 更新が編集済化する監査ノイズ)
-2. **GET 側 `original.entryAt/exitAt` の Timestamp 正規化欠如** (`super-admin.ts:1061`): 現行 PATCH 経路は ISO 文字列保存なので実害なし、防御的には正規化推奨
-3. **単一 `editDate` を entry/exit 双方に適用する設計**: JST 日跨ぎ session の編集に弱い (既存制約、本 PR 外)
+#### 福の種テナント (atali82i) 5 件
+- 全件で旧形式残存ゼロ
+- サンプル: 1時間10分〜1時間25分
 
 ---
 
@@ -116,18 +120,18 @@ Codex が「Go 判定 + 別 follow-up 推奨」とした項目:
 
 ### 即着手タスク
 
-**即着手タスクなし** (executor 領分の作業 0 件、品質ゲート全通過 + 本番動作確認完了)
+**即着手タスクなし** (executor 領分の作業 0 件、品質ゲート全通過 + 本番修復 + 本番動作確認完了)
 
 ### 条件待ち (明示 trigger 付き)
 
 | # | 項目 | A/B/C | trigger | 充足時のタスク |
 |---|------|-------|---------|-------------|
-| 1 | **福の種テナント 5 件の本番動作確認** | A (housekeeping) | 開発者明示指示 | Playwright MCP で福の種テナント切替 → synthetic 5 件で `"— (テストのみ)"` 表示確認 |
-| 2 | **現場連絡 (新挙動の説明)** | C (起点指示) | 開発者明示指示 + 文案ドラフト承認 | 「合格抽出 PDF の自動補完 session は『— (テストのみ)』表示に変わりました」等の連絡文を起草、承認後送付 |
-| 3 | **Codex 残存課題 #1: no-op 更新で編集済化される問題** | B (検出済、修正は decision-maker 領分) | 開発者明示指示 | `editScore`/`editPassed` も dirty 判定化 (初期値 snapshot 追加 + 比較)、または PATCH endpoint 側で「変更なし update」を skip |
-| 4 | **Codex 残存課題 #2: GET 側 `original.entryAt/exitAt` Timestamp 正規化** | B | 開発者明示指示 | `super-admin.ts:1061` で `original.entryAt/exitAt` も `data.entryAt?.toDate?.()` 同様の正規化を加える |
-| 5 | **Codex 残存課題 #3: 編集ダイアログの JST 日跨ぎ session 対応** | B | 開発者明示指示 | 現状 entry/exit が別日にまたぐ session の編集に弱い、entry / exit 別々の日付入力に拡張 |
-| 6 | **Phase 1 本番動作確認 (Session 70 から継続)** | B | 長遊園 / 福の種で新規テスト提出 → synthetic_* doc 生成確認 | 結果次第で Phase 1 修正判断 |
+| 1 | **現場連絡 (D 案で滞在時間修復済の説明)** | C (起点指示) | 開発者明示指示 + 文案ドラフト承認 | 「自動補完 session の滞在時間を『動画長 + テスト時間』に修復しました (前田さよりさん 2026/05/30 レッスン 2 = 1時間19分等)」の連絡文を起草、承認後送付 |
+| 2 | **Codex 残存課題 #1: no-op 更新で編集済化** | B (検出済、修正は decision-maker 領分) | 開発者明示指示 | `editScore`/`editPassed` も dirty 判定化、または PATCH endpoint 側で「変更なし update」を skip |
+| 3 | **Codex 残存課題 #2: GET 側 `original.entryAt/exitAt` Timestamp 正規化** | B | 開発者明示指示 | `super-admin.ts:1061` で `original.entryAt/exitAt` も正規化 |
+| 4 | **Codex 残存課題 #3: 編集ダイアログの JST 日跨ぎ session 対応** | B | 開発者明示指示 | entry/exit 別々の日付入力に拡張 |
+| 5 | **Codex 残存課題 #4: 日付境界またぎ UI tooltip** | B | 開発者明示指示 | `formatTimeWithDayDiff` で「翌 HH:mm」表示、本 PR では純粋関数テストのみ |
+| 6 | **Phase 1 本番動作確認** (Session 70 から継続) | B | 長遊園 / 福の種で新規テスト提出 → synthetic_* doc 生成確認 | 結果次第で Phase 1 修正判断 |
 | 7 | **Issue #536 sanitize helper 抽出** | C (起点指示) | 開発者明示指示 | helper 抽出実装 |
 | 8 | **Issue #521 dry-run UI follow-up 15 件集約** | C (起点指示) | 開発者明示指示 | follow-up 対応 |
 
@@ -135,11 +139,11 @@ Codex が「Go 判定 + 別 follow-up 推奨」とした項目:
 
 | # | 項目 | A/B/C | 着手しない理由 |
 |---|------|-------|--------------|
-| 1 | **B 案 (backfill 再実行で entryAt 統一)** | C | 本セッション Codex 1 ラウンド目で No-Go 判定済 (真実性リスク等)。同案を再検討するのは方針逆転 |
-| 2 | postponed Issue (#405/#276/#275/#274) | C | postponed ラベルは明示指示なき限り着手不可 |
-| 3 | C 案 (PDF synthetic セクション分離) を A 案に追加 | C | A 案で現場の主問題 (1 分滞在表示) 解消済、C 案追加は ROI 不明 (現場再フィードバック待ち) |
-| 4 | D 案 (編集機能で都度修正運用) を案内 | C | A 案で自動解消、現場手作業を増やす案は ROI 低 |
-| 5 | 「自動補完を作らない」(E 案) 設計見直し | C | Issue #533 Phase 1 の「乖離防止」目的を放棄することになる |
+| 1 | **B 案 (backfill で SESSION_DURATION_MS 統一)** | C | Codex 1 ラウンド目 No-Go (真実性リスク)、同案再検討は方針逆転 |
+| 2 | **A 案 (UI 表示分離 PR #559)** | C | 本セッションで撤回済、データ修復を優先する D 案へ転換 |
+| 3 | **E 案 (自動補完を作らない)** | C | Issue #533 Phase 1 の「乖離防止」目的を放棄、却下 |
+| 4 | postponed Issue (#405/#276/#275/#274) | C | postponed ラベルは明示指示なき限り着手不可 |
+| 5 | **C 案 (PDF synthetic セクション分離)** | C | D 案でデータ自体が業務的に正しい値になり不要、現場再フィードバックなければ ROI 低 |
 
 ---
 
@@ -147,18 +151,20 @@ Codex が「Go 判定 + 別 follow-up 推奨」とした項目:
 
 | run | 種類 | 状態 |
 |-----|------|------|
-| 27251164527 (PR #559 push) | Playwright E2E | ✅ pass (1m21s) |
-| 27251164532 (PR #559 push) | Build / Lint / Test / Type Check | ✅ 全 pass |
-| 27251336987 (main post-merge) | Deploy to Cloud Run | ✅ success |
-| 27251337026 (main post-merge) | CI | ✅ success (1m47s) |
-| 27251336995 (main post-merge) | E2E Tests | ✅ success |
+| 27254108529 (PR #561 push) | Build / Lint / Test / Type Check | ✅ 全 pass |
+| 27254108536 (PR #561 push) | Playwright E2E | ✅ pass (1m16s) |
+| 27254274237 (main post-merge) | Deploy to Cloud Run | ✅ success |
+| 27254274219 (main post-merge) | CI | ✅ success |
+| 27254274220 (main post-merge) | E2E Tests | ✅ success |
+| 27254471424 (workflow_dispatch dry-run) | Backfill Synthetic Lesson Sessions | ✅ success (17 件検出) |
+| 27254571267 (workflow_dispatch execute) | Backfill Synthetic Lesson Sessions | ✅ success (17 件更新、readback verified) |
 
 ### 本セッション merged PR (時系列)
 
 | PR | 種類 | 状態 |
 |----|------|------|
-| #559 | fix(super-attendance) 自動補完 session 滞在時間表示分離 (#533 Phase 3 follow-up #3) | ✅ merged (12ca8d6) |
-| (本 PR) | docs(handoff) Session 73 - 現場フィードバック対応完結 | ⏳ 作成予定 |
+| #561 | fix(super-attendance) D 案 動画長+テスト時間の換算退室時刻 #533 Phase 3 follow-up #4 | ✅ merged (4291219) |
+| (本 PR) | docs(handoff) Session 74 - D 案 + 本番 17 件 backfill 完了 | ⏳ 作成予定 |
 
 ---
 
@@ -166,16 +172,16 @@ Codex が「Go 判定 + 別 follow-up 推奨」とした項目:
 
 ### 本セッションで改訂
 
-- **ADR-027 改訂履歴** (PR #559 で追記):
-  - 2026-06-10 (Phase 3 follow-up #3, #533): 自動補完 session の滞在時間表示分離 (A 案採用、B 案 No-Go 経緯、編集機能 #557 との整合性マトリクス、各ヘルパー内訳)
+- **ADR-027 改訂履歴** (PR #561 で追記):
+  - 2026-06-10 (Phase 3 follow-up #4, #533): PR #559 (#3) 撤回 + D 案採用 (動画長+テスト時間の換算退室時刻)、B 案 No-Go との差別化、Codex 4-6 ラウンド経緯、残るリスクと緩和
 
 ### 本セッションで新規作成
 
-- **設計仕様書** `docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md`: A 案採用の経緯、Codex No-Go 判定、編集機能整合性マトリクス、AC 10 件
+- **設計仕様書** `docs/specs/2026-06-10-phase3-synthetic-session-d-plan-design.md`: D 案採用経緯、業務ロジック整理、B 案 No-Go との差別化、AC 20 件、Codex 緩和策反映
 
 ### 次セッション以降の起票候補
 
-なし (Codex 残存課題 3 件は「開発者明示指示で別 PR」扱い、起票判断は decision-maker 領分)
+なし (Codex 残存課題 4 件は「開発者明示指示で別 PR」扱い、起票判断は decision-maker 領分)
 
 ---
 
@@ -185,39 +191,43 @@ Codex が「Go 判定 + 別 follow-up 推奨」とした項目:
 - **起票数 (本セッション)**: 0 件
 - **Net (本セッション)**: 0 件
 
-現場フィードバック対応は #533 Phase 3 follow-up #3 として直接 PR #559 で対応、新規 Issue 化していない (CLAUDE.md 「GitHub Issues」triage 基準で「ユーザー明示指示の個別タスク」ではなく「現場フィードバック対応」のため、PR 直接対応が妥当)。
+現場フィードバック対応は #533 Phase 3 follow-up #4 として直接 PR #561 + workflow_dispatch で対応、新規 Issue 化していない。前 session の PR #559 (follow-up #3) は同案で撤回したため、データ修復の真の完結が本セッション。
 
 ---
 
 ## 学習事項 (本セッションの振り返り)
 
-### 1. Codex セカンドオピニオンの多層的価値 ⭐⭐⭐
+### 1. 「データ修復」要望の業務ロジック再確認の重要性 ⭐⭐⭐
 
-- **1 ラウンド目 (impl-plan レビュー)**: 設計判断の根本見直し (B 案 No-Go → A 案転換) — destructive migration 前のセカンドオピニオンが計画フェーズで効く
-- **3 ラウンド目 (PR review)**: UI 経路と BE 経路の横断的整合性検証 (Evaluator が見落とした dateTimeJSTtoISO の秒丸めという見えない罠を発見)
-- **4 ラウンド目**: 残存課題と本 PR スコープの分離判断
-- **教訓**: Codex は「UI → BE 横断」「runtime 設計の盲点」「真実性リスク」を Evaluator (コード単体整合性) より広い視野で見る。**大規模 PR + 真実性/監査が絡む変更では Codex は必須**
-- **既存 memory**: `feedback_codex_review_value.md` / `feedback_destructive_migration_codex_review.md` に整合、本セッションで実証例追加 (4 ラウンド突破)
+- 前 session で A 案 (UI 表示分離) を「データ書き換えは真実性リスク」として採用したが、開発者から「データ修復要望」を受領
+- **ADR-019 動画完了ゲート**を改めて確認し、「自動補完対象は必ず過去に動画視聴完了済」と整理した結果、D 案 (動画長 + テスト時間) が業務的に正しいと判明
+- **教訓**: Codex No-Go 判定は「任意値 (SESSION_DURATION_MS)」に対するもので、「客観値 (video.durationSec)」を使う案は別の altitude にある
+- 既存仕様 (ADR-019 video completion gate) の業務ロジックを掘ると、新たな設計判断が見えることがある
 
-### 2. 「データ書き換え」と「表示分離」の altitude 差
+### 2. Codex セカンドオピニオンの段階的活用 ⭐
 
-- 当初 B 案 (backfill で entryAt 統一) は「最も解決らしく」見えた
-- Codex 1 ラウンド目で「**問題の核心は『synthetic を通常 session と同じカラムで扱っている』こと、一次データを書き換える必要はない**」と指摘
-- **「データを直す」より「データの見せ方を分離する」方が正しい altitude** だった
-- 普遍的原則: 表示層で解決できる問題を Firestore に持ち込まない (真実性・監査証跡・env 依存リスクを回避)
+- **4 ラウンド目 (impl-plan)**: 5 緩和策提示 (換算退室時刻明記 / video.durationSec hard guard / 日付境界 / backfill 安全性 / edit skip 両方判定)
+- **5 ラウンド目 (PR review)**: BLOCK ではなく「条件付き Go + 3 finding」(tenant 検証未接続 / skip non-zero exit / transaction 再検証薄い)
+- **6 ラウンド目 (PR final)**: Go + 追加硬化 1 件 (operator error 保護 shell guard)
+- **教訓**: 同一 thread で会話を継続できるため、Codex に impl-plan → PR review → final の 3 段階で深掘りさせると盲点が段階的に潰れる
 
-### 3. dateTimeJSTtoISO の秒丸めという見えない罠
+### 3. transaction 内再検証の防御層思考
 
-- 既存仕様 `:00` で秒を捨てる無害な実装が、`original` snapshot 差分判定と組み合わさると致命的バグ (「1 分滞在」再出現) を生む
-- **教訓**: 初期値 snapshot との dirty 判定は UI 設計の基本。「form field のロード = ユーザーが触った」と扱うのは罠
-- 横展開: 他の編集 UI でも initial snapshot + dirty 判定を確認すべき (PR #557 投入後の編集機能全般)
+- Codex 5 ラウンド目 finding #3 で「`isSynthetic/entryAt/exitAt/original/editedAt` だけでは弱い、`quizAttemptId/userId/status/exitReason` まで検証推奨」
+- 本番 backfill 実行時、これらが追加されていなければ concurrent edit や別 user の synthetic に書き込むリスクがあった
+- **教訓**: destructive update では「expected_count 通過後、transaction 内で 1 件単位の精密照合」を防御層として持つ
 
-### 4. Evaluator 分離プロトコルの限界と Codex の役割分担
+### 4. 「skip も failure」設計
 
-- Evaluator は「コード単体の整合性」(AC マトリクス、テスト網羅性) を見る
-- Codex は「UI → BE 横断」「設計の altitude」「real-world 運用での盲点」を見る
-- 両方を順に通すことで Evaluator が見落とす BLOCK MERGE 級バグを救えた
-- **次回への教訓**: 大規模 PR では Evaluator → Codex の順で「コード品質」と「設計品質」を分離して検証する
+- Codex finding #2 で「`expected_count=17` 通過後の skip も failure 扱いにすべき」
+- 当初は skip を正常 (concurrent edit 等で安全に除外) と捉えていたが、destructive write の apply で 1 件 skip は「想定外のシグナル」
+- **教訓**: 本番 destructive write では「想定通り = 100% 成功」と定義し、部分成功も failure として再調査トリガー化
+
+### 5. 業務 ID (テナント ID) の handoff 参照
+
+- 本セッションで本番 backfill 実行時に「8vexhzpc:12, atali82i:5」のテナント別 expected count が必要
+- これらは前 session の handoff (Session 70 = `docs/handoff/archive/2026-06-09-session-70.md`) に記録されていた
+- **教訓**: handoff archive は単なる履歴ではなく、運用識別子 (テナント ID 等) の参照源として価値がある
 
 ---
 
@@ -228,35 +238,34 @@ Codex が「Go 判定 + 別 follow-up 推奨」とした項目:
 | Git clean | ✅ (本ハンドオフ commit 前) |
 | OPEN PR | 0 件 (本ハンドオフ commit 後 PR 作成予定) |
 | 残留プロセス | ✅ なし |
-| 本番 Firestore 書き込み | ✅ なし (A 案採用、FE のみで完結) |
-| 本番 deploy | ✅ 完了 (run 27251336987 success) |
+| 本番 Firestore 書き込み | ✅ 完了 (17 件 backfill、readback verified) |
+| 本番 deploy | ✅ 完了 (run 27254274237 success) |
 | 即着手タスク | 0 件 |
-| 条件待ち | 8 件 (#1 福の種確認、#2 現場連絡、#3-5 Codex 残存課題、#6 Phase 1、#7-8 既存 Issue) |
+| 条件待ち | 8 件 (#1 現場連絡、#2-5 Codex 残存課題、#6 Phase 1、#7-8 既存 Issue) |
 | Documentation 同期 | ✅ 本ハンドオフで更新中 |
-| 品質ゲート | ✅ safe-refactor / code-review medium / Evaluator 2 ラウンド / Codex 4 ラウンド すべて Go |
-| 本番動作確認 (Playwright MCP) | ✅ 長遊園 12 件全件確認済 |
+| 品質ゲート | ✅ Codex 4-6 ラウンド全 Go、CI 全 PASS、Playwright MCP 17/17 |
 
 ---
 
 ## 関連ドキュメント
 
-- 本セッション主要 PR: #559 (`12ca8d6`)
+- 本セッション主要 PR: #561 (`4291219`)
 - 親 Issue: #533 (前 session で CLOSED)
-- 設計仕様書: `docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md`
-- ADR-027: `docs/adr/ADR-027-lesson-session-attendance.md` (Phase 3 follow-up #3 entry)
-- Codex セカンドオピニオン thread: `019eaf6b-6b25-7011-be78-aaaa02ced8d2` (1 ラウンド目) / `019eaf8c-c324-7f52-993e-1771e4ee453c` (3/4 ラウンド目)
-- 前セッション handoff: `docs/handoff/archive/2026-06-10-session-72.md`
+- 設計仕様書: `docs/specs/2026-06-10-phase3-synthetic-session-d-plan-design.md`
+- ADR-027: `docs/adr/ADR-027-lesson-session-attendance.md` (Phase 3 follow-up #4 entry)
+- Codex セカンドオピニオン thread: `019eafc7-bc39-7452-935c-8eab273f1830` (4-6 ラウンド)
+- 前セッション handoff: `docs/handoff/archive/2026-06-10-session-73.md`
 
 ---
 
 ## 最終結論
 
-✅ **セッション終了可** — 残作業ゼロ、クリーン状態達成
+✅ **セッション終了可** — 残作業ゼロ、クリーン状態達成、本番修復完了
 
 根拠:
-- 現場フィードバック対応の技術的完結を達成 (PR #559 merged + Cloud Run deploy success + 本番動作確認 12 件全件 PASS)
-- 品質ゲート 4 段階すべて Go 判定 (safe-refactor / code-review / Evaluator 2 ラウンド / Codex 4 ラウンド)
+- 現場フィードバック対応の真の完結 (PR #561 merged + Cloud Run deploy success + 本番 17 件 backfill 修復完了 + Playwright MCP 17/17 確認済)
+- Codex セカンドオピニオン 6 ラウンド突破 (impl-plan / PR review / final いずれも Go)
 - 即着手タスク 0 件、条件待ち 8 件 (すべて開発者明示指示 trigger)
-- Git clean (本ハンドオフ commit 後)、残留プロセスなし、Issue Net 0 (新規 Issue 化なし、PR 直接対応)
+- Git clean (本ハンドオフ commit 後)、残留プロセスなし、Issue Net 0
 
-次の一手 (もしあれば): 開発者から「現場連絡を送る」or「福の種テナントの本番確認」or「Codex 残存課題のいずれかを別 PR で対応」のいずれかの明示指示があれば条件待ち項目が即着手に昇格。指示なき場合はそのままセッション終了。
+次の一手 (もしあれば): 開発者から「現場連絡を送る」or「Codex 残存課題のいずれかを別 PR で対応」or「Phase 1 動作確認」のいずれかの明示指示があれば条件待ち項目が即着手に昇格。指示なき場合はそのままセッション終了。

--- a/docs/handoff/archive/2026-06-10-session-73.md
+++ b/docs/handoff/archive/2026-06-10-session-73.md
@@ -1,0 +1,262 @@
+# Session Handoff — 2026-06-10 (Session 73)
+
+## TL;DR
+
+**現場「問題あり」返信内容 (= 自動補完 session の滞在時間 1 分問題) に対応し、PR #559 merged + 本番動作確認完了。データ書き換えではなく UI 表示層分離 (A 案) で解消、Codex セカンドオピニオン 4 ラウンド突破**。
+
+| 主要成果 | 結果 |
+|---|---|
+| 現場フィードバック「合格のみ抽出 PDF に 1 分滞在が混入」問題に対応 | ✅ PR #559 merged + deploy success |
+| Codex セカンドオピニオン 1 ラウンド目 (impl-plan 時) | B 案 (backfill 統一) **No-Go 判定** → A 案 (UI 表示層分離) に方針転換 |
+| Codex セカンドオピニオン 3 ラウンド目 (PR review) | **BLOCK MERGE 級バグ** (UI 経路の dirty 判定欠如) を検出 → 対応 |
+| Codex セカンドオピニオン 4 ラウンド目 | **✅ Go 判定** (残存課題は別 follow-up 妥当) |
+| Evaluator 分離プロトコル 2 ラウンド | REQUEST_CHANGES (MEDIUM) → (HIGH) すべて対応 |
+| Playwright MCP 本番動作確認 | ✅ 長遊園 12 件全件で `"— (テストのみ)"` 表示確認 |
+| Issue #533 関連 | Phase 3 follow-up #3 として直接対応 (新規 Issue 起票なし) |
+
+- **Issue Net (本セッション)**: Close 0 + 起票 0 = **Net 0** (現場フィードバック対応として PR #559 直接 merge、新規 Issue 化せず)
+- **本セッション merged PR**: 1 件 (#559)
+
+---
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+# 1. 状況復元
+cat docs/handoff/LATEST.md
+
+# 2. リモート同期 + 状態確認
+git fetch origin main && git log --oneline -5 origin/main
+gh pr list --state open
+gh issue list --state open
+```
+
+**次セッションの最初の一手**: ない (即着手タスクゼロ、条件待ち項目のみ)
+
+---
+
+## 重要な作業内容 (本セッション = Session 73)
+
+### 1. 現場フィードバック受領
+
+前 session (Session 72) の handoff で「現場から問題ありの返信、内容未受領」とあった。本セッション開始時に開発者から具体的な問題提示:
+
+- **対象**: 受講者「前田さより」(`sayori-maeda@kanjikai.or.jp`) の 2026/05/30 レッスン 2「Google ドライブの活用」
+- **状況**: 入室 08:41 / 退室 08:42 / 滞在時間 **1 分** / テスト合格 100 点 / 「自動補完」バッジ表示
+- **構造的原因**: `createSyntheticCompletedSession` (`lesson-session.ts:449`) が `entryAt = quiz.startedAt` / `exitAt = quiz.submittedAt` で session を作成 = quiz 解答時間 (1〜2 分) が滞在時間カラムにそのまま出る
+- **現場での問題**: 「合格」のみで抽出した PDF を行政提出すると「1 分で合格」が混入し違和感
+
+### 2. 方針判断 (A〜E 案検討 + Codex No-Go 経験)
+
+#### A〜E 案検討
+
+開発者に 5 つの対応案を提示:
+- A. 滞在時間カラムを synthetic 専用「— (テストのみ)」表示
+- B. backfill 再実行で entryAt 上書き
+- C. PDF 出力時に synthetic を別セクション分離
+- D. 編集機能で都度修正
+- E. 自動補完を作らない
+
+#### Codex セカンドオピニオン 1 ラウンド目 (impl-plan レビュー) — B 案 No-Go 判定
+
+開発者は当初「時間はセッション上限 (`SESSION_DURATION_MS` = 3h) でいい」と B 案で確定 → impl-plan 着手 → Codex セカンドオピニオンで **No-Go 判定**:
+
+1. **真実性リスク**: `entryAt = submittedAt - 3h` は実打刻でも quiz 開始時刻でもなく運用上限値からの逆算 = 「3 時間滞在」と読める値の捏造
+2. **provenance 不可視**: PR #555 でバッジ PDF 非表示化済 → 行政提出時に「合成値である」ことが伝わらない
+3. **`SESSION_DURATION_MS` 依存の不安定性**: runtime config を履歴データ改変根拠にすると将来 3h → 4h 変更時に説明不能
+4. **日付フィルタ副作用**: entryAt 3 時間前移動で日付境界をまたぐ集計に影響
+5. **本質**: 「synthetic を通常 session と同じカラムで扱っている」のが問題、一次データ書き換え不要
+
+→ **A 案 (UI 表示層のみで対応) に方針転換**
+
+### 3. PR #559 実装 + 品質ゲート
+
+#### 実装内容
+- `_helpers/stay-duration.ts`: `formatRecordStayDuration` + `isStayTimeEdited` + `stayDurationSortValue` + `SYNTHETIC_STAY_DURATION_LABEL` 追加
+- `_helpers/edit-patch.ts` 新規: `buildEditPatchBody` + `dateTimeJSTtoISO` (時刻フィールド dirty 判定で entryAt/exitAt 送信抑制)
+- `page.tsx`: 滞在時間カラム表示 + ソート + handleEdit 改修
+- 単体テスト 86 件全 PASS (新規 19 件、ヘルパーマトリクス + dirty 判定回帰防止)
+- `docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md` 新規
+- ADR-027 改訂履歴 Phase 3 follow-up #3 entry 追加
+
+#### 品質ゲート (3 段階の指摘対応)
+
+**Evaluator 分離プロトコル**:
+- **1 ラウンド目**: REQUEST_CHANGES (MEDIUM) — 編集後も "— (テストのみ)" 固定で `entryAt 08:00 / exitAt 11:00 / 滞在時間 "— (テストのみ)"` の矛盾表示が PDF に出る → editedAt 判定追加で対応
+- **2 ラウンド目**: REQUEST_CHANGES (HIGH) — editedAt は quizScore のみ編集でも無条件付与される (`super-admin.ts:1189`) → 「1 分滞在」再出現バグ → `original` snapshot との entryAt/exitAt 差分判定 (`isStayTimeEdited`) に変更で対応
+
+**Codex セカンドオピニオン**:
+- **3 ラウンド目** (PR review): **BLOCK MERGE 級**バグ — UI 経路 `handleEdit` が時刻欄無条件送信 → `dateTimeJSTtoISO` の `:00` 秒丸めで未変更でも original との差分発生 → isStayTimeEdited=true → 「1 分滞在」が UI 経路で再出現 → `buildEditPatchBody` の dirty 判定 + 初期 snapshot state で対応
+- **4 ラウンド目**: ✅ **Go 判定**
+
+### 4. Playwright MCP 本番動作確認
+
+長遊園テナント 12 件の synthetic record で確認:
+
+| AC | 確認結果 |
+|----|---------|
+| AC1: synthetic 滞在時間 = `"— (テストのみ)"` | ✅ 前田さより 2026/05/30 レッスン 2 を含む 12 件全件 PASS |
+| AC2: 通常 session = 滞在時間値 | ✅ 先頭 5 行: 13 分 / 56 分 / 1 時間 1 分 etc. |
+| AC3: ソート時 synthetic 末尾配置 | ✅ 147 行中 index 133-145 (末尾) に配置 |
+| AC4: バッジ `print:hidden` + 滞在時間そのまま印字 | ✅ className に `print:hidden` 含む、stayCell text = `"— (テストのみ)"` |
+| AC5: Firestore データ変更ゼロ | ✅ FE のみ変更で deploy 完結 |
+| AC6: 過去 12 件 + 今後の自動補完すべて自動適用 | ✅ 長遊園 12 件全件で挙動確認 |
+
+### 5. Codex 4 ラウンド目で提示された残存課題 (別 follow-up 妥当)
+
+Codex が「Go 判定 + 別 follow-up 推奨」とした項目:
+
+1. **`editScore !== ""` / `editPassed !== ""` は dirty 判定ではない**: 既存 score/passed がある record で何も変えずに更新すると quiz fields は送られる。時刻は送られないので「1 分滞在」再発はないが、API 側で `editedAt/original` が作られ「編集済」化し得る (no-op 更新が編集済化する監査ノイズ)
+2. **GET 側 `original.entryAt/exitAt` の Timestamp 正規化欠如** (`super-admin.ts:1061`): 現行 PATCH 経路は ISO 文字列保存なので実害なし、防御的には正規化推奨
+3. **単一 `editDate` を entry/exit 双方に適用する設計**: JST 日跨ぎ session の編集に弱い (既存制約、本 PR 外)
+
+---
+
+## 次のアクション
+
+### 即着手タスク
+
+**即着手タスクなし** (executor 領分の作業 0 件、品質ゲート全通過 + 本番動作確認完了)
+
+### 条件待ち (明示 trigger 付き)
+
+| # | 項目 | A/B/C | trigger | 充足時のタスク |
+|---|------|-------|---------|-------------|
+| 1 | **福の種テナント 5 件の本番動作確認** | A (housekeeping) | 開発者明示指示 | Playwright MCP で福の種テナント切替 → synthetic 5 件で `"— (テストのみ)"` 表示確認 |
+| 2 | **現場連絡 (新挙動の説明)** | C (起点指示) | 開発者明示指示 + 文案ドラフト承認 | 「合格抽出 PDF の自動補完 session は『— (テストのみ)』表示に変わりました」等の連絡文を起草、承認後送付 |
+| 3 | **Codex 残存課題 #1: no-op 更新で編集済化される問題** | B (検出済、修正は decision-maker 領分) | 開発者明示指示 | `editScore`/`editPassed` も dirty 判定化 (初期値 snapshot 追加 + 比較)、または PATCH endpoint 側で「変更なし update」を skip |
+| 4 | **Codex 残存課題 #2: GET 側 `original.entryAt/exitAt` Timestamp 正規化** | B | 開発者明示指示 | `super-admin.ts:1061` で `original.entryAt/exitAt` も `data.entryAt?.toDate?.()` 同様の正規化を加える |
+| 5 | **Codex 残存課題 #3: 編集ダイアログの JST 日跨ぎ session 対応** | B | 開発者明示指示 | 現状 entry/exit が別日にまたぐ session の編集に弱い、entry / exit 別々の日付入力に拡張 |
+| 6 | **Phase 1 本番動作確認 (Session 70 から継続)** | B | 長遊園 / 福の種で新規テスト提出 → synthetic_* doc 生成確認 | 結果次第で Phase 1 修正判断 |
+| 7 | **Issue #536 sanitize helper 抽出** | C (起点指示) | 開発者明示指示 | helper 抽出実装 |
+| 8 | **Issue #521 dry-run UI follow-up 15 件集約** | C (起点指示) | 開発者明示指示 | follow-up 対応 |
+
+### 却下候補 (記録のみ・包括指示の対象外)
+
+| # | 項目 | A/B/C | 着手しない理由 |
+|---|------|-------|--------------|
+| 1 | **B 案 (backfill 再実行で entryAt 統一)** | C | 本セッション Codex 1 ラウンド目で No-Go 判定済 (真実性リスク等)。同案を再検討するのは方針逆転 |
+| 2 | postponed Issue (#405/#276/#275/#274) | C | postponed ラベルは明示指示なき限り着手不可 |
+| 3 | C 案 (PDF synthetic セクション分離) を A 案に追加 | C | A 案で現場の主問題 (1 分滞在表示) 解消済、C 案追加は ROI 不明 (現場再フィードバック待ち) |
+| 4 | D 案 (編集機能で都度修正運用) を案内 | C | A 案で自動解消、現場手作業を増やす案は ROI 低 |
+| 5 | 「自動補完を作らない」(E 案) 設計見直し | C | Issue #533 Phase 1 の「乖離防止」目的を放棄することになる |
+
+---
+
+## CI / Deploy 状態 (本セッション)
+
+| run | 種類 | 状態 |
+|-----|------|------|
+| 27251164527 (PR #559 push) | Playwright E2E | ✅ pass (1m21s) |
+| 27251164532 (PR #559 push) | Build / Lint / Test / Type Check | ✅ 全 pass |
+| 27251336987 (main post-merge) | Deploy to Cloud Run | ✅ success |
+| 27251337026 (main post-merge) | CI | ✅ success (1m47s) |
+| 27251336995 (main post-merge) | E2E Tests | ✅ success |
+
+### 本セッション merged PR (時系列)
+
+| PR | 種類 | 状態 |
+|----|------|------|
+| #559 | fix(super-attendance) 自動補完 session 滞在時間表示分離 (#533 Phase 3 follow-up #3) | ✅ merged (12ca8d6) |
+| (本 PR) | docs(handoff) Session 73 - 現場フィードバック対応完結 | ⏳ 作成予定 |
+
+---
+
+## ADR / 設計判断記録
+
+### 本セッションで改訂
+
+- **ADR-027 改訂履歴** (PR #559 で追記):
+  - 2026-06-10 (Phase 3 follow-up #3, #533): 自動補完 session の滞在時間表示分離 (A 案採用、B 案 No-Go 経緯、編集機能 #557 との整合性マトリクス、各ヘルパー内訳)
+
+### 本セッションで新規作成
+
+- **設計仕様書** `docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md`: A 案採用の経緯、Codex No-Go 判定、編集機能整合性マトリクス、AC 10 件
+
+### 次セッション以降の起票候補
+
+なし (Codex 残存課題 3 件は「開発者明示指示で別 PR」扱い、起票判断は decision-maker 領分)
+
+---
+
+## Issue Net 変化
+
+- **Close 数 (本セッション)**: 0 件
+- **起票数 (本セッション)**: 0 件
+- **Net (本セッション)**: 0 件
+
+現場フィードバック対応は #533 Phase 3 follow-up #3 として直接 PR #559 で対応、新規 Issue 化していない (CLAUDE.md 「GitHub Issues」triage 基準で「ユーザー明示指示の個別タスク」ではなく「現場フィードバック対応」のため、PR 直接対応が妥当)。
+
+---
+
+## 学習事項 (本セッションの振り返り)
+
+### 1. Codex セカンドオピニオンの多層的価値 ⭐⭐⭐
+
+- **1 ラウンド目 (impl-plan レビュー)**: 設計判断の根本見直し (B 案 No-Go → A 案転換) — destructive migration 前のセカンドオピニオンが計画フェーズで効く
+- **3 ラウンド目 (PR review)**: UI 経路と BE 経路の横断的整合性検証 (Evaluator が見落とした dateTimeJSTtoISO の秒丸めという見えない罠を発見)
+- **4 ラウンド目**: 残存課題と本 PR スコープの分離判断
+- **教訓**: Codex は「UI → BE 横断」「runtime 設計の盲点」「真実性リスク」を Evaluator (コード単体整合性) より広い視野で見る。**大規模 PR + 真実性/監査が絡む変更では Codex は必須**
+- **既存 memory**: `feedback_codex_review_value.md` / `feedback_destructive_migration_codex_review.md` に整合、本セッションで実証例追加 (4 ラウンド突破)
+
+### 2. 「データ書き換え」と「表示分離」の altitude 差
+
+- 当初 B 案 (backfill で entryAt 統一) は「最も解決らしく」見えた
+- Codex 1 ラウンド目で「**問題の核心は『synthetic を通常 session と同じカラムで扱っている』こと、一次データを書き換える必要はない**」と指摘
+- **「データを直す」より「データの見せ方を分離する」方が正しい altitude** だった
+- 普遍的原則: 表示層で解決できる問題を Firestore に持ち込まない (真実性・監査証跡・env 依存リスクを回避)
+
+### 3. dateTimeJSTtoISO の秒丸めという見えない罠
+
+- 既存仕様 `:00` で秒を捨てる無害な実装が、`original` snapshot 差分判定と組み合わさると致命的バグ (「1 分滞在」再出現) を生む
+- **教訓**: 初期値 snapshot との dirty 判定は UI 設計の基本。「form field のロード = ユーザーが触った」と扱うのは罠
+- 横展開: 他の編集 UI でも initial snapshot + dirty 判定を確認すべき (PR #557 投入後の編集機能全般)
+
+### 4. Evaluator 分離プロトコルの限界と Codex の役割分担
+
+- Evaluator は「コード単体の整合性」(AC マトリクス、テスト網羅性) を見る
+- Codex は「UI → BE 横断」「設計の altitude」「real-world 運用での盲点」を見る
+- 両方を順に通すことで Evaluator が見落とす BLOCK MERGE 級バグを救えた
+- **次回への教訓**: 大規模 PR では Evaluator → Codex の順で「コード品質」と「設計品質」を分離して検証する
+
+---
+
+## 再開可能性判定
+
+| 項目 | 状態 |
+|------|------|
+| Git clean | ✅ (本ハンドオフ commit 前) |
+| OPEN PR | 0 件 (本ハンドオフ commit 後 PR 作成予定) |
+| 残留プロセス | ✅ なし |
+| 本番 Firestore 書き込み | ✅ なし (A 案採用、FE のみで完結) |
+| 本番 deploy | ✅ 完了 (run 27251336987 success) |
+| 即着手タスク | 0 件 |
+| 条件待ち | 8 件 (#1 福の種確認、#2 現場連絡、#3-5 Codex 残存課題、#6 Phase 1、#7-8 既存 Issue) |
+| Documentation 同期 | ✅ 本ハンドオフで更新中 |
+| 品質ゲート | ✅ safe-refactor / code-review medium / Evaluator 2 ラウンド / Codex 4 ラウンド すべて Go |
+| 本番動作確認 (Playwright MCP) | ✅ 長遊園 12 件全件確認済 |
+
+---
+
+## 関連ドキュメント
+
+- 本セッション主要 PR: #559 (`12ca8d6`)
+- 親 Issue: #533 (前 session で CLOSED)
+- 設計仕様書: `docs/specs/2026-06-10-phase3-synthetic-stay-duration-display.md`
+- ADR-027: `docs/adr/ADR-027-lesson-session-attendance.md` (Phase 3 follow-up #3 entry)
+- Codex セカンドオピニオン thread: `019eaf6b-6b25-7011-be78-aaaa02ced8d2` (1 ラウンド目) / `019eaf8c-c324-7f52-993e-1771e4ee453c` (3/4 ラウンド目)
+- 前セッション handoff: `docs/handoff/archive/2026-06-10-session-72.md`
+
+---
+
+## 最終結論
+
+✅ **セッション終了可** — 残作業ゼロ、クリーン状態達成
+
+根拠:
+- 現場フィードバック対応の技術的完結を達成 (PR #559 merged + Cloud Run deploy success + 本番動作確認 12 件全件 PASS)
+- 品質ゲート 4 段階すべて Go 判定 (safe-refactor / code-review / Evaluator 2 ラウンド / Codex 4 ラウンド)
+- 即着手タスク 0 件、条件待ち 8 件 (すべて開発者明示指示 trigger)
+- Git clean (本ハンドオフ commit 後)、残留プロセスなし、Issue Net 0 (新規 Issue 化なし、PR 直接対応)
+
+次の一手 (もしあれば): 開発者から「現場連絡を送る」or「福の種テナントの本番確認」or「Codex 残存課題のいずれかを別 PR で対応」のいずれかの明示指示があれば条件待ち項目が即着手に昇格。指示なき場合はそのままセッション終了。


### PR DESCRIPTION
## Summary

- Session 74 handoff
- PR #561 (D 案) merged + 本番 17 件 backfill 修復完了 + Playwright MCP 17/17 確認済
- Codex セカンドオピニオン 4-6 ラウンド全 Go 取得
- 現場担当へ「対応報告 + 認識確認質問」付きメッセージ送付完了
- 次セッションは現場返信受領待ち、即着手タスクゼロ

## 主要成果

| 項目 | 結果 |
|------|------|
| PR #561 (D 案 動画長+テスト時間の換算退室時刻) | ✅ merged (4291219) + Cloud Run deploy success |
| 本番 17 件 backfill (workflow_dispatch execute) | ✅ updated 17 / skipped 0 / failed 0 / readback verified 17 |
| Codex 4-6 ラウンド (impl-plan / PR review / final) | ✅ 全 Go 判定 |
| Playwright MCP 本番動作確認 | ✅ 長遊園 12 + 福の種 5 = 17 件、旧形式残存ゼロ |
| 現場連絡 (対応報告 + 認識確認) | ✅ 送付完了、現場返信待ち |
| Issue Net | 0 (PR + workflow_dispatch 直接対応で新規起票なし) |

## 学習事項

1. 「データ修復」要望時の業務ロジック再確認の重要性 (ADR-019 動画完了ゲート整理で D 案発見)
2. Codex セカンドオピニオンの段階的活用 (impl-plan → PR review → final の 3 段階で盲点潰し)
3. transaction 内再検証の防御層思考 (expected_count 通過後の精密照合)
4. 「skip も failure」設計 (本番 destructive write の想定通り = 100% 成功定義)

## Test plan

- [x] handoff コンテンツ整合性確認
- [x] Issue Net 計測 (0 件)
- [ ] CI 全 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)