### PR TITLE
docs(handoff): Session 77 - PDF アップロード上限 150→300 MB 引き上げ完了

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,22 +1,22 @@
-# Session Handoff — 2026-06-19 (Session 76)
+# Session Handoff — 2026-06-19 (Session 77)
 
 ## TL;DR
 
-**本番インシデント緊急対応 — 福の種テナント (atali82i) 受講生・前田さまの動画視聴 500 エラーを Cloud Run 単一インスタンスの IAM signBlob スタック起因と特定、新リビジョン作成で復旧**。コード変更ゼロ、env var `RESTART_AT` 追加のみで全インスタンスをローリング drain。社内対応担当者経由で前田さまへの動作確認連絡文案を引き渡し済、復旧確認は外部 trigger 待ち。
+**現場フィードバック対応 — 講座資料 PDF アップロード上限を 150 MB → 300 MB に再引き上げ**。Session 75 (PR #574) で 50 → 150 MB に上げた直後、現場から「230 MB 超のスライド資料を添付したい」要望が発生。decision-maker 判断で 300 MB を採用、PR #574 と同パターンでサーバー側 + クライアント側 + ADR-036 / spec / runbook を更新、本番デプロイ反映済。現場連絡文案を起草、送付は decision-maker 領分。
 
 | 主要成果 | 結果 |
 |---|---|
-| 福の種テナント動画視聴不可の原因特定 | ✅ `SigningError: Premature close` calling iamcredentials.googleapis.com signBlob、単一 Cloud Run インスタンス (`002f8ffd47c07...`) で全 30 件発生 |
-| 期限切れ仮説の棄却 | ✅ `videoAccessUntil` 期限切れ (403) ではなく内部エラー (500) と確定、enrollment-setting 起因を除外 |
-| 本番緊急復旧 | ✅ env var `RESTART_AT=2026-06-19T11-30` 追加 → 新リビジョン `api-00430-lct` 作成 + 旧 `api-00429-gb7` drain 完了 |
-| 復旧後の動作 | ✅ 新リビジョンで新規 SigningError 0 件 (10 分監視) |
-| 前田さまへの連絡文案 | ✅ 起草済 + 社内対応担当者に引き渡し済 (送付・結果収集は decision-maker 領分) |
-| コード変更 | ❌ ゼロ (Cloud Run 設定のみ、PR 不要) |
+| PDF アップロード上限引き上げ (150 → 300 MB) | ✅ PR #577 merged + Cloud Run deploy success (revision `api-00432-x7s`) |
+| ユニット / コンポーネントテスト | ✅ services/api 1672 件 + web 329 件 全 PASS |
+| code-review low | ✅ findings なし |
+| ADR-036 / spec / runbook 更新 | ✅ 2026-06-19 改訂として記録 |
+| 現場連絡文案 | ✅ 起草済 (送付は decision-maker 領分) |
+| 追加実機テスト | ❌ 不要判断 (ROI 評価、既存テストで十分) |
 
 - **Issue Net (本セッション)**: Close 0 + 起票 0 = **Net 0**
-- **本セッション merged PR**: 0 件
+- **本セッション merged PR**: 1 件 (#577)
 - **本セッション workflow_dispatch**: 0 件
-- **本セッション本番 destructive 操作**: 1 件 (`gcloud run services update api --update-env-vars=RESTART_AT=...`、開発者明示認可済)
+- **本セッション本番 destructive 操作**: 0 件 (定数引き上げのみ、データ操作なし)
 
 ---
 
@@ -27,122 +27,128 @@ cat docs/handoff/LATEST.md
 git fetch origin main && git log --oneline -5 origin/main
 gh pr list --state open
 gh issue list --state open
-# 前田さま動作確認結果の有無を確認 (社内連絡経路は GitHub 管理外)
+# 現場連絡 (300 MB 引き上げ完了) の結果反応の有無を確認 (チャット経路は GitHub 管理外)
 ```
 
-**次セッションの最初の一手**: なし (即着手タスク 0 件、条件待ち項目のみ。trigger #1 充足時 = 前田さま結果連絡が来た時に分岐判断)
+**次セッションの最初の一手**: なし (即着手タスク 0 件、条件待ち項目のみ)
 
 ---
 
-## 重要な作業内容 (本セッション = Session 76)
+## 重要な作業内容 (本セッション = Session 77)
 
-### 1. 症状受領 — 福の種・前田さま「動画 7️⃣以降と前も見れない」
+### 1. 現場フィードバック受領
 
-開発者経由で福の種テナント受講生・前田さまから報告:
+catchup 起動直後、開発者経由で現場から PDF 添付不可フィードバック受領:
 
-> 「今、動画7️⃣を見ようとしたが、見れないようです。それ以降前も見れないようです。」
+> 「資料添付の件です 230MB超えているのでもう少しアップしていただけると 資料添付できそうです」
 
-「以降と前も」というキーワードからテナント全体に影響が出ていると仮定し、3 仮説を並列で立案:
+添付画像 (lesson 4 「Gmail の活用」の super-admin 画面 PDF 選択 UI) から、Session 75 で引き上げた **150 MB 上限が 230 MB 超のスライド資料に対して足りていない** と確認。
 
-| 仮説 | 採用後の対応 |
-|------|-----------|
-| ① テナント全体の `videoAccessUntil` 期限切れ | 期限延長 (super-admin で update) |
-| ② 特定動画ファイルの GCS 喪失 | 動画再アップロード |
-| ③ Cloud Run 障害 (内部エラー) | リビジョン入れ替えまたはロールバック |
+### 2. 上限値の判断 — 300 MB 採用
 
-### 2. 仮説検証 — 本番 Cloud Run ログ照会 (開発者明示認可 A 案)
+decision-maker 領分の数値選択として AskUserQuestion を実施、以下から選択:
 
-開発者認可 (`lms-279 本番ログ読み取りを承認`) のうえ `gcloud logging read` で照会。
+| 案 | 評価 |
+|---|---|
+| 256 MB (2^28) | 230 MB の直近の余裕のみ、次回再引き上げ可能性 |
+| **300 MB (採用)** | 230 MB の余裕 + 次回 Canva 圧縮失敗や付録追加に対応可能、50 → 150 → 300 と倍々 |
+| 500 MB | バッファ厚め、低速回線で upload 1 時間内が現実的 (実効 1.1 Mbps 以上必要) |
 
-#### 2.1 期限切れ仮説 (403) の棄却
+decision-maker 判断で **300 MB** 採用。
 
-```bash
-gcloud logging read 'jsonPayload.error="video_access_expired"' --freshness=2d
-# → 0 件
-```
+### 3. 実装変更
 
-期限切れガード (`services/api/src/services/enrollment.ts:108-138 guardVideoAccess()`) は発火していない。
+PR #574 と完全同一パターンの定数引き上げ:
 
-#### 2.2 playback-url の状態分布
+| ファイル | 内容 |
+|---|---|
+| `services/api/src/services/lesson-resource.ts` | `MAX_PDF_SIZE_BYTES = 300 * 1024 * 1024` + エラーメッセージ 2 箇所 + コメント 1 箇所 |
+| `web/components/master/MasterLessonPdfUploader.tsx` | クライアント側 pre-check 定数 + 表示文言 / a11y label 4 箇所 |
+| `services/api/src/services/__tests__/lesson-resource.test.ts` | テストタイトル 2 箇所 (150MB → 300MB) |
+| `web/components/master/__tests__/MasterLessonPdfUploader.test.tsx` | 境界値 151 → 301 MB に変更 |
+| `docs/adr/ADR-036-course-resource-pdf-distribution.md` | ステータス行に再改訂日 (2026-06-19) と引き上げ理由を追記 |
+| `docs/specs/2026-05-17-course-pdf-download-design.md` | 仕様書 4 箇所 (F-1 / 制約 / エラー表 / AC-10) |
+| `docs/ops/2026-05-17-pdf-smoke-test-runbook.md` | smoke runbook 実装挙動説明を更新 |
 
-```bash
-# 過去 24h の atali82i (= 福の種) 動画 playback-url
-# 200: 4 件 (旧リビジョン api-00427-lh7 時代)
-# 500: 16 件 (新リビジョン api-00429-gb7 で発生)
-# 204: 20 件 (CORS preflight OPTIONS)
-```
+### 4. 品質ゲート
 
-500 開始時刻: 2026-06-18 23:41:01 UTC (= 08:41 JST)
-新リビジョン `api-00429-gb7` のデプロイ: 2026-06-18 22:31:03 UTC (= 07:31 JST、handoff commit 243234f によるトリガー)
+- ✅ `npm run type-check`: 4 workspace PASS
+- ✅ `npm run lint`: 0 errors, 1 既存 warning (本 PR と無関係、PR #574 でも同じ)
+- ✅ `npm run test`: services/api 1672 件 + web 329 件 全 PASS
+- ✅ `/code-review low`: findings なし
+- ✅ Cloud Run デプロイ: success (revision `api-00432-x7s`)
 
-#### 2.3 エラー詳細
+### 5. 追加実機テストの ROI 判断
 
-```
-SigningError: Invalid response body while trying to fetch
-  https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/1034821634012-compute@developer.gserviceaccount.com:signBlob:
-  Premature close
+「実機テストはどうするか」を decision-maker と協議:
 
-  at Gaxios._request (/app/node_modules/gaxios/build/src/gaxios.js:149:19)
-  at async GoogleAuth.signBlob (...)
-  at async sign (file:///app/node_modules/@google-cloud/storage/build/esm/src/signer.js:193:35)
-```
+| 観点 | 評価 |
+|---|---|
+| 追加テストコスト | decision-maker DevTools 操作 + smoke リソース選定 + AI curl 実行 = 10-15 分 |
+| 既存カバレッジ | ユニットテスト 26 件で境界値 (300 MB + 1 → file_too_large) 検証済、code-review findings なし、Cloud Run revision 反映確認済 |
+| 回帰リスク | 定数 150 → 300 のみ、ロジック変更ゼロ、前回 PR #574 と完全同一パターン |
+| ROI 結論 | **低 (利益 < コスト)、追加テスト不要** |
 
-GCS 署名付き URL 生成 (`services/api/src/services/gcs.ts:51 generatePlaybackUrl()`) が IAM Credentials API `signBlob` 呼び出しで失敗。「Premature close」は HTTP レスポンスが途中で切断された状態。
+**前回 Session 75 のテスト品質との比較**: Session 75 でも実機テストは PR Test plan で unchecked のまま完結したが、本番で問題は発生していない (今回の 230 MB 要望は仕様改善で品質問題ではない)。前回品質で十分という decision-maker 評価を尊重。
 
-### 3. 単一インスタンス起因の確定
+### 6. AI の越権発言の訂正
 
-```bash
-gcloud logging read 'jsonPayload.error.name="SigningError"' --freshness=2d \
-  --format='value(labels.instanceId)' | sort -u
-# → 002f8ffd47c07e6aca31d333d14a3ca79b005bd900274414c9488ab3cda0fa7f742542c7b4484eb0c7c4d5167ec1667026cf5223db91bfb089dbecc89937a9c9c1a6ec893875a3b98de45867be2477fb74
-# (1 件のみ)
-```
+途中、AI が「前回は実機テストせず本番反映していました。今回はそれを改善する形ですね。」と発言、decision-maker から「以前のテスト品質では駄目でしたか？」と訂正される。AI が「テスト未実施＝問題」と決めつけて「改善が必要」と能動提案したのは 4 原則 §1 違反 (executor 越権)。発言を撤回し、ROI ベース判断に切り替えた。
 
-**過去 2 日間の全 30 件の SigningError が同一 Cloud Run インスタンスから発生**。原因は単一インスタンスの keep-alive HTTP コネクションが iamcredentials.googleapis.com に対してスタック (途中切断状態のまま再利用) と推定。
+### 7. 現場連絡文案
 
-#### 棄却した代替仮説
+PR #574 と同テンプレで起草、decision-maker に引き渡し済:
 
-| 仮説 | 棄却理由 |
-|------|--------|
-| コード回帰 (PR #574 起因) | `gcs.ts` / `package.json` / `Dockerfile` いずれも未変更 (git show 056c441 で確認) |
-| IAM 権限不足 | compute SA に `roles/iam.serviceAccountTokenCreator` 保有確認 (project IAM policy) |
-| iamcredentials API 無効化 | `gcloud services list --enabled` で enabled 確認 |
-| VPC connector / egress 制限 | Cloud Run 設定に VPC connector annotation なし |
-| イメージ全体の問題 | 単一 instanceId のみで発生、他インスタンスは正常 (の可能性) |
+**カジュアル版**:
+> PDF アップロードの上限を 150 MB → 300 MB に引き上げました！ 230 MB の資料も問題なく添付できるはずです。お試しください 🙏 何かエラーが出たり、まだ足りなければ気軽に連絡ください。
 
-### 4. 復旧アクション — A 案実行 (開発者明示認可済)
+**丁寧版**:
+> お疲れ様です。ご要望いただいた PDF アップロード上限、150 MB → 300 MB に引き上げ完了しました。230 MB の資料も添付できるようになっているはずなので、よろしければお試しいただけますか？ 不具合などあればお知らせください！
 
-開発者認可文言: `本番 Cloud Run api (lms-279, asia-northeast1) に env var RESTART_AT を追加して新リビジョン作成を承認する`
+---
 
-```bash
-gcloud run services update api \
-  --region=asia-northeast1 \
-  --update-env-vars=RESTART_AT=2026-06-19T11-30 \
-  --project=lms-279
-```
+## 学び・気づき
 
-実行結果:
-- 新リビジョン `api-00430-lct` 作成 + 100% トラフィック切替完了
-- 旧リビジョン `api-00429-gb7` drain (スタックインスタンス `002f8ffd47c07...` 消滅)
-- デプロイ完了時刻: 2026-06-19 02:29:52 UTC (= 11:29 JST)
-- 設定変更内容: env var `RESTART_AT=2026-06-19T11-30` 追加のみ、コード/イメージ無変更
-- デプロイ後監視: 新規 SigningError 0 件 (10 分間)
+### 1. PR #574 と同パターンの再演でも越権発言が混入し得る
 
-### 5. 前田さまへの連絡 (社内対応担当者経由)
+定数引き上げという完全に同じパターンでも、AI 側が「前回はテスト不足、今回は改善が必要」と勝手に品質基準を上げる発言が混入。decision-maker の判断 (前回の品質で十分) を尊重し、AI 側からの能動的「改善提案」は 4 原則 §1 違反になり得る。同パターンの再演時こそ「前回と同じ品質で完了」を default 判断とする。
 
-文案を起草し開発者経由で社内対応担当者に引き渡し済:
+### 2. ROI ベース判断の徹底
 
-```
-動画の再生に一時的なシステム障害が発生しておりました。
-サーバー側で対応が完了しましたので、お手数ですが
-ページを再読み込みしていただき、もう一度動画7️⃣を
-再生してみていただけますでしょうか。
+「テストできる」≠「テストすべき」。今回の場合:
+- 変更内容: 定数値のみ
+- ロジック変更: なし
+- 既存テスト: 境界値含む 1672 + 329 件 PASS
+- 前回 PR #574 と同パターン
+→ 追加実機テスト ROI 低 = 不要判断
 
-もし問題が続くようでしたら、再度お知らせください。
-ご不便をおかけして申し訳ございません。
-```
+「念のため」「より安全に」という能動的品質向上は decision-maker 判断であり、AI が能動提案するのは越権。
 
-送付実行・結果収集は decision-maker 領分。
+### 3. AI の越権発言を decision-maker が早期検出した
+
+「以前のテスト品質では駄目でしたか？」という問いで AI の越権発言を即座に検出。AI 側は発言を撤回し ROI ベース判断に切り替えた。これは feedback_promise_overengineering.md の類似事例 (過剰実装は発言訂正も選択肢)。
+
+---
+
+## 関連 PR / Issue
+
+| # | 内容 | 状態 |
+|---|---|---|
+| #577 | feat(lesson-resource): PDF アップロード上限を 150 MB → 300 MB に引き上げ | ✅ merged (8502653) |
+| (本 PR) | docs(handoff): Session 77 - PDF 上限 300 MB 引き上げ完了 | ⏳ 作成予定 |
+| #574 (参考) | 前回 (Session 75) の 50 → 150 MB 引き上げ | ✅ merged |
+| #536 (continued) | [refactor] FirestoreDataSource lesson_sessions の sanitize ロジック重複を helper 抽出 | OPEN, 着手指示待ち |
+| #521 (continued) | [Phase 4 α-7 follow-up] dry-run UI 両レーン化 follow-up 15 件集約 | OPEN, 着手指示待ち |
+
+---
+
+## ADR / 仕様書更新
+
+- `docs/adr/ADR-036-course-resource-pdf-distribution.md`:
+  - 2026-06-19: PDF アップロード上限を 150 MB → 300 MB に再引き上げ。理由: 230 MB 超のスライド資料を添付したい現場要望が発生。
+  - ステータス行: `採用 (2026-05-17) / 上限 150 MB に改訂 (2026-06-18) / 上限 300 MB に再改訂 (2026-06-19)`
+- `docs/specs/2026-05-17-course-pdf-download-design.md`: F-1 / 制約 / エラー表 / AC-10 を 300 MB に更新
+- `docs/ops/2026-05-17-pdf-smoke-test-runbook.md`: 実装挙動説明を 300 MB に更新
 
 ---
 
@@ -150,106 +156,44 @@ gcloud run services update api \
 
 ### 即着手タスク
 
-**即着手タスクなし** (executor 領分の作業 0 件、本番復旧完了 + 連絡文案引き渡し済)
+**該当なし** (executor 領分のタスクゼロ)
 
 ### 条件待ち (明示 trigger 付き)
 
-| # | 項目 | A/B/C | trigger | 充足時のタスク |
-|---|------|-------|---------|-------------|
-| 1 | **前田さま動作確認結果** | C (起点指示) | 社内対応担当者から前田さま返信、開発者経由で報告 | OK → 本件クローズ。NG → 再調査 (#2 へエスカレート) |
-| 2 | **SigningError 再発時の再調査** | B 検出 | `gcloud logging read jsonPayload.error.name=SigningError` で 30 分以内に新規発生 | 同一インスタンス起因なら再リサイクル、複数インスタンスなら image 起因疑い → Node.js / `@google-cloud/storage` SDK バージョン精査 |
-| 3 | **中長期: signed URL 生成の retry / health-check 設計** | C (起点指示) | 開発者から「再発防止策を検討して」の明示指示 | impl-plan: ① signBlob 呼び出しの透過 retry ② 起動時 sanity check ③ keep-alive 上限調整 |
-| 4 | **Codex 残存課題 #1: no-op 更新で編集済化** (Session 74 継承) | B 修正 | 開発者明示指示 | `editScore`/`editPassed` も dirty 判定化、または PATCH endpoint で「変更なし update」を skip |
-| 5 | **Codex 残存課題 #2: GET 側 `original.entryAt/exitAt` Timestamp 正規化** (Session 74 継承) | B 修正 | 開発者明示指示 | `super-admin.ts:1061` で `original.entryAt/exitAt` も正規化 |
-| 6 | **Codex 残存課題 #3: 編集ダイアログの JST 日跨ぎ session 対応** (Session 74 継承) | B 修正 | 開発者明示指示 | entry/exit 別々の日付入力に拡張 |
-| 7 | **Codex 残存課題 #4: 日付境界またぎ UI tooltip** (Session 74 継承) | B 修正 | 開発者明示指示 | `formatTimeWithDayDiff` で「翌 HH:mm」表示 |
-| 8 | **Phase 1 本番動作確認** (Session 70 継承) | B 検出 | 長遊園 / 福の種で新規テスト提出 → synthetic_* doc 生成確認 | 結果次第で Phase 1 修正判断 |
-| 9 | **Issue #536 sanitize helper 抽出** | C (起点指示) | 開発者明示指示 | helper 抽出実装 |
-| 10 | **Issue #521 dry-run UI follow-up 15 件集約** | C (起点指示) | 開発者明示指示 | follow-up 対応 |
+| # | 項目 | A/B/C | trigger (充足条件) | 充足時のタスク |
+|---|------|-------|------------------|--------------|
+| 1 | 現場から不具合報告 | B 修正 | 「300 MB でも upload できない」「想定外の挙動」等の報告 | 再現確認 → 原因調査 → 修正 PR |
+| 2 | Issue #536 (lesson_sessions sanitize helper 抽出) | B 修正 | decision-maker から「#536 を進めて」の明示指示 | refactor タスクとして impl-plan → tdd → safe-refactor → code-review |
+| 3 | Issue #521 (dry-run UI 両レーン化 follow-up 15 件) | B 修正 | decision-maker から「#521 を進めて」の明示指示 | 15 件の集約内容を確認した上で個別対応 |
 
 ### 却下候補 (記録のみ・包括指示の対象外)
 
 | # | 項目 | A/B/C | 着手しない理由 |
 |---|------|-------|--------------|
-| 1 | **env var `RESTART_AT` の cleanup** | A | 次回正規デプロイ時に他の env var 更新で自然消化、明示 cleanup 不要。手動削除は別 destructive 操作になりリスク増 |
-| 2 | **新リビジョン `api-00430-lct` 以前のリビジョンの cleanup** | A | Cloud Run の自動 retention で十分、明示 cleanup ROI 低 |
-| 3 | **本番環境での AI 能動的動作確認** | C | `feedback_deploy_proactive_verification.md` 越権ルール抵触 (4 原則 §1)、開発者領分 |
-| 4 | **D 案関連 / PDF 上限 200MB 化等** (Session 74-75 継承) | C | Session 74-75 で確定済、再オープンは方針逆転 |
-| 5 | postponed Issue (#405/#276/#275/#274) | C | postponed ラベルは明示指示なき限り着手不可 |
-
----
-
-## CI / Deploy 状態 (本セッション)
-
-| 操作 | 種類 | 状態 |
-|------|------|------|
-| `gcloud run services update api --update-env-vars=RESTART_AT=2026-06-19T11-30` | 本番 Cloud Run 設定変更 (緊急復旧) | ✅ 新リビジョン `api-00430-lct` 100% トラフィック (約 11:30 JST) |
-| GitHub Actions CI / Deploy | - | (本セッションは PR なし、CI ラン無) |
-
-### 本セッション merged PR
-
-| PR | 種類 | 状態 |
-|----|------|------|
-| (本 handoff PR) | docs(handoff): Session 76 - 福の種テナント動画視聴不可緊急復旧 | ⏳ 作成予定 |
-
----
-
-## ADR / 設計判断記録
-
-### 本セッションで新規作成
-
-なし (本件は単発の運用インシデント、設計判断は伴わない)
-
-### 次セッション以降の起票候補
-
-なし (中長期 follow-up #3 「retry / health-check 設計」は開発者起点指示後に impl-plan で ADR 化判断)
+| 1 | PDF 上限 500 MB 化 | C | decision-maker が 300 MB を選択済、現場再フィードバックなければ ROI 低 |
+| 2 | 本番実機 smoke test | B 修正 | decision-maker 判断で ROI 低と評価済、前回 PR #574 でも未実施で問題なし |
+| 3 | postponed Issue 4 件 (#405, #276, #275, #274) | A (指示なし)/ postponed | 明示指示なき限り着手不可、再開条件未確認 |
+| 4 | 新機能・改善アイデアの能動提案 | C (unclear) | 起点アイデアは decision-maker 領分 (4 原則 §1) |
 
 ---
 
 ## Issue Net 変化
 
-- **Close 数 (本セッション)**: 0 件
-- **起票数 (本セッション)**: 0 件
-- **Net (本セッション)**: 0 件
+- Close 数: 0 件
+- 起票数: 0 件
+- **Net: 0 件**
 
-本件は単一インスタンスの一過性スタックで、再現性 / 再発リスク / 影響範囲が現時点で不明 (CLAUDE.md Issue Triage 基準で起票判断保留)。再発した場合に triage 基準 #2 (再現可能なバグ) または #4 (rating ≥ 7 / confidence ≥ 80) で起票判断。
-
----
-
-## 学習事項 (本セッションの振り返り)
-
-### 1. 「症状の言葉」から仮説を絞り込む
-
-- 前田さまの「7️⃣以降と前も見れない」表現から、テナント全体影響を仮定 → `videoAccessUntil` 期限切れを第一仮説に
-- 実際は 500 (Cloud Run 内部エラー) で、特定テナント全体に影響が出るが原因は別 (単一インスタンス) だった
-- **教訓**: 「テナント全体に見える症状」も、Cloud Run のインスタンス単位ルーティング次第で「特定インスタンスにヒットした全テナント」と一致しうる。最初から複数仮説を並列で立てる
-
-### 2. instanceId ベースの集約は強力
-
-- `gcloud logging read ... --format='value(labels.instanceId)' | sort -u` で「全エラーが単一インスタンス起因」と即座に判定
-- これがイメージ全体起因かインスタンス単発起因かを切り分ける決定打になった
-- **教訓**: Cloud Run の `labels.instanceId` での集約は signed URL / IAM / external API stuck パターンの調査で最初に試すべきステップ
-
-### 3. 復旧手段の選択肢を ROI 順で並べる
-
-- 候補 A (env var 追加でローリング)、B (再デプロイ)、C (旧リビジョンへロールバック)、D (待機) を並列提示
-- 開発者は A を即選択 → 1 分で復旧完了
-- **教訓**: 緊急時こそ「やるべきこと 1 つ」ではなく「リスク順 N 候補」を提示し、decision-maker が即選べる状態にする (4 原則 §1 = executor 領分)
-
-### 4. classifier ブロック時の認可文言の具体性
-
-- 1 回目の `gcloud run services update` は classifier に「本番変更で具体的認可なし」とブロックされた
-- 「本番 Cloud Run api (lms-279, asia-northeast1) に env var RESTART_AT を追加」レベルの具体性で開発者が認可文言を返してくれて初めて通過
-- **教訓**: destructive 本番操作は「対象 (project + region + service) + 変更内容」を文言に含む必要あり。一般的な「A 案 OK」では classifier が通さない。AI 側で予め貼り付け可能な認可文言テンプレを提示すると往復が減る
+Net = 0 は進捗ゼロ評価 (`feedback_issue_triage.md`)。本セッションは本番現場フィードバック対応のため Issue 起票プロセスは経由せず、現場 → 開発者 → AI の経路で進行。triage 基準 #5 (decision-maker から明示指示された個別タスク) に該当。
 
 ---
 
-## 関連ドキュメント
+## 構造的整合性チェック
 
-- 前セッション handoff: `docs/handoff/archive/2026-06-18-session-75.md`
-- 該当コード: `services/api/src/services/gcs.ts:51 generatePlaybackUrl()` / `services/api/src/services/enrollment.ts:108 guardVideoAccess()` / `services/api/src/routes/shared/videos.ts:229 GET /videos/:videoId/playback-url`
-- 福の種テナント参考: `docs/adr/ADR-038-url-path-invisible-char-sanitization-middleware.md` (tenant `atali82i` 確認の根拠)
-- 本セッション本番操作対象: Cloud Run service `api` (lms-279 / asia-northeast1)、現行リビジョン `api-00430-lct`
+| 変更内容 | 必要なスキル | 実施状況 |
+|---------|------------|---------|
+| 型・共有ロジック・設定ファイル | `/impact-analysis` | ⏭️ スキップ (定数値変更のみ、共有ロジック・型変更なし) |
+| 新規テーブル/API追加 | `/new-resource` | ⏭️ スキップ (追加なし) |
+| データフロー実装 | `/trace-dataflow` | ⏭️ スキップ (新規データフローなし) |
 
 ---
 
@@ -257,26 +201,22 @@ gcloud run services update api \
 
 | 項目 | 状態 |
 |------|------|
-| Git clean (本ハンドオフ commit 前) | ✅ |
-| OPEN PR (本ハンドオフ commit 後 PR 作成予定) | 1 件予定 |
+| Git clean | ✅ |
+| main 同期済 | ✅ |
+| CI / E2E / Deploy 全 success | ✅ |
+| OPEN PR | 0 件 (本 handoff PR 作成後は 1 件) |
+| Active executor タスク | 0 件 |
 | 残留プロセス | ✅ なし |
-| 本番 deploy 状態 | ✅ 復旧完了 (api-00430-lct 100%、新規エラー 0 件) |
-| 即着手タスク | 0 件 |
-| 条件待ち | 10 件 (#1 前田さま結果、#2 SigningError 監視、#3 中長期 retry 設計、#4-7 Codex 残存課題、#8 Phase 1、#9-10 既存 Issue) |
-| Documentation 同期 | ✅ 本ハンドオフで更新中 |
-| memory scope チェック | ⏭️ memory 変更なし (該当なし) |
-| 構造的整合性チェック (impact-analysis 等) | ⏭️ 該当なし (コード変更なし、本番設定変更のみ) |
-| Issue Net | 0 件 (本件は再発リスク不明により起票保留) |
+| ADR 更新 | ✅ ADR-036 改訂済 (PR #577 内) |
+| 既存 OPEN Issue | 4 件 (postponed 3 件 + 着手指示待ち 1 件 + α、本セッション影響なし) |
 
 ---
 
 ## 最終結論
 
-✅ **セッション終了可** — 本番復旧完了、外部 trigger 待ち以外の executor 残作業ゼロ
+✅ **セッション終了可** — 残作業ゼロ、クリーン状態達成
 
-根拠:
-- 本番 Cloud Run `api-00430-lct` 100% トラフィック稼働中、新規 SigningError 0 件 (10 分監視)
-- 前田さまへの連絡文案は社内対応担当者に引き渡し済 (送付・結果収集は decision-maker 領分)
-- Git clean、残留プロセスなし、Issue Net 0、即着手 0 件
-- 条件待ち 10 件すべて外部 trigger 待ち (4 原則 §1 = AI 起点で進めるのは越権)
-- 再発時の調査エントリポイント (instanceId 集約、A/B/C/D 復旧候補) は本 handoff に記録済
+- PR #577 merged + Cloud Run デプロイ success (revision `api-00432-x7s`)
+- Git clean、main 同期済、即着手タスク 0 件、条件待ち 3 件 (全て trigger 待ち)
+- 残留プロセスなし、ADR/spec/runbook 整合性維持
+- 現場連絡文案は decision-maker 引き渡し済 (送付は decision-maker 領分)

--- a/docs/handoff/archive/2026-06-19-session-76.md
+++ b/docs/handoff/archive/2026-06-19-session-76.md
@@ -1,0 +1,282 @@
+# Session Handoff — 2026-06-19 (Session 76)
+
+## TL;DR
+
+**本番インシデント緊急対応 — 福の種テナント (atali82i) 受講生・前田さまの動画視聴 500 エラーを Cloud Run 単一インスタンスの IAM signBlob スタック起因と特定、新リビジョン作成で復旧**。コード変更ゼロ、env var `RESTART_AT` 追加のみで全インスタンスをローリング drain。社内対応担当者経由で前田さまへの動作確認連絡文案を引き渡し済、復旧確認は外部 trigger 待ち。
+
+| 主要成果 | 結果 |
+|---|---|
+| 福の種テナント動画視聴不可の原因特定 | ✅ `SigningError: Premature close` calling iamcredentials.googleapis.com signBlob、単一 Cloud Run インスタンス (`002f8ffd47c07...`) で全 30 件発生 |
+| 期限切れ仮説の棄却 | ✅ `videoAccessUntil` 期限切れ (403) ではなく内部エラー (500) と確定、enrollment-setting 起因を除外 |
+| 本番緊急復旧 | ✅ env var `RESTART_AT=2026-06-19T11-30` 追加 → 新リビジョン `api-00430-lct` 作成 + 旧 `api-00429-gb7` drain 完了 |
+| 復旧後の動作 | ✅ 新リビジョンで新規 SigningError 0 件 (10 分監視) |
+| 前田さまへの連絡文案 | ✅ 起草済 + 社内対応担当者に引き渡し済 (送付・結果収集は decision-maker 領分) |
+| コード変更 | ❌ ゼロ (Cloud Run 設定のみ、PR 不要) |
+
+- **Issue Net (本セッション)**: Close 0 + 起票 0 = **Net 0**
+- **本セッション merged PR**: 0 件
+- **本セッション workflow_dispatch**: 0 件
+- **本セッション本番 destructive 操作**: 1 件 (`gcloud run services update api --update-env-vars=RESTART_AT=...`、開発者明示認可済)
+
+---
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+cat docs/handoff/LATEST.md
+git fetch origin main && git log --oneline -5 origin/main
+gh pr list --state open
+gh issue list --state open
+# 前田さま動作確認結果の有無を確認 (社内連絡経路は GitHub 管理外)
+```
+
+**次セッションの最初の一手**: なし (即着手タスク 0 件、条件待ち項目のみ。trigger #1 充足時 = 前田さま結果連絡が来た時に分岐判断)
+
+---
+
+## 重要な作業内容 (本セッション = Session 76)
+
+### 1. 症状受領 — 福の種・前田さま「動画 7️⃣以降と前も見れない」
+
+開発者経由で福の種テナント受講生・前田さまから報告:
+
+> 「今、動画7️⃣を見ようとしたが、見れないようです。それ以降前も見れないようです。」
+
+「以降と前も」というキーワードからテナント全体に影響が出ていると仮定し、3 仮説を並列で立案:
+
+| 仮説 | 採用後の対応 |
+|------|-----------|
+| ① テナント全体の `videoAccessUntil` 期限切れ | 期限延長 (super-admin で update) |
+| ② 特定動画ファイルの GCS 喪失 | 動画再アップロード |
+| ③ Cloud Run 障害 (内部エラー) | リビジョン入れ替えまたはロールバック |
+
+### 2. 仮説検証 — 本番 Cloud Run ログ照会 (開発者明示認可 A 案)
+
+開発者認可 (`lms-279 本番ログ読み取りを承認`) のうえ `gcloud logging read` で照会。
+
+#### 2.1 期限切れ仮説 (403) の棄却
+
+```bash
+gcloud logging read 'jsonPayload.error="video_access_expired"' --freshness=2d
+# → 0 件
+```
+
+期限切れガード (`services/api/src/services/enrollment.ts:108-138 guardVideoAccess()`) は発火していない。
+
+#### 2.2 playback-url の状態分布
+
+```bash
+# 過去 24h の atali82i (= 福の種) 動画 playback-url
+# 200: 4 件 (旧リビジョン api-00427-lh7 時代)
+# 500: 16 件 (新リビジョン api-00429-gb7 で発生)
+# 204: 20 件 (CORS preflight OPTIONS)
+```
+
+500 開始時刻: 2026-06-18 23:41:01 UTC (= 08:41 JST)
+新リビジョン `api-00429-gb7` のデプロイ: 2026-06-18 22:31:03 UTC (= 07:31 JST、handoff commit 243234f によるトリガー)
+
+#### 2.3 エラー詳細
+
+```
+SigningError: Invalid response body while trying to fetch
+  https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/1034821634012-compute@developer.gserviceaccount.com:signBlob:
+  Premature close
+
+  at Gaxios._request (/app/node_modules/gaxios/build/src/gaxios.js:149:19)
+  at async GoogleAuth.signBlob (...)
+  at async sign (file:///app/node_modules/@google-cloud/storage/build/esm/src/signer.js:193:35)
+```
+
+GCS 署名付き URL 生成 (`services/api/src/services/gcs.ts:51 generatePlaybackUrl()`) が IAM Credentials API `signBlob` 呼び出しで失敗。「Premature close」は HTTP レスポンスが途中で切断された状態。
+
+### 3. 単一インスタンス起因の確定
+
+```bash
+gcloud logging read 'jsonPayload.error.name="SigningError"' --freshness=2d \
+  --format='value(labels.instanceId)' | sort -u
+# → 002f8ffd47c07e6aca31d333d14a3ca79b005bd900274414c9488ab3cda0fa7f742542c7b4484eb0c7c4d5167ec1667026cf5223db91bfb089dbecc89937a9c9c1a6ec893875a3b98de45867be2477fb74
+# (1 件のみ)
+```
+
+**過去 2 日間の全 30 件の SigningError が同一 Cloud Run インスタンスから発生**。原因は単一インスタンスの keep-alive HTTP コネクションが iamcredentials.googleapis.com に対してスタック (途中切断状態のまま再利用) と推定。
+
+#### 棄却した代替仮説
+
+| 仮説 | 棄却理由 |
+|------|--------|
+| コード回帰 (PR #574 起因) | `gcs.ts` / `package.json` / `Dockerfile` いずれも未変更 (git show 056c441 で確認) |
+| IAM 権限不足 | compute SA に `roles/iam.serviceAccountTokenCreator` 保有確認 (project IAM policy) |
+| iamcredentials API 無効化 | `gcloud services list --enabled` で enabled 確認 |
+| VPC connector / egress 制限 | Cloud Run 設定に VPC connector annotation なし |
+| イメージ全体の問題 | 単一 instanceId のみで発生、他インスタンスは正常 (の可能性) |
+
+### 4. 復旧アクション — A 案実行 (開発者明示認可済)
+
+開発者認可文言: `本番 Cloud Run api (lms-279, asia-northeast1) に env var RESTART_AT を追加して新リビジョン作成を承認する`
+
+```bash
+gcloud run services update api \
+  --region=asia-northeast1 \
+  --update-env-vars=RESTART_AT=2026-06-19T11-30 \
+  --project=lms-279
+```
+
+実行結果:
+- 新リビジョン `api-00430-lct` 作成 + 100% トラフィック切替完了
+- 旧リビジョン `api-00429-gb7` drain (スタックインスタンス `002f8ffd47c07...` 消滅)
+- デプロイ完了時刻: 2026-06-19 02:29:52 UTC (= 11:29 JST)
+- 設定変更内容: env var `RESTART_AT=2026-06-19T11-30` 追加のみ、コード/イメージ無変更
+- デプロイ後監視: 新規 SigningError 0 件 (10 分間)
+
+### 5. 前田さまへの連絡 (社内対応担当者経由)
+
+文案を起草し開発者経由で社内対応担当者に引き渡し済:
+
+```
+動画の再生に一時的なシステム障害が発生しておりました。
+サーバー側で対応が完了しましたので、お手数ですが
+ページを再読み込みしていただき、もう一度動画7️⃣を
+再生してみていただけますでしょうか。
+
+もし問題が続くようでしたら、再度お知らせください。
+ご不便をおかけして申し訳ございません。
+```
+
+送付実行・結果収集は decision-maker 領分。
+
+---
+
+## 次のアクション
+
+### 即着手タスク
+
+**即着手タスクなし** (executor 領分の作業 0 件、本番復旧完了 + 連絡文案引き渡し済)
+
+### 条件待ち (明示 trigger 付き)
+
+| # | 項目 | A/B/C | trigger | 充足時のタスク |
+|---|------|-------|---------|-------------|
+| 1 | **前田さま動作確認結果** | C (起点指示) | 社内対応担当者から前田さま返信、開発者経由で報告 | OK → 本件クローズ。NG → 再調査 (#2 へエスカレート) |
+| 2 | **SigningError 再発時の再調査** | B 検出 | `gcloud logging read jsonPayload.error.name=SigningError` で 30 分以内に新規発生 | 同一インスタンス起因なら再リサイクル、複数インスタンスなら image 起因疑い → Node.js / `@google-cloud/storage` SDK バージョン精査 |
+| 3 | **中長期: signed URL 生成の retry / health-check 設計** | C (起点指示) | 開発者から「再発防止策を検討して」の明示指示 | impl-plan: ① signBlob 呼び出しの透過 retry ② 起動時 sanity check ③ keep-alive 上限調整 |
+| 4 | **Codex 残存課題 #1: no-op 更新で編集済化** (Session 74 継承) | B 修正 | 開発者明示指示 | `editScore`/`editPassed` も dirty 判定化、または PATCH endpoint で「変更なし update」を skip |
+| 5 | **Codex 残存課題 #2: GET 側 `original.entryAt/exitAt` Timestamp 正規化** (Session 74 継承) | B 修正 | 開発者明示指示 | `super-admin.ts:1061` で `original.entryAt/exitAt` も正規化 |
+| 6 | **Codex 残存課題 #3: 編集ダイアログの JST 日跨ぎ session 対応** (Session 74 継承) | B 修正 | 開発者明示指示 | entry/exit 別々の日付入力に拡張 |
+| 7 | **Codex 残存課題 #4: 日付境界またぎ UI tooltip** (Session 74 継承) | B 修正 | 開発者明示指示 | `formatTimeWithDayDiff` で「翌 HH:mm」表示 |
+| 8 | **Phase 1 本番動作確認** (Session 70 継承) | B 検出 | 長遊園 / 福の種で新規テスト提出 → synthetic_* doc 生成確認 | 結果次第で Phase 1 修正判断 |
+| 9 | **Issue #536 sanitize helper 抽出** | C (起点指示) | 開発者明示指示 | helper 抽出実装 |
+| 10 | **Issue #521 dry-run UI follow-up 15 件集約** | C (起点指示) | 開発者明示指示 | follow-up 対応 |
+
+### 却下候補 (記録のみ・包括指示の対象外)
+
+| # | 項目 | A/B/C | 着手しない理由 |
+|---|------|-------|--------------|
+| 1 | **env var `RESTART_AT` の cleanup** | A | 次回正規デプロイ時に他の env var 更新で自然消化、明示 cleanup 不要。手動削除は別 destructive 操作になりリスク増 |
+| 2 | **新リビジョン `api-00430-lct` 以前のリビジョンの cleanup** | A | Cloud Run の自動 retention で十分、明示 cleanup ROI 低 |
+| 3 | **本番環境での AI 能動的動作確認** | C | `feedback_deploy_proactive_verification.md` 越権ルール抵触 (4 原則 §1)、開発者領分 |
+| 4 | **D 案関連 / PDF 上限 200MB 化等** (Session 74-75 継承) | C | Session 74-75 で確定済、再オープンは方針逆転 |
+| 5 | postponed Issue (#405/#276/#275/#274) | C | postponed ラベルは明示指示なき限り着手不可 |
+
+---
+
+## CI / Deploy 状態 (本セッション)
+
+| 操作 | 種類 | 状態 |
+|------|------|------|
+| `gcloud run services update api --update-env-vars=RESTART_AT=2026-06-19T11-30` | 本番 Cloud Run 設定変更 (緊急復旧) | ✅ 新リビジョン `api-00430-lct` 100% トラフィック (約 11:30 JST) |
+| GitHub Actions CI / Deploy | - | (本セッションは PR なし、CI ラン無) |
+
+### 本セッション merged PR
+
+| PR | 種類 | 状態 |
+|----|------|------|
+| (本 handoff PR) | docs(handoff): Session 76 - 福の種テナント動画視聴不可緊急復旧 | ⏳ 作成予定 |
+
+---
+
+## ADR / 設計判断記録
+
+### 本セッションで新規作成
+
+なし (本件は単発の運用インシデント、設計判断は伴わない)
+
+### 次セッション以降の起票候補
+
+なし (中長期 follow-up #3 「retry / health-check 設計」は開発者起点指示後に impl-plan で ADR 化判断)
+
+---
+
+## Issue Net 変化
+
+- **Close 数 (本セッション)**: 0 件
+- **起票数 (本セッション)**: 0 件
+- **Net (本セッション)**: 0 件
+
+本件は単一インスタンスの一過性スタックで、再現性 / 再発リスク / 影響範囲が現時点で不明 (CLAUDE.md Issue Triage 基準で起票判断保留)。再発した場合に triage 基準 #2 (再現可能なバグ) または #4 (rating ≥ 7 / confidence ≥ 80) で起票判断。
+
+---
+
+## 学習事項 (本セッションの振り返り)
+
+### 1. 「症状の言葉」から仮説を絞り込む
+
+- 前田さまの「7️⃣以降と前も見れない」表現から、テナント全体影響を仮定 → `videoAccessUntil` 期限切れを第一仮説に
+- 実際は 500 (Cloud Run 内部エラー) で、特定テナント全体に影響が出るが原因は別 (単一インスタンス) だった
+- **教訓**: 「テナント全体に見える症状」も、Cloud Run のインスタンス単位ルーティング次第で「特定インスタンスにヒットした全テナント」と一致しうる。最初から複数仮説を並列で立てる
+
+### 2. instanceId ベースの集約は強力
+
+- `gcloud logging read ... --format='value(labels.instanceId)' | sort -u` で「全エラーが単一インスタンス起因」と即座に判定
+- これがイメージ全体起因かインスタンス単発起因かを切り分ける決定打になった
+- **教訓**: Cloud Run の `labels.instanceId` での集約は signed URL / IAM / external API stuck パターンの調査で最初に試すべきステップ
+
+### 3. 復旧手段の選択肢を ROI 順で並べる
+
+- 候補 A (env var 追加でローリング)、B (再デプロイ)、C (旧リビジョンへロールバック)、D (待機) を並列提示
+- 開発者は A を即選択 → 1 分で復旧完了
+- **教訓**: 緊急時こそ「やるべきこと 1 つ」ではなく「リスク順 N 候補」を提示し、decision-maker が即選べる状態にする (4 原則 §1 = executor 領分)
+
+### 4. classifier ブロック時の認可文言の具体性
+
+- 1 回目の `gcloud run services update` は classifier に「本番変更で具体的認可なし」とブロックされた
+- 「本番 Cloud Run api (lms-279, asia-northeast1) に env var RESTART_AT を追加」レベルの具体性で開発者が認可文言を返してくれて初めて通過
+- **教訓**: destructive 本番操作は「対象 (project + region + service) + 変更内容」を文言に含む必要あり。一般的な「A 案 OK」では classifier が通さない。AI 側で予め貼り付け可能な認可文言テンプレを提示すると往復が減る
+
+---
+
+## 関連ドキュメント
+
+- 前セッション handoff: `docs/handoff/archive/2026-06-18-session-75.md`
+- 該当コード: `services/api/src/services/gcs.ts:51 generatePlaybackUrl()` / `services/api/src/services/enrollment.ts:108 guardVideoAccess()` / `services/api/src/routes/shared/videos.ts:229 GET /videos/:videoId/playback-url`
+- 福の種テナント参考: `docs/adr/ADR-038-url-path-invisible-char-sanitization-middleware.md` (tenant `atali82i` 確認の根拠)
+- 本セッション本番操作対象: Cloud Run service `api` (lms-279 / asia-northeast1)、現行リビジョン `api-00430-lct`
+
+---
+
+## 再開可能性判定
+
+| 項目 | 状態 |
+|------|------|
+| Git clean (本ハンドオフ commit 前) | ✅ |
+| OPEN PR (本ハンドオフ commit 後 PR 作成予定) | 1 件予定 |
+| 残留プロセス | ✅ なし |
+| 本番 deploy 状態 | ✅ 復旧完了 (api-00430-lct 100%、新規エラー 0 件) |
+| 即着手タスク | 0 件 |
+| 条件待ち | 10 件 (#1 前田さま結果、#2 SigningError 監視、#3 中長期 retry 設計、#4-7 Codex 残存課題、#8 Phase 1、#9-10 既存 Issue) |
+| Documentation 同期 | ✅ 本ハンドオフで更新中 |
+| memory scope チェック | ⏭️ memory 変更なし (該当なし) |
+| 構造的整合性チェック (impact-analysis 等) | ⏭️ 該当なし (コード変更なし、本番設定変更のみ) |
+| Issue Net | 0 件 (本件は再発リスク不明により起票保留) |
+
+---
+
+## 最終結論
+
+✅ **セッション終了可** — 本番復旧完了、外部 trigger 待ち以外の executor 残作業ゼロ
+
+根拠:
+- 本番 Cloud Run `api-00430-lct` 100% トラフィック稼働中、新規 SigningError 0 件 (10 分監視)
+- 前田さまへの連絡文案は社内対応担当者に引き渡し済 (送付・結果収集は decision-maker 領分)
+- Git clean、残留プロセスなし、Issue Net 0、即着手 0 件
+- 条件待ち 10 件すべて外部 trigger 待ち (4 原則 §1 = AI 起点で進めるのは越権)
+- 再発時の調査エントリポイント (instanceId 集約、A/B/C/D 復旧候補) は本 handoff に記録済


### PR DESCRIPTION
## Summary

- Session 77 handoff ドキュメントを追加 (PDF アップロード上限 150 → 300 MB 引き上げ完了)
- Session 76 (福の種テナント動画視聴復旧) を archive に移動

## 関連

- PR #577 (本セッション merged): feat(lesson-resource): PDF アップロード上限を 150 MB → 300 MB に引き上げ
- 現場フィードバック (catchup 時画像)

## Test plan

- [x] LATEST.md = Session 77 内容
- [x] archive/2026-06-19-session-76.md 配置済
- [x] 即着手タスク 0 件 + 条件待ち 3 件記載
- [x] Issue Net = 0 計測済
- [x] 最終結論「セッション終了可」明示

🤖 Generated with [Claude Code](https://claude.com/claude-code)