### PR TITLE
fix(infra): Docker ベースイメージを node:24.16.0-slim に固定 (signBlob Premature close 根治)

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,4 +1,8 @@
-FROM node:24-slim
+# Node 24.17.0 の http.Agent keep-alive regression (Premature close, nodejs/node#63989) 回避のため
+# パッチ固定。floating tag `node:24-slim` は再ビルド時に最新 24.x を引き込み、gaxios 経由の
+# IAM signBlob が壊れて GCS 署名 URL 生成 (動画再生 / PDF) が 500 になる本番障害を起こした
+# (Session 76/78/79 で再発、root cause)。修正版 Node リリース後に追従すること。
+FROM node:24.16.0-slim
 
 WORKDIR /app
 

--- a/services/notification/Dockerfile
+++ b/services/notification/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:24-slim
+# Node 24.17.0 の http.Agent keep-alive regression (Premature close, nodejs/node#63989) 回避のため
+# パッチ固定。floating tag は再ビルド時に最新 24.x を引き込むため、全サービスで固定を揃える。
+# 修正版 Node リリース後に追従すること。
+FROM node:24.16.0-slim
 
 WORKDIR /app
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:24-slim AS builder
+# Node 24.17.0 の http.Agent keep-alive regression (Premature close, nodejs/node#63989) 回避のため
+# パッチ固定。floating tag は再ビルド時に最新 24.x を引き込むため、全サービスで固定を揃える。
+# 修正版 Node リリース後に追従すること。
+FROM node:24.16.0-slim AS builder
 
 WORKDIR /app
 
@@ -34,7 +37,7 @@ ENV NEXT_PUBLIC_USER_ROLE=$NEXT_PUBLIC_USER_ROLE
 
 RUN npm run build -w @lms-279/web
 
-FROM node:24-slim AS runner
+FROM node:24.16.0-slim AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
## 本番障害の真の root cause（4連続の根治）

全 Dockerfile が `node:24-slim`（floating tag）で、デプロイ毎の再ビルドで **Node 24.17.0**（約1日前リリース）を引き込んでいた。24.17.0 の `http.Agent` keep-alive regression（[nodejs/node#63989](https://github.com/nodejs/node/issues/63989)）が gaxios 経由の IAM `signBlob` を壊し、GCS 署名 URL 生成（動画再生 / PDF）が `SigningError: Premature close` で 500 になっていた。

### 同一原因の連続再発（対症療法で根本を外し続けた）

| Session | 症状 | 当時の対処 | 根本到達 |
|---|---|---|---|
| #576 | 福の種 動画視聴500 | インスタンス再起動(RESTART_AT) | ❌ |
| #577 | (PDF上限変更でイメージ再ビルド) | — | — |
| #579 | PDF [object Object] | PDFにretry | ❌ |
| #582 | 動画 [object Object] | 動画にretry | ❌ |

`gcs.ts:51 generatePlaybackUrl` の Premature close は **#576 で既に特定済み**だったが、根本（Node）に到達せず対症療法を繰り返していた。

## 修正

`services/api` / `web`（builder+runner）/ `services/notification` の Dockerfile を **`node:24.16.0-slim`**（regression 前の最終パッチ、Docker Hub 実在確認済 2026-06-11）にピン留め。

## PR #582 (retry) の扱い

本障害には無効だったが、将来の真の transient の保険として残置（PDF側 `lesson-resource.ts` と一貫）。Node 修正版リリース後にタグ追従する。

## Test plan

- [x] `24.16.0-slim` 実在確認（Docker Hub HTTP 200）
- [x] 全3サービスの Dockerfile 固定（4箇所）
- [ ] CI で docker build 成功（api / web / notification）
- [ ] **デプロイ後**: 福の種で playback-url が Premature close なしで 200（本番ログ監視中）

## 再発防止（別途 memory / CLAUDE.md 反映予定）

- catchup が未解決障害の archive handoff を遡る（#576 が見えていれば即解決した）
- 謎の外部エラーメッセージは即 WebSearch
- Docker ベースイメージのパッチ固定ルール（floating tag 禁止）
- 失敗分布（全/部分）確認 → transient 対策の順序
