### PR TITLE
docs(handoff): Session 80 - スーパー管理者ヘルプに資料反映セクション追加 + screenshot 運用ミス再発防止

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,27 +1,22 @@
-# Session Handoff — 2026-06-20 (Session 79)
+# Session Handoff — 2026-06-24 (Session 80)
 
 ## TL;DR
 
-**メタ前提見直し + 同根再発対策の最終 PR**。Session 78 (PR #579 / #582 / #583) で発覚した同根障害 (Docker base image `node:24-slim` floating tag → Node 24.17.0 引き込み → `http.Agent` regression → `signBlob` `Premature close` 多発) を踏まえ、本セッションは:
-
-1. 本番修正の **実機検証ステータスを正確に区別** (コード/CI レベル ✅ / 現場再試行レベル ⚠️)
-2. 現場向け修正報告メッセージに含めた「**実機での動作確認を必須化**」が AI executor 越権 (4 原則 §1 違反、確約化動詞、`feedback_promise_overengineering.md` 未参照) であったことを認識・訂正文案起草
-3. プロジェクト / グローバル両層のメタ前提 (memory / handoff / CLAUDE.md / hook) を俯瞰し、破綻 5 つを抽出
-4. グローバル handoff スキル §4.6 (同根再発スキャン) + §4.7 (対症療法判定) の追加テキスト案を起草 (別 AI 担当領域へ引き継ぎ)
-5. プロジェクト側で実施可能な構造対策として **PR #586 (engines `24.16.0` 固定 + `.nvmrc` + プロジェクト memory `feedback_lms_floating_tag_avoidance.md` 追加)** をマージ
+**現場相談起点でスーパー管理者ヘルプの「配信済みテナント資料反映」セクションを追加 + スクリーンショット skill の運用ミスを構造的に防ぐ MUST 追加**。マスター講座への資料 PDF 後追い添付について現場担当者から「配信済みテナントには紐づかないのでは?」と質問あり。ADR-024 / ADR-036 通り後追い反映 API + UI ボタンは既存だが、ヘルプマニュアル未掲載で発見できなかった事案。スクショ付き解説を追加した過程で、AI が `screenshot` skill を invoke せず `browser_take_screenshot` を直接呼んだため Next.js dev indicator (N マーク) が画像に焼き付くインシデント発生。skill 強化 + global CLAUDE.md CRITICAL に MUST 追加で再発防止。
 
 | 主要成果 | 結果 |
 |---|---|
-| PR #586 マージ (engines + nvmrc + memory) | ✅ merged + CI 全 pass (Build / Lint / Playwright / Test / Type Check) |
-| プロジェクト memory 追加 | ✅ `feedback_lms_floating_tag_avoidance.md` (Dockerfile / engines / Actions の floating tag 方針) |
-| Dockerfile / engines / `.nvmrc` の 3 点整合 | ✅ いずれも `24.16.0` で揃った |
-| 現場訂正文案 (α 追伸型 / β 独立型) 起草 | ✅ 起草完了 (送付タイミングは decision-maker 領分) |
-| グローバル handoff スキル §4.6 / §4.7 追加テキスト | ✅ 起草完了、本セッション外の別 AI へ引き継ぎ予定 |
-| メタ前提破綻 5 つ + 真の主原因の言語化 | ✅ 「メタは寄与因子、主原因は AI executor のターン内判断ミス」を区別 |
+| PR #588 マージ (スーパー管理者ヘルプに「配信済みテナント資料反映」セクション追加) | ✅ merged + 本番反映完了、N マーク版で初版公開 |
+| PR #589 マージ (N マーク除去版で画像差し替え) | ✅ merged + 本番反映完了 (`last-modified: 2026-06-24 04:22 GMT`) |
+| PR #590 マージ (スクショ拡大ダイアログを 95vw / 上限 1400px に拡張) | ✅ merged + 本番デプロイ完了 |
+| global skill PR #308 (yasushi-honda/claude-code-config) | ⏳ 別レポでオープン、decision-maker レビュー & マージ待ち |
+| ~/.claude/CLAUDE.md CRITICAL に MUST 追加 (browser_take_screenshot 直接呼び禁止条件) | ✅ decision-maker 側で追記済み |
+| ~/.claude/skills/screenshot/SKILL.md 起動条件強化 | ✅ decision-maker 側で追記済み |
+| 現場担当者への案内 (マスター→配信済みテナントへの資料反映手順) | ✅ コピペ用文案 + 本番リンク (`/help/super#super-sync-resources`) 共有済み |
 
-- **Issue Net (本セッション)**: Close 0 + 起票 0 = **Net 0** (triage 基準を満たす追加 Issue なし、本セッションは既存メタ前提の見直し + 既知の同根対策の最終 PR で完結)
-- **本セッション merged PR**: 1 件 (#586)
-- **本セッション本番 destructive 操作**: 0 件 (PR #586 は memory + config のみ、実行時挙動影響なし)
+- **Issue Net (本セッション)**: Close 0 + 起票 0 = **Net 0** (triage 基準を満たす新規 Issue なし、本セッションは現場相談起点の ad-hoc ドキュメント追加で完結)
+- **本セッション merged PR**: 3 件 (#588, #589, #590) + 別レポ 1 件 (#308)
+- **本セッション本番 destructive 操作**: 0 件 (PR は全て docs / UI 微調整、Firestore / GCS 書き込み一切なし)
 
 ---
 
@@ -32,8 +27,8 @@ cat docs/handoff/LATEST.md
 git fetch origin main && git log --oneline -5 origin/main
 gh pr list --state open
 gh issue list --state open
-# 福の種テナント / 213 MB PDF 現場再試行報告の有無を確認 (チャット経路は GitHub 管理外)
-# グローバル handoff スキル §4.6 / §4.7 の追加が完了しているか確認 (別 AI 担当)
+# global skill PR #308 (yasushi-honda/claude-code-config) の状態確認
+# 本案件のヘルプセクションを現場が活用できているかフィードバック確認
 ```
 
 ---
@@ -42,37 +37,29 @@ gh issue list --state open
 
 | 層 | 変更内容 |
 |---|---|
-| `package.json` engines | `">=24.12.0"` → `"24.16.0"` (パッチ固定、Dockerfile と整合) |
-| `.nvmrc` (新規) | `24.16.0` (nodenv / volta / fnm / nvm でローカル自動切替) |
-| `.claude/memory/feedback_lms_floating_tag_avoidance.md` (新規) | Dockerfile / engines / GitHub Actions の floating tag 方針を明文化 |
-| `.claude/memory/MEMORY.md` | インデックス追記 |
+| `web/app/help/_data/super-sections.ts` | 新セクション `super-sync-resources` 追加 (super-distribute の直後、5 step + 4 callout + 5 FAQ) |
+| `web/public/help/screenshots/super-sync-resources-button.png` (新規) | マスターコース詳細画面のボタン、N マーク除去版 (1280x720) |
+| `web/public/help/screenshots/super-sync-resources-dialog.png` (新規) | 確認ダイアログ、N マーク除去版 (1280x720) |
+| `web/app/help/_components/ScreenshotViewer.tsx` | 拡大ダイアログ `max-w-4xl` → `!max-w-[min(95vw,1400px)]` + `max-h-[85vh]` + `sizes` 更新 |
 
-詳細: PR #586 description
+詳細: PR #588 / #589 / #590 description
 
----
-
-## メタ前提見直しで明確にしたこと
-
-| 項目 | 区別 |
-|---|---|
-| 真の主原因 | **AI executor のターン内判断ミス** (越権 / memory 未参照 / 事実確認不足 / 楽観判定) |
-| 寄与因子 (二次) | handoff スキルに同根再発チェックなし / グローバル MEMORY.md が grep されにくい構造 |
-| 「メタを更新すれば再発防止」は錯覚 | memory 追加 = 完了の錯覚を構造的に避ける必要 |
-| 確約化動詞は memory が既に警告していた | `feedback_promise_overengineering.md` / `feedback_field_message_approval.md` の grep がターン内に行われなかった |
-| 規模感 | 1560 行のメタ (CLAUDE.md + rules + memory) は少人数プロジェクトに対し物理的に毎ターン scan 不可能 |
+別レポ:
+- `~/.claude/skills/screenshot/SKILL.md`: 起動条件強化 + Step 5.5 自己診断 + 撮影後 PNG 目視確認 MUST 化 (PR #308)
+- `~/.claude/CLAUDE.md`: CRITICAL に「git 管理 PNG 出力先パスへの `browser_take_screenshot` 直接呼びを禁止し `/screenshot` 経由必須」MUST 追加 (decision-maker 側で実施)
 
 ---
 
-## 別 AI 担当領域への引き継ぎ
+## 構造的再発防止 (本セッションの恒久対策)
 
-グローバル handoff スキル `~/.claude/skills/handoff/SKILL.md` への §4.6 / §4.7 追加テキスト (起草済) を別 AI 担当へ引き継ぎ。プロジェクト固有名詞 (固有のサービス名 / 障害固有 token) は含めず、抽象表現で書いてある (グローバル memory ルール準拠)。
+| 層 | 対策 |
+|---|------|
+| skill 本体 | Step 5.5 自己診断 (style_injected / nextjs_portal_visible / suspicious_fixed_bottom_left) と撮影後 PNG 目視確認を MUST 化 |
+| skill description | コミット対象スクショ撮影時は明示依頼なくても起動 MUST と明示 |
+| global CLAUDE.md CRITICAL | `browser_take_screenshot` を呼ぶ前に filename 判定を要求、git 管理 PNG パスなら `/screenshot` 経由必須 |
+| 運用ルール | `.playwright-mcp/` 等 gitignored の動作確認スクショは対象外、判定基準を明文化 |
 
----
-
-## ルール反映 (本セッション)
-
-- **プロジェクト memory** (`.claude/memory/feedback_lms_floating_tag_avoidance.md`, PR #586 で repo 管理化): Dockerfile / engines / GitHub Actions の floating tag 方針、新 PR で floating tag を導入していないかレビュー段階で目視確認する運用とする
-- **グローバル memory への追加なし**: §4.6 / §4.7 は handoff スキル本体への構造化が筋、grep リストは既存 `feedback_promise_overengineering.md` / `feedback_field_message_approval.md` 強化で対応 (別 AI 担当)
+これにより「動作確認のついでにマニュアルにも流用」事故パターンが構造的に止まる。
 
 ---
 
@@ -80,26 +67,25 @@ gh issue list --state open
 
 ### 即着手タスク
 
-**なし** — 本セッション主目的 (メタ前提見直し + PR #586) 完了、git clean、main 同期済、CI 全 pass、本番デプロイ影響なし。executor 領分の作業ゼロ。
+**なし** — 本セッション主目的 (現場ヘルプ追加 + 構造的再発防止) 完了、Git clean、main 同期 (`21437c8`)、CI 全 pass、本番デプロイ完了。executor 領分の作業ゼロ。
 
 ### 条件待ち (明示 trigger 付き)
 
 | # | 項目 | trigger | 充足時のタスク |
 |---|------|---------|--------------|
-| 1 | 福の種テナントの動画再生現場再試行報告 | チャット等で「動画が見られる」「まだ赤画面が出る」等の報告 | 成功 → 本件完全クローズ / 失敗 → スクショ + 時刻 + サーバーログ再調査 |
-| 2 | 213 MB PDF アップロード現場再試行報告 | チャット等で「アップロード成功」「まだエラー」等の報告 | 成功 → 本件完全クローズ / 失敗 → スクショ + 時刻 + サーバーログ再調査 |
-| 3 | 現場訂正メッセージ (α または β) の送付反応 | decision-maker から送付タイミング判断後の現場反応 | 反応に応じてフォローアップ文案再起草 (必要時) |
-| 4 | グローバル handoff スキル §4.6 / §4.7 追加完了 | 別 AI 担当からの完了報告 | 本リポジトリ次セッションで新 handoff 出力時に §4.6 / §4.7 が自動適用されることを確認 |
-| 5 | Issue #584 (Phase 4 α-7 Playwright E2E) | decision-maker から cutover Step 6 スケジュール確定 or 番号単位の明示指示 | impl-plan → tdd → e2e 実装 |
+| 1 | 本案件のヘルプセクションを現場が活用できているか | 現場担当者からのフィードバック (「見つけられた」「分かりやすかった」「△△が分からない」等) | 反応に応じて step / callouts / FAQ の文言調整 |
+| 2 | global skill PR #308 (yasushi-honda/claude-code-config) のマージ | decision-maker のレビュー & マージ判断 | 反映後、本リポジトリ次セッションで自動適用される (本リポジトリ側のタスクなし) |
+| 3 | Issue #584 (Phase 4 α-7 Playwright E2E) | decision-maker から cutover Step 6 スケジュール確定 or 番号単位の明示指示 | impl-plan → tdd → e2e 実装 |
+| 4 | Cleanup Orphan Auth Users scheduled job 失敗 (2026-06-22) の原因調査 | decision-maker から「失敗原因を調べて」の明示指示 (Issue #276 が postponed のため自動修正は不可、孤児 Auth 設計判断が絡む) | gh run view で log 確認 → 原因切り分け → 修正方針を decision-maker へ報告 |
 
 ### 却下候補 (記録のみ)
 
 | # | 項目 | 理由 |
 |---|------|-----|
-| 1 | GitHub Actions の `@v6` / `@v3` / `@v7` を SHA-pin する PR | 中期検討事項として memory に記録済、Node ほどの破壊的変更ペースではない。dependabot 設定との整合性検討が要るため即時着手対象外。decision-maker 起点指示があれば対応 |
-| 2 | errorHandler を ADR-010 flat 形式に統一 (Session 78 引継ぎ) | 本質的負債だが FE 防御で吸収済、`[object Object]` 再発なし。横断影響大、緊急性なし。decision-maker 起点の指示があれば対応 |
-| 3 | gmail 系 transient util を新 `transient-error.ts` に統合 (Session 78 引継ぎ) | ROI 不明確。既存配送経路を緊急性なく触るリスクが効果を上回る。decision-maker 起点の指示があれば対応 |
-| 4 | dependabot 11 件 (#563-#573) + #585 (actions/checkout v6→v7) のマージ | A カテゴリ housekeeping、decision-maker 明示指示なき限り保留。`@v6 → @v7` などの依存更新は影響範囲確認要 |
+| 1 | postponed Issue #521 / #405 / #276 / #275 / #274 の再開 | postponed ラベル + 再開条件未確認、明示指示必須。catchup でも自動除外対象 |
+| 2 | ヘルプセクションの他ロール (admin / student) 全般のスクショ追加 | 本セッションのスコープ外。ScreenshotViewer 拡張 (#590) の効果で既存スクショも見やすくなったため当面急を要さず、decision-maker 起点の指示があれば対応 |
+| 3 | dependabot PR の連続マージ | A カテゴリ housekeeping、decision-maker 明示指示なき限り保留 |
+| 4 | `/screenshot` 関連の自動化 (起動忘れ検知 hook 等) | global CLAUDE.md MUST 追加で対症は完了。さらなる hook 自動化は AI 起点では越権、必要性が確認できてから decision-maker 起点で検討 |
 
 ---
 
@@ -107,9 +93,9 @@ gh issue list --state open
 
 | 項目 | 実施可否 | 備考 |
 |---|---|---|
-| `/impact-analysis` (型・共有ロジック変更) | ⏭️ スキップ | 本 PR は memory + config (engines / nvmrc) のみ、共有型 / API 契約変更なし |
-| `/new-resource` (新規テーブル / API) | ⏭️ スキップ | 該当なし |
-| `/trace-dataflow` (データフロー) | ⏭️ スキップ | 既存データフロー変更なし |
+| `/impact-analysis` (型・共有ロジック変更) | ⏭️ スキップ | 本セッション PR は静的データ (help section) + UI 微調整 (Tailwind class) のみ、共有型 / API 契約変更なし |
+| `/new-resource` (新規テーブル / API) | ⏭️ スキップ | 既存 API (sync-resources) のヘルプ追加のみ、新規 API なし |
+| `/trace-dataflow` (データフロー) | ⏭️ スキップ | データフロー変更なし |
 
 ---
 
@@ -117,18 +103,32 @@ gh issue list --state open
 
 | 項目 | 結果 |
 |---|---|
-| 本セッション内修正 PR (`fix:` / `hotfix:`) | 0 件 (PR #586 は `chore:`、本セッションは Session 78 同根問題の最終構造対策) |
-| 過去 7 日 archive 内 `signBlob` / `Premature close` keyword ヒット | 1 件 (`2026-06-19-session-76.md`、本事案の起点として既知) |
-| 同根判定 | **本セッションは既知の同根問題への最終構造対策 (engines / nvmrc / memory) を完了**。新たな同根再発候補なし、§ 8 最終結論 判定継続 |
+| 本セッション内修正 PR (`fix:` プレフィックス) | 1 件 (PR #589 N マーク除去) |
+| 本セッション内の同根候補 (共有 util / 共通ライブラリ / 同 ADR) | 0 件 (#589 は global skill 運用ミス、#588/#590 は別系統) |
+| 過去 7 日 archive 内 `screenshot` / `N マーク` / `nextjs-portal` keyword ヒット | 0 件 (本セッションが本リポジトリでの初検出) |
+| 過去 PR title 内 `screenshot` / `スクショ` / `スクリーンショット` ヒット | 本セッション PR (#589 / #590) のみ、過去なし |
+| 同根判定 | **過去事案なし、本セッションが起点**。global skill 強化 + CLAUDE.md MUST 追加で同根再発を構造的に阻止、§ 8 最終結論 判定継続 |
 
 ---
 
 ## § 4.7 対症療法判定結果
 
+| 判定基準 | 該当 | 説明 |
+|---|---|---|
+| 1. retry / fallback / エラー文言修正のみで調査ログなし | ❌ 該当なし | 画像差し替えだけでなく、global skill 強化 + CLAUDE.md MUST 追加で根本原因 (skill invoke スキップ運用ミス) に対処 |
+| 2. 「なぜそれが今起きたか」の調査ログなし | ❌ 該当なし | 原因明確: AI executor が skill 起動条件を判定せず browser_take_screenshot を直接呼んだ運用ミス。skill 本体には N マーク除去 CSS 注入ロジックは既に組み込み済み |
+| 3. 同症状の修正 PR が過去 30 日に 1 件以上 | ❌ 該当なし | 過去 PR / handoff archive grep で同症状ヒット 0 件 |
+| 4. 修正後の動作確認が単体テスト / smoke のみ | ❌ 該当なし | 本番デプロイ後の PNG hash 確認 + decision-maker による実機確認で OK 判定取得済み |
+| **総合判定** | **対症療法疑い 0 件** | 通常通り § 8 へ |
+
+---
+
+## § 4.5 グローバル memory scope チェック
+
 | 項目 | 結果 |
 |---|---|
-| 本セッション内修正 PR | 0 件、判定対象外 |
-| 既知 root cause (Node floating tag) への対応 | PR #583 (Docker base image パッチ固定) + PR #586 (engines / nvmrc パッチ固定) で構造的に根治。retry / fallback だけで終わっていない |
+| 本セッション内で `memory/feedback_*.md` / `memory/reference_*.md` / `memory/MEMORY.md` の変更 | なし (本セッションは global skill 本体と CLAUDE.md の変更で、memory ファイルは触っていない) |
+| 判定 | ⏭️ スキップ |
 
 ---
 
@@ -137,7 +137,7 @@ gh issue list --state open
 - Close 数: 0 件
 - 起票数: 0 件
 - **Net: 0 件**
-- **言語化**: 本セッションは Session 78 同根問題の最終構造対策 + メタ前提見直しで完結。triage 基準 (実害 / 再現バグ / CI 破壊 / rating≥7 / 明示指示) を満たす追加課題なし。Issue Net 0 だが、本セッションは「メタ前提見直し + 同根問題の構造的根治の完成」という実質進捗あり
+- **言語化**: 本セッションは現場相談起点の ad-hoc ドキュメント追加 + スクリーンショット運用ミスの構造的再発防止で完結。triage 基準 (実害 / 再現バグ / CI 破壊 / rating≥7 / 明示指示) を満たす追加課題なし。Issue Net 0 だが、ヘルプセクション追加で現場の自己解決経路が 1 つ増えた + 同種のスクショ運用事故を CLAUDE.md MUST 追加で構造的に阻止という実質進捗あり
 
 ---
 
@@ -151,18 +151,20 @@ gh issue list --state open
 
 | 項目 | 状態 |
 |------|------|
-| Git clean | ✅ (PR #586 マージ後、本 handoff PR 作成中) |
-| main 同期済 | ✅ (`34a9c50` まで) |
-| 本セッション merged PR | ✅ #586 |
-| 本番デプロイ影響 | ⏭️ 該当なし (memory + config のみ) |
-| 本番ログ (api-00438-k94 / web-00433-5q6) | ✅ signBlob エラー再発なし、健全稼働 |
-| OPEN PR | dependabot 11 件 (#563-#573) + #585 (actions/checkout v6→v7、本 handoff PR は別) |
+| Git clean | ✅ (本 handoff PR 作成前) |
+| main 同期済 | ✅ (`21437c8` まで) |
+| 本セッション merged PR | ✅ #588, #589, #590 (3 件すべて本番反映完了) |
+| 別レポ open PR | ⏳ #308 (yasushi-honda/claude-code-config, decision-maker 領分) |
+| 本番デプロイ影響 | ✅ ヘルプセクション追加 / UI 微調整、destructive ゼロ |
+| OPEN PR (本リポジトリ) | 0 件 (本 handoff PR は別) |
 | 残留プロセス | ✅ なし |
 | 即着手タスク | 0 件 |
-| 条件待ち | 5 件 (全て外部 trigger 待ち) |
+| 条件待ち | 4 件 (全て外部 trigger 待ち or decision-maker 領分) |
+| § 4.6 同根再発スキャン | 過去事案 0 件 (本セッションが起点) |
+| § 4.7 対症療法判定 | 該当 0 件 |
 
 ---
 
 ## 最終結論
 
-✅ **セッション終了可** — メタ前提見直し + 同根問題の最終構造対策 (PR #586) 完了。executor 領分の作業ゼロ、条件待ち 5 件は全て外部 trigger 待ちで次セッション以降の対応。残留プロセスなし、Git clean、本番デプロイ健全。同根再発スキャン (§ 4.6) / 対症療法判定 (§ 4.7) いずれも該当なし。
+✅ **セッション終了可** — 現場相談起点のヘルプ追加 (PR #588) + N マーク除去 (PR #589) + 拡大ダイアログ UX 改善 (PR #590) すべて本番反映完了。global skill 強化 + CLAUDE.md CRITICAL MUST 追加で同種スクショ運用事故の構造的再発防止を確立。executor 領分の作業ゼロ、Git clean、main 同期 (`21437c8`)、残留プロセスなし、同根再発スキャン (§ 4.6) / 対症療法判定 (§ 4.7) いずれも該当なし。条件待ち 4 件はすべて外部 trigger 待ちで次セッション以降の対応。

--- a/docs/handoff/archive/2026-06-20-session-79.md
+++ b/docs/handoff/archive/2026-06-20-session-79.md
@@ -1,0 +1,168 @@
+# Session Handoff — 2026-06-20 (Session 79)
+
+## TL;DR
+
+**メタ前提見直し + 同根再発対策の最終 PR**。Session 78 (PR #579 / #582 / #583) で発覚した同根障害 (Docker base image `node:24-slim` floating tag → Node 24.17.0 引き込み → `http.Agent` regression → `signBlob` `Premature close` 多発) を踏まえ、本セッションは:
+
+1. 本番修正の **実機検証ステータスを正確に区別** (コード/CI レベル ✅ / 現場再試行レベル ⚠️)
+2. 現場向け修正報告メッセージに含めた「**実機での動作確認を必須化**」が AI executor 越権 (4 原則 §1 違反、確約化動詞、`feedback_promise_overengineering.md` 未参照) であったことを認識・訂正文案起草
+3. プロジェクト / グローバル両層のメタ前提 (memory / handoff / CLAUDE.md / hook) を俯瞰し、破綻 5 つを抽出
+4. グローバル handoff スキル §4.6 (同根再発スキャン) + §4.7 (対症療法判定) の追加テキスト案を起草 (別 AI 担当領域へ引き継ぎ)
+5. プロジェクト側で実施可能な構造対策として **PR #586 (engines `24.16.0` 固定 + `.nvmrc` + プロジェクト memory `feedback_lms_floating_tag_avoidance.md` 追加)** をマージ
+
+| 主要成果 | 結果 |
+|---|---|
+| PR #586 マージ (engines + nvmrc + memory) | ✅ merged + CI 全 pass (Build / Lint / Playwright / Test / Type Check) |
+| プロジェクト memory 追加 | ✅ `feedback_lms_floating_tag_avoidance.md` (Dockerfile / engines / Actions の floating tag 方針) |
+| Dockerfile / engines / `.nvmrc` の 3 点整合 | ✅ いずれも `24.16.0` で揃った |
+| 現場訂正文案 (α 追伸型 / β 独立型) 起草 | ✅ 起草完了 (送付タイミングは decision-maker 領分) |
+| グローバル handoff スキル §4.6 / §4.7 追加テキスト | ✅ 起草完了、本セッション外の別 AI へ引き継ぎ予定 |
+| メタ前提破綻 5 つ + 真の主原因の言語化 | ✅ 「メタは寄与因子、主原因は AI executor のターン内判断ミス」を区別 |
+
+- **Issue Net (本セッション)**: Close 0 + 起票 0 = **Net 0** (triage 基準を満たす追加 Issue なし、本セッションは既存メタ前提の見直し + 既知の同根対策の最終 PR で完結)
+- **本セッション merged PR**: 1 件 (#586)
+- **本セッション本番 destructive 操作**: 0 件 (PR #586 は memory + config のみ、実行時挙動影響なし)
+
+---
+
+## 🚀 次セッション開始時の必読手順
+
+```bash
+cat docs/handoff/LATEST.md
+git fetch origin main && git log --oneline -5 origin/main
+gh pr list --state open
+gh issue list --state open
+# 福の種テナント / 213 MB PDF 現場再試行報告の有無を確認 (チャット経路は GitHub 管理外)
+# グローバル handoff スキル §4.6 / §4.7 の追加が完了しているか確認 (別 AI 担当)
+```
+
+---
+
+## 本セッションでの変更要旨
+
+| 層 | 変更内容 |
+|---|---|
+| `package.json` engines | `">=24.12.0"` → `"24.16.0"` (パッチ固定、Dockerfile と整合) |
+| `.nvmrc` (新規) | `24.16.0` (nodenv / volta / fnm / nvm でローカル自動切替) |
+| `.claude/memory/feedback_lms_floating_tag_avoidance.md` (新規) | Dockerfile / engines / GitHub Actions の floating tag 方針を明文化 |
+| `.claude/memory/MEMORY.md` | インデックス追記 |
+
+詳細: PR #586 description
+
+---
+
+## メタ前提見直しで明確にしたこと
+
+| 項目 | 区別 |
+|---|---|
+| 真の主原因 | **AI executor のターン内判断ミス** (越権 / memory 未参照 / 事実確認不足 / 楽観判定) |
+| 寄与因子 (二次) | handoff スキルに同根再発チェックなし / グローバル MEMORY.md が grep されにくい構造 |
+| 「メタを更新すれば再発防止」は錯覚 | memory 追加 = 完了の錯覚を構造的に避ける必要 |
+| 確約化動詞は memory が既に警告していた | `feedback_promise_overengineering.md` / `feedback_field_message_approval.md` の grep がターン内に行われなかった |
+| 規模感 | 1560 行のメタ (CLAUDE.md + rules + memory) は少人数プロジェクトに対し物理的に毎ターン scan 不可能 |
+
+---
+
+## 別 AI 担当領域への引き継ぎ
+
+グローバル handoff スキル `~/.claude/skills/handoff/SKILL.md` への §4.6 / §4.7 追加テキスト (起草済) を別 AI 担当へ引き継ぎ。プロジェクト固有名詞 (固有のサービス名 / 障害固有 token) は含めず、抽象表現で書いてある (グローバル memory ルール準拠)。
+
+---
+
+## ルール反映 (本セッション)
+
+- **プロジェクト memory** (`.claude/memory/feedback_lms_floating_tag_avoidance.md`, PR #586 で repo 管理化): Dockerfile / engines / GitHub Actions の floating tag 方針、新 PR で floating tag を導入していないかレビュー段階で目視確認する運用とする
+- **グローバル memory への追加なし**: §4.6 / §4.7 は handoff スキル本体への構造化が筋、grep リストは既存 `feedback_promise_overengineering.md` / `feedback_field_message_approval.md` 強化で対応 (別 AI 担当)
+
+---
+
+## 次のアクション
+
+### 即着手タスク
+
+**なし** — 本セッション主目的 (メタ前提見直し + PR #586) 完了、git clean、main 同期済、CI 全 pass、本番デプロイ影響なし。executor 領分の作業ゼロ。
+
+### 条件待ち (明示 trigger 付き)
+
+| # | 項目 | trigger | 充足時のタスク |
+|---|------|---------|--------------|
+| 1 | 福の種テナントの動画再生現場再試行報告 | チャット等で「動画が見られる」「まだ赤画面が出る」等の報告 | 成功 → 本件完全クローズ / 失敗 → スクショ + 時刻 + サーバーログ再調査 |
+| 2 | 213 MB PDF アップロード現場再試行報告 | チャット等で「アップロード成功」「まだエラー」等の報告 | 成功 → 本件完全クローズ / 失敗 → スクショ + 時刻 + サーバーログ再調査 |
+| 3 | 現場訂正メッセージ (α または β) の送付反応 | decision-maker から送付タイミング判断後の現場反応 | 反応に応じてフォローアップ文案再起草 (必要時) |
+| 4 | グローバル handoff スキル §4.6 / §4.7 追加完了 | 別 AI 担当からの完了報告 | 本リポジトリ次セッションで新 handoff 出力時に §4.6 / §4.7 が自動適用されることを確認 |
+| 5 | Issue #584 (Phase 4 α-7 Playwright E2E) | decision-maker から cutover Step 6 スケジュール確定 or 番号単位の明示指示 | impl-plan → tdd → e2e 実装 |
+
+### 却下候補 (記録のみ)
+
+| # | 項目 | 理由 |
+|---|------|-----|
+| 1 | GitHub Actions の `@v6` / `@v3` / `@v7` を SHA-pin する PR | 中期検討事項として memory に記録済、Node ほどの破壊的変更ペースではない。dependabot 設定との整合性検討が要るため即時着手対象外。decision-maker 起点指示があれば対応 |
+| 2 | errorHandler を ADR-010 flat 形式に統一 (Session 78 引継ぎ) | 本質的負債だが FE 防御で吸収済、`[object Object]` 再発なし。横断影響大、緊急性なし。decision-maker 起点の指示があれば対応 |
+| 3 | gmail 系 transient util を新 `transient-error.ts` に統合 (Session 78 引継ぎ) | ROI 不明確。既存配送経路を緊急性なく触るリスクが効果を上回る。decision-maker 起点の指示があれば対応 |
+| 4 | dependabot 11 件 (#563-#573) + #585 (actions/checkout v6→v7) のマージ | A カテゴリ housekeeping、decision-maker 明示指示なき限り保留。`@v6 → @v7` などの依存更新は影響範囲確認要 |
+
+---
+
+## 構造的整合性チェック
+
+| 項目 | 実施可否 | 備考 |
+|---|---|---|
+| `/impact-analysis` (型・共有ロジック変更) | ⏭️ スキップ | 本 PR は memory + config (engines / nvmrc) のみ、共有型 / API 契約変更なし |
+| `/new-resource` (新規テーブル / API) | ⏭️ スキップ | 該当なし |
+| `/trace-dataflow` (データフロー) | ⏭️ スキップ | 既存データフロー変更なし |
+
+---
+
+## § 4.6 同根再発スキャン結果
+
+| 項目 | 結果 |
+|---|---|
+| 本セッション内修正 PR (`fix:` / `hotfix:`) | 0 件 (PR #586 は `chore:`、本セッションは Session 78 同根問題の最終構造対策) |
+| 過去 7 日 archive 内 `signBlob` / `Premature close` keyword ヒット | 1 件 (`2026-06-19-session-76.md`、本事案の起点として既知) |
+| 同根判定 | **本セッションは既知の同根問題への最終構造対策 (engines / nvmrc / memory) を完了**。新たな同根再発候補なし、§ 8 最終結論 判定継続 |
+
+---
+
+## § 4.7 対症療法判定結果
+
+| 項目 | 結果 |
+|---|---|
+| 本セッション内修正 PR | 0 件、判定対象外 |
+| 既知 root cause (Node floating tag) への対応 | PR #583 (Docker base image パッチ固定) + PR #586 (engines / nvmrc パッチ固定) で構造的に根治。retry / fallback だけで終わっていない |
+
+---
+
+## Issue Net 変化
+
+- Close 数: 0 件
+- 起票数: 0 件
+- **Net: 0 件**
+- **言語化**: 本セッションは Session 78 同根問題の最終構造対策 + メタ前提見直しで完結。triage 基準 (実害 / 再現バグ / CI 破壊 / rating≥7 / 明示指示) を満たす追加課題なし。Issue Net 0 だが、本セッションは「メタ前提見直し + 同根問題の構造的根治の完成」という実質進捗あり
+
+---
+
+## 残留プロセス
+
+✅ 残留 Node プロセスなし
+
+---
+
+## 再開可能性判定
+
+| 項目 | 状態 |
+|------|------|
+| Git clean | ✅ (PR #586 マージ後、本 handoff PR 作成中) |
+| main 同期済 | ✅ (`34a9c50` まで) |
+| 本セッション merged PR | ✅ #586 |
+| 本番デプロイ影響 | ⏭️ 該当なし (memory + config のみ) |
+| 本番ログ (api-00438-k94 / web-00433-5q6) | ✅ signBlob エラー再発なし、健全稼働 |
+| OPEN PR | dependabot 11 件 (#563-#573) + #585 (actions/checkout v6→v7、本 handoff PR は別) |
+| 残留プロセス | ✅ なし |
+| 即着手タスク | 0 件 |
+| 条件待ち | 5 件 (全て外部 trigger 待ち) |
+
+---
+
+## 最終結論
+
+✅ **セッション終了可** — メタ前提見直し + 同根問題の最終構造対策 (PR #586) 完了。executor 領分の作業ゼロ、条件待ち 5 件は全て外部 trigger 待ちで次セッション以降の対応。残留プロセスなし、Git clean、本番デプロイ健全。同根再発スキャン (§ 4.6) / 対症療法判定 (§ 4.7) いずれも該当なし。


### PR DESCRIPTION
## Session 80 ハンドオフ

現場担当者から「マスター講座に資料を後追い添付したが、配信済みテナントには紐づかない?」との相談を起点に、スーパー管理者ヘルプに「配信済みテナント資料反映」セクションを追加 (PR #588)。撮影過程で AI が \`screenshot\` skill を invoke せず \`browser_take_screenshot\` を直接呼び、Next.js dev indicator (N マーク) が画像に焼き付くインシデント発生。N マーク除去版で差し替え (PR #589) + 拡大ダイアログ UX 改善 (PR #590) + global skill 強化 (#308) + CLAUDE.md CRITICAL MUST 追加で構造的再発防止。

## 本セッション merged PR (本リポジトリ)

| PR | 内容 |
|----|------|
| #588 | スーパー管理者ヘルプに「配信済みテナント資料反映」セクション追加 |
| #589 | スクショ Next.js dev indicator (N マーク) 除去 |
| #590 | スクショ拡大ダイアログを 95vw / 上限 1400px に拡張 |

## 別レポ open

- yasushi-honda/claude-code-config #308 (screenshot skill 強化、decision-maker レビュー & マージ待ち)

## 構造的再発防止

- skill 本体: Step 5.5 自己診断 + 撮影後 PNG 目視確認 MUST 化
- skill description: コミット対象スクショ撮影時は明示依頼なくても起動 MUST
- global CLAUDE.md CRITICAL: \`browser_take_screenshot\` 直前の filename 判定 MUST 追加
- 運用判定基準: \`docs/images/\` / \`public/\` 等 git 管理パス vs \`.playwright-mcp/\` 等 gitignored パスの分岐を明文化

## Issue Net: 0 件
- close 0, 起票 0
- triage 基準を満たす追加課題なし

## § 4.6 同根再発スキャン: 過去事案 0 件
本セッションが本リポジトリでの起点。global 側で構造対策完了。

## § 4.7 対症療法判定: 該当 0 件
根本原因 (skill invoke スキップ運用ミス) 明確、global skill + CLAUDE.md で構造的根治。

## Test plan

- [x] LATEST.md の Session 80 内容が本セッション成果を反映
- [x] 前回 LATEST (Session 79) を archive にコピー済み
- [x] handoff サイズ 500 行以下 (現在 168 行 → Session 80 で 226 行、目標内)
- [ ] マージ後、次セッション開始時に Session 80 が catchup で参照される

🤖 Generated with [Claude Code](https://claude.com/claude-code)