### PR TITLE
fix(lesson-resource): GCS signBlob Premature close リトライ + apiFetch エラー正規化

### DIFF
--- a/services/api/src/services/__tests__/lesson-resource.test.ts
+++ b/services/api/src/services/__tests__/lesson-resource.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { Storage } from "@google-cloud/storage";
 import { InMemoryDataSource } from "../../datasource/in-memory.js";
 import {
@@ -119,6 +119,83 @@ describe("generatePdfUploadUrl", () => {
     await expect(
       generatePdfUploadUrl(ds, storage, MASTER_LESSON_ID, "x.exe", PDF_MIME_TYPE, 1024),
     ).rejects.toMatchObject({ code: "invalid_file_type" });
+  });
+});
+
+// -----------------------------------------------
+// 2026-06-19 本番障害回帰テスト:
+// IAM Credentials API `signBlob` が `Premature close` で失敗するケース。
+// 旧 withGcsErrorMapping は `timeout|ECONNRESET` のみ判定でこれを素通りさせ、
+// Express errorHandler 経由で FE に `[object Object]` を表示させた。
+// 新実装は bounded retry → 最終的に gcs_unavailable に変換する。
+// -----------------------------------------------
+describe("generatePdfUploadUrl — transient retry", () => {
+  let ds: InMemoryDataSource;
+  beforeEach(() => {
+    ds = new InMemoryDataSource({ readOnly: false });
+    vi.useFakeTimers();
+    // jitter を確定値に固定 (factor 1.0 相当)
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("Premature close (1 回) → リトライで成功し署名 URL を返す", async () => {
+    const getSignedUrl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Premature close"))
+      .mockResolvedValueOnce(["https://signed.example.com/recovered"]);
+    const { storage } = buildMockStorage({ getSignedUrl });
+
+    const promise = generatePdfUploadUrl(
+      ds,
+      storage,
+      MASTER_LESSON_ID,
+      "資料.pdf",
+      PDF_MIME_TYPE,
+      1024,
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.uploadUrl).toBe("https://signed.example.com/recovered");
+    expect(getSignedUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("Premature close (連続失敗) → gcs_unavailable に変換", async () => {
+    const getSignedUrl = vi.fn(() => Promise.reject(new Error("Premature close")));
+    const { storage } = buildMockStorage({ getSignedUrl });
+
+    const promise = generatePdfUploadUrl(
+      ds,
+      storage,
+      MASTER_LESSON_ID,
+      "資料.pdf",
+      PDF_MIME_TYPE,
+      1024,
+    );
+    const assertion = expect(promise).rejects.toMatchObject({
+      name: "LessonResourceError",
+      code: "gcs_unavailable",
+    });
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(getSignedUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("permanent エラー (Error message が transient パターンに合致しない) は即時 throw", async () => {
+    const permanentErr = new Error("invalid_request");
+    const getSignedUrl = vi.fn(() => Promise.reject(permanentErr));
+    const { storage } = buildMockStorage({ getSignedUrl });
+
+    await expect(
+      generatePdfUploadUrl(ds, storage, MASTER_LESSON_ID, "資料.pdf", PDF_MIME_TYPE, 1024),
+    ).rejects.toBe(permanentErr);
+
+    expect(getSignedUrl).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/services/api/src/services/__tests__/lesson-resource.test.ts
+++ b/services/api/src/services/__tests__/lesson-resource.test.ts
@@ -429,6 +429,84 @@ describe("generatePdfDownloadUrl", () => {
   });
 });
 
+// silent-failure-hunter H2: confirmPdfUpload 内の getMetadata も transient retry 対象に
+// しないと本番障害の再発条件が残存する。
+describe("confirmPdfUpload — getMetadata transient retry", () => {
+  let ds: InMemoryDataSource;
+  beforeEach(() => {
+    ds = new InMemoryDataSource({ readOnly: false });
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("getMetadata の Premature close は retry されて confirm 成功", async () => {
+    const getMetadata = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Premature close"))
+      .mockResolvedValueOnce([{ size: "100", contentType: "application/pdf" }]);
+    const { storage } = buildMockStorage({ getMetadata });
+
+    const promise = confirmPdfUpload(
+      ds,
+      storage,
+      MASTER_LESSON_ID,
+      `lessons/${MASTER_LESSON_ID}/x.pdf`,
+      "資料.pdf",
+      100,
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.pdfFileName).toBe("資料.pdf");
+    expect(getMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it("getMetadata の Premature close が連続 → gcs_unavailable に変換", async () => {
+    const getMetadata = vi.fn(() => Promise.reject(new Error("Premature close")));
+    const { storage } = buildMockStorage({ getMetadata });
+
+    const promise = confirmPdfUpload(
+      ds,
+      storage,
+      MASTER_LESSON_ID,
+      `lessons/${MASTER_LESSON_ID}/x.pdf`,
+      "資料.pdf",
+      100,
+    );
+    const assertion = expect(promise).rejects.toMatchObject({
+      name: "LessonResourceError",
+      code: "gcs_unavailable",
+    });
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(getMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it("getMetadata の 404 は retry されず gcs_file_missing に変換", async () => {
+    const notFound = Object.assign(new Error("Not Found"), { code: 404 });
+    const getMetadata = vi.fn(() => Promise.reject(notFound));
+    const { storage } = buildMockStorage({ getMetadata });
+
+    await expect(
+      confirmPdfUpload(
+        ds,
+        storage,
+        MASTER_LESSON_ID,
+        `lessons/${MASTER_LESSON_ID}/x.pdf`,
+        "資料.pdf",
+        100,
+      ),
+    ).rejects.toMatchObject({ code: "gcs_file_missing" });
+
+    expect(getMetadata).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("toLessonResource", () => {
   it("全フィールド揃いで LessonResource を返す", () => {
     const result = toLessonResource({

--- a/services/api/src/services/lesson-resource.ts
+++ b/services/api/src/services/lesson-resource.ts
@@ -18,6 +18,7 @@ import type {
   LessonPdfUploadUrlResponse,
 } from "@lms-279/shared-types";
 import { logger } from "../utils/logger.js";
+import { isTransientError, retryOnTransient } from "../utils/transient-error.js";
 
 export const PDF_MIME_TYPE = "application/pdf";
 export const MAX_PDF_SIZE_BYTES = 300 * 1024 * 1024; // 300 MB
@@ -57,17 +58,34 @@ function sanitizeFileName(fileName: string): string {
 }
 
 /**
- * GCS API 呼び出しを安全に包む。一時的エラー (503/429/timeout) は gcs_unavailable に変換。
+ * GCS / IAM Credentials API 呼び出しを transient リトライで包む。
+ *
+ * - transient (HTTP 429/500/502/503/504 + transport code + `Premature close` 等の
+ *   message パターン) は bounded retry (最大 2 attempts) → それでも失敗したら
+ *   `gcs_unavailable` に変換。
+ * - permanent エラーは即時 throw (上位で LessonResourceError 等の判別に進む)。
+ *
+ * 2026-06-19 本番障害: IAM Credentials API `signBlob` が `Premature close` で失敗し、
+ * 旧実装は `timeout|ECONNRESET` のみ判定でこれを素通りさせていた。
+ * `services/api/src/utils/transient-error.ts` の `isTransientError` で一元判定する。
+ *
+ * 副作用なし / idempotent な op (署名 URL 生成、メタデータ取得) にのみ使う。
  */
 async function withGcsErrorMapping<T>(op: () => Promise<T>, context: string): Promise<T> {
   try {
-    return await op();
+    return await retryOnTransient(op, {
+      maxAttempts: 2,
+      baseDelayMs: 150,
+      onRetry: ({ attempt, error, delayMs }) => {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn("gcs_transient_retry", { context, attempt, delayMs, message });
+      },
+    });
   } catch (e) {
-    const error = e as { code?: number; message?: string };
-    const status = typeof error.code === "number" ? error.code : 0;
-    if (status === 429 || status === 503 || /timeout|ECONNRESET/i.test(error.message ?? "")) {
-      logger.error("gcs_transient_error", { context, status, message: error.message });
-      throw new LessonResourceError("gcs_unavailable", "一時的に取得できません");
+    if (isTransientError(e)) {
+      const message = e instanceof Error ? e.message : String(e);
+      logger.error("gcs_transient_error", { context, message });
+      throw new LessonResourceError("gcs_unavailable", "一時的に処理できません。再度お試しください");
     }
     throw e;
   }

--- a/services/api/src/services/lesson-resource.ts
+++ b/services/api/src/services/lesson-resource.ts
@@ -173,7 +173,13 @@ export async function confirmPdfUpload(
   const file = storage.bucket(RESOURCE_BUCKET()).file(gcsPath);
   let metadata: { size?: string | number; contentType?: string };
   try {
-    const [m] = await file.getMetadata();
+    // 2026-06-19 本番障害の再発条件残存対策 (silent-failure-hunter H2):
+    // getMetadata も Premature close 等の transient で失敗しうるため retry 対象に含める。
+    // 404 は permanent として LessonResourceError("gcs_file_missing") に変換。
+    const [m] = await withGcsErrorMapping(
+      () => file.getMetadata(),
+      "confirmPdfUpload.getMetadata",
+    );
     metadata = m;
   } catch (e) {
     const error = e as { code?: number };

--- a/services/api/src/utils/__tests__/transient-error.test.ts
+++ b/services/api/src/utils/__tests__/transient-error.test.ts
@@ -130,4 +130,60 @@ describe("retryOnTransient", () => {
       delayMs: expect.any(Number),
     });
   });
+
+  // pr-test-analyzer H1: exponential backoff factor 検証
+  it("baseDelayMs * 2^(attempt-1) で exponential backoff (factor 検証)", async () => {
+    const onRetry = vi.fn();
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Premature close"))
+      .mockRejectedValueOnce(new Error("Premature close"))
+      .mockResolvedValueOnce("ok");
+    const promise = retryOnTransient(op, { maxAttempts: 3, baseDelayMs: 100, onRetry });
+    await vi.runAllTimersAsync();
+    await promise;
+    // jitter = 0.8 + 0.5 * 0.4 = 1.0 (Math.random mock により)
+    // attempt 1 → 100 * 2^0 * 1.0 = 100
+    // attempt 2 → 100 * 2^1 * 1.0 = 200
+    expect(onRetry.mock.calls[0][0].delayMs).toBe(100);
+    expect(onRetry.mock.calls[1][0].delayMs).toBe(200);
+  });
+
+  // pr-test-analyzer H3: maxAttempts 境界条件
+  it("maxAttempts: 1 では絶対にリトライしない (初回失敗で即時 throw)", async () => {
+    const err = new Error("Premature close");
+    const op = vi.fn(() => Promise.reject(err));
+    await expect(retryOnTransient(op, { maxAttempts: 1 })).rejects.toBe(err);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("maxAttempts: 3 で 2 回失敗 → 3 回目成功", async () => {
+    const econnreset = Object.assign(new Error("network error"), { code: "ECONNRESET" });
+    let attempt = 0;
+    const op = vi.fn(() => {
+      attempt += 1;
+      if (attempt === 1) return Promise.reject(new Error("Premature close"));
+      if (attempt === 2) return Promise.reject(econnreset);
+      return Promise.resolve("ok");
+    });
+    const promise = retryOnTransient(op, { maxAttempts: 3, baseDelayMs: 50 });
+    await vi.runAllTimersAsync();
+    expect(await promise).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  // pr-test-analyzer M2: onRetry throw 耐性 (rules/error-handling.md §1)
+  it("onRetry が throw してもリトライ自体は継続する (logger 破損耐性)", async () => {
+    const onRetry = vi.fn(() => {
+      throw new Error("logger broken");
+    });
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Premature close"))
+      .mockResolvedValueOnce("ok");
+    const promise = retryOnTransient(op, { maxAttempts: 2, baseDelayMs: 100, onRetry });
+    await vi.runAllTimersAsync();
+    expect(await promise).toBe("ok");
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
 });

--- a/services/api/src/utils/__tests__/transient-error.test.ts
+++ b/services/api/src/utils/__tests__/transient-error.test.ts
@@ -1,0 +1,133 @@
+/**
+ * transient-error util のテスト
+ *
+ * 本番障害 2026-06-19: IAM Credentials API signBlob が `Premature close` で失敗 →
+ * lesson-resource.ts の旧 withGcsErrorMapping が捕捉せず Express errorHandler に到達
+ * → FE で `[object Object]` 表示。本テストは Premature close 等の transient
+ * 判定とリトライ挙動を保証する。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isTransientError, retryOnTransient, TRANSIENT_NETWORK_CODES } from "../transient-error.js";
+
+describe("isTransientError", () => {
+  it("transport code ECONNRESET を transient と判定", () => {
+    expect(isTransientError({ code: "ECONNRESET", message: "" })).toBe(true);
+  });
+
+  it("cause.code ETIMEDOUT を transient と判定", () => {
+    expect(isTransientError({ cause: { code: "ETIMEDOUT" } })).toBe(true);
+  });
+
+  it("HTTP 503 / 429 / 504 を transient と判定", () => {
+    expect(isTransientError({ response: { status: 503 } })).toBe(true);
+    expect(isTransientError({ response: { status: 429 } })).toBe(true);
+    expect(isTransientError({ response: { status: 504 } })).toBe(true);
+  });
+
+  it("HTTP 400 / 404 / 403 を permanent と判定", () => {
+    expect(isTransientError({ response: { status: 400 } })).toBe(false);
+    expect(isTransientError({ response: { status: 404 } })).toBe(false);
+    expect(isTransientError({ response: { status: 403 } })).toBe(false);
+  });
+
+  it("message 'Premature close' を transient と判定 (本番障害再現)", () => {
+    const err = new Error(
+      "Invalid response body while trying to fetch https://iamcredentials.googleapis.com/...:signBlob: Premature close",
+    );
+    expect(isTransientError(err)).toBe(true);
+  });
+
+  it("message 'socket hang up' を transient と判定", () => {
+    expect(isTransientError(new Error("socket hang up"))).toBe(true);
+  });
+
+  it("cause.message が Premature close でも transient と判定", () => {
+    const err = new Error("upstream failed");
+    (err as { cause?: unknown }).cause = { message: "Premature close" };
+    expect(isTransientError(err)).toBe(true);
+  });
+
+  it("無関係の Error は permanent と判定", () => {
+    expect(isTransientError(new Error("invalid argument"))).toBe(false);
+  });
+
+  it("null / undefined / プリミティブは permanent と判定", () => {
+    expect(isTransientError(null)).toBe(false);
+    expect(isTransientError(undefined)).toBe(false);
+    expect(isTransientError("string error")).toBe(false);
+    expect(isTransientError(42)).toBe(false);
+  });
+
+  it("TRANSIENT_NETWORK_CODES に主要 transport code が含まれる", () => {
+    expect(TRANSIENT_NETWORK_CODES.has("ECONNRESET")).toBe(true);
+    expect(TRANSIENT_NETWORK_CODES.has("ETIMEDOUT")).toBe(true);
+    expect(TRANSIENT_NETWORK_CODES.has("ENOTFOUND")).toBe(true);
+    expect(TRANSIENT_NETWORK_CODES.has("EAI_AGAIN")).toBe(true);
+  });
+});
+
+describe("retryOnTransient", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // jitter を確定値に固定 (factor 1.0 相当)
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("初回成功時はリトライしない", async () => {
+    const op = vi.fn().mockResolvedValue("ok");
+    const result = await retryOnTransient(op);
+    expect(result).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("Premature close で 1 回リトライして成功 (本番障害復旧シナリオ)", async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Premature close"))
+      .mockResolvedValueOnce("ok");
+    const promise = retryOnTransient(op, { maxAttempts: 2, baseDelayMs: 100 });
+    await vi.runAllTimersAsync();
+    expect(await promise).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it("maxAttempts 使い切ったら最後の例外を throw", async () => {
+    const finalErr = new Error("Premature close");
+    const op = vi.fn(() => Promise.reject(finalErr));
+    const promise = retryOnTransient(op, { maxAttempts: 2, baseDelayMs: 100 });
+    // unhandled rejection 警告を避けるため先に rejects アサーションを attach
+    const assertion = expect(promise).rejects.toBe(finalErr);
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it("permanent エラーは即時 throw (リトライしない)", async () => {
+    const err = new Error("invalid argument");
+    const op = vi.fn().mockRejectedValue(err);
+    await expect(retryOnTransient(op, { maxAttempts: 3 })).rejects.toBe(err);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("onRetry observer が delayMs / attempt 情報を受け取る", async () => {
+    const onRetry = vi.fn();
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Premature close"))
+      .mockResolvedValueOnce("ok");
+    const promise = retryOnTransient(op, { maxAttempts: 2, baseDelayMs: 100, onRetry });
+    await vi.runAllTimersAsync();
+    await promise;
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0][0]).toMatchObject({
+      attempt: 1,
+      delayMs: expect.any(Number),
+    });
+  });
+});

--- a/services/api/src/utils/transient-error.ts
+++ b/services/api/src/utils/transient-error.ts
@@ -117,7 +117,13 @@ export async function retryOnTransient<T>(
       const factor = 2 ** (attempt - 1);
       const jitter = 0.8 + Math.random() * 0.4;
       const delayMs = Math.round(baseDelayMs * factor * jitter);
-      opts.onRetry?.({ attempt, error: e, delayMs });
+      // onRetry が throw してもリトライ自体は止めない (logger 破損耐性、
+      // rules/error-handling.md §1 と整合 — pr-test-analyzer M2)
+      try {
+        opts.onRetry?.({ attempt, error: e, delayMs });
+      } catch {
+        // observer 失敗はリトライ継続より優先しない
+      }
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
   }

--- a/services/api/src/utils/transient-error.ts
+++ b/services/api/src/utils/transient-error.ts
@@ -1,0 +1,125 @@
+/**
+ * 外部 API 呼び出しで transient (一時的) か permanent (恒久的) かを判定する共通 util。
+ *
+ * 用途:
+ *  - GCS / IAM Credentials / その他 Google API 呼び出しでネットワーク不安定や
+ *    TCP 切断 (`Premature close`) を transient として扱い、自動リトライ可否を判定する。
+ *
+ * gmail-draft.ts / gmail-dwd-send.ts にも類似定義が存在するが、Phase 7 既存
+ * 配送経路への影響を避けるため本 util は lesson-resource.ts 用途に絞って導入。
+ * 後続 PR で gmail 系を統合予定 (Codex 指摘の共通 util 化方針)。
+ */
+
+/**
+ * Node.js / undici / gaxios の transport-level error code。
+ * これらは一時的なネットワーク不安定で発生し、リトライで回復しうる。
+ */
+export const TRANSIENT_NETWORK_CODES: ReadonlySet<string> = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ESOCKETTIMEDOUT",
+  "ECONNABORTED",
+  "EPIPE",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/**
+ * transient とみなすメッセージパターン。
+ * `Premature close` は IAM Credentials API signBlob 等で観測 (本番障害 2026-06-19)。
+ * `socket hang up` は Node.js HTTP の TCP 早期切断時に出る。
+ */
+const TRANSIENT_MESSAGE_PATTERN =
+  /timeout|premature close|socket hang up|read econnreset|aborted|network socket disconnected/i;
+
+/**
+ * HTTP status 系 transient コード (リトライ可能)。
+ */
+const TRANSIENT_HTTP_STATUS: ReadonlySet<number> = new Set([408, 429, 500, 502, 503, 504]);
+
+/**
+ * 例外を transient (= リトライ価値あり) と判定する。
+ *
+ * 評価順 (上位ほど優先):
+ *   1. `response.status` / `status` / `code` (number) が transient HTTP status
+ *   2. `code` / `cause.code` (string) が transport-level transient code
+ *   3. `message` が transient な文字列パターンにマッチ
+ *
+ * いずれにも当たらなければ permanent (false)。
+ */
+export function isTransientError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as {
+    code?: unknown;
+    status?: unknown;
+    message?: unknown;
+    response?: { status?: unknown };
+    cause?: { code?: unknown; message?: unknown };
+  };
+
+  const httpStatus =
+    (typeof e.response?.status === "number" ? e.response.status : undefined) ??
+    (typeof e.status === "number" ? e.status : undefined) ??
+    (typeof e.code === "number" ? e.code : undefined);
+  if (typeof httpStatus === "number" && TRANSIENT_HTTP_STATUS.has(httpStatus)) {
+    return true;
+  }
+
+  const code = typeof e.code === "string" ? e.code : null;
+  if (code && TRANSIENT_NETWORK_CODES.has(code)) return true;
+
+  const causeCode = typeof e.cause?.code === "string" ? e.cause.code : null;
+  if (causeCode && TRANSIENT_NETWORK_CODES.has(causeCode)) return true;
+
+  const message = typeof e.message === "string" ? e.message : "";
+  const causeMessage = typeof e.cause?.message === "string" ? e.cause.message : "";
+  if (TRANSIENT_MESSAGE_PATTERN.test(message) || TRANSIENT_MESSAGE_PATTERN.test(causeMessage)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * transient な op を有限回リトライする。permanent エラーは即時 throw。
+ *
+ * - delay は exponential backoff (factor 2) + ±20% jitter
+ * - 副作用なし / idempotent な op を想定 (GCS signed URL 生成、メタデータ取得 等)
+ * - リトライ回数を使い切ったら最後の例外を throw
+ *
+ * @param op リトライ対象の async 関数
+ * @param opts.maxAttempts 試行回数 (デフォルト 2、つまり初回 + 1 リトライ)
+ * @param opts.baseDelayMs 初回 backoff 基準 (デフォルト 150ms)
+ * @param opts.onRetry 各リトライ前に呼ばれる observer (ログ等)
+ */
+export async function retryOnTransient<T>(
+  op: () => Promise<T>,
+  opts: {
+    maxAttempts?: number;
+    baseDelayMs?: number;
+    onRetry?: (info: { attempt: number; error: unknown; delayMs: number }) => void;
+  } = {},
+): Promise<T> {
+  const maxAttempts = opts.maxAttempts ?? 2;
+  const baseDelayMs = opts.baseDelayMs ?? 150;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await op();
+    } catch (e) {
+      lastError = e;
+      if (attempt === maxAttempts || !isTransientError(e)) throw e;
+      const factor = 2 ** (attempt - 1);
+      const jitter = 0.8 + Math.random() * 0.4;
+      const delayMs = Math.round(baseDelayMs * factor * jitter);
+      opts.onRetry?.({ attempt, error: e, delayMs });
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastError;
+}

--- a/web/lib/__tests__/api.test.ts
+++ b/web/lib/__tests__/api.test.ts
@@ -42,10 +42,22 @@ describe("ApiError constructor — runtime defense", () => {
     expect(err.message).toBe("not_found");
   });
 
-  it("code も空 / message も空なら HTTP fallback", () => {
+  it("code も空 / message も空なら HTTP fallback (5xx)", () => {
     const err = new ApiError(500, "", "");
     expect(err.message).toBe("サーバーエラー (HTTP 500)。再度お試しください。");
     expect(err.message).not.toContain("[object Object]");
+  });
+
+  // pr-test-analyzer M4: 4xx は「サーバーエラー」だと誤誘導 → 専用文言
+  it("4xx で code/message 空ならクライアントエラー文言を使う", () => {
+    const err = new ApiError(400, "", "");
+    expect(err.message).toBe("リクエストエラー (HTTP 400)。");
+    expect(err.message).not.toContain("サーバーエラー");
+  });
+
+  it("status=0 (fetch 自体失敗) は通信エラー文言を使う", () => {
+    const err = new ApiError(0, "", "");
+    expect(err.message).toBe("通信エラーが発生しました。再度お試しください。");
   });
 });
 
@@ -139,6 +151,27 @@ describe("apiFetch — error body normalization", () => {
     const apiErr = captured as ApiError;
     expect(apiErr.code).toBe("not_found");
     expect(apiErr.message).toBe("not_found");
+  });
+
+  // code-reviewer H1: nested 形式の details も拾う
+  it("nested 形式 { error: { code, message, details } } で details を保持する", async () => {
+    mockFetchResponse(422, {
+      error: {
+        code: "validation_failed",
+        message: "Invalid input",
+        details: { field: "fileName" },
+      },
+    });
+    let captured: unknown;
+    try {
+      await apiFetch("/test", {});
+    } catch (e) {
+      captured = e;
+    }
+    const apiErr = captured as ApiError;
+    expect(apiErr.code).toBe("validation_failed");
+    expect(apiErr.message).toBe("Invalid input");
+    expect(apiErr.details).toEqual({ field: "fileName" });
   });
 
   it("details が record 形式なら保持、それ以外は undefined", async () => {

--- a/web/lib/__tests__/api.test.ts
+++ b/web/lib/__tests__/api.test.ts
@@ -1,0 +1,159 @@
+/**
+ * apiFetch / ApiError のエラー正規化テスト。
+ *
+ * 2026-06-19 本番障害 (PR #577 後):
+ *   - BE `errorHandler` (ADR-0025 nested) が `{ error: { code, message } }` を返す
+ *   - 旧 apiFetch (ADR-010 flat 想定) は `body.error` を string と仮定して
+ *     ApiError constructor に object を渡してしまい、Error.super で `[object Object]`
+ *     化して画面表示。
+ *   - 本テストは nested / flat / parse 不能 / 部分欠落 で `[object Object]` が二度と
+ *     画面に出ないことを保証する。
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { apiFetch, ApiError } from "../api";
+
+const ORIGINAL_FETCH = global.fetch;
+
+function mockFetchResponse(status: number, body: unknown, isJson = true): void {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: vi.fn().mockResolvedValue(isJson ? JSON.stringify(body) : String(body)),
+    json: isJson
+      ? vi.fn().mockResolvedValue(body)
+      : vi.fn().mockRejectedValue(new SyntaxError("Unexpected token")),
+  } as unknown as Response);
+}
+
+describe("ApiError constructor — runtime defense", () => {
+  it("string message を保持する", () => {
+    const err = new ApiError(400, "bad_request", "リクエストが不正です");
+    expect(err.message).toBe("リクエストが不正です");
+  });
+
+  it("message が undefined なら code を使用", () => {
+    const err = new ApiError(404, "not_found");
+    expect(err.message).toBe("not_found");
+  });
+
+  it("message が空文字なら code を使用", () => {
+    const err = new ApiError(404, "not_found", "");
+    expect(err.message).toBe("not_found");
+  });
+
+  it("code も空 / message も空なら HTTP fallback", () => {
+    const err = new ApiError(500, "", "");
+    expect(err.message).toBe("サーバーエラー (HTTP 500)。再度お試しください。");
+    expect(err.message).not.toContain("[object Object]");
+  });
+});
+
+describe("apiFetch — error body normalization", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = "http://test-api";
+  });
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    vi.restoreAllMocks();
+  });
+
+  it("ADR-010 flat 形式 { error, message } を正しく ApiError に変換", async () => {
+    mockFetchResponse(400, { error: "file_too_large", message: "ファイルサイズが上限を超えています" });
+    await expect(apiFetch("/test", {})).rejects.toMatchObject({
+      status: 400,
+      code: "file_too_large",
+      message: "ファイルサイズが上限を超えています",
+    });
+  });
+
+  it("nested 形式 { error: { code, message } } を吸収する (本番障害再現)", async () => {
+    mockFetchResponse(500, {
+      error: { code: "INTERNAL_ERROR", message: "Internal server error" },
+    });
+    let captured: unknown;
+    try {
+      await apiFetch("/test", {});
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(ApiError);
+    const apiErr = captured as ApiError;
+    expect(apiErr.status).toBe(500);
+    expect(apiErr.code).toBe("INTERNAL_ERROR");
+    expect(apiErr.message).toBe("Internal server error");
+    // 絶対に [object Object] が含まれないこと (本テストの核心)
+    expect(apiErr.message).not.toContain("[object Object]");
+  });
+
+  it("response body が JSON parse 不能でも [object Object] を出さない", async () => {
+    mockFetchResponse(500, "<html>500 Internal Server Error</html>", false);
+    let captured: unknown;
+    try {
+      await apiFetch("/test", {});
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(ApiError);
+    const apiErr = captured as ApiError;
+    expect(apiErr.status).toBe(500);
+    expect(apiErr.code).toBe("unknown_error");
+    expect(apiErr.message).toBe("サーバーエラー (HTTP 500)。再度お試しください。");
+    expect(apiErr.message).not.toContain("[object Object]");
+  });
+
+  it("nested で message のみ欠落しても fallback で 500 文言が入る", async () => {
+    mockFetchResponse(500, { error: { code: "INTERNAL_ERROR" } });
+    let captured: unknown;
+    try {
+      await apiFetch("/test", {});
+    } catch (e) {
+      captured = e;
+    }
+    const apiErr = captured as ApiError;
+    expect(apiErr.code).toBe("INTERNAL_ERROR");
+    expect(apiErr.message).toBe("サーバーエラー (HTTP 500)。再度お試しください。");
+  });
+
+  it("body が空オブジェクトでも [object Object] を出さない", async () => {
+    mockFetchResponse(503, {});
+    let captured: unknown;
+    try {
+      await apiFetch("/test", {});
+    } catch (e) {
+      captured = e;
+    }
+    const apiErr = captured as ApiError;
+    expect(apiErr.code).toBe("unknown_error");
+    expect(apiErr.message).toBe("サーバーエラー (HTTP 503)。再度お試しください。");
+  });
+
+  it("4xx で message 欠落時は code を message に使用 (情報量を保つ)", async () => {
+    mockFetchResponse(404, { error: "not_found" });
+    let captured: unknown;
+    try {
+      await apiFetch("/test", {});
+    } catch (e) {
+      captured = e;
+    }
+    const apiErr = captured as ApiError;
+    expect(apiErr.code).toBe("not_found");
+    expect(apiErr.message).toBe("not_found");
+  });
+
+  it("details が record 形式なら保持、それ以外は undefined", async () => {
+    mockFetchResponse(422, {
+      error: "validation_failed",
+      message: "Invalid input",
+      details: { field: "fileName" },
+    });
+    let captured: unknown;
+    try {
+      await apiFetch("/test", {});
+    } catch (e) {
+      captured = e;
+    }
+    const apiErr = captured as ApiError;
+    expect(apiErr.details).toEqual({ field: "fileName" });
+  });
+});

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -10,6 +10,54 @@ const AUTH_MODE = process.env.NEXT_PUBLIC_AUTH_MODE ?? "dev";
 const DEV_USER_ID = process.env.NEXT_PUBLIC_USER_ID ?? "admin-dev";
 const DEV_USER_ROLE = process.env.NEXT_PUBLIC_USER_ROLE ?? "admin";
 
+/**
+ * BE のエラー body から code / message / details を堅牢に抽出する。
+ *
+ * 想定する形式:
+ *  - ADR-010 flat 形式 (推奨): `{ error: "code_string", message: "...", details?: {...} }`
+ *  - 旧 errorHandler nested 形式: `{ error: { code: "...", message: "..." } }`
+ *  - レスポンスが JSON parse 不能 (HTML 500 等): `{}` を受け取り fallback
+ *
+ * `[object Object]` を絶対に画面に出さないため string 強制 + fallback を実装する。
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asTrimmedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function extractErrorCode(body: unknown): string {
+  if (!isRecord(body)) return "unknown_error";
+  const flat = asTrimmedString(body.error);
+  if (flat) return flat;
+  if (isRecord(body.error)) {
+    const nested = asTrimmedString(body.error.code);
+    if (nested) return nested;
+  }
+  return "unknown_error";
+}
+
+function extractErrorMessage(body: unknown, status: number): string | undefined {
+  if (!isRecord(body)) return undefined;
+  const flat = asTrimmedString(body.message);
+  if (flat) return flat;
+  if (isRecord(body.error)) {
+    const nested = asTrimmedString(body.error.message);
+    if (nested) return nested;
+  }
+  // 500/502/503/504 等のサーバー側障害は専用文言で fallback
+  if (status >= 500) return `サーバーエラー (HTTP ${status})。再度お試しください。`;
+  return undefined;
+}
+
+function extractErrorDetails(body: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(body)) return undefined;
+  if (isRecord(body.details)) return body.details;
+  return undefined;
+}
+
 export class ApiError extends Error {
   constructor(
     public status: number,
@@ -17,7 +65,16 @@ export class ApiError extends Error {
     message?: string,
     public details?: Record<string, unknown>
   ) {
-    super(message ?? code);
+    // 2026-06-19 本番障害: BE 側 errorHandler (nested) と apiFetch (flat) の形式
+    // 不整合により body.message が非文字列で渡り、Error の super() で `[object Object]`
+    // 化していた。constructor 側で runtime 防御し、表示用 fallback を強制する。
+    const safeMessage =
+      typeof message === "string" && message.trim()
+        ? message
+        : typeof code === "string" && code.trim()
+          ? code
+          : `サーバーエラー (HTTP ${status})。再度お試しください。`;
+    super(safeMessage);
     this.name = "ApiError";
   }
 }
@@ -63,8 +120,13 @@ export async function apiFetch<T>(
   }
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new ApiError(res.status, body.error ?? "unknown_error", body.message, body.details);
+    const body = await res.json().catch(() => ({} as unknown));
+    throw new ApiError(
+      res.status,
+      extractErrorCode(body),
+      extractErrorMessage(body, res.status),
+      extractErrorDetails(body),
+    );
   }
 
   const text = await res.text();

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -48,6 +48,8 @@ function extractErrorMessage(body: unknown, status: number): string | undefined 
     if (nested) return nested;
   }
   // 500/502/503/504 等のサーバー側障害は専用文言で fallback
+  // 5xx は専用文言、4xx は constructor の code → fallback 連鎖に委ねる
+  // (4xx で「サーバーエラー」は誤誘導 — pr-test-analyzer M4)
   if (status >= 500) return `サーバーエラー (HTTP ${status})。再度お試しください。`;
   return undefined;
 }
@@ -55,6 +57,9 @@ function extractErrorMessage(body: unknown, status: number): string | undefined 
 function extractErrorDetails(body: unknown): Record<string, unknown> | undefined {
   if (!isRecord(body)) return undefined;
   if (isRecord(body.details)) return body.details;
+  // nested 形式 `{ error: { code, message, details } }` (ADR-0025 互換) からも拾う。
+  // code-reviewer H1: code/message と一貫して details も nested 対応必須
+  if (isRecord(body.error) && isRecord(body.error.details)) return body.error.details;
   return undefined;
 }
 
@@ -68,12 +73,19 @@ export class ApiError extends Error {
     // 2026-06-19 本番障害: BE 側 errorHandler (nested) と apiFetch (flat) の形式
     // 不整合により body.message が非文字列で渡り、Error の super() で `[object Object]`
     // 化していた。constructor 側で runtime 防御し、表示用 fallback を強制する。
+    // pr-test-analyzer M4: 4xx で「サーバーエラー」は誤誘導なので分岐する。
+    const fallback =
+      status >= 500
+        ? `サーバーエラー (HTTP ${status})。再度お試しください。`
+        : status > 0
+          ? `リクエストエラー (HTTP ${status})。`
+          : "通信エラーが発生しました。再度お試しください。";
     const safeMessage =
       typeof message === "string" && message.trim()
         ? message
         : typeof code === "string" && code.trim()
           ? code
-          : `サーバーエラー (HTTP ${status})。再度お試しください。`;
+          : fallback;
     super(safeMessage);
     this.name = "ApiError";
   }


### PR DESCRIPTION
## Summary

本番障害 2026-06-19 緊急対応。super-admin による PDF アップロード (212.7 MB) で画面に `[object Object]` 表示。サーバー側 `SigningError: Premature close` (IAM Credentials API `signBlob` TCP 早期切断) が transient リトライ対象から漏れ、Express errorHandler 経由で nested 形式 500 を返却 → FE 旧 `apiFetch` (flat 形式想定) が `body.error` を string と仮定して object を `ApiError` に渡し、`Error.super()` で `[object Object]` 化していた。

Codex セカンドオピニオン (`/codex fix` MCP) で仮説と修正案を事前検証済。

## 直接原因 / 連鎖

1. `withGcsErrorMapping` の正規表現 `timeout|ECONNRESET` のみ判定で `Premature close` を素通り
2. route handler の `throw e` → `services/api/src/middleware/error-handler.ts` の global errorHandler (ADR-0025 nested 形式) が `{ error: { code, message } }` 500 を返す
3. `web/lib/api.ts` の `apiFetch` が ADR-010 flat 形式想定で `body.error ?? "unknown_error"` を string 扱い → object が `ApiError(500, {code, message}, ...)` 相当に
4. `super(undefined ?? object)` → `Error.message` に object 文字列化 → `[object Object]`
5. `formatPdfError` 末尾の `err.message` が `[object Object]` を返却し画面表示

## 変更内容

### BE (transient リトライ強化)

| ファイル | 内容 |
|---------|------|
| `services/api/src/utils/transient-error.ts` (新規) | `isTransientError` / `retryOnTransient` 共通 util。HTTP status (408/429/500/502/503/504) + transport code (ECONNRESET/ETIMEDOUT/ENOTFOUND 等 11 種) + cause.code + message パターン (`Premature close` / `socket hang up` / `aborted` 等) を判定。exponential backoff + ±20% jitter、最大 2 attempts (初回 + 1 リトライ) |
| `services/api/src/services/lesson-resource.ts` | `withGcsErrorMapping` を新 util ベースに置換。`getSignedUrl` / `getMetadata` 等の副作用なし op を自動リトライ。permanent は即時 throw |
| `services/api/src/utils/__tests__/transient-error.test.ts` (新規) | 15 cases — Premature close / socket hang up / cause / HTTP / transport / permanent |
| `services/api/src/services/__tests__/lesson-resource.test.ts` | 3 cases 追加 (本番障害回帰テスト) — Premature close 1 回 → retry 成功 / 連続失敗 → gcs_unavailable / permanent 即 throw |

### FE (`[object Object]` 表示の runtime 防御)

| ファイル | 内容 |
|---------|------|
| `web/lib/api.ts` | `extractErrorCode/Message/Details` を新設し flat / nested / JSON parse 不能 / 部分欠落を正規化。`ApiError` constructor で string 強制 + 5xx fallback 文言「サーバーエラー (HTTP ${status})。再度お試しください。」 |
| `web/lib/__tests__/api.test.ts` (新規) | 11 cases — flat / nested / JSON parse 失敗 / 部分欠落 / `ApiError` constructor 防御 (各 case で `message` に `[object Object]` が含まれないことを assert) |

## 影響範囲

- ✅ `mapLessonResourceError` 経由の既存 4xx (file_too_large / invalid_file_type 等) は flat 形式維持、挙動変化なし
- ✅ 既存 lesson-resource テスト 26 件回帰なし
- ✅ 全 workspace テスト PASS: services/api 1690、web 340
- ✅ retry は副作用なし op のみ (署名 URL 生成 / メタデータ取得) — 冪等性問題なし
- ⚠️ `withGcsErrorMapping` の transient 文言「一時的に取得できません」→「一時的に処理できません」に変更 (upload/download 両方で使われるため)
- ⚠️ ADR-010 flat と ADR-0025 nested の正式統一は **別 PR** で対応 (errorHandler 形式変更は横断影響が広いため緊急対応からは除外)

## Test plan

- [x] `npm run type-check` PASS (全 workspace)
- [x] `npm run lint` PASS (既存 warning 1 件、本 PR と無関係)
- [x] `npm run test` PASS (services/api 1690 / web 340)
- [x] transient-error.test.ts: Premature close → transient 判定 ✅
- [x] lesson-resource.test.ts: Premature close 1 回 → retry 成功 / 連続失敗 → gcs_unavailable
- [x] web api.test.ts: nested error / JSON parse 失敗 で `[object Object]` 表示なし
- [ ] **マージ前必須**: super-admin で 200 MB 超 PDF を実機 upload、成功画面表示確認 (前回 PR #574/#577 で未実施だった smoke test を本 PR では必須化)
- [ ] **マージ前必須**: 実機 upload 時、開発者ツールで `gcs_transient_retry` ログ (リトライ発生) または成功レスポンスを観測

## 関連

- 直接の起因: 本番障害 2026-06-19 (Session 78 catchup 時に現場報告画像で発覚)
- 前段 PR: #574 (50→150 MB) / #577 (150→300 MB) — いずれも実機 smoke 未実施
- Codex セカンドオピニオン: `/codex fix` MCP で本仮説 / 修正案検証済 (threadId: 019ede18-b367-70d1-aca7-b6a97f30c600)
- ADR 統一の follow-up: ADR-010 (flat) vs ADR-0025 (nested) の正式統一 — 別 PR / 別 ADR で対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)