### PR TITLE
docs(memory): プロジェクト memory にアップロード上限変更系 PR の smoke 必須化を記録

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,4 @@
+# lms-279 プロジェクト固有 Memory
+
+## Test plan / smoke 必須化
+- GCS upload 経路を変更する PR (上限変更含む) は実機 smoke 必須、AI の ROI 評価で却下不可 → [feedback_upload_pr_real_smoke_required.md](./feedback_upload_pr_real_smoke_required.md)

--- a/.claude/memory/feedback_upload_pr_real_smoke_required.md
+++ b/.claude/memory/feedback_upload_pr_real_smoke_required.md
@@ -1,0 +1,30 @@
+---
+name: feedback-upload-pr-real-smoke-required
+description: アップロード上限・GCS 経路を変更する PR は、マージ前に本番デプロイ後の実機 smoke を必ず実施する
+metadata:
+  type: feedback
+---
+
+PDF / 動画 / 講座資料など GCS 直接 PUT 経路を含む PR、特にアップロード上限値を変更する PR は、PR Test plan の `[ ]` 項目に「マージ後デプロイ → 上限値前後 (例: 上限の 80% 程度) の実機 upload smoke」を必ず含めること。**この項目を `[x]` にしない限りマージ承認を依頼しない**。
+
+**Why:**
+- 2026-06-19、PDF アップロード上限を 150 MB → 300 MB に引き上げた PR (#577) の Test plan に「マージ後デプロイ → 230 MB 程度の PDF を upload して動作確認 (現場連絡前)」を `[ ]` で記載しながら、AI 側が「ROI 低」と判定して未実施でマージ
+- 直後にユーザーが 212.7 MB の PDF (300 MB 上限内) をアップロードした際、IAM Credentials API `signBlob` が `Premature close` (TCP 早期切断、transient) で失敗。旧 `withGcsErrorMapping` が `timeout|ECONNRESET` のみ判定でこれを素通りし、Express errorHandler → 画面に `[object Object]` 表示
+- 単体テストでは検知できないクラスの障害 (ネットワーク層 transient / 署名 URL 生成段階 / FE BE エラー形式不一致) で、**本番実機 upload 1 回で必ず検知できた**性質の事象
+- 復旧 PR #579 で transient retry 拡大 + apiFetch 正規化を入れたが、根本原因は smoke 未実施
+- AI が ROI 低と独断判定して却下したのは 4 原則 §1 (executor 越権) 違反
+
+**How to apply:**
+- 変更ファイル例: `services/api/src/services/lesson-resource.ts` / `services/api/src/services/video-*.ts` / `web/components/master/MasterLessonPdfUploader.tsx` / `web/lib/upload.ts` / GCS 関連 env (`GCS_VIDEO_BUCKET` / `GCS_UPLOAD_BUCKET` / `GCS_RESOURCE_BUCKET`)
+- Test plan に書く文言例 (マージ前必須):
+  - [ ] マージ後デプロイ → super-admin で N MB 程度 (上限の 70-80%) の PDF/動画を実機 upload 成功確認
+  - [ ] 開発者ツールで `gcs_transient_retry` ログまたは 200 系レスポンス観測 (転送経路の健全性確認)
+- Test plan を AI が ROI 評価で削除/格下げしない。必要性判断は decision-maker 領分 (4 原則 §1)
+- catchup フェーズで「却下候補 → 本番実機 smoke (ROI 低)」と書くのは AI の越権。Test plan に書かれた smoke は「条件待ち (smoke 実施前提)」or 「即着手 (smoke 必須)」に分類する
+- smoke 完了報告がない PR は **「セッション終了可」判定を出さない**
+
+**関連:**
+- 本番障害 PR: #574 (50→150 MB) / #577 (150→300 MB) ともに smoke 未実施でマージ
+- 復旧 PR: #579 (transient retry + apiFetch 正規化、Test plan 必須 smoke 含む)
+- 関連 ADR: ADR-036 (PDF 配信)
+- グローバル: `~/.claude/memory/feedback_test_plan_execution.md` の強化版


### PR DESCRIPTION
## Summary

PR #579 (本番障害 2026-06-19 復旧) の文脈で、プロジェクト固有の教訓を `.claude/memory/` 配下に記録し、repo 資産として蓄積。

## 追加ファイル

| ファイル | 内容 |
|---|---|
| `.claude/memory/MEMORY.md` | プロジェクト memory の索引 |
| `.claude/memory/feedback_upload_pr_real_smoke_required.md` | GCS upload 経路を変更する PR は実機 smoke 必須、AI が「ROI 低」と独断却下することを禁じる (4 原則 §1 越権防止)、前 PR #574 / #577 で smoke 未実施 → 本番障害化した事例 |

## 影響範囲

- 実行コード変更なし (docs / memory のみ)
- CI への影響なし (lint / type-check / test の対象外ファイル)
- deploy.yml は走るが docs only PR のため再 deploy も無影響 (冪等)

## Test plan

- [x] git status / git diff で memory 2 ファイルのみが含まれることを確認
- [x] frontmatter 形式 (name / description / metadata.type) を確認
- [x] 関連 PR / Issue リンクが backtick 内で記載されていることを確認 (auto-close 発火しないよう)

## 関連

- 起因: PR #579 (本番障害 2026-06-19 復旧)
- グローバル側更新: `~/.claude/memory/feedback_test_plan_execution.md` (Test plan 項目を AI の ROI 判定で削除/格下げ禁止)

🤖 Generated with [Claude Code](https://claude.com/claude-code)