### PR TITLE
feat(lesson-resource): PDF アップロード上限を 50 MB → 150 MB に引き上げ

### DIFF
--- a/docs/adr/ADR-036-course-resource-pdf-distribution.md
+++ b/docs/adr/ADR-036-course-resource-pdf-distribution.md
@@ -1,7 +1,7 @@
 # ADR-036: 講座資料スライド PDF 配信
 
 ## ステータス
-採用 (2026-05-17)
+採用 (2026-05-17) / 上限 150 MB に改訂 (2026-06-18)
 
 ## コンテキスト
 
@@ -11,7 +11,7 @@
 
 ### スコープ
 
-- レッスン単位 (1 レッスン 1 PDF)、最大 50 MB
+- レッスン単位 (1 レッスン 1 PDF)、最大 150 MB (2026-06-18 改訂: 旧 50 MB。Canva 等から出力した圧縮済みスライド PDF が 50 MB を超過するケースが現場で発生したため引き上げ)
 - 受講者は当該レッスンのテスト合格 (`user_progress.quizPassed === true`) + 受講期間内 (`TenantEnrollmentSetting.videoAccessUntil > now`) でダウンロード可能
 - super-admin が `_master` テナント配下でアップロード/差し替え/削除 (一元管理)
 - マスター→テナント配信時に PDF メタ (`pdfGcsPath` / `pdfFileName` / `pdfSizeBytes` / `pdfUpdatedAt`) をディープコピー、GCS ファイル本体は全テナントで共有 (ADR-024 と同方針)

--- a/docs/ops/2026-05-17-pdf-smoke-test-runbook.md
+++ b/docs/ops/2026-05-17-pdf-smoke-test-runbook.md
@@ -182,7 +182,7 @@ curl -X POST "$API_BASE/super/master/lessons/$SMOKE_LESSON_ID/pdf" \
 {"resource":{"pdfFileName":"smoke-test-2026-05-17.pdf","pdfSizeBytes":<実サイズ>,"pdfUpdatedAt":"..."}}
 ```
 
-> **実装挙動 (Codex High #2 対策)**: サーバーは GCS metadata の actual size を信頼して `pdfSizeBytes` に保存する。actual size が 50 MB を超える、または contentType が `application/pdf` でない場合のみ拒否 (`file_too_large` / `invalid_file_type`)。request の `sizeBytes` 値と実 GCS metadata の差異自体は reject 条件ではない。
+> **実装挙動 (Codex High #2 対策)**: サーバーは GCS metadata の actual size を信頼して `pdfSizeBytes` に保存する。actual size が 150 MB (2026-06-18 改訂、旧 50 MB) を超える、または contentType が `application/pdf` でない場合のみ拒否 (`file_too_large` / `invalid_file_type`)。request の `sizeBytes` 値と実 GCS metadata の差異自体は reject 条件ではない。
 
 ### Step 7: マスターコース公開
 

--- a/docs/specs/2026-05-17-course-pdf-download-design.md
+++ b/docs/specs/2026-05-17-course-pdf-download-design.md
@@ -20,7 +20,7 @@
 
 | # | 要件 |
 |---|---|
-| F-1 | super-admin はマスターレッスンに PDF (最大 50 MB) を 1 個アップロードできる |
+| F-1 | super-admin はマスターレッスンに PDF (最大 150 MB) を 1 個アップロードできる |
 | F-2 | 受講者は当該レッスンの quiz_attempts でテスト合格 (`user_progress.quizPassed === true`) 後、PDF をダウンロードできる |
 | F-3 | ダウンロード可能期間は受講開始から `videoAccessUntil` (デフォルト +1 年) まで |
 | F-4 | マスターコースをテナントに配信 (`distributeCourseToTenant`) する際、PDF メタ情報 (gcsPath/fileName/sizeBytes/updatedAt) もディープコピーされる |
@@ -190,7 +190,7 @@ const lessonData = {
 
 制約:
 - `contentType === "application/pdf"` 限定
-- `sizeBytes <= 50 * 1024 * 1024` (50 MB)
+- `sizeBytes <= 150 * 1024 * 1024` (150 MB、2026-06-18 改訂、旧 50 MB)
 - ファイル名は basename + 安全文字のみ (path traversal 防止)
 
 **#5 GET `/:tenant/lessons/:lessonId/pdf-download`**
@@ -219,7 +219,7 @@ export async function syncResourcesToTenants(masterCourseId): Promise<{ tenantsC
 | エラー種別 | 状況 | HTTP | message | リトライ |
 |---|---|---|---|---|
 | `invalid_file_type` | contentType ≠ application/pdf | 400 | "PDF ファイルのみアップロード可能です" | permanent |
-| `file_too_large` | sizeBytes > 50 MB | 400 | "50 MB を超えるファイルはアップロードできません" | permanent |
+| `file_too_large` | sizeBytes > 150 MB | 400 | "150 MB を超えるファイルはアップロードできません" | permanent |
 | `lesson_not_found` | masterLessonId が _master に存在しない | 404 | | permanent |
 | `quiz_not_passed` | user_progress.quizPassed !== true | 403 | "テスト合格後にダウンロード可能です" | permanent |
 | `access_expired` | now >= videoAccessUntil | 403 | "受講期間が終了しています" | permanent |
@@ -281,7 +281,7 @@ logger.error("pdf_download_denied", { tenantId, lessonId, userId, reason });
 | AC-7 | DL: PDF 未添付 | pdfGcsPath 未設定 → 404 resource_not_found |
 | AC-8 | DL: 他テナント侵入 | tenant=A token で tenant=B lessonId → 404 lesson_not_found |
 | AC-9 | 削除順序 | メタ削除失敗 → throw, メタ削除成功 + GCS 削除失敗 → orphan ログのみで成功 |
-| AC-10 | サイズ上限 | sizeBytes > 50MB → 400 file_too_large |
+| AC-10 | サイズ上限 | sizeBytes > 150MB → 400 file_too_large |
 | AC-11 | MIME 制限 | contentType ≠ application/pdf → 400 invalid_file_type |
 | AC-12 | UI: 未合格時 disabled | quizPassed=false → DL ボタン disabled + ツールチップ |
 | AC-13 | UI: 期間切れ hide | now >= videoAccessUntil → DL ボタン hide |

--- a/services/api/src/services/__tests__/lesson-resource.test.ts
+++ b/services/api/src/services/__tests__/lesson-resource.test.ts
@@ -72,7 +72,7 @@ describe("generatePdfUploadUrl", () => {
     ).rejects.toThrow(LessonResourceError);
   });
 
-  it("file_too_large: 50MB + 1 byte → エラー", async () => {
+  it("file_too_large: 150MB + 1 byte → エラー", async () => {
     const { storage } = buildMockStorage();
     await expect(
       generatePdfUploadUrl(
@@ -201,7 +201,7 @@ describe("confirmPdfUpload", () => {
     ).rejects.toMatchObject({ code: "gcs_file_missing" });
   });
 
-  it("file_too_large: 実メタデータが 50MB 超 → エラー (Codex High #2)", async () => {
+  it("file_too_large: 実メタデータが 150MB 超 → エラー (Codex High #2)", async () => {
     const { storage } = buildMockStorage({
       getMetadata: vi
         .fn()

--- a/services/api/src/services/lesson-resource.ts
+++ b/services/api/src/services/lesson-resource.ts
@@ -20,7 +20,7 @@ import type {
 import { logger } from "../utils/logger.js";
 
 export const PDF_MIME_TYPE = "application/pdf";
-export const MAX_PDF_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
+export const MAX_PDF_SIZE_BYTES = 150 * 1024 * 1024; // 150 MB
 const UPLOAD_URL_EXPIRES_MS = 60 * 60 * 1000; // 1 時間
 const DOWNLOAD_URL_EXPIRES_MS = 15 * 60 * 1000; // 15 分
 
@@ -90,7 +90,7 @@ export async function generatePdfUploadUrl(
     throw new LessonResourceError("invalid_file_type", "PDF ファイルのみアップロード可能です");
   }
   if (!Number.isFinite(sizeBytes) || sizeBytes <= 0 || sizeBytes > MAX_PDF_SIZE_BYTES) {
-    throw new LessonResourceError("file_too_large", "50 MB を超えるファイルはアップロードできません");
+    throw new LessonResourceError("file_too_large", "150 MB を超えるファイルはアップロードできません");
   }
 
   const lesson = await ds.getLessonById(masterLessonId);
@@ -142,7 +142,7 @@ export async function confirmPdfUpload(
   }
   // sizeBytes の再検証 (Evaluator 指摘、upload-url と confirm 間で乖離する可能性)
   if (!Number.isFinite(sizeBytes) || sizeBytes <= 0 || sizeBytes > MAX_PDF_SIZE_BYTES) {
-    throw new LessonResourceError("file_too_large", "50 MB を超えるファイルはアップロードできません");
+    throw new LessonResourceError("file_too_large", "150 MB を超えるファイルはアップロードできません");
   }
 
   const lesson = await ds.getLessonById(masterLessonId);
@@ -151,7 +151,7 @@ export async function confirmPdfUpload(
   }
 
   // GCS object の実メタデータを検証 (Codex 指摘: クライアント値だけでは不足)。
-  // 漏洩した署名 URL や誤操作で 50 MB 超 / 非 PDF を upload しても、ここで弾く。
+  // 漏洩した署名 URL や誤操作で 150 MB 超 / 非 PDF を upload しても、ここで弾く。
   const file = storage.bucket(RESOURCE_BUCKET()).file(gcsPath);
   let metadata: { size?: string | number; contentType?: string };
   try {

--- a/web/components/master/MasterLessonPdfUploader.tsx
+++ b/web/components/master/MasterLessonPdfUploader.tsx
@@ -23,7 +23,7 @@ import {
   type UploadProgressEvent,
 } from "@/lib/upload";
 
-const MAX_PDF_SIZE_BYTES = 50 * 1024 * 1024;
+const MAX_PDF_SIZE_BYTES = 150 * 1024 * 1024;
 const PDF_CONTENT_TYPE = "application/pdf";
 
 interface MasterLessonPdfUploaderProps {
@@ -47,7 +47,7 @@ function formatPdfError(err: unknown): string {
       case "invalid_file_type":
         return "PDF ファイルのみアップロード可能です。";
       case "file_too_large":
-        return "ファイルサイズが上限 (50 MB) を超えています。";
+        return "ファイルサイズが上限 (150 MB) を超えています。";
       case "gcs_unavailable":
         return "一時的に取得できません。しばらくしてから再度お試しください。";
       case "lesson_not_found":
@@ -107,7 +107,7 @@ export function MasterLessonPdfUploader({
       return;
     }
     if (file.size > MAX_PDF_SIZE_BYTES) {
-      setValidationError("ファイルサイズが上限 (50 MB) を超えています。");
+      setValidationError("ファイルサイズが上限 (150 MB) を超えています。");
       setSelectedFile(null);
       if (inputRef.current) inputRef.current.value = "";
       return;
@@ -240,7 +240,7 @@ export function MasterLessonPdfUploader({
         <div className="space-y-2">
           {/* label と input は a11y / 既存テスト (getByLabelText) 互換のため sr-only で残す */}
           <label className="sr-only" htmlFor={`pdf-input-${lessonId}`}>
-            PDF ファイル (最大 50 MB)
+            PDF ファイル (最大 150 MB)
           </label>
           <input
             ref={inputRef}
@@ -261,7 +261,7 @@ export function MasterLessonPdfUploader({
                 {resource ? "別の PDF を選択" : "PDF ファイルを選択"}
               </Button>
               <span className="text-xs text-muted-foreground">
-                PDF 形式 / 最大 50 MB
+                PDF 形式 / 最大 150 MB
               </span>
             </div>
           ) : (

--- a/web/components/master/__tests__/MasterLessonPdfUploader.test.tsx
+++ b/web/components/master/__tests__/MasterLessonPdfUploader.test.tsx
@@ -30,8 +30,13 @@ const RESOURCE = {
 };
 
 function makePdfFile(sizeMB: number, name = "test.pdf", type = "application/pdf"): File {
-  const sizeBytes = sizeMB * 1024 * 1024;
-  return new File([new Uint8Array(sizeBytes)], name, { type });
+  // 上限が 150 MB に拡張されたため、実バイト列は最小化して size プロパティだけ偽装する
+  // (大きい Uint8Array を確保すると vitest 並列実行時にメモリ圧迫の恐れ)
+  // defineProperty は writable:false 既定のため同インスタンスで size を再定義不可。
+  // 毎回 new File を返す前提で使うこと。
+  const file = new File([new Uint8Array(1)], name, { type });
+  Object.defineProperty(file, "size", { value: sizeMB * 1024 * 1024 });
+  return file;
 }
 
 beforeEach(() => {
@@ -40,13 +45,13 @@ beforeEach(() => {
 });
 
 describe("MasterLessonPdfUploader - validation", () => {
-  it("AC-2 50MB 超過ファイル選択 → エラー表示 + API 未呼出", async () => {
+  it("AC-2 150MB 超過ファイル選択 → エラー表示 + API 未呼出", async () => {
     const onUpdated = vi.fn();
     render(
       <MasterLessonPdfUploader lessonId="L1" resource={undefined} onUpdated={onUpdated} />,
     );
     const input = screen.getByLabelText(/PDF ファイル/) as HTMLInputElement;
-    const overSizeFile = makePdfFile(51, "big.pdf");
+    const overSizeFile = makePdfFile(151, "big.pdf");
     fireEvent.change(input, { target: { files: [overSizeFile] } });
     expect(
       await screen.findByText(/ファイルサイズが上限/),
@@ -215,7 +220,7 @@ describe("MasterLessonPdfUploader - a11y (AC-16)", () => {
       <MasterLessonPdfUploader lessonId="L1" resource={undefined} onUpdated={vi.fn()} />,
     );
     const input = screen.getByLabelText(/PDF ファイル/) as HTMLInputElement;
-    fireEvent.change(input, { target: { files: [makePdfFile(51)] } });
+    fireEvent.change(input, { target: { files: [makePdfFile(151)] } });
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent(/ファイルサイズが上限/);
   });


### PR DESCRIPTION
## Summary

- 講座資料 PDF のアップロード上限を **50 MB → 150 MB** に引き上げ
- 現場で Canva 出力 PDF (圧縮後) が 50 MB を超過するケースが発生したため、ADR-036 を改訂
- GCS 直接 PUT 方式のため Cloud Run body 上限への影響なし

## 背景

現場から「Canva の PDF 圧縮を使っても 50 MB を超えてしまう」フィードバック ([Image #2] 参照)。スライド資料の運用上、150 MB に引き上げる判断。

## 変更内容

| ファイル | 内容 |
|----------|------|
| `services/api/src/services/lesson-resource.ts` | `MAX_PDF_SIZE_BYTES = 150 * 1024 * 1024` + エラーメッセージ 2 箇所 |
| `web/components/master/MasterLessonPdfUploader.tsx` | クライアント側 pre-check 定数 + 表示文言 / a11y label 4 箇所 |
| `services/api/src/services/__tests__/lesson-resource.test.ts` | テストタイトル 2 箇所 (50MB → 150MB) |
| `web/components/master/__tests__/MasterLessonPdfUploader.test.tsx` | 境界値 51 → 151 MB に変更、`makePdfFile` を size 偽装方式に変更（vitest 並列実行時のメモリ圧迫予防） |
| `docs/adr/ADR-036-course-resource-pdf-distribution.md` | ステータス行に改訂日 (2026-06-18) と引き上げ理由を追記 |
| `docs/specs/2026-05-17-course-pdf-download-design.md` | 仕様書 4 箇所 (F-1 / 制約 / エラー表 / AC-10) |
| `docs/ops/2026-05-17-pdf-smoke-test-runbook.md` | smoke runbook 実装挙動説明を更新 |

## 影響範囲

- ✅ サーバー側 (`MAX_PDF_SIZE_BYTES`) とクライアント側 pre-check の上限が一致 (150 MB)
- ✅ `confirmPdfUpload` の GCS 実メタデータ再検証も 150 MB を参照、バイパス経路なし
- ✅ GCS 署名 URL 直接 PUT 方式のため Cloud Run body 上限への影響なし
- ⚠️ GCS 署名 URL の有効期限 (upload 1 時間 / download 15 分) は据え置き、低速回線での DL 失敗リスクは現状運用範囲内
- ⚠️ GCS storage cost は素直に増加 (ファイル数 × 増分)、軽微

## Test plan

- [x] `npm run type-check` PASS
- [x] `npm run lint` PASS (既存 warning 1 件、本 PR と無関係)
- [x] `npm run test` PASS (1672 tests passed, services/api / services/notification / web 全 workspace)
- [x] `services/api` lesson-resource.test.ts 26 PASS (境界値 150 MB + 1 で `file_too_large`)
- [x] `web` MasterLessonPdfUploader.test.tsx 12 PASS (UI 側 151 MB で エラー表示)
- [x] code-reviewer エージェントレビュー: Critical/High/Medium 0 件、Low 1 件 (コメント補足のみで対応済)
- [ ] マージ後デプロイ → super-admin で 100 MB 程度の PDF を upload して動作確認 (現場連絡前)

## 関連

- ADR-036 (改訂 2026-06-18)
- 現場フィードバック (catchup 時画像 [Image #2])

🤖 Generated with [Claude Code](https://claude.com/claude-code)