### PR TITLE
ui(help): スクショ拡大ダイアログの最大幅を 95vw / 上限 1400px に拡張

### DIFF
--- a/web/app/help/_components/ScreenshotViewer.tsx
+++ b/web/app/help/_components/ScreenshotViewer.tsx
@@ -46,18 +46,18 @@ export function ScreenshotViewer({
       </div>
 
       <Dialog open={open !== null} onOpenChange={() => setOpen(null)}>
-        <DialogContent className="max-w-4xl p-2">
+        <DialogContent className="!max-w-[min(95vw,1400px)] p-2 sm:p-3">
           <DialogTitle className="sr-only">
             スクリーンショット
           </DialogTitle>
           {open && (
-            <div className="relative aspect-video w-full">
+            <div className="relative aspect-video w-full max-h-[85vh]">
               <Image
                 src={open}
                 alt="スクリーンショット拡大"
                 fill
                 className="rounded object-contain"
-                sizes="90vw"
+                sizes="(max-width: 1400px) 95vw, 1400px"
                 unoptimized
               />
             </div>


### PR DESCRIPTION
## 背景

ヘルプページの ScreenshotViewer で、サムネイル画像をクリックして表示される拡大ダイアログが \`max-w-4xl\` (896px) で固定されていた。1280x720 px のスクショ画像が viewport サイズに対して小さく表示され、細部の確認がしづらかった (現場担当者からのフィードバック)。

## 変更内容

\`web/app/help/_components/ScreenshotViewer.tsx\`:

- **width**: \`max-w-4xl\` (896px) → \`!max-w-[min(95vw,1400px)]\`
  - \`!\` 修飾子で \`DialogContent\` の default \`max-w\` を確実に上書き
  - viewport の 95% 以下、上限 1400px (大画面 5K/4K でも余白を残す)
- **height**: \`max-h-[85vh]\` を追加 (縦長 viewport で画像が画面下にはみ出ない)
- **sizes**: \`90vw\` → \`(max-width: 1400px) 95vw, 1400px\` (実際の幅に合わせて Next.js Image の最適化を改善)

## 影響範囲

ScreenshotViewer は \`FeatureSection\` 経由で **全 help ロール** (student / admin / super) のすべてのスクショで共通利用されているため、ヘルプページ全体の UX 改善になる。

## Test plan

- [x] \`npm run type-check\` PASS
- [x] \`npm run lint\` PASS (0 errors, 既存 warning 1 件は本変更とは無関係)
- [ ] マージ後、本番 \`/help/super\` でスクショサムネイルをクリックし、拡大ダイアログが画面いっぱい (95vw 上限 1400px) で表示されることを開発者が確認
- [ ] 同様に \`/help/student\` / \`/help/admin\` の既存スクショでも拡大ダイアログが画面いっぱいで表示されることを確認
- [ ] 縦長 viewport (例: iPhone 縦持ち / モバイル想定) で max-h-[85vh] が効いて画像が画面下にはみ出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)