### PR TITLE
fix(video): 動画署名 URL に transient retry 適用 (signBlob Premature close 再発復旧)

### DIFF
--- a/services/api/src/services/__tests__/gcs.test.ts
+++ b/services/api/src/services/__tests__/gcs.test.ts
@@ -1,0 +1,129 @@
+/**
+ * gcs.ts 署名 URL 生成の transient リトライ回帰テスト。
+ *
+ * 2026-06-19 本番障害 (再発): 動画再生 URL 生成の IAM Credentials API `signBlob`
+ * が `Premature close` で失敗し `GET /videos/:id/playback-url` が 500 を返した。
+ * Session 78 (#579) は PDF 署名のみ retry 化し、動画署名 (gcs.ts) が漏れていた。
+ *
+ * テスト観点 (rules/testing.md §5 外部API transient/permanent 分類):
+ *  - 初回成功時はリトライしない
+ *  - transient (`Premature close`) で bounded retry → 回復すれば成功
+ *  - transient が maxAttempts (3) 連続したら最後のエラーを throw
+ *  - permanent エラー (HTTP 403) は即 throw (リトライしない)
+ *  - generateUploadUrl (write 署名) も同じ retry が効く (横展開の検証)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { getSignedUrlMock } = vi.hoisted(() => ({
+  getSignedUrlMock: vi.fn(),
+}));
+
+vi.mock("@google-cloud/storage", () => ({
+  // new Storage() で使われるため class でモックする (アロー関数は constructor 不可)。
+  Storage: class {
+    bucket() {
+      return {
+        file: () => ({ getSignedUrl: getSignedUrlMock }),
+      };
+    }
+  },
+}));
+
+import { generatePlaybackUrl, generateUploadUrl } from "../gcs.js";
+import { logger } from "../../utils/logger.js";
+
+const SIGNED_URL = "https://signed.example.com/video.mp4?sig=abc";
+
+/** 本番障害で観測された SigningError (transient な TCP 早期切断) を再現する。 */
+function prematureCloseError(): Error {
+  const e = new Error(
+    "Invalid response body while trying to fetch " +
+      "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/sa:signBlob: Premature close",
+  );
+  e.name = "SigningError";
+  return e;
+}
+
+/** リトライ対象外の permanent エラー (権限不足等)。 */
+function permanentError(): Error & { code: number } {
+  const e = new Error("Permission denied") as Error & { code: number };
+  e.code = 403;
+  return e;
+}
+
+describe("gcs 署名 URL の transient リトライ (本番障害 2026-06-19 再発防止)", () => {
+  let loggerWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loggerWarnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    loggerWarnSpy.mockRestore();
+  });
+
+  describe("generatePlaybackUrl (受講者の動画視聴 / 障害の直接原因)", () => {
+    it("初回成功時はリトライせず URL を返す", async () => {
+      getSignedUrlMock.mockResolvedValue([SIGNED_URL]);
+
+      const url = await generatePlaybackUrl("tenant/videos/v1.mp4");
+
+      expect(url).toBe(SIGNED_URL);
+      expect(getSignedUrlMock).toHaveBeenCalledTimes(1);
+      expect(loggerWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("Premature close で 1 回失敗しても retry で回復し URL を返す", async () => {
+      getSignedUrlMock
+        .mockRejectedValueOnce(prematureCloseError())
+        .mockResolvedValue([SIGNED_URL]);
+
+      const url = await generatePlaybackUrl("tenant/videos/v1.mp4");
+
+      expect(url).toBe(SIGNED_URL);
+      expect(getSignedUrlMock).toHaveBeenCalledTimes(2);
+      expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+      // context が log payload に渡ること
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        "gcs_signing_transient_retry",
+        expect.objectContaining({ context: "generatePlaybackUrl" }),
+      );
+    });
+
+    it("Premature close が maxAttempts (3) 連続したら最後のエラーを throw する", async () => {
+      getSignedUrlMock.mockRejectedValue(prematureCloseError());
+
+      await expect(generatePlaybackUrl("tenant/videos/v1.mp4")).rejects.toThrow(
+        /Premature close/,
+      );
+      expect(getSignedUrlMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("permanent エラー (HTTP 403) はリトライせず即 throw する", async () => {
+      getSignedUrlMock.mockRejectedValue(permanentError());
+
+      await expect(generatePlaybackUrl("tenant/videos/v1.mp4")).rejects.toThrow(
+        /Permission denied/,
+      );
+      expect(getSignedUrlMock).toHaveBeenCalledTimes(1);
+      expect(loggerWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("generateUploadUrl (管理者のアップロード署名 / 同一 signBlob 経路)", () => {
+    it("Premature close で 1 回失敗しても retry で回復し uploadUrl を返す", async () => {
+      getSignedUrlMock
+        .mockRejectedValueOnce(prematureCloseError())
+        .mockResolvedValue([SIGNED_URL]);
+
+      const result = await generateUploadUrl("lesson.mp4", "video/mp4", "tenant-a");
+
+      expect(result.uploadUrl).toBe(SIGNED_URL);
+      expect(result.gcsPath).toContain("tenant-a/videos/");
+      expect(result.gcsPath).toContain("lesson.mp4");
+      expect(getSignedUrlMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/services/api/src/services/gcs.ts
+++ b/services/api/src/services/gcs.ts
@@ -1,8 +1,37 @@
 import { Storage } from "@google-cloud/storage";
+import { logger } from "../utils/logger.js";
+import { retryOnTransient } from "../utils/transient-error.js";
 
 const storage = new Storage();
 const VIDEO_BUCKET = process.env.GCS_VIDEO_BUCKET || "lms-279-videos";
 const UPLOAD_BUCKET = process.env.GCS_UPLOAD_BUCKET || "lms-279-uploads";
+
+/**
+ * GCS V4 署名 URL 生成 (内部で IAM Credentials API `signBlob` を呼ぶ) を
+ * transient リトライで包む共通ヘルパー。
+ *
+ * 2026-06-19 本番障害 (再発): 動画再生 URL 生成の `signBlob` が
+ * `Premature close` (transient な TCP 早期切断) で失敗し、
+ * `GET /videos/:id/playback-url` が 500 を返して受講者が動画を開けなかった
+ * (赤背景に `[object Object]` 表示)。Session 78 (#579) では PDF 署名
+ * (lesson-resource.ts) のみ retry 化し、動画署名 (本ファイル) への適用が漏れていた。
+ *
+ * 署名 URL 生成は副作用なし / idempotent なので bounded retry が安全。
+ * transient 判定は utils/transient-error.ts の isTransientError に一元化
+ * (`premature close` を含む message パターン + transport code + HTTP status)。
+ * playback-url は受講者をブロックする critical path のため、PDF 署名 (2 attempts)
+ * より 1 回多い 3 attempts で回復率を上げる。
+ */
+async function withSigningRetry<T>(op: () => Promise<T>, context: string): Promise<T> {
+  return retryOnTransient(op, {
+    maxAttempts: 3,
+    baseDelayMs: 150,
+    onRetry: ({ attempt, error, delayMs }) => {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn("gcs_signing_transient_retry", { context, attempt, delayMs, message });
+    },
+  });
+}
 
 /**
  * 動画アップロード用の署名付きURL生成
@@ -18,12 +47,17 @@ export async function generateUploadUrl(
   tenantId: string
 ): Promise<{ uploadUrl: string; gcsPath: string }> {
   const gcsPath = `${tenantId}/videos/${Date.now()}_${fileName}`;
-  const [url] = await storage.bucket(UPLOAD_BUCKET).file(gcsPath).getSignedUrl({
-    version: "v4",
-    action: "write",
-    expires: Date.now() + 60 * 60 * 1000, // 1時間有効
-    contentType,
-  });
+  const expires = Date.now() + 60 * 60 * 1000; // 1時間有効
+  const [url] = await withSigningRetry(
+    () =>
+      storage.bucket(UPLOAD_BUCKET).file(gcsPath).getSignedUrl({
+        version: "v4",
+        action: "write",
+        expires,
+        contentType,
+      }),
+    "generateUploadUrl",
+  );
   return { uploadUrl: url, gcsPath };
 }
 
@@ -49,11 +83,16 @@ export async function moveToVideoBucket(
  * @returns 署名付きURL（2時間有効）
  */
 export async function generatePlaybackUrl(gcsPath: string): Promise<string> {
-  const [url] = await storage.bucket(VIDEO_BUCKET).file(gcsPath).getSignedUrl({
-    version: "v4",
-    action: "read",
-    expires: Date.now() + 2 * 60 * 60 * 1000, // 2時間有効
-  });
+  const expires = Date.now() + 2 * 60 * 60 * 1000; // 2時間有効
+  const [url] = await withSigningRetry(
+    () =>
+      storage.bucket(VIDEO_BUCKET).file(gcsPath).getSignedUrl({
+        version: "v4",
+        action: "read",
+        expires,
+      }),
+    "generatePlaybackUrl",
+  );
   return url;
 }
 


### PR DESCRIPTION
## 本番障害（緊急ホットフィックス）

福の種テナント（`atali82i`）で**動画が開けず、赤背景に `[object Object]` 表示**。前田様より報告 + エラー画面受領。

### 根本原因（本番ログで確定）

`GET /videos/:id/playback-url` が IAM Credentials API `signBlob` の `Premature close`（transient な TCP 早期切断）で **500 を連発**していた。

```
SigningError: Invalid response body while trying to fetch
https://iamcredentials.googleapis.com/.../signBlob: Premature close
```
（本番ログ: テナント `atali82i`、04:17〜05:18 で複数 video ID）

これは **Session 78 (#579) の修正漏れ**。#579 は transient retry を PDF 署名（`lesson-resource.ts`）にのみ適用し、**動画署名（`services/api/src/services/gcs.ts`）への適用が漏れていた**。同一の `signBlob Premature close` が動画再生 URL 生成で再発した。`transient-error.ts` のコメントも「本 util は lesson-resource.ts 用途に絞って導入」と明言しており、動画署名が未対応だった。

`[object Object]` 表示は症状に過ぎず、本質は playback-url の 500。500 を解消すれば動画は開く。

## 修正

| 対象 | 内容 |
|---|---|
| `gcs.ts` | `withSigningRetry` ヘルパー追加。`generatePlaybackUrl` / `generateUploadUrl` を `retryOnTransient` でラップ（maxAttempts 3、exponential backoff + jitter） |
| 判定 | transient 判定は既存 `utils/transient-error.ts` の `isTransientError` に一元化（`premature close` を含む message パターン + transport code + HTTP status） |
| 安全性 | 署名 URL 生成は副作用なし / idempotent なので bounded retry が安全。`expires` / `gcsPath` は op 外で固定しリトライ間でブレないようにした |
| 対象外 | `moveToVideoBucket`（非 idempotent な move）は今回の signBlob 障害と別経路のため対象外 |

`playback-url` は受講者をブロックする critical path のため、PDF 署名（2 attempts）より 1 回多い 3 attempts で回復率を上げた。

## Test plan

- [x] `gcs.test.ts` 回帰防止テスト 5 件追加（成功 / Premature close → retry 回復 / maxAttempts 超過で throw / permanent(403) 即 throw / upload 横展開）
- [x] `npm run test -w @lms-279/api` → **1702 passed**（106 files、+5）
- [x] `tsc --noEmit` → PASS
- [x] `eslint gcs.ts gcs.test.ts` → exit 0
- [x] `/code-review low` → findings なし
- [ ] **本番デプロイ後**: 福の種テナントで playback-url が 200 を返し動画が開くこと（現場再試行 or 本番ログで `signBlob` エラー消失を確認）

## 関連

- Session 78 / PR #579（PDF 側の同一障害修正、動画側が漏れていた）