### PR TITLE
docs(handoff): Session 76 - 福の種テナント動画視聴不可緊急復旧

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,21 +1,22 @@
-# Session Handoff — 2026-06-18 (Session 75)
+# Session Handoff — 2026-06-19 (Session 76)
 
 ## TL;DR
 
-**現場フィードバック対応 — 講座資料 PDF アップロード上限を 50MB → 150MB に引き上げ**。Canva 出力 PDF が 50MB を超える運用課題を受け、開発者判断で 150MB に決定。コード変更 + ADR-036 改訂 + テスト + CI/CD まで完結、本番デプロイ反映済。現場連絡文案を起草、送付は decision-maker 領分。
+**本番インシデント緊急対応 — 福の種テナント (atali82i) 受講生・前田さまの動画視聴 500 エラーを Cloud Run 単一インスタンスの IAM signBlob スタック起因と特定、新リビジョン作成で復旧**。コード変更ゼロ、env var `RESTART_AT` 追加のみで全インスタンスをローリング drain。社内対応担当者経由で前田さまへの動作確認連絡文案を引き渡し済、復旧確認は外部 trigger 待ち。
 
 | 主要成果 | 結果 |
 |---|---|
-| PDF アップロード上限引き上げ (50 → 150 MB) | ✅ PR #574 merged + Cloud Run deploy success |
-| ADR-036 / spec / smoke runbook 改訂 | ✅ 改訂日 2026-06-18 + 旧上限併記 |
-| サーバー / クライアント / テスト 同期 | ✅ 定数 + エラー文言 + 表示文言 + 境界値テスト |
-| 品質ゲート | ✅ CI 5 件 PASS / code-reviewer 0 件 / 全 1672 tests PASS |
-| ローカル dry test 試行 | ⚠ super-admin UI は Firebase Auth 固定で実機 UI 検証不可、コンポーネントテストで境界値担保 |
-| 現場連絡文案起草 | ✅ 起草済 (反映済前提)、送付は decision-maker |
+| 福の種テナント動画視聴不可の原因特定 | ✅ `SigningError: Premature close` calling iamcredentials.googleapis.com signBlob、単一 Cloud Run インスタンス (`002f8ffd47c07...`) で全 30 件発生 |
+| 期限切れ仮説の棄却 | ✅ `videoAccessUntil` 期限切れ (403) ではなく内部エラー (500) と確定、enrollment-setting 起因を除外 |
+| 本番緊急復旧 | ✅ env var `RESTART_AT=2026-06-19T11-30` 追加 → 新リビジョン `api-00430-lct` 作成 + 旧 `api-00429-gb7` drain 完了 |
+| 復旧後の動作 | ✅ 新リビジョンで新規 SigningError 0 件 (10 分監視) |
+| 前田さまへの連絡文案 | ✅ 起草済 + 社内対応担当者に引き渡し済 (送付・結果収集は decision-maker 領分) |
+| コード変更 | ❌ ゼロ (Cloud Run 設定のみ、PR 不要) |
 
-- **Issue Net (本セッション)**: Close 0 + 起票 0 = **Net 0** (現場フィードバック対応は PR で直接対応、新規 Issue 化せず)
-- **本セッション merged PR**: 1 件 (#574)
+- **Issue Net (本セッション)**: Close 0 + 起票 0 = **Net 0**
+- **本セッション merged PR**: 0 件
 - **本セッション workflow_dispatch**: 0 件
+- **本セッション本番 destructive 操作**: 1 件 (`gcloud run services update api --update-env-vars=RESTART_AT=...`、開発者明示認可済)
 
 ---
 
@@ -26,98 +27,122 @@ cat docs/handoff/LATEST.md
 git fetch origin main && git log --oneline -5 origin/main
 gh pr list --state open
 gh issue list --state open
+# 前田さま動作確認結果の有無を確認 (社内連絡経路は GitHub 管理外)
 ```
 
-**次セッションの最初の一手**: なし (即着手タスク 0 件、条件待ち項目のみ)
+**次セッションの最初の一手**: なし (即着手タスク 0 件、条件待ち項目のみ。trigger #1 充足時 = 前田さま結果連絡が来た時に分岐判断)
 
 ---
 
-## 重要な作業内容 (本セッション = Session 75)
+## 重要な作業内容 (本セッション = Session 76)
 
-### 1. 現場フィードバック受領 — Canva 圧縮済み PDF が 50MB 超
+### 1. 症状受領 — 福の種・前田さま「動画 7️⃣以降と前も見れない」
 
-現場 (スーパー管理者) から `super-admin > マスターコース > レッスン編集` 画面の PDF アップロード時に以下メッセージが発生する旨報告。
+開発者経由で福の種テナント受講生・前田さまから報告:
 
-> `PDF 形式 / 最大 50 MB`
-> `ファイルサイズが上限 (50 MB) を超えています。`
+> 「今、動画7️⃣を見ようとしたが、見れないようです。それ以降前も見れないようです。」
 
-> 「canva から PDF 圧縮で DL しておりますがそれでも 50MB 以上になってしまっております」
+「以降と前も」というキーワードからテナント全体に影響が出ていると仮定し、3 仮説を並列で立案:
 
-### 2. 上限値の決定
+| 仮説 | 採用後の対応 |
+|------|-----------|
+| ① テナント全体の `videoAccessUntil` 期限切れ | 期限延長 (super-admin で update) |
+| ② 特定動画ファイルの GCS 喪失 | 動画再アップロード |
+| ③ Cloud Run 障害 (内部エラー) | リビジョン入れ替えまたはロールバック |
 
-| 選択肢 | 評価 |
-|--------|------|
-| 100 MB | Canva 標準圧縮 + 一般資料サイズに余裕、最も保守的 |
-| **150 MB (採用)** | 中規模写真資料も対応、署名 URL 有効期限内 DL 現実的 |
-| 200 MB | 大規模資料対応、低速回線 DL リスク↑ |
+### 2. 仮説検証 — 本番 Cloud Run ログ照会 (開発者明示認可 A 案)
 
-開発者判断で **150 MB** 採用。
+開発者認可 (`lms-279 本番ログ読み取りを承認`) のうえ `gcloud logging read` で照会。
 
-### 3. PR #574 実装内容
+#### 2.1 期限切れ仮説 (403) の棄却
 
-#### 変更ファイル (7 件、+28/-23)
-
-| ファイル | 内容 |
-|----------|------|
-| `services/api/src/services/lesson-resource.ts` | `MAX_PDF_SIZE_BYTES = 150 * 1024 * 1024` + エラーメッセージ 2 箇所 |
-| `web/components/master/MasterLessonPdfUploader.tsx` | クライアント側 pre-check 定数 + 表示文言 / a11y label 4 箇所 |
-| `services/api/src/services/__tests__/lesson-resource.test.ts` | テストタイトル 2 箇所 (50MB → 150MB) |
-| `web/components/master/__tests__/MasterLessonPdfUploader.test.tsx` | 境界値 51 → 151 MB、`makePdfFile` を `Object.defineProperty(file, "size", ...)` の size 偽装方式に変更 (vitest 並列実行時のメモリ圧迫予防) |
-| `docs/adr/ADR-036-course-resource-pdf-distribution.md` | ステータス行に改訂日 (2026-06-18) と引き上げ理由を追記 |
-| `docs/specs/2026-05-17-course-pdf-download-design.md` | 仕様書 4 箇所 (F-1 / 制約 / エラー表 / AC-10) |
-| `docs/ops/2026-05-17-pdf-smoke-test-runbook.md` | smoke runbook 実装挙動説明を更新 |
-
-#### 影響範囲
-
-- ✅ サーバー側 (`MAX_PDF_SIZE_BYTES`) とクライアント側 pre-check が一致 (150 MB)
-- ✅ `confirmPdfUpload` の GCS 実メタデータ再検証も 150 MB を参照、バイパス経路なし
-- ✅ GCS 直接 PUT 方式のため Cloud Run body 上限への影響なし
-- ⚠️ GCS 署名 URL 有効期限 (upload 1 時間 / download 15 分) は据え置き
-- ⚠️ GCS storage cost は素直に増加 (ファイル数 × 増分)、軽微
-
-### 4. 品質ゲート
-
-- ✅ サーバー側ユニットテスト 26 件 PASS (境界値 150 MB + 1 で `file_too_large`)
-- ✅ クライアント側コンポーネントテスト 12 件 PASS (151 MB で「ファイルサイズが上限 (150 MB) を超えています。」表示)
-- ✅ 全 workspace 1672 tests PASS
-- ✅ 型チェック / lint 全 PASS (既存 warning 1 件、本 PR と無関係)
-- ✅ code-reviewer エージェント: Critical/High/Medium 0 件、Low 1 件 (コメント補足のみで対応済)
-- ✅ CI 5 件 PASS (Build / Lint / Test / Type Check / Playwright E2E)
-
-### 5. ローカル dry test の試行と限界
-
-開発者依頼で「ローカル dev server で実機確認」を試行したが、以下の環境制約で実機 UI 検証は不可:
-
-| 検証経路 | 阻害要因 |
-|----------|----------|
-| super-admin UI フル操作 (Playwright) | `web/app/super/layout.tsx` の auth gate が `AUTH_MODE=dev` でも `!user` で「Googleでサインイン」画面に止まる。super 画面は **Firebase Auth 固定**仕様 |
-| API への curl 直接検証 | DataSource ファクトリが dev mode でも本番 Firestore + GCS を参照する仕様。検証リクエストでも本番副作用リスク (本番データ保護ルール抵触) |
-| E2E_TEST_ENABLED=true で In-Memory 起動 | `_master` テナントの seed データが必要、ROI 低 |
-
-**実施できた検証**:
-- API/Web の dev server 起動成功 (port 8080 / 3003)
-- ビルド成果物 `services/api/dist/services/lesson-resource.js` に `MAX_PDF_SIZE_BYTES = 150 * 1024 * 1024` 反映確認
-
-**後始末**: dev server プロセス停止、`/tmp/lms-pdf-test/` (60/120/160 MB のダミー PDF) 削除済。残留プロセスなし。
-
-### 6. 現場連絡文案起草 (送付は decision-maker)
-
-デプロイ反映済確認後の差し替え文案:
-
-```
-資料添付の件、ご連絡ありがとうございます。
-
-PDF アップロードの上限を 50MB → 150MB に引き上げました。
-すでにシステムにも反映済みです。
-Canva から書き出した圧縮済みの PDF も、そのまま添付いただけるようになっているはずです。
-
-お手数ですが、改めてアップロードをお試しいただけますでしょうか。
-もし問題があればまたご連絡ください。
-
-よろしくお願いいたします。
+```bash
+gcloud logging read 'jsonPayload.error="video_access_expired"' --freshness=2d
+# → 0 件
 ```
 
-開発者から「連絡は送ります」とのコメント、送付実行は decision-maker 領分。
+期限切れガード (`services/api/src/services/enrollment.ts:108-138 guardVideoAccess()`) は発火していない。
+
+#### 2.2 playback-url の状態分布
+
+```bash
+# 過去 24h の atali82i (= 福の種) 動画 playback-url
+# 200: 4 件 (旧リビジョン api-00427-lh7 時代)
+# 500: 16 件 (新リビジョン api-00429-gb7 で発生)
+# 204: 20 件 (CORS preflight OPTIONS)
+```
+
+500 開始時刻: 2026-06-18 23:41:01 UTC (= 08:41 JST)
+新リビジョン `api-00429-gb7` のデプロイ: 2026-06-18 22:31:03 UTC (= 07:31 JST、handoff commit 243234f によるトリガー)
+
+#### 2.3 エラー詳細
+
+```
+SigningError: Invalid response body while trying to fetch
+  https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/1034821634012-compute@developer.gserviceaccount.com:signBlob:
+  Premature close
+
+  at Gaxios._request (/app/node_modules/gaxios/build/src/gaxios.js:149:19)
+  at async GoogleAuth.signBlob (...)
+  at async sign (file:///app/node_modules/@google-cloud/storage/build/esm/src/signer.js:193:35)
+```
+
+GCS 署名付き URL 生成 (`services/api/src/services/gcs.ts:51 generatePlaybackUrl()`) が IAM Credentials API `signBlob` 呼び出しで失敗。「Premature close」は HTTP レスポンスが途中で切断された状態。
+
+### 3. 単一インスタンス起因の確定
+
+```bash
+gcloud logging read 'jsonPayload.error.name="SigningError"' --freshness=2d \
+  --format='value(labels.instanceId)' | sort -u
+# → 002f8ffd47c07e6aca31d333d14a3ca79b005bd900274414c9488ab3cda0fa7f742542c7b4484eb0c7c4d5167ec1667026cf5223db91bfb089dbecc89937a9c9c1a6ec893875a3b98de45867be2477fb74
+# (1 件のみ)
+```
+
+**過去 2 日間の全 30 件の SigningError が同一 Cloud Run インスタンスから発生**。原因は単一インスタンスの keep-alive HTTP コネクションが iamcredentials.googleapis.com に対してスタック (途中切断状態のまま再利用) と推定。
+
+#### 棄却した代替仮説
+
+| 仮説 | 棄却理由 |
+|------|--------|
+| コード回帰 (PR #574 起因) | `gcs.ts` / `package.json` / `Dockerfile` いずれも未変更 (git show 056c441 で確認) |
+| IAM 権限不足 | compute SA に `roles/iam.serviceAccountTokenCreator` 保有確認 (project IAM policy) |
+| iamcredentials API 無効化 | `gcloud services list --enabled` で enabled 確認 |
+| VPC connector / egress 制限 | Cloud Run 設定に VPC connector annotation なし |
+| イメージ全体の問題 | 単一 instanceId のみで発生、他インスタンスは正常 (の可能性) |
+
+### 4. 復旧アクション — A 案実行 (開発者明示認可済)
+
+開発者認可文言: `本番 Cloud Run api (lms-279, asia-northeast1) に env var RESTART_AT を追加して新リビジョン作成を承認する`
+
+```bash
+gcloud run services update api \
+  --region=asia-northeast1 \
+  --update-env-vars=RESTART_AT=2026-06-19T11-30 \
+  --project=lms-279
+```
+
+実行結果:
+- 新リビジョン `api-00430-lct` 作成 + 100% トラフィック切替完了
+- 旧リビジョン `api-00429-gb7` drain (スタックインスタンス `002f8ffd47c07...` 消滅)
+- デプロイ完了時刻: 2026-06-19 02:29:52 UTC (= 11:29 JST)
+- 設定変更内容: env var `RESTART_AT=2026-06-19T11-30` 追加のみ、コード/イメージ無変更
+- デプロイ後監視: 新規 SigningError 0 件 (10 分間)
+
+### 5. 前田さまへの連絡 (社内対応担当者経由)
+
+文案を起草し開発者経由で社内対応担当者に引き渡し済:
+
+```
+動画の再生に一時的なシステム障害が発生しておりました。
+サーバー側で対応が完了しましたので、お手数ですが
+ページを再読み込みしていただき、もう一度動画7️⃣を
+再生してみていただけますでしょうか。
+
+もし問題が続くようでしたら、再度お知らせください。
+ご不便をおかけして申し訳ございません。
+```
+
+送付実行・結果収集は decision-maker 領分。
 
 ---
 
@@ -125,67 +150,59 @@ Canva から書き出した圧縮済みの PDF も、そのまま添付いただ
 
 ### 即着手タスク
 
-**即着手タスクなし** (executor 領分の作業 0 件、品質ゲート全通過 + 本番反映完了)
+**即着手タスクなし** (executor 領分の作業 0 件、本番復旧完了 + 連絡文案引き渡し済)
 
 ### 条件待ち (明示 trigger 付き)
 
 | # | 項目 | A/B/C | trigger | 充足時のタスク |
 |---|------|-------|---------|-------------|
-| 1 | **現場再フィードバック対応 (PDF 上限引き上げ)** | C (起点指示) | 開発者が現場連絡送付後、現場からの返信 | 内容に応じて対応 (動作 OK ならクローズ、問題報告なら原因調査) |
-| 2 | **Codex 残存課題 #1: no-op 更新で編集済化** (Session 74 継承) | B | 開発者明示指示 | `editScore`/`editPassed` も dirty 判定化、または PATCH endpoint で「変更なし update」を skip |
-| 3 | **Codex 残存課題 #2: GET 側 `original.entryAt/exitAt` Timestamp 正規化** (Session 74 継承) | B | 開発者明示指示 | `super-admin.ts:1061` で `original.entryAt/exitAt` も正規化 |
-| 4 | **Codex 残存課題 #3: 編集ダイアログの JST 日跨ぎ session 対応** (Session 74 継承) | B | 開発者明示指示 | entry/exit 別々の日付入力に拡張 |
-| 5 | **Codex 残存課題 #4: 日付境界またぎ UI tooltip** (Session 74 継承) | B | 開発者明示指示 | `formatTimeWithDayDiff` で「翌 HH:mm」表示 |
-| 6 | **Phase 1 本番動作確認** (Session 70 から継続) | B | 長遊園 / 福の種で新規テスト提出 → synthetic_* doc 生成確認 | 結果次第で Phase 1 修正判断 |
-| 7 | **Issue #536 sanitize helper 抽出** | C (起点指示) | 開発者明示指示 | helper 抽出実装 |
-| 8 | **Issue #521 dry-run UI follow-up 15 件集約** | C (起点指示) | 開発者明示指示 | follow-up 対応 |
+| 1 | **前田さま動作確認結果** | C (起点指示) | 社内対応担当者から前田さま返信、開発者経由で報告 | OK → 本件クローズ。NG → 再調査 (#2 へエスカレート) |
+| 2 | **SigningError 再発時の再調査** | B 検出 | `gcloud logging read jsonPayload.error.name=SigningError` で 30 分以内に新規発生 | 同一インスタンス起因なら再リサイクル、複数インスタンスなら image 起因疑い → Node.js / `@google-cloud/storage` SDK バージョン精査 |
+| 3 | **中長期: signed URL 生成の retry / health-check 設計** | C (起点指示) | 開発者から「再発防止策を検討して」の明示指示 | impl-plan: ① signBlob 呼び出しの透過 retry ② 起動時 sanity check ③ keep-alive 上限調整 |
+| 4 | **Codex 残存課題 #1: no-op 更新で編集済化** (Session 74 継承) | B 修正 | 開発者明示指示 | `editScore`/`editPassed` も dirty 判定化、または PATCH endpoint で「変更なし update」を skip |
+| 5 | **Codex 残存課題 #2: GET 側 `original.entryAt/exitAt` Timestamp 正規化** (Session 74 継承) | B 修正 | 開発者明示指示 | `super-admin.ts:1061` で `original.entryAt/exitAt` も正規化 |
+| 6 | **Codex 残存課題 #3: 編集ダイアログの JST 日跨ぎ session 対応** (Session 74 継承) | B 修正 | 開発者明示指示 | entry/exit 別々の日付入力に拡張 |
+| 7 | **Codex 残存課題 #4: 日付境界またぎ UI tooltip** (Session 74 継承) | B 修正 | 開発者明示指示 | `formatTimeWithDayDiff` で「翌 HH:mm」表示 |
+| 8 | **Phase 1 本番動作確認** (Session 70 継承) | B 検出 | 長遊園 / 福の種で新規テスト提出 → synthetic_* doc 生成確認 | 結果次第で Phase 1 修正判断 |
+| 9 | **Issue #536 sanitize helper 抽出** | C (起点指示) | 開発者明示指示 | helper 抽出実装 |
+| 10 | **Issue #521 dry-run UI follow-up 15 件集約** | C (起点指示) | 開発者明示指示 | follow-up 対応 |
 
 ### 却下候補 (記録のみ・包括指示の対象外)
 
 | # | 項目 | A/B/C | 着手しない理由 |
 |---|------|-------|--------------|
-| 1 | **PDF 上限 200 MB 化** | C | decision-maker が 150 MB を選択済、現場再フィードバックなければ ROI 低 |
-| 2 | **D 案関連 (Session 74)** B 案 / A 案 / E 案 | C | Session 74 で確定済、再オープンは方針逆転 |
-| 3 | postponed Issue (#405/#276/#275/#274) | C | postponed ラベルは明示指示なき限り着手不可 |
-| 4 | **ローカル dry test 用の認証バイパス実装** | C | super-admin Firebase Auth 固定は意図的設計、PR 範囲外、ROI 低 |
-| 5 | **本番環境での AI 能動的動作確認** | C | `feedback_deploy_proactive_verification.md` 越権ルール抵触、開発者領分 |
+| 1 | **env var `RESTART_AT` の cleanup** | A | 次回正規デプロイ時に他の env var 更新で自然消化、明示 cleanup 不要。手動削除は別 destructive 操作になりリスク増 |
+| 2 | **新リビジョン `api-00430-lct` 以前のリビジョンの cleanup** | A | Cloud Run の自動 retention で十分、明示 cleanup ROI 低 |
+| 3 | **本番環境での AI 能動的動作確認** | C | `feedback_deploy_proactive_verification.md` 越権ルール抵触 (4 原則 §1)、開発者領分 |
+| 4 | **D 案関連 / PDF 上限 200MB 化等** (Session 74-75 継承) | C | Session 74-75 で確定済、再オープンは方針逆転 |
+| 5 | postponed Issue (#405/#276/#275/#274) | C | postponed ラベルは明示指示なき限り着手不可 |
 
 ---
 
 ## CI / Deploy 状態 (本セッション)
 
-| run | 種類 | 状態 |
-|-----|------|------|
-| 27764646837 (PR #574 push) | Build / Lint / Test / Type Check | ✅ 全 pass |
-| 27764646835 (PR #574 push) | Playwright E2E | ✅ pass (1m37s) |
-| 27764810084 (main post-merge) | CI | ✅ success (2m13s) |
-| 27764810832 (main post-merge) | E2E Tests | ✅ success (1m12s) |
-| 27764811311 (main post-merge) | Deploy to Cloud Run | ✅ success (4m53s) |
+| 操作 | 種類 | 状態 |
+|------|------|------|
+| `gcloud run services update api --update-env-vars=RESTART_AT=2026-06-19T11-30` | 本番 Cloud Run 設定変更 (緊急復旧) | ✅ 新リビジョン `api-00430-lct` 100% トラフィック (約 11:30 JST) |
+| GitHub Actions CI / Deploy | - | (本セッションは PR なし、CI ラン無) |
 
 ### 本セッション merged PR
 
 | PR | 種類 | 状態 |
 |----|------|------|
-| #574 | feat(lesson-resource): PDF アップロード上限を 50 MB → 150 MB に引き上げ | ✅ merged (056c441) |
-| (本 PR) | docs(handoff): Session 75 - PDF 上限 150 MB 引き上げ完了 + 現場連絡文案 | ⏳ 作成予定 |
+| (本 handoff PR) | docs(handoff): Session 76 - 福の種テナント動画視聴不可緊急復旧 | ⏳ 作成予定 |
 
 ---
 
 ## ADR / 設計判断記録
 
-### 本セッションで改訂
-
-- **ADR-036 改訂** (PR #574):
-  - 2026-06-18: PDF アップロード上限を 50 MB → 150 MB に引き上げ。理由: Canva 出力 PDF (圧縮後) が 50 MB を超過するケースが現場で発生。
-  - ステータス行: `採用 (2026-05-17) / 上限 150 MB に改訂 (2026-06-18)`
-
 ### 本セッションで新規作成
 
-なし (既存 ADR の改訂で対応)
+なし (本件は単発の運用インシデント、設計判断は伴わない)
 
 ### 次セッション以降の起票候補
 
-なし
+なし (中長期 follow-up #3 「retry / health-check 設計」は開発者起点指示後に impl-plan で ADR 化判断)
 
 ---
 
@@ -195,48 +212,44 @@ Canva から書き出した圧縮済みの PDF も、そのまま添付いただ
 - **起票数 (本セッション)**: 0 件
 - **Net (本セッション)**: 0 件
 
-現場フィードバック対応は PR #574 で直接対応、新規 Issue 化していない。
+本件は単一インスタンスの一過性スタックで、再現性 / 再発リスク / 影響範囲が現時点で不明 (CLAUDE.md Issue Triage 基準で起票判断保留)。再発した場合に triage 基準 #2 (再現可能なバグ) または #4 (rating ≥ 7 / confidence ≥ 80) で起票判断。
 
 ---
 
 ## 学習事項 (本セッションの振り返り)
 
-### 1. 「ローカル dry test」と「本番実機確認」の境界
+### 1. 「症状の言葉」から仮説を絞り込む
 
-- 開発者の「dry test 実施してほしい」依頼に対し、Playwright MCP で実機 UI 検証を試行
-- super-admin layout が Firebase Auth 固定で dev mode 認証バイパス不可
-- DataSource が dev mode でも本番 Firestore に向かう仕様
-- **教訓**: 「ローカル実機確認」は executor 領分でも、AUTH_MODE と DataSource の仕様次第で物理的に不可能なケースがある。事前に env / 認証 / データソース仕様を確認する
-- **教訓**: コンポーネントテスト + ビルド成果物確認 + CI で「定数変更の正しさ」は多重担保できる。実機 UI スクショは本番デプロイ後の最終確認 (decision-maker 領分) で代替
+- 前田さまの「7️⃣以降と前も見れない」表現から、テナント全体影響を仮定 → `videoAccessUntil` 期限切れを第一仮説に
+- 実際は 500 (Cloud Run 内部エラー) で、特定テナント全体に影響が出るが原因は別 (単一インスタンス) だった
+- **教訓**: 「テナント全体に見える症状」も、Cloud Run のインスタンス単位ルーティング次第で「特定インスタンスにヒットした全テナント」と一致しうる。最初から複数仮説を並列で立てる
 
-### 2. デプロイ反映確認の重要性
+### 2. instanceId ベースの集約は強力
 
-- 現場連絡文案を「反映完了後にご連絡します」で起草した直後、ユーザーから「え？まだ出来てないの？」とリアクション
-- `gh run list` 確認の結果、PR マージから約 5 分で Cloud Run deploy success 完了済 (約 24 分前)
-- **教訓**: 「反映予定」「反映後」等の時間表現を使う前に、必ず `gh run list --branch main` で Deploy to Cloud Run の状態を確認する
-- **教訓**: 自動デプロイの完了タイミング (push → 反映まで約 5 分) は通常運用情報として handoff に記録すると、次セッションで保守的に書き過ぎず済む
+- `gcloud logging read ... --format='value(labels.instanceId)' | sort -u` で「全エラーが単一インスタンス起因」と即座に判定
+- これがイメージ全体起因かインスタンス単発起因かを切り分ける決定打になった
+- **教訓**: Cloud Run の `labels.instanceId` での集約は signed URL / IAM / external API stuck パターンの調査で最初に試すべきステップ
 
-### 3. 定数変更でも 7 ファイル波及
+### 3. 復旧手段の選択肢を ROI 順で並べる
 
-- サーバー定数 1 + クライアント定数 1 だけでなく、エラーメッセージ / 表示文言 / a11y label / テストタイトル / テスト境界値 / ADR / spec / runbook と 7 ファイル波及
-- 単純な「50 → 150」置換でも、grep で残存を全件確認するプロセスが必要
-- **教訓**: 数値定数の変更は「定数だけ変えて完了」ではない。`grep -rn "50 MB\|50MB"` の全件確認 + 改訂日記録の運用を踏襲する
+- 候補 A (env var 追加でローリング)、B (再デプロイ)、C (旧リビジョンへロールバック)、D (待機) を並列提示
+- 開発者は A を即選択 → 1 分で復旧完了
+- **教訓**: 緊急時こそ「やるべきこと 1 つ」ではなく「リスク順 N 候補」を提示し、decision-maker が即選べる状態にする (4 原則 §1 = executor 領分)
 
-### 4. テストでの大容量メモリ確保回避
+### 4. classifier ブロック時の認可文言の具体性
 
-- 上限 50 MB → 150 MB に変更する際、`makePdfFile(51)` を `makePdfFile(151)` に置換するだけでは vitest 並列実行で 151 MB の Uint8Array 確保リスク
-- `Object.defineProperty(file, "size", { value: ... })` で size プロパティのみ偽装、実バイト列は 1 byte に最小化
-- **教訓**: ファイルサイズ境界値テストでは「実バイト列」ではなく「`size` プロパティ偽装」が標準パターン。code-reviewer の Low finding (「writable: false 既定で同インスタンス再定義不可」) もコメントで明示しておく
+- 1 回目の `gcloud run services update` は classifier に「本番変更で具体的認可なし」とブロックされた
+- 「本番 Cloud Run api (lms-279, asia-northeast1) に env var RESTART_AT を追加」レベルの具体性で開発者が認可文言を返してくれて初めて通過
+- **教訓**: destructive 本番操作は「対象 (project + region + service) + 変更内容」を文言に含む必要あり。一般的な「A 案 OK」では classifier が通さない。AI 側で予め貼り付け可能な認可文言テンプレを提示すると往復が減る
 
 ---
 
 ## 関連ドキュメント
 
-- 本セッション主要 PR: #574 (`056c441`)
-- 改訂 ADR: `docs/adr/ADR-036-course-resource-pdf-distribution.md`
-- 仕様書: `docs/specs/2026-05-17-course-pdf-download-design.md`
-- smoke runbook: `docs/ops/2026-05-17-pdf-smoke-test-runbook.md`
-- 前セッション handoff: `docs/handoff/archive/2026-06-10-session-74.md`
+- 前セッション handoff: `docs/handoff/archive/2026-06-18-session-75.md`
+- 該当コード: `services/api/src/services/gcs.ts:51 generatePlaybackUrl()` / `services/api/src/services/enrollment.ts:108 guardVideoAccess()` / `services/api/src/routes/shared/videos.ts:229 GET /videos/:videoId/playback-url`
+- 福の種テナント参考: `docs/adr/ADR-038-url-path-invisible-char-sanitization-middleware.md` (tenant `atali82i` 確認の根拠)
+- 本セッション本番操作対象: Cloud Run service `api` (lms-279 / asia-northeast1)、現行リビジョン `api-00430-lct`
 
 ---
 
@@ -244,27 +257,26 @@ Canva から書き出した圧縮済みの PDF も、そのまま添付いただ
 
 | 項目 | 状態 |
 |------|------|
-| Git clean | ✅ (本ハンドオフ commit 前) |
-| OPEN PR | 0 件 (本ハンドオフ commit 後 PR 作成予定) |
+| Git clean (本ハンドオフ commit 前) | ✅ |
+| OPEN PR (本ハンドオフ commit 後 PR 作成予定) | 1 件予定 |
 | 残留プロセス | ✅ なし |
-| 本番 deploy | ✅ 完了 (run 27764811311 success、約 23:05 JST) |
+| 本番 deploy 状態 | ✅ 復旧完了 (api-00430-lct 100%、新規エラー 0 件) |
 | 即着手タスク | 0 件 |
-| 条件待ち | 8 件 (#1 現場再フィードバック、#2-5 Codex 残存課題、#6 Phase 1、#7-8 既存 Issue) |
+| 条件待ち | 10 件 (#1 前田さま結果、#2 SigningError 監視、#3 中長期 retry 設計、#4-7 Codex 残存課題、#8 Phase 1、#9-10 既存 Issue) |
 | Documentation 同期 | ✅ 本ハンドオフで更新中 |
-| 品質ゲート | ✅ CI 全 PASS、code-reviewer 0 件、1672 tests PASS |
 | memory scope チェック | ⏭️ memory 変更なし (該当なし) |
-| 構造的整合性チェック (impact-analysis 等) | ⏭️ 該当なし (定数値変更のみ、API 契約 / 共有型変更なし) |
+| 構造的整合性チェック (impact-analysis 等) | ⏭️ 該当なし (コード変更なし、本番設定変更のみ) |
+| Issue Net | 0 件 (本件は再発リスク不明により起票保留) |
 
 ---
 
 ## 最終結論
 
-✅ **セッション終了可** — 残作業ゼロ、クリーン状態達成、本番反映完了
+✅ **セッション終了可** — 本番復旧完了、外部 trigger 待ち以外の executor 残作業ゼロ
 
 根拠:
-- 現場フィードバック対応の完結 (PR #574 merged + Cloud Run deploy success + ADR-036 改訂 + 現場連絡文案起草済)
-- 即着手タスク 0 件、条件待ち 8 件 (すべて開発者明示指示 or 現場再フィードバック trigger)
-- Git clean (本ハンドオフ commit 後)、残留プロセスなし、Issue Net 0
-- 本番実機の最終動作確認は decision-maker 領分 (`feedback_deploy_proactive_verification.md`)
-
-次の一手 (もしあれば): 開発者が現場連絡を送付し、現場からの返信 (動作 OK / 問題報告) を待つフェーズ。返信内容次第で条件待ち #1 が即着手に昇格。指示なき場合はそのままセッション終了。
+- 本番 Cloud Run `api-00430-lct` 100% トラフィック稼働中、新規 SigningError 0 件 (10 分監視)
+- 前田さまへの連絡文案は社内対応担当者に引き渡し済 (送付・結果収集は decision-maker 領分)
+- Git clean、残留プロセスなし、Issue Net 0、即着手 0 件
+- 条件待ち 10 件すべて外部 trigger 待ち (4 原則 §1 = AI 起点で進めるのは越権)
+- 再発時の調査エントリポイント (instanceId 集約、A/B/C/D 復旧候補) は本 handoff に記録済

--- a/docs/handoff/archive/2026-06-18-session-75.md
+++ b/docs/handoff/archive/2026-06-18-session-75.md
@@ -1,0 +1,270 @@
+# Session Handoff — 2026-06-18 (Session 75)
+
+## TL;DR
+
+**現場フィードバック対応 — 講座資料 PDF アップロード上限を 50MB → 150MB に引き上げ**。Canva 出力 PDF が 50MB を超える運用課題を受け、開発者判断で 150MB に決定。コード変更 + ADR-036 改訂 + テスト + CI/CD まで完結、本番デプロイ反映済。現場連絡文案を起草、送付は decision-maker 領分。
+
+| 主要成果 | 結果 |
+|---|---|
+| PDF アップロード上限引き上げ (50 → 150 MB) | ✅ PR #574 merged + Cloud Run deploy success |
+| ADR-036 / spec / smoke runbook 改訂 | ✅ 改訂日 2026-06-18 + 旧上限併記 |
+| サーバー / クライアント / テスト 同期 | ✅ 定数 + エラー文言 + 表示文言 + 境界値テスト |
+| 品質ゲート | ✅ CI 5 件 PASS / code-reviewer 0 件 / 全 1672 tests PASS |
+| ローカル dry test 試行 | ⚠ super-admin UI は Firebase Auth 固定で実機 UI 検証不可、コンポーネントテストで境界値担保 |
+| 現場連絡文案起草 | ✅ 起草済 (反映済前提)、送付は decision-maker |
+
+- **Issue Net (本セッション)**: Close 0 + 起票 0 = **Net 0** (現場フィードバック対応は PR で直接対応、新規 Issue 化せず)
+- **本セッション merged PR**: 1 件 (#574)
+- **本セッション workflow_dispatch**: 0 件
+
+---
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+cat docs/handoff/LATEST.md
+git fetch origin main && git log --oneline -5 origin/main
+gh pr list --state open
+gh issue list --state open
+```
+
+**次セッションの最初の一手**: なし (即着手タスク 0 件、条件待ち項目のみ)
+
+---
+
+## 重要な作業内容 (本セッション = Session 75)
+
+### 1. 現場フィードバック受領 — Canva 圧縮済み PDF が 50MB 超
+
+現場 (スーパー管理者) から `super-admin > マスターコース > レッスン編集` 画面の PDF アップロード時に以下メッセージが発生する旨報告。
+
+> `PDF 形式 / 最大 50 MB`
+> `ファイルサイズが上限 (50 MB) を超えています。`
+
+> 「canva から PDF 圧縮で DL しておりますがそれでも 50MB 以上になってしまっております」
+
+### 2. 上限値の決定
+
+| 選択肢 | 評価 |
+|--------|------|
+| 100 MB | Canva 標準圧縮 + 一般資料サイズに余裕、最も保守的 |
+| **150 MB (採用)** | 中規模写真資料も対応、署名 URL 有効期限内 DL 現実的 |
+| 200 MB | 大規模資料対応、低速回線 DL リスク↑ |
+
+開発者判断で **150 MB** 採用。
+
+### 3. PR #574 実装内容
+
+#### 変更ファイル (7 件、+28/-23)
+
+| ファイル | 内容 |
+|----------|------|
+| `services/api/src/services/lesson-resource.ts` | `MAX_PDF_SIZE_BYTES = 150 * 1024 * 1024` + エラーメッセージ 2 箇所 |
+| `web/components/master/MasterLessonPdfUploader.tsx` | クライアント側 pre-check 定数 + 表示文言 / a11y label 4 箇所 |
+| `services/api/src/services/__tests__/lesson-resource.test.ts` | テストタイトル 2 箇所 (50MB → 150MB) |
+| `web/components/master/__tests__/MasterLessonPdfUploader.test.tsx` | 境界値 51 → 151 MB、`makePdfFile` を `Object.defineProperty(file, "size", ...)` の size 偽装方式に変更 (vitest 並列実行時のメモリ圧迫予防) |
+| `docs/adr/ADR-036-course-resource-pdf-distribution.md` | ステータス行に改訂日 (2026-06-18) と引き上げ理由を追記 |
+| `docs/specs/2026-05-17-course-pdf-download-design.md` | 仕様書 4 箇所 (F-1 / 制約 / エラー表 / AC-10) |
+| `docs/ops/2026-05-17-pdf-smoke-test-runbook.md` | smoke runbook 実装挙動説明を更新 |
+
+#### 影響範囲
+
+- ✅ サーバー側 (`MAX_PDF_SIZE_BYTES`) とクライアント側 pre-check が一致 (150 MB)
+- ✅ `confirmPdfUpload` の GCS 実メタデータ再検証も 150 MB を参照、バイパス経路なし
+- ✅ GCS 直接 PUT 方式のため Cloud Run body 上限への影響なし
+- ⚠️ GCS 署名 URL 有効期限 (upload 1 時間 / download 15 分) は据え置き
+- ⚠️ GCS storage cost は素直に増加 (ファイル数 × 増分)、軽微
+
+### 4. 品質ゲート
+
+- ✅ サーバー側ユニットテスト 26 件 PASS (境界値 150 MB + 1 で `file_too_large`)
+- ✅ クライアント側コンポーネントテスト 12 件 PASS (151 MB で「ファイルサイズが上限 (150 MB) を超えています。」表示)
+- ✅ 全 workspace 1672 tests PASS
+- ✅ 型チェック / lint 全 PASS (既存 warning 1 件、本 PR と無関係)
+- ✅ code-reviewer エージェント: Critical/High/Medium 0 件、Low 1 件 (コメント補足のみで対応済)
+- ✅ CI 5 件 PASS (Build / Lint / Test / Type Check / Playwright E2E)
+
+### 5. ローカル dry test の試行と限界
+
+開発者依頼で「ローカル dev server で実機確認」を試行したが、以下の環境制約で実機 UI 検証は不可:
+
+| 検証経路 | 阻害要因 |
+|----------|----------|
+| super-admin UI フル操作 (Playwright) | `web/app/super/layout.tsx` の auth gate が `AUTH_MODE=dev` でも `!user` で「Googleでサインイン」画面に止まる。super 画面は **Firebase Auth 固定**仕様 |
+| API への curl 直接検証 | DataSource ファクトリが dev mode でも本番 Firestore + GCS を参照する仕様。検証リクエストでも本番副作用リスク (本番データ保護ルール抵触) |
+| E2E_TEST_ENABLED=true で In-Memory 起動 | `_master` テナントの seed データが必要、ROI 低 |
+
+**実施できた検証**:
+- API/Web の dev server 起動成功 (port 8080 / 3003)
+- ビルド成果物 `services/api/dist/services/lesson-resource.js` に `MAX_PDF_SIZE_BYTES = 150 * 1024 * 1024` 反映確認
+
+**後始末**: dev server プロセス停止、`/tmp/lms-pdf-test/` (60/120/160 MB のダミー PDF) 削除済。残留プロセスなし。
+
+### 6. 現場連絡文案起草 (送付は decision-maker)
+
+デプロイ反映済確認後の差し替え文案:
+
+```
+資料添付の件、ご連絡ありがとうございます。
+
+PDF アップロードの上限を 50MB → 150MB に引き上げました。
+すでにシステムにも反映済みです。
+Canva から書き出した圧縮済みの PDF も、そのまま添付いただけるようになっているはずです。
+
+お手数ですが、改めてアップロードをお試しいただけますでしょうか。
+もし問題があればまたご連絡ください。
+
+よろしくお願いいたします。
+```
+
+開発者から「連絡は送ります」とのコメント、送付実行は decision-maker 領分。
+
+---
+
+## 次のアクション
+
+### 即着手タスク
+
+**即着手タスクなし** (executor 領分の作業 0 件、品質ゲート全通過 + 本番反映完了)
+
+### 条件待ち (明示 trigger 付き)
+
+| # | 項目 | A/B/C | trigger | 充足時のタスク |
+|---|------|-------|---------|-------------|
+| 1 | **現場再フィードバック対応 (PDF 上限引き上げ)** | C (起点指示) | 開発者が現場連絡送付後、現場からの返信 | 内容に応じて対応 (動作 OK ならクローズ、問題報告なら原因調査) |
+| 2 | **Codex 残存課題 #1: no-op 更新で編集済化** (Session 74 継承) | B | 開発者明示指示 | `editScore`/`editPassed` も dirty 判定化、または PATCH endpoint で「変更なし update」を skip |
+| 3 | **Codex 残存課題 #2: GET 側 `original.entryAt/exitAt` Timestamp 正規化** (Session 74 継承) | B | 開発者明示指示 | `super-admin.ts:1061` で `original.entryAt/exitAt` も正規化 |
+| 4 | **Codex 残存課題 #3: 編集ダイアログの JST 日跨ぎ session 対応** (Session 74 継承) | B | 開発者明示指示 | entry/exit 別々の日付入力に拡張 |
+| 5 | **Codex 残存課題 #4: 日付境界またぎ UI tooltip** (Session 74 継承) | B | 開発者明示指示 | `formatTimeWithDayDiff` で「翌 HH:mm」表示 |
+| 6 | **Phase 1 本番動作確認** (Session 70 から継続) | B | 長遊園 / 福の種で新規テスト提出 → synthetic_* doc 生成確認 | 結果次第で Phase 1 修正判断 |
+| 7 | **Issue #536 sanitize helper 抽出** | C (起点指示) | 開発者明示指示 | helper 抽出実装 |
+| 8 | **Issue #521 dry-run UI follow-up 15 件集約** | C (起点指示) | 開発者明示指示 | follow-up 対応 |
+
+### 却下候補 (記録のみ・包括指示の対象外)
+
+| # | 項目 | A/B/C | 着手しない理由 |
+|---|------|-------|--------------|
+| 1 | **PDF 上限 200 MB 化** | C | decision-maker が 150 MB を選択済、現場再フィードバックなければ ROI 低 |
+| 2 | **D 案関連 (Session 74)** B 案 / A 案 / E 案 | C | Session 74 で確定済、再オープンは方針逆転 |
+| 3 | postponed Issue (#405/#276/#275/#274) | C | postponed ラベルは明示指示なき限り着手不可 |
+| 4 | **ローカル dry test 用の認証バイパス実装** | C | super-admin Firebase Auth 固定は意図的設計、PR 範囲外、ROI 低 |
+| 5 | **本番環境での AI 能動的動作確認** | C | `feedback_deploy_proactive_verification.md` 越権ルール抵触、開発者領分 |
+
+---
+
+## CI / Deploy 状態 (本セッション)
+
+| run | 種類 | 状態 |
+|-----|------|------|
+| 27764646837 (PR #574 push) | Build / Lint / Test / Type Check | ✅ 全 pass |
+| 27764646835 (PR #574 push) | Playwright E2E | ✅ pass (1m37s) |
+| 27764810084 (main post-merge) | CI | ✅ success (2m13s) |
+| 27764810832 (main post-merge) | E2E Tests | ✅ success (1m12s) |
+| 27764811311 (main post-merge) | Deploy to Cloud Run | ✅ success (4m53s) |
+
+### 本セッション merged PR
+
+| PR | 種類 | 状態 |
+|----|------|------|
+| #574 | feat(lesson-resource): PDF アップロード上限を 50 MB → 150 MB に引き上げ | ✅ merged (056c441) |
+| (本 PR) | docs(handoff): Session 75 - PDF 上限 150 MB 引き上げ完了 + 現場連絡文案 | ⏳ 作成予定 |
+
+---
+
+## ADR / 設計判断記録
+
+### 本セッションで改訂
+
+- **ADR-036 改訂** (PR #574):
+  - 2026-06-18: PDF アップロード上限を 50 MB → 150 MB に引き上げ。理由: Canva 出力 PDF (圧縮後) が 50 MB を超過するケースが現場で発生。
+  - ステータス行: `採用 (2026-05-17) / 上限 150 MB に改訂 (2026-06-18)`
+
+### 本セッションで新規作成
+
+なし (既存 ADR の改訂で対応)
+
+### 次セッション以降の起票候補
+
+なし
+
+---
+
+## Issue Net 変化
+
+- **Close 数 (本セッション)**: 0 件
+- **起票数 (本セッション)**: 0 件
+- **Net (本セッション)**: 0 件
+
+現場フィードバック対応は PR #574 で直接対応、新規 Issue 化していない。
+
+---
+
+## 学習事項 (本セッションの振り返り)
+
+### 1. 「ローカル dry test」と「本番実機確認」の境界
+
+- 開発者の「dry test 実施してほしい」依頼に対し、Playwright MCP で実機 UI 検証を試行
+- super-admin layout が Firebase Auth 固定で dev mode 認証バイパス不可
+- DataSource が dev mode でも本番 Firestore に向かう仕様
+- **教訓**: 「ローカル実機確認」は executor 領分でも、AUTH_MODE と DataSource の仕様次第で物理的に不可能なケースがある。事前に env / 認証 / データソース仕様を確認する
+- **教訓**: コンポーネントテスト + ビルド成果物確認 + CI で「定数変更の正しさ」は多重担保できる。実機 UI スクショは本番デプロイ後の最終確認 (decision-maker 領分) で代替
+
+### 2. デプロイ反映確認の重要性
+
+- 現場連絡文案を「反映完了後にご連絡します」で起草した直後、ユーザーから「え？まだ出来てないの？」とリアクション
+- `gh run list` 確認の結果、PR マージから約 5 分で Cloud Run deploy success 完了済 (約 24 分前)
+- **教訓**: 「反映予定」「反映後」等の時間表現を使う前に、必ず `gh run list --branch main` で Deploy to Cloud Run の状態を確認する
+- **教訓**: 自動デプロイの完了タイミング (push → 反映まで約 5 分) は通常運用情報として handoff に記録すると、次セッションで保守的に書き過ぎず済む
+
+### 3. 定数変更でも 7 ファイル波及
+
+- サーバー定数 1 + クライアント定数 1 だけでなく、エラーメッセージ / 表示文言 / a11y label / テストタイトル / テスト境界値 / ADR / spec / runbook と 7 ファイル波及
+- 単純な「50 → 150」置換でも、grep で残存を全件確認するプロセスが必要
+- **教訓**: 数値定数の変更は「定数だけ変えて完了」ではない。`grep -rn "50 MB\|50MB"` の全件確認 + 改訂日記録の運用を踏襲する
+
+### 4. テストでの大容量メモリ確保回避
+
+- 上限 50 MB → 150 MB に変更する際、`makePdfFile(51)` を `makePdfFile(151)` に置換するだけでは vitest 並列実行で 151 MB の Uint8Array 確保リスク
+- `Object.defineProperty(file, "size", { value: ... })` で size プロパティのみ偽装、実バイト列は 1 byte に最小化
+- **教訓**: ファイルサイズ境界値テストでは「実バイト列」ではなく「`size` プロパティ偽装」が標準パターン。code-reviewer の Low finding (「writable: false 既定で同インスタンス再定義不可」) もコメントで明示しておく
+
+---
+
+## 関連ドキュメント
+
+- 本セッション主要 PR: #574 (`056c441`)
+- 改訂 ADR: `docs/adr/ADR-036-course-resource-pdf-distribution.md`
+- 仕様書: `docs/specs/2026-05-17-course-pdf-download-design.md`
+- smoke runbook: `docs/ops/2026-05-17-pdf-smoke-test-runbook.md`
+- 前セッション handoff: `docs/handoff/archive/2026-06-10-session-74.md`
+
+---
+
+## 再開可能性判定
+
+| 項目 | 状態 |
+|------|------|
+| Git clean | ✅ (本ハンドオフ commit 前) |
+| OPEN PR | 0 件 (本ハンドオフ commit 後 PR 作成予定) |
+| 残留プロセス | ✅ なし |
+| 本番 deploy | ✅ 完了 (run 27764811311 success、約 23:05 JST) |
+| 即着手タスク | 0 件 |
+| 条件待ち | 8 件 (#1 現場再フィードバック、#2-5 Codex 残存課題、#6 Phase 1、#7-8 既存 Issue) |
+| Documentation 同期 | ✅ 本ハンドオフで更新中 |
+| 品質ゲート | ✅ CI 全 PASS、code-reviewer 0 件、1672 tests PASS |
+| memory scope チェック | ⏭️ memory 変更なし (該当なし) |
+| 構造的整合性チェック (impact-analysis 等) | ⏭️ 該当なし (定数値変更のみ、API 契約 / 共有型変更なし) |
+
+---
+
+## 最終結論
+
+✅ **セッション終了可** — 残作業ゼロ、クリーン状態達成、本番反映完了
+
+根拠:
+- 現場フィードバック対応の完結 (PR #574 merged + Cloud Run deploy success + ADR-036 改訂 + 現場連絡文案起草済)
+- 即着手タスク 0 件、条件待ち 8 件 (すべて開発者明示指示 or 現場再フィードバック trigger)
+- Git clean (本ハンドオフ commit 後)、残留プロセスなし、Issue Net 0
+- 本番実機の最終動作確認は decision-maker 領分 (`feedback_deploy_proactive_verification.md`)
+
+次の一手 (もしあれば): 開発者が現場連絡を送付し、現場からの返信 (動作 OK / 問題報告) を待つフェーズ。返信内容次第で条件待ち #1 が即着手に昇格。指示なき場合はそのままセッション終了。


### PR DESCRIPTION
## Summary

本番インシデント緊急対応の handoff 記録 PR (Session 76)。コード変更なし、docs のみ。

- 福の種テナント (atali82i) 受講生・前田さまの動画視聴 500 エラーを Cloud Run 単一インスタンスの IAM signBlob keep-alive スタック起因と特定
- env var `RESTART_AT=2026-06-19T11-30` 追加で新リビジョン `api-00430-lct` を作成、旧 `api-00429-gb7` の stuck インスタンスを drain
- 復旧後の新規 SigningError 0 件 (10 分監視)
- 前田さまへの動作確認連絡文案は社内対応担当者経由で引き渡し済 (送付・結果収集は decision-maker 領分)

## 次のアクション分類

- 即着手: 0 件
- 条件待ち: 10 件 (#1 前田さま結果連絡、#2 SigningError 再発監視、#3 中長期 retry 設計、#4-7 Session 74 Codex 残存、#8 Phase 1、#9-10 既存 Issue #536/#521)
- 却下候補: 5 件 (env var cleanup / リビジョン cleanup / AI 能動動作確認 / 既存方針逆転候補 / postponed Issue)

## Issue Net 変化

- Close 0 / 起票 0 / **Net 0** (本件は再発リスク不明により起票保留、CLAUDE.md Issue Triage 基準で再発時に判定)

## 本番 destructive 操作の記録

- `gcloud run services update api --region=asia-northeast1 --update-env-vars=RESTART_AT=2026-06-19T11-30 --project=lms-279`
- 開発者明示認可文言: 「本番 Cloud Run api (lms-279, asia-northeast1) に env var RESTART_AT を追加して新リビジョン作成を承認する」(2026-06-19 11:30 JST)

## Test plan

- [x] LATEST.md 282 行 (handoff size target 500 行以内)
- [x] Session 75 を `docs/handoff/archive/2026-06-18-session-75.md` にアーカイブ
- [x] 3 分割構造 (即着手 / 条件待ち / 却下候補) + A/B/C 分類済
- [x] Issue Net 計測済
- [x] 最終結論 1 行明示済
- [ ] CI green 確認 (CI / E2E は docs 変更のため即 pass 想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)